### PR TITLE
Forward-port review-fixes through the rename (supersedes #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,46 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+
+- **Never lose the log.** `eval()` always produces and persists an `EvalLog`
+  once rollouts have started: scorer/reducer failures degrade the run to an
+  error log instead of crashing; `policy.reset`/`embodiment.reset` failures are
+  wrapped into the error taxonomy; every error raised from inside a trial
+  carries the partial `TrialRecord` on `exc.record` (recorded and delivered to
+  sinks — errored trials are never scored); `on_trial_end` fires for halted
+  trials too.
+- **A crashing approver now halts the eval as `SafetyAbort`** — an approver that
+  crashed cannot vouch for safety — and approved-but-modified actions emit an
+  `approval_event`.
+- **`eval()` owns what it opens:** an embodiment resolved from a registry name
+  is closed when the run finishes (even on a halt); caller-constructed
+  embodiments stay caller-owned.
+- **`fail_on_error` is checked after every trial** (Inspect semantics:
+  `True` = first error, `0<x<1` = proportion, `x>1` = count), not just at the
+  end of the run.
+- `derive_seed`: `seed=None` no longer aliases `seed=0` — unseeded runs draw a
+  fresh OS seed and record it in the log.
+- `Task`/`Epochs`/`Box`/`ObservationSpace` validate their configuration at
+  construction (`max_steps`/`epochs` must be positive, `Box` bounds must be
+  elementwise ordered, `state_keys` must agree with `StateSpec`), raising
+  `ConfigError`/`ValueError` instead of failing mid-eval. `Task.scorer` also
+  accepts registry names.
+- Inference events no longer overstate `chunk_len` when `replan_interval`
+  exceeds the chunk; the ensembling no-semantics warning fires per instance
+  (at construction) instead of once per process.
+- Collision-safe frame-file slugs (camera names and trial ids are fully
+  sanitized); broken plugin entry points warn loudly instead of being silently
+  skipped.
+- Rerun sink: per-trial namespacing, new-SDK (`>=0.23`) compatibility, and a
+  correct install hint.
+
 ### Added
+
+- CLI: `inspect-robots run` gained `--epochs`, `--fail-on-error`, and
+  `--store-frames`; the written log's path is printed at the end of a run.
+- Tests are now type-checked under strict mypy (`files = ["src/inspect_robots",
+  "tests"]`).
 
 - **Widened the public API for plugin authors.** `inspect_robots.__all__` now exports
   the authoring primitives directly — `Task`/`Epochs`, `Scene`/`Target`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,11 +35,13 @@ rollout, scores it, and writes an immutable `EvalLog`. Mirrors Inspect AI's
 
 - Dev loop: `uv pip install -e ".[dev]"`, `uv run pre-commit install`, then
   `uv run pytest --cov`.
-- Gates that must pass: `ruff check .`, `ruff format --check .`, `mypy` (strict),
-  and `pytest --cov` at **100% coverage** (`--cov-fail-under=100`). Pre-commit
-  runs ruff+mypy on commit and the coverage gate on push
-  (`.pre-commit-config.yaml`). CI runs all gates on Linux+macOS / py3.11-3.12 as
-  **blocking, required PR checks**; coverage below 100% fails the build.
+- Gates that must pass: `ruff check .`, `ruff format --check .`, `mypy` (strict,
+  covers `src` **and** `tests`), and `pytest --cov` at **100% coverage**
+  (`--cov-fail-under=100`). Pre-commit runs ruff+mypy on commit and the coverage
+  gate on push (`.pre-commit-config.yaml`). CI runs all gates on Linux+macOS /
+  py3.11-3.12 as **blocking, required PR checks** (coverage below 100% fails the
+  build), plus a **non-blocking** `test-extra` tier for py3.10/py3.13, Windows,
+  and the NumPy floor — together covering the py3.10–3.13 range pyproject claims.
 - **Core stays NumPy-only.** New deps are optional extras, lazily imported; the
   `core-only-import` CI job enforces this.
 - Test-driven; commit/push in small focused steps.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -24,6 +24,11 @@ inspect-robots run --task cubepick-reach -T num_scenes=10 --policy scripted -P c
              --embodiment cubepick --log-dir logs --seed 0
 ```
 
+`--epochs N` overrides the task's epoch count, `--fail-on-error X` halts on
+`PolicyError`s (`1` = first error, `0<X<1` = proportion, `X>1` = count), and
+`--store-frames` streams camera frames to `<log-dir>/frames`. When the run
+finishes, the path of the written log is printed.
+
 The exit code is `0` on a successful eval, `1` otherwise.
 
 ## `inspect-robots inspect`

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -68,12 +68,30 @@ The error taxonomy resolves the "fail fast vs never-crash-overnight" tension:
 | Class | Policy |
 |---|---|
 | [`CompatibilityError`][inspect_robots.errors.CompatibilityError], `ConfigError` | fail fast, before any rollout |
-| [`PolicyError`][inspect_robots.errors.PolicyError] | record the trial, continue (governed by `fail_on_error`) |
+| [`PolicyError`][inspect_robots.errors.PolicyError] | record the trial, then continue or halt per `fail_on_error` (`True` = first error, `0<x<1` = proportion, `x>1` = count), checked after every trial |
 | [`EmbodimentFault`][inspect_robots.errors.EmbodimentFault], [`SafetyAbort`][inspect_robots.errors.SafetyAbort] | **always halt** — a faulted/unsafe robot never auto-advances |
+
+Failures inside a trial (including `reset`) are wrapped into the taxonomy; a
+crashing approver becomes a `SafetyAbort` (it can no longer vouch for safety).
+Every error raised from inside a trial carries the partial
+[`TrialRecord`][inspect_robots.rollout.TrialRecord] on its `record` attribute, so the
+steps that did run are delivered to sinks. Errored trials are recorded but
+**never scored** — a failed trial cannot masquerade as data in the metrics.
 
 ## The eval log
 
 [`eval`][inspect_robots.eval.eval] orchestrates scenes × epochs and returns immutable
 [`EvalLog`][inspect_robots.log.EvalLog]s (status, spec, results, stats, per-scene samples,
 error). Logs are written atomically as schema-versioned JSON with a read-back
-guarantee.
+guarantee. Once rollouts have started, an `EvalLog` is always produced and
+persisted: scorer or reducer failures degrade the run to an error log rather
+than crashing away the night's data.
+
+`eval()` also owns what it opens: an embodiment resolved from a **registry
+name** is closed when the run finishes (even on a halt), while a
+caller-constructed embodiment object stays open — its lifecycle belongs to the
+caller.
+
+Passing `seed=None` draws a fresh seed from the OS and records it in the log,
+so an "unseeded" run remains reproducible after the fact (and is distinct from
+`seed=0`).

--- a/docs/guide/policies-and-embodiments.md
+++ b/docs/guide/policies-and-embodiments.md
@@ -88,6 +88,11 @@ class MyArm:
         ...
 ```
 
+Lifecycle: [`eval`][inspect_robots.eval.eval] closes what it resolves — an
+embodiment looked up by **registry name** is closed when the run finishes (even
+on a halt). If you construct the embodiment object yourself, you own it: call
+`close()` yourself when you are done.
+
 ## Real-robot vs simulator
 
 The interfaces assume **real-robot reality**: no guaranteed privileged success,

--- a/docs/guide/writing-a-benchmark.md
+++ b/docs/guide/writing-a-benchmark.md
@@ -37,7 +37,9 @@ analog):
   `kind` is resolved in the *embodiment's* namespace (compatibility checking
   verifies the embodiment can realize it).
 - `init_seed` — combined with the eval seed and epoch index to seed each trial
-  deterministically.
+  deterministically. (An eval run with `seed=None` draws a fresh OS seed and
+  records it in the log, so even "unseeded" runs are reproducible after the
+  fact — and distinct from `seed=0`.)
 
 ## Epochs and reducers
 

--- a/plugins/inspect-robots-isaacsim/README.md
+++ b/plugins/inspect-robots-isaacsim/README.md
@@ -87,9 +87,11 @@ constructor exposes hooks so you don't edit the adapter:
 Long unattended evals should not creep in RAM or VRAM. This adapter is built to
 hold nothing per step, but a few usage rules keep a full run leak-free:
 
-- **Free the simulator when done.** `eval()` does *not* close the embodiment for
-  you, and an open `SimulationApp` holds GPU memory until the process exits. Use
-  the embodiment as a context manager (or `close()` in a `finally`):
+- **Free the simulator when done.** `eval()` closes what it resolves: an
+  embodiment looked up by **registry name** (e.g. `embodiment="isaacsim"`) is
+  closed when the run finishes. An embodiment object *you* construct is yours
+  to close — an open `SimulationApp` holds GPU memory until the process exits,
+  so use it as a context manager (or `close()` in a `finally`):
 
   ```python
   with IsaacSimEmbodiment() as emb:

--- a/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
+++ b/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
@@ -243,10 +243,12 @@ class IsaacSimEmbodiment:
     def close(self) -> None:
         """Release the gym env and Isaac Sim app (and the GPU memory they hold).
 
-        Idempotent: safe to call before launch or twice. ``eval()`` does not call
-        this for you, so use the embodiment as a context manager (or call
-        ``close()`` in a ``finally``) to guarantee the simulator is torn down and
-        GPU memory is freed when a run ends.
+        Idempotent: safe to call before launch or twice. ``eval()`` closes what
+        it resolves — an embodiment looked up by registry name is closed when
+        the run finishes, but an embodiment object you construct is yours to
+        close. Use it as a context manager (or call ``close()`` in a
+        ``finally``) to guarantee the simulator is torn down and GPU memory is
+        freed when a run ends.
         """
         global _ACTIVE_APP
         if self._env is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ python_version = "3.10"
 strict = true
 warn_unreachable = true
 disallow_untyped_defs = true
-files = ["src/inspect_robots"]
+files = ["src/inspect_robots", "tests"]
 
 [[tool.mypy.overrides]]
 module = ["rerun.*"]

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -34,6 +34,13 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
   inference/replanning is controller-internal (so ensembling composes — R3).
 - Frames live in a rollout-owned `FrameStore`, never in a sink (R5).
 - Action *semantics* live on the action `Box`, not on every `Action` (R8).
-- Generic policy/embodiment exceptions are wrapped into `PolicyError` /
-  `EmbodimentFault`; `SafetyAbort`/`EmbodimentFault` always halt the eval.
+- Generic policy/embodiment exceptions (incl. from `reset`) are wrapped into
+  `PolicyError` / `EmbodimentFault`; a crashing approver becomes `SafetyAbort`;
+  `SafetyAbort`/`EmbodimentFault` always halt the eval. Every error raised from
+  inside a trial carries the partial `TrialRecord` on `exc.record`.
+- `eval()` must always return/persist an `EvalLog` once rollouts have started —
+  scorer/reducer failures degrade to an error log, never a crash. Errored
+  trials are recorded (and delivered to sinks) but **never scored**.
+- `eval()` closes embodiments it resolved from registry names ("close what we
+  open"); caller-constructed objects are caller-owned.
 - `mock/` and core must never import `rerun`/`torch` at module top.

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -5,7 +5,10 @@ Subcommands:
 - ``inspect-robots list [tasks|policies|embodiments|scorers|sinks]`` — show registered
   components (builtins + installed plugins).
 - ``inspect-robots run --task T --policy P --embodiment E`` — run an eval, resolving
-  components from the registry. Pass constructor args with ``-T/-P/-E k=v``.
+  components from the registry. Pass constructor args with ``-T/-P/-E k=v``;
+  ``--epochs``, ``--fail-on-error``, and ``--store-frames`` tune the run. The
+  written log's path is printed at the end.
+- ``inspect-robots inspect LOG.json`` — print a saved eval log.
 """
 
 from __future__ import annotations
@@ -75,6 +78,19 @@ def build_parser() -> argparse.ArgumentParser:
     p_run.add_argument("-E", dest="embodiment_args", action="append", metavar="k=v")
     p_run.add_argument("--log-dir", default="logs")
     p_run.add_argument("--seed", type=int, default=0)
+    p_run.add_argument("--epochs", type=int, default=None, help="override the task's epoch count")
+    p_run.add_argument(
+        "--fail-on-error",
+        type=float,
+        default=None,
+        metavar="X",
+        help="halt on PolicyErrors: 1 = first error, 0<X<1 = proportion, X>1 = count",
+    )
+    p_run.add_argument(
+        "--store-frames",
+        action="store_true",
+        help="stream camera frames to <log-dir>/frames instead of keeping them in memory",
+    )
 
     p_inspect = sub.add_parser("inspect", help="print a saved eval log")
     p_inspect.add_argument("log", help="path to an EvalLog JSON file")
@@ -97,19 +113,36 @@ def _cmd_list(what: str | None) -> int:
 
 
 def _cmd_run(args: argparse.Namespace) -> int:
+    from dataclasses import replace
+
     from inspect_robots import eval
+    from inspect_robots.logging import JsonLogSink
     from inspect_robots.registry import resolve
 
     task = resolve("task", args.task, **_parse_kvs(args.task_args))
     policy = resolve("policy", args.policy, **_parse_kvs(args.policy_args))
     embodiment = resolve("embodiment", args.embodiment, **_parse_kvs(args.embodiment_args))
+    if args.epochs is not None:
+        task = replace(task, epochs=args.epochs)
 
-    logs = eval(task, policy, embodiment, log_dir=args.log_dir, seed=args.seed)
+    # Construct the sink explicitly so we can tell the user where the log went.
+    sink = JsonLogSink(args.log_dir)
+    logs = eval(
+        task,
+        policy,
+        embodiment,
+        log_dir=args.log_dir,
+        seed=args.seed,
+        sinks=[sink],
+        fail_on_error=args.fail_on_error if args.fail_on_error is not None else False,
+        store_frames=args.store_frames,
+    )
     log = logs[0]
     print(f"status: {log.status}")
     print(f"scenes: {log.results.total_scenes}  trials: {log.results.total_trials}")
     for name, value in sorted(log.results.metrics.items()):
         print(f"  {name}: {value:.4g}")
+    print(f"log: {sink.path}")
     return 0 if log.status == "success" else 1
 
 

--- a/src/inspect_robots/controller.py
+++ b/src/inspect_robots/controller.py
@@ -55,8 +55,11 @@ class DefaultController:
         if not buffer:
             chunk = policy.act(observation)
             take = self.replan_interval or len(chunk)
-            buffer.extend(list(chunk.actions)[:take])
-            store.setdefault(_INFER_KEY, []).append((chunk.inference_latency_s, take))
+            taken = list(chunk.actions)[:take]
+            buffer.extend(taken)
+            # Record the number of actions actually buffered (the chunk may be
+            # shorter than replan_interval), so the transcript never overstates.
+            store.setdefault(_INFER_KEY, []).append((chunk.inference_latency_s, len(taken)))
         return buffer.popleft()
 
 
@@ -98,7 +101,6 @@ _AVERAGEABLE_MODES = frozenset(
 # "rot6d" is averaged un-normalized here on the assumption the consumer applies
 # Gram-Schmidt on decode (true for the standard rot6d->matrix path).
 _AVERAGEABLE_ROT = frozenset({"none", "rot6d"})
-_ENSEMBLE_WARNED = False
 
 
 class EnsemblingController:
@@ -122,15 +124,12 @@ class EnsemblingController:
         self.m = m
         sem = action_space.semantics
         if sem is None:
-            global _ENSEMBLE_WARNED
-            if not _ENSEMBLE_WARNED:
-                warnings.warn(
-                    "EnsemblingController: action space has no semantics; cannot "
-                    "verify that actions are safe to average.",
-                    RuntimeWarning,
-                    stacklevel=2,
-                )
-                _ENSEMBLE_WARNED = True
+            warnings.warn(
+                "EnsemblingController: action space has no semantics; cannot "
+                "verify that actions are safe to average.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         else:
             if sem.control_mode not in _AVERAGEABLE_MODES:  # pragma: no cover
                 # Defensive: every valid ControlMode literal is currently averageable.

--- a/src/inspect_robots/errors.py
+++ b/src/inspect_robots/errors.py
@@ -16,9 +16,23 @@ aborts the eval
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from inspect_robots.rollout import TrialRecord
+
 
 class InspectRobotsError(Exception):
-    """Base class for all Inspect Robots errors."""
+    """Base class for all Inspect Robots errors.
+
+    When an error is raised from inside a running trial, the rollout engine
+    attaches the partial [`TrialRecord`][inspect_robots.rollout.TrialRecord] — the
+    steps walked and the transcript events up to the failure — as ``record``,
+    so the orchestrator can preserve it in logs. ``record`` is ``None`` for
+    errors raised outside a rollout (configuration, compatibility, ...).
+    """
+
+    record: TrialRecord | None = None
 
 
 class ConfigError(InspectRobotsError):

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -9,6 +9,7 @@ slice accepts already-constructed objects; registry-string resolution
 
 from __future__ import annotations
 
+import os
 import subprocess
 import time
 from collections.abc import Sequence
@@ -23,12 +24,12 @@ from inspect_robots.approver import Approver, AutoApprover
 from inspect_robots.compat import assert_compatible
 from inspect_robots.controller import Controller, DefaultController
 from inspect_robots.embodiment import Embodiment
-from inspect_robots.errors import EmbodimentFault, PolicyError, SafetyAbort
+from inspect_robots.errors import ConfigError, EmbodimentFault, PolicyError, SafetyAbort
 from inspect_robots.frames import FrameStore
 from inspect_robots.log import EvalLog, EvalResults, EvalSpec, EvalStats, SceneResult
 from inspect_robots.policy import Policy
 from inspect_robots.rollout import TrialRecord, derive_seed, rollout
-from inspect_robots.scorer import Score, reduce_scores, value_to_float
+from inspect_robots.scorer import Score, get_reducer, reduce_scores, value_to_float
 from inspect_robots.task import Task
 
 if TYPE_CHECKING:
@@ -41,17 +42,33 @@ def _now_iso() -> str:
 
 
 def _git_commit() -> str | None:
-    try:
-        out = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=2,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError):
+    """HEAD commit of the *current working directory's* repository, if any.
+
+    This is deliberately the caller's repo (the code driving the eval), not
+    Inspect Robots's own install. A ``-dirty`` suffix is appended when the working
+    tree has uncommitted changes, so a log never silently claims a clean commit.
+    """
+
+    def _git(*args: str) -> subprocess.CompletedProcess[str] | None:
+        try:
+            return subprocess.run(
+                ["git", *args],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+
+    head = _git("rev-parse", "HEAD")
+    if head is None or head.returncode != 0 or not head.stdout.strip():
         return None
-    return out.stdout.strip() or None if out.returncode == 0 else None
+    commit = head.stdout.strip()
+    tree = _git("status", "--porcelain")
+    if tree is not None and tree.returncode == 0 and tree.stdout.strip():
+        commit += "-dirty"
+    return commit
 
 
 class _Broadcast:
@@ -101,21 +118,33 @@ def eval(
 
     ``task``/``policy``/``embodiment`` may be objects or **registry names**
     (e.g. ``policy="scripted"``), resolved through the registry — the Inspect-style
-    ergonomic that keeps logs and the CLI reproducible.
+    ergonomic that keeps logs and the CLI reproducible. An embodiment resolved
+    from a registry name is owned by ``eval()`` and is closed when the run
+    finishes (even on a halt); a caller-constructed embodiment object stays
+    open — the caller owns its lifecycle.
+
+    ``seed=None`` draws a fresh seed from the OS and records it in the log, so
+    an "unseeded" run remains reproducible after the fact (and is distinct from
+    ``seed=0``).
 
     ``fail_on_error`` follows Inspect semantics for ``PolicyError`` (``True`` =
-    fail on first, ``False`` = never, ``0<x<1`` = proportion, ``x>1`` = count).
-    ``EmbodimentFault``/``SafetyAbort`` always halt regardless.
+    fail on first, ``False`` = never, ``0<x<1`` = proportion, ``x>1`` = count),
+    checked after every trial. ``EmbodimentFault``/``SafetyAbort`` always halt
+    regardless. Errored trials are recorded (with their partial trajectory
+    delivered to sinks) but never scored, so a failed trial cannot masquerade
+    as data in the metrics; it stays visible via ``SceneResult.status`` and an
+    empty entry in ``SceneResult.epochs``.
 
     When ``store_frames`` is set, camera frames are streamed to
     ``<log_dir>/frames`` as binary side-cars (R5) rather than kept in memory.
 
     Raises [`CompatibilityError`][inspect_robots.errors.CompatibilityError] (fail fast, before any
-    rollout) if the policy and embodiment are incompatible.
+    rollout) if the policy and embodiment are incompatible, and
+    [`ConfigError`][inspect_robots.errors.ConfigError] for an invalid epoch reducer.
     """
-    from inspect_robots.logging.json_log import JsonLogSink
     from inspect_robots.registry import resolve
 
+    owns_embodiment = isinstance(embodiment, str)
     task = cast(Task, resolve("task", task)) if isinstance(task, str) else task
     policy = cast(Policy, resolve("policy", policy)) if isinstance(policy, str) else policy
     embodiment = (
@@ -123,9 +152,59 @@ def eval(
         if isinstance(embodiment, str)
         else embodiment
     )
+    try:
+        return _run_eval(
+            task,
+            policy,
+            embodiment,
+            log_dir=log_dir,
+            sinks=sinks,
+            seed=seed,
+            fail_on_error=fail_on_error,
+            controller=controller,
+            approver=approver,
+            remap=remap,
+            store_frames=store_frames,
+        )
+    finally:
+        # Close what we opened: a registry-resolved embodiment is released even
+        # when the run halts, so a real robot never leaks its connection.
+        if owns_embodiment:
+            embodiment.close()
+
+
+def _run_eval(
+    task: Task,
+    policy: Policy,
+    embodiment: Embodiment,
+    *,
+    log_dir: str,
+    sinks: list[LogSink] | None,
+    seed: int | None,
+    fail_on_error: bool | float,
+    controller: Controller | None,
+    approver: Approver | None,
+    remap: dict[str, str] | None,
+    store_frames: bool,
+) -> list[EvalLog]:
+    """The body of [`eval`][inspect_robots.eval.eval], after resolution/ownership."""
+    from inspect_robots.logging.json_log import JsonLogSink
 
     # Fail fast on incompatible pairings before touching any hardware/sim.
     assert_compatible(policy, embodiment, task, remap=remap)
+
+    epoch_spec = task.epoch_spec
+    scorers = task.scorers
+    # Fail fast on an unknown/invalid epoch reducer, before any rollout runs.
+    try:
+        get_reducer(epoch_spec.reducer)
+    except ValueError as exc:
+        raise ConfigError(str(exc)) from exc
+
+    if seed is None:
+        # Draw and record a real seed so the run stays reproducible after the
+        # fact; None must not silently alias seed=0 (see derive_seed).
+        seed = int.from_bytes(os.urandom(4), "little")
 
     sink_list: list[LogSink] = sinks if sinks is not None else [JsonLogSink(log_dir)]
     bus = _Broadcast(sink_list)
@@ -155,8 +234,6 @@ def eval(
 
     started = time.perf_counter()
     started_iso = _now_iso()
-    epoch_spec = task.epoch_spec
-    scorers = task.scorers
 
     scene_results: list[SceneResult] = []
     all_latencies: list[float] = []
@@ -167,6 +244,7 @@ def eval(
     error_count = 0
 
     halted = False
+    stopped = False
     for scene in task.scenes:
         per_scorer_scores: dict[str, list[Score]] = {s.name: [] for s in scorers}
         epoch_dicts: list[dict[str, float]] = []
@@ -176,6 +254,7 @@ def eval(
         for epoch in range(epoch_spec.count):
             trial_seed = derive_seed(seed, scene.init_seed, epoch)
             bus.on_trial_start(scene.id, epoch)
+            record: TrialRecord | None
             try:
                 record = rollout(
                     policy,
@@ -191,18 +270,19 @@ def eval(
                     frame_store=frame_store,
                 )
             except (EmbodimentFault, SafetyAbort) as exc:
-                # Hardware/safety failures always halt the whole eval.
+                # Hardware/safety failures always halt the whole eval; the
+                # partial trial record (if any) is preserved below.
                 status = "error"
                 error = f"{type(exc).__name__}: {exc}"
                 scene_status = "error"
                 scene_error = error
                 halted = True
-                break
+                record = exc.record
             except PolicyError as exc:
                 error_count += 1
                 scene_status = "error"
                 scene_error = f"{type(exc).__name__}: {exc}"
-                record = TrialRecord(
+                record = exc.record or TrialRecord(
                     scene_id=scene.id,
                     epoch=epoch,
                     seed=trial_seed,
@@ -210,23 +290,54 @@ def eval(
                     error=scene_error,
                 )
 
-            total_trials += 1
-            total_steps += len(record.steps)
-            all_latencies.extend(record.inference_latencies)
+            if record is not None:
+                total_trials += 1
+                total_steps += len(record.steps)
+                all_latencies.extend(record.inference_latencies)
+                if record.status == "error":
+                    # Errored trials are not scored: a failed trial must not
+                    # masquerade as data (e.g. an inf min-distance poisoning
+                    # the metric mean). It stays visible via scene status.
+                    epoch_dicts.append({})
+                else:
+                    epoch_values: dict[str, float] = {}
+                    for scorer in scorers:
+                        score = scorer(record, scene.target)
+                        per_scorer_scores[scorer.name].append(score)
+                        epoch_values[scorer.name] = value_to_float(score.value)
+                    epoch_dicts.append(epoch_values)
+                bus.on_trial_end(record)
 
-            epoch_values: dict[str, float] = {}
-            for scorer in scorers:
-                score = scorer(record, scene.target)
-                per_scorer_scores[scorer.name].append(score)
-                epoch_values[scorer.name] = value_to_float(score.value)
-            epoch_dicts.append(epoch_values)
-            bus.on_trial_end(record)
+            if halted:
+                stopped = True
+                break
+            if _should_fail(fail_on_error, error_count, total_trials):
+                # Checked after every trial, so fail_on_error=True stops at the
+                # first PolicyError instead of finishing the scene's epochs.
+                status = "error"
+                error = f"fail_on_error threshold exceeded ({error_count} errors)"
+                stopped = True
+                break
 
-        reduced = {
-            name: value_to_float(reduce_scores(epoch_spec.reducer, scores).value)
-            for name, scores in per_scorer_scores.items()
-            if scores
-        }
+        reduced: dict[str, float] = {}
+        for name, scene_scores in per_scorer_scores.items():
+            if not scene_scores:
+                continue
+            try:
+                reduced[name] = value_to_float(
+                    reduce_scores(epoch_spec.reducer, scene_scores).value
+                )
+            except Exception as exc:
+                # A reducer failure (e.g. pass_at_k over fewer epochs than k
+                # after a halt, or mean over categorical scores) degrades to an
+                # error log — it must never crash the eval and lose the log.
+                note = f"reducer {epoch_spec.reducer!r} failed for scorer {name!r}: {exc}"
+                scene_status = "error"
+                scene_error = note if scene_error is None else f"{scene_error}; {note}"
+                if status == "success":
+                    status = "error"
+                    error = note
+
         scene_results.append(
             SceneResult(
                 scene_id=scene.id,
@@ -236,10 +347,7 @@ def eval(
                 error=scene_error,
             )
         )
-        if halted or _should_fail(fail_on_error, error_count, total_trials):
-            if not halted:
-                status = "error"
-                error = error or f"fail_on_error threshold exceeded ({error_count} errors)"
+        if stopped:
             break
 
     metrics: dict[str, float] = {}

--- a/src/inspect_robots/frames.py
+++ b/src/inspect_robots/frames.py
@@ -10,11 +10,27 @@ recorded (and scorable) independent of which optional sinks are enabled.
 
 from __future__ import annotations
 
+import re
+import zlib
 from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
+
+_SAFE_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _safe(name: str) -> str:
+    """Make ``name`` filesystem-safe without introducing collisions.
+
+    Unsafe characters become ``-``; when anything was replaced, a short hash of
+    the original is appended so e.g. ``a/b`` and ``a-b`` stay distinct.
+    """
+    safe = _SAFE_RE.sub("-", name)
+    if safe != name:
+        safe = f"{safe}-{zlib.crc32(name.encode()) & 0xFFFFFFFF:08x}"
+    return safe
 
 
 @dataclass(frozen=True)
@@ -38,8 +54,7 @@ class FrameStore:
         self.count = 0
 
     def put(self, trial_id: str, t: int, camera: str, image: npt.NDArray[np.uint8]) -> FrameRef:
-        safe_trial = trial_id.replace("/", "-")
-        path = self.root / f"{safe_trial}_{camera}_{t:06d}.npy"
+        path = self.root / f"{_safe(trial_id)}_{_safe(camera)}_{t:06d}.npy"
         np.save(path, image)
         self.count += 1
         return FrameRef(camera=camera, t=t, path=str(path))

--- a/src/inspect_robots/logging/json_log.py
+++ b/src/inspect_robots/logging/json_log.py
@@ -27,13 +27,15 @@ def _slug(name: str) -> str:
 
 
 class JsonLogSink:
-    """Persist the final [`EvalLog`][inspect_robots.log.EvalLog] as JSON; step
-    events counted only."""
+    """Persist the final [`EvalLog`][inspect_robots.log.EvalLog] as JSON.
+
+    Per-step data lives in the ``TrialRecord``/``FrameStore``, not here; this
+    sink only writes the final log (``path`` holds where it landed).
+    """
 
     def __init__(self, log_dir: str):
         self.log_dir = Path(log_dir)
         self.path: Path | None = None
-        self._steps = 0
 
     def on_eval_start(self, spec: EvalSpec) -> None:
         return None
@@ -44,7 +46,7 @@ class JsonLogSink:
     def log_step(
         self, t: int, observation: Observation, action: Action, result: StepResult
     ) -> None:
-        self._steps += 1
+        return None
 
     def on_trial_end(self, record: TrialRecord) -> None:
         return None

--- a/src/inspect_robots/logging/rerun_sink.py
+++ b/src/inspect_robots/logging/rerun_sink.py
@@ -6,6 +6,9 @@ lazily *inside* methods so the core package never depends on it; if it is not
 installed, the sink warns once and becomes a no-op (so unattended runs and the
 core-only import gate are unaffected).
 
+Each trial's entities are namespaced under ``trial/<scene_id>/e<epoch>`` so
+successive trials never overwrite one another on the shared step timeline.
+
 Install with ``pip install "inspect-robots[rerun]"``.
 """
 
@@ -20,8 +23,6 @@ if TYPE_CHECKING:
     from inspect_robots.log import EvalLog, EvalSpec
     from inspect_robots.rollout import TrialRecord
     from inspect_robots.types import Action, Observation, StepResult
-
-_WARNED = False
 
 
 class RerunSink:
@@ -38,23 +39,23 @@ class RerunSink:
         self.application_id = application_id
         self.spawn = spawn
         self._rr: Any | None = None
-        self._t = 0
+        self._warned = False
+        self._prefix = "trial"
 
     def _ensure_rerun(self) -> Any | None:
-        global _WARNED
         if self._rr is not None:
             return self._rr
         try:
             import rerun as rr
         except ImportError:
-            if not _WARNED:
+            if not self._warned:
                 warnings.warn(
                     "rerun-sdk is not installed; RerunSink is a no-op. "
                     'Install with: pip install "inspect-robots[rerun]"',
                     RuntimeWarning,
                     stacklevel=2,
                 )
-                _WARNED = True
+                self._warned = True
             return None
         self._rr = rr
         return rr
@@ -62,6 +63,20 @@ class RerunSink:
     @property
     def available(self) -> bool:
         return self._ensure_rerun() is not None
+
+    @staticmethod
+    def _set_step(rr: Any, t: int) -> None:
+        if hasattr(rr, "set_time"):  # rerun-sdk >= 0.23
+            rr.set_time("step", sequence=t)
+        else:  # older SDKs
+            rr.set_time_sequence("step", t)
+
+    @staticmethod
+    def _scalar(rr: Any, value: float) -> Any:
+        scalars = getattr(rr, "Scalars", None)  # rerun-sdk >= 0.23
+        if scalars is not None:
+            return scalars(value)
+        return rr.Scalar(value)  # older SDKs
 
     def on_eval_start(self, spec: EvalSpec) -> None:
         rr = self._ensure_rerun()
@@ -72,7 +87,8 @@ class RerunSink:
             rr.save(self.recording_path)
 
     def on_trial_start(self, scene_id: str, epoch: int) -> None:
-        self._t = 0
+        # Namespace this trial's entities so trials never overwrite each other.
+        self._prefix = f"trial/{scene_id}/e{epoch}"
 
     def log_step(
         self, t: int, observation: Observation, action: Action, result: StepResult
@@ -80,18 +96,22 @@ class RerunSink:
         rr = self._ensure_rerun()
         if rr is None:
             return
-        rr.set_time_sequence("step", t)
+        self._set_step(rr, t)
+        pre = self._prefix
         for cam, image in observation.images.items():
-            rr.log(f"camera/{cam}", rr.Image(image))
+            rr.log(f"{pre}/camera/{cam}", rr.Image(image))
         for key, value in observation.state.items():
             for i, scalar in enumerate(np.atleast_1d(np.asarray(value, dtype=np.float64))):
-                rr.log(f"state/{key}/{i}", rr.Scalar(float(scalar)))
+                rr.log(f"{pre}/state/{key}/{i}", self._scalar(rr, float(scalar)))
         for i, scalar in enumerate(np.atleast_1d(np.asarray(action.data, dtype=np.float64))):
-            rr.log(f"action/{i}", rr.Scalar(float(scalar)))
+            rr.log(f"{pre}/action/{i}", self._scalar(rr, float(scalar)))
         if result.reward is not None:
-            rr.log("reward", rr.Scalar(float(result.reward)))
+            rr.log(f"{pre}/reward", self._scalar(rr, float(result.reward)))
         if result.terminated:
-            rr.log("event/terminated", rr.TextLog(result.termination_reason or "terminated"))
+            rr.log(
+                f"{pre}/event/terminated",
+                rr.TextLog(result.termination_reason or "terminated"),
+            )
 
     def on_trial_end(self, record: TrialRecord) -> None:
         return None

--- a/src/inspect_robots/mock/cubepick.py
+++ b/src/inspect_robots/mock/cubepick.py
@@ -101,8 +101,9 @@ class CubePickEmbodiment:
 
     def _render(self) -> np.ndarray:
         img = np.zeros((_IMG, _IMG, 3), dtype=np.uint8)
-        cy, cx = (np.clip(self._cube, 0, 1) * (_IMG - 1)).astype(int)
-        ey, ex = (np.clip(self._eef, 0, 1) * (_IMG - 1)).astype(int)
-        img[cx, cy] = (0, 200, 0)  # cube = green
-        img[ex, ey] = (200, 0, 0)  # effector = red
+        # Unit-square coordinates map x -> column, y -> row.
+        cube_col, cube_row = (np.clip(self._cube, 0, 1) * (_IMG - 1)).astype(int)
+        eef_col, eef_row = (np.clip(self._eef, 0, 1) * (_IMG - 1)).astype(int)
+        img[cube_row, cube_col] = (0, 200, 0)  # cube = green
+        img[eef_row, eef_col] = (200, 0, 0)  # effector = red
         return img

--- a/src/inspect_robots/registry.py
+++ b/src/inspect_robots/registry.py
@@ -13,6 +13,7 @@ Entry-point groups:
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from importlib.metadata import entry_points
 from typing import Any, TypeVar
@@ -86,7 +87,15 @@ def _ensure_loaded() -> None:
             for ep in entry_points(group=group):
                 try:
                     factory = ep.load()
-                except Exception:
+                except Exception as exc:
+                    # A broken plugin must not crash discovery, but it must not
+                    # vanish silently either — that is undebuggable.
+                    warnings.warn(
+                        f"failed to load inspect_robots plugin {ep.name!r} from "
+                        f"entry-point group {group!r}: {exc!r}",
+                        RuntimeWarning,
+                        stacklevel=2,
+                    )
                     continue
                 _FACTORIES[kind].setdefault(ep.name, factory)
 

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -14,15 +14,18 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
+
 from inspect_robots.approver import Approver
-from inspect_robots.controller import Controller
-from inspect_robots.embodiment import SELF_PACED, Embodiment
-from inspect_robots.errors import EmbodimentFault, InspectRobotsError, PolicyError
+from inspect_robots.controller import _INFER_KEY, Controller
+from inspect_robots.embodiment import Embodiment
+from inspect_robots.errors import EmbodimentFault, InspectRobotsError, PolicyError, SafetyAbort
 from inspect_robots.frames import FrameRef, FrameStore
 from inspect_robots.policy import Policy
 from inspect_robots.scene import Scene
 from inspect_robots.transcript import (
     Event,
+    approval_event,
     error_event,
     inference_event,
     reset_event,
@@ -39,9 +42,10 @@ def derive_seed(eval_seed: int | None, scene_seed: int | None, epoch: int) -> in
 
     Distinct epochs of the same scene get distinct seeds so repeats actually vary
     for stochastic policies, while a fixed ``(eval_seed, scene_seed, epoch)``
-    reproduces bitwise.
+    reproduces bitwise. ``None`` and ``0`` hash differently, so an unseeded
+    input does not silently alias ``seed=0``.
     """
-    payload = f"{eval_seed or 0}:{scene_seed or 0}:{epoch}".encode()
+    payload = f"{eval_seed}:{scene_seed}:{epoch}".encode()
     return zlib.crc32(payload) & 0xFFFFFFFF
 
 
@@ -84,11 +88,31 @@ class TrialRecord:
 def _effective_control_hz(
     chunk_hz: float | None, task_hz: float | None, embodiment_hz: float | None
 ) -> float | None:
-    """First non-None of chunk → task → embodiment rate (R1)."""
+    """First non-None of chunk → task → embodiment rate (R1).
+
+    Real-time pacing (sleeping the control loop to this rate, honoring the
+    ``SELF_PACED`` capability) is wired up together with the first real-robot
+    adapter; until then the test suite stays fast and this helper is unused by
+    the loop below.
+    """
     for hz in (chunk_hz, task_hz, embodiment_hz):
         if hz is not None:
             return hz
     return None
+
+
+def _record_failure(record: TrialRecord, exc: InspectRobotsError, t: int) -> InspectRobotsError:
+    """Mark ``record`` failed and attach it to ``exc`` (see ``InspectRobotsError.record``).
+
+    The partial record — steps walked and transcript events up to the failure —
+    is forensic data the orchestrator preserves in the eval log.
+    """
+    message = str(exc)
+    record.events.append(error_event(t, type(exc).__name__, message))
+    record.status = "error"
+    record.error = f"{type(exc).__name__}: {message}"
+    exc.record = record
+    return exc
 
 
 def _store_frames(
@@ -119,72 +143,113 @@ def rollout(
 
     Generic exceptions raised by the policy are wrapped as
     [`PolicyError`][inspect_robots.errors.PolicyError]; by the embodiment as
-    [`EmbodimentFault`][inspect_robots.errors.EmbodimentFault]. Already-typed Inspect Robots errors
-    (incl. [`SafetyAbort`][inspect_robots.errors.SafetyAbort]) propagate unchanged, so the
-    eval orchestrator can apply the correct continue-vs-halt policy.
+    [`EmbodimentFault`][inspect_robots.errors.EmbodimentFault]; by the approver as
+    [`SafetyAbort`][inspect_robots.errors.SafetyAbort] (an approver that crashed cannot
+    vouch for safety). Already-typed Inspect Robots errors (incl.
+    [`SafetyAbort`][inspect_robots.errors.SafetyAbort]) propagate unchanged, so the
+    eval orchestrator can apply the correct continue-vs-halt policy. Every error
+    raised from inside the trial carries the partial ``TrialRecord`` on
+    ``exc.record`` for the orchestrator to preserve.
+
+    ``control_hz`` is accepted for R1's rate-precedence chain; real-time pacing
+    lands with the first real-robot adapter (see ``_effective_control_hz``).
     """
     trial_id = f"{scene.id}-e{epoch}"
     record = TrialRecord(scene_id=scene.id, epoch=epoch, seed=seed)
     record.events.append(reset_event(seed))
     store: dict[str, Any] = {}
+    expected_dim = embodiment.info.action_space.dim
 
-    policy.reset(scene)
-    obs = embodiment.reset(scene, seed=seed)
-
-    t = 0
-    while t < max_steps:
-        prev_inferences = len(store.get("_controller_inferences", []))
+    try:
         try:
-            action = controller.next_action(policy, obs, t, store)
-        except InspectRobotsError:
+            policy.reset(scene)
+        except InspectRobotsError as exc:
+            _record_failure(record, exc, -1)
             raise
         except Exception as exc:
-            record.events.append(error_event(t, "PolicyError", str(exc)))
-            raise PolicyError(str(exc)) from exc
-
-        inferences = store.get("_controller_inferences", [])
-        if len(inferences) > prev_inferences:
-            latency, chunk_len = inferences[-1]
-            record.events.append(inference_event(t, latency, chunk_len))
-
-        action = approver.review(action, store)  # may raise SafetyAbort
-
+            raise _record_failure(record, PolicyError(str(exc)), -1) from exc
         try:
-            result: StepResult = embodiment.step(action)
-        except InspectRobotsError:
+            obs = embodiment.reset(scene, seed=seed)
+        except InspectRobotsError as exc:
+            _record_failure(record, exc, -1)
             raise
         except Exception as exc:
-            record.events.append(error_event(t, "EmbodimentFault", str(exc)))
-            raise EmbodimentFault(str(exc)) from exc
+            raise _record_failure(record, EmbodimentFault(str(exc)), -1) from exc
 
-        sink.log_step(t, obs, action, result)
-        obs_rec, refs = _store_frames(frame_store, trial_id, t, obs)
-        record.steps.append(
-            StepRecord(t=t, observation=obs_rec, action=action, result=result, image_refs=refs)
-        )
-        record.events.append(
-            step_event(t, result.terminated, result.truncated, result.termination_reason)
-        )
-        t += 1
+        t = 0
+        while t < max_steps:
+            prev_inferences = len(store.get(_INFER_KEY, []))
+            try:
+                action = controller.next_action(policy, obs, t, store)
+            except InspectRobotsError as exc:
+                _record_failure(record, exc, t)
+                raise
+            except Exception as exc:
+                raise _record_failure(record, PolicyError(str(exc)), t) from exc
 
-        if result.terminated:
-            record.terminated = True
-            record.termination_reason = result.termination_reason
-            break
-        if result.truncated:
+            inferences = store.get(_INFER_KEY, [])
+            if len(inferences) > prev_inferences:
+                latency, chunk_len = inferences[-1]
+                record.events.append(inference_event(t, latency, chunk_len))
+
+            # A malformed action is the policy's fault; catching it here keeps it
+            # from surfacing inside the approver/embodiment as a halting fault.
+            emitted_dim = int(np.asarray(action.data).size)
+            if emitted_dim != expected_dim:
+                raise _record_failure(
+                    record,
+                    PolicyError(
+                        f"policy emitted a {emitted_dim}-D action but embodiment "
+                        f"{embodiment.info.name!r} expects {expected_dim}-D"
+                    ),
+                    t,
+                )
+
+            try:
+                reviewed = approver.review(action, store)  # may raise SafetyAbort
+            except InspectRobotsError as exc:
+                _record_failure(record, exc, t)
+                raise
+            except Exception as exc:
+                raise _record_failure(record, SafetyAbort(str(exc)), t) from exc
+            if reviewed is not action:
+                detail = "clamped" if reviewed.meta.get("clamped") else None
+                record.events.append(approval_event(t, modified=True, detail=detail))
+            action = reviewed
+
+            try:
+                result: StepResult = embodiment.step(action)
+            except InspectRobotsError as exc:
+                _record_failure(record, exc, t)
+                raise
+            except Exception as exc:
+                raise _record_failure(record, EmbodimentFault(str(exc)), t) from exc
+
+            sink.log_step(t, obs, action, result)
+            obs_rec, refs = _store_frames(frame_store, trial_id, t, obs)
+            record.steps.append(
+                StepRecord(t=t, observation=obs_rec, action=action, result=result, image_refs=refs)
+            )
+            record.events.append(
+                step_event(t, result.terminated, result.truncated, result.termination_reason)
+            )
+            t += 1
+
+            if result.terminated:
+                record.terminated = True
+                record.termination_reason = result.termination_reason
+                break
+            if result.truncated:
+                record.truncated = True
+                record.termination_reason = result.termination_reason or "truncated"
+                break
+            obs = result.observation
+        else:
             record.truncated = True
-            record.termination_reason = result.termination_reason or "truncated"
-            break
-        obs = result.observation
-    else:
-        record.truncated = True
-        record.termination_reason = "max_steps"
-
-    record.inference_latencies = [
-        lat for lat, _ in store.get("_controller_inferences", []) if lat is not None
-    ]
-    # ``control_hz`` / SELF_PACED are wired here; real-time pacing (sleep) is added
-    # with a real-robot adapter so the test suite stays fast.
-    _ = _effective_control_hz(None, control_hz, embodiment.info.control_hz)
-    _ = SELF_PACED
+            record.termination_reason = "max_steps"
+    finally:
+        # Preserve measured latencies even when the trial ends in an error.
+        record.inference_latencies = [
+            lat for lat, _ in store.get(_INFER_KEY, []) if lat is not None
+        ]
     return record

--- a/src/inspect_robots/spaces.py
+++ b/src/inspect_robots/spaces.py
@@ -65,6 +65,8 @@ class Box:
                 raise ValueError(
                     f"Box {name} shape {tuple(bound.shape)} != space shape {self.shape}"
                 )
+        if self.low is not None and self.high is not None and bool(np.any(self.low > self.high)):
+            raise ValueError("Box low must be elementwise <= high")
 
     @property
     def dim(self) -> int:
@@ -134,8 +136,15 @@ class ObservationSpace:
 
     def __post_init__(self) -> None:
         # If a rich StateSpec is given, keep state_keys consistent with it.
-        if self.state is not None and not self.state_keys:
-            object.__setattr__(self, "state_keys", self.state.keys)
+        if self.state is not None:
+            if not self.state_keys:
+                object.__setattr__(self, "state_keys", self.state.keys)
+            elif self.state_keys != self.state.keys:
+                raise ValueError(
+                    f"ObservationSpace state_keys {sorted(self.state_keys)} inconsistent "
+                    f"with StateSpec keys {sorted(self.state.keys)}; provide one or make "
+                    "them agree"
+                )
 
     @property
     def camera_names(self) -> frozenset[str]:

--- a/src/inspect_robots/task.py
+++ b/src/inspect_robots/task.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
+from inspect_robots.errors import ConfigError
 from inspect_robots.scene import Scene
 from inspect_robots.scorer import Scorer
 
@@ -26,24 +27,49 @@ class Epochs:
     count: int = 1
     reducer: str = "mean"
 
+    def __post_init__(self) -> None:
+        if self.count < 1:
+            raise ConfigError(f"Epochs count must be >= 1, got {self.count}")
+
 
 @dataclass
 class Task:
-    """A benchmark: scenes + scorer(s) + horizon, independent of any embodiment."""
+    """A benchmark: scenes + scorer(s) + horizon, independent of any embodiment.
+
+    ``scorer`` accepts scorer objects or **registry names** (e.g.
+    ``scorer="success_at_end"``), or a sequence mixing both.
+    """
 
     name: str
     scenes: Sequence[Scene]
-    scorer: Scorer | Sequence[Scorer]
+    scorer: Scorer | str | Sequence[Scorer | str]
     max_steps: int
     epochs: int | Epochs = 1
     control_hz: float | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        if self.max_steps < 1:
+            raise ConfigError(f"Task {self.name!r}: max_steps must be >= 1, got {self.max_steps}")
+        _ = self.epoch_spec  # validates an int epochs count via Epochs
+
     @property
     def scorers(self) -> list[Scorer]:
-        if isinstance(self.scorer, Sequence):
-            return list(self.scorer)
-        return [self.scorer]
+        # A str IS a Sequence: treat it as a single registry name, never as a
+        # sequence of one-character "scorers".
+        if isinstance(self.scorer, str) or not isinstance(self.scorer, Sequence):
+            raw: list[Scorer | str] = [self.scorer]
+        else:
+            raw = list(self.scorer)
+        out: list[Scorer] = []
+        for entry in raw:
+            if isinstance(entry, str):
+                from inspect_robots.registry import resolve
+
+                out.append(cast(Scorer, resolve("scorer", entry)))
+            else:
+                out.append(entry)
+        return out
 
     @property
     def epoch_spec(self) -> Epochs:

--- a/tests/test_coverage_completion.py
+++ b/tests/test_coverage_completion.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import functools
 import json
-import warnings
 from pathlib import Path
 
 import numpy as np
@@ -122,13 +121,25 @@ def test_controller_validation_raises() -> None:
         EnsemblingController(Box(shape=(2,), semantics=_CUBE_SEM), m=-1.0)
 
 
-def test_ensembling_warns_only_once(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(controller_mod, "_ENSEMBLE_WARNED", False)
+def test_ensembling_warns_per_instance() -> None:
+    # No global warn-once state: every instance constructed without semantics
+    # warns, independent of construction order elsewhere in the process.
     with pytest.warns(RuntimeWarning):
         EnsemblingController(Box(shape=(2,)))
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # a second warning would raise
-        EnsemblingController(Box(shape=(2,)))  # already warned -> no warning
+    with pytest.warns(RuntimeWarning):
+        EnsemblingController(Box(shape=(2,)))
+
+
+def test_default_controller_records_actual_buffered_count() -> None:
+    # replan_interval larger than the chunk: the recorded per-inference count is
+    # the number of actions actually buffered, not the requested interval.
+    policy = ScriptedPolicy(chunk_size=4)
+    embodiment = CubePickEmbodiment()
+    obs = embodiment.reset(_SCENE, seed=0)
+    store: dict[str, object] = {}
+    DefaultController(replan_interval=10).next_action(policy, obs, 0, store)
+    inferences = store[controller_mod._INFER_KEY]
+    assert inferences[-1][1] == 4  # type: ignore[index]
 
 
 # --------------------------------------------------------------------------- #
@@ -212,8 +223,12 @@ def test_min_distance_without_signal() -> None:
 # --------------------------------------------------------------------------- #
 # rollout
 # --------------------------------------------------------------------------- #
-def test_effective_control_hz_all_none() -> None:
+def test_effective_control_hz_precedence() -> None:
+    # First non-None of chunk -> task -> embodiment (R1).
     assert _effective_control_hz(None, None, None) is None
+    assert _effective_control_hz(30.0, 20.0, 10.0) == 30.0
+    assert _effective_control_hz(None, 20.0, 10.0) == 20.0
+    assert _effective_control_hz(None, None, 10.0) == 10.0
 
 
 class _PolicyErrorPolicy:
@@ -294,11 +309,11 @@ def test_null_sink_lifecycle() -> None:
     sink = NullSink()
     obs = Observation()
     record = TrialRecord(scene_id="s", epoch=0, seed=0)
-    assert sink.on_eval_start(None) is None  # type: ignore[arg-type]
-    assert sink.on_trial_start("s", 0) is None
-    assert sink.log_step(0, obs, Action(data=np.zeros(2)), StepResult(observation=obs)) is None
-    assert sink.on_trial_end(record) is None
-    assert sink.on_eval_end(None) is None  # type: ignore[arg-type]
+    sink.on_eval_start(None)  # type: ignore[arg-type]
+    sink.on_trial_start("s", 0)
+    sink.log_step(0, obs, Action(data=np.zeros(2)), StepResult(observation=obs))
+    sink.on_trial_end(record)
+    sink.on_eval_end(None)  # type: ignore[arg-type]
 
 
 # --------------------------------------------------------------------------- #
@@ -320,7 +335,7 @@ def test_registered_unknown_kind() -> None:
         registered("bogus")
 
 
-def test_entrypoint_load_failure_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_entrypoint_load_failure_is_skipped_with_warning(monkeypatch: pytest.MonkeyPatch) -> None:
     class _BadEP:
         name = "broken"
 
@@ -333,7 +348,10 @@ def test_entrypoint_load_failure_is_skipped(monkeypatch: pytest.MonkeyPatch) -> 
         lambda *, group: [_BadEP()] if group == "inspect_robots.policies" else [],
     )
     monkeypatch.setattr(reg, "_loaded_entrypoints", False)
-    assert "broken" not in registered("policy")  # a broken plugin must not crash discovery
+    # A broken plugin must not crash discovery — but must not vanish silently.
+    with pytest.warns(RuntimeWarning, match="failed to load inspect_robots plugin 'broken'"):
+        names = registered("policy")
+    assert "broken" not in names
 
 
 def test_resolve_forwards_kwargs() -> None:
@@ -439,22 +457,32 @@ def test_pass_at_k_edge_cases() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# RerunSink — exercise the rerun-present logging path with a fake backend
+# RerunSink — exercise the rerun-present logging path with fake backends
 # --------------------------------------------------------------------------- #
-def test_rerun_sink_logs_with_fake_backend(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    import sys
+def _fake_rerun_module(calls: list[str], paths: list[str], *, new_api: bool) -> object:
     import types
 
-    calls: list[str] = []
     fake = types.ModuleType("rerun")
     fake.init = lambda *a, **k: calls.append("init")  # type: ignore[attr-defined]
     fake.save = lambda p: calls.append("save")  # type: ignore[attr-defined]
-    fake.set_time_sequence = lambda *a: calls.append("time")  # type: ignore[attr-defined]
-    fake.log = lambda *a, **k: calls.append("log")  # type: ignore[attr-defined]
+    fake.log = lambda path, *a, **k: paths.append(path)  # type: ignore[attr-defined]
     fake.Image = lambda img: ("Image",)  # type: ignore[attr-defined]
-    fake.Scalar = lambda v: ("Scalar", v)  # type: ignore[attr-defined]
     fake.TextLog = lambda t: ("TextLog", t)  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "rerun", fake)
+    if new_api:  # rerun-sdk >= 0.23 surface
+        fake.set_time = lambda *a, **k: calls.append("time")  # type: ignore[attr-defined]
+        fake.Scalars = lambda v: ("Scalars", v)  # type: ignore[attr-defined]
+    else:  # older SDK surface
+        fake.set_time_sequence = lambda *a: calls.append("time")  # type: ignore[attr-defined]
+        fake.Scalar = lambda v: ("Scalar", v)  # type: ignore[attr-defined]
+    return fake
+
+
+def test_rerun_sink_logs_with_fake_backend(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import sys
+
+    calls: list[str] = []
+    paths: list[str] = []
+    monkeypatch.setitem(sys.modules, "rerun", _fake_rerun_module(calls, paths, new_api=False))
 
     from inspect_robots.logging.rerun_sink import RerunSink
 
@@ -464,7 +492,9 @@ def test_rerun_sink_logs_with_fake_backend(monkeypatch: pytest.MonkeyPatch, tmp_
 
     (log,) = eval(_task(max_steps=40), ScriptedPolicy(), CubePickEmbodiment(), sinks=[sink])
     assert log.status == "success"
-    assert "init" in calls and "save" in calls and "log" in calls and "time" in calls
+    assert "init" in calls and "save" in calls and "time" in calls
+    # Entities are namespaced per trial so trials never overwrite each other.
+    assert paths and all(p.startswith("trial/s/e0/") for p in paths)
 
     # Exercise the empty-observation and reward-is-None branches directly.
     sink.log_step(
@@ -476,3 +506,19 @@ def test_rerun_sink_logs_with_fake_backend(monkeypatch: pytest.MonkeyPatch, tmp_
 
     # A sink with no recording path skips rr.save (the other on_eval_start branch).
     RerunSink().on_eval_start(None)  # type: ignore[arg-type]
+
+
+def test_rerun_sink_supports_new_sdk_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+
+    calls: list[str] = []
+    paths: list[str] = []
+    monkeypatch.setitem(sys.modules, "rerun", _fake_rerun_module(calls, paths, new_api=True))
+
+    from inspect_robots.logging.rerun_sink import RerunSink
+
+    sink = RerunSink()
+    (log,) = eval(_task(max_steps=40), ScriptedPolicy(), CubePickEmbodiment(), sinks=[sink])
+    assert log.status == "success"
+    assert "time" in calls  # rr.set_time (>=0.23) was used
+    assert paths and all(p.startswith("trial/s/e0/") for p in paths)

--- a/tests/test_ensembling.py
+++ b/tests/test_ensembling.py
@@ -8,6 +8,7 @@ import pytest
 from inspect_robots import eval
 from inspect_robots.controller import EnsemblingController
 from inspect_robots.mock import CubePickEmbodiment, ScriptedPolicy
+from inspect_robots.policy import PolicyConfig, PolicyInfo
 from inspect_robots.scene import Scene
 from inspect_robots.scorer import success_at_end
 from inspect_robots.spaces import ActionSemantics, Box
@@ -24,6 +25,11 @@ class _FixedChunkPolicy:
         self._actions = [np.array(a0, dtype=np.float64), np.array(a1, dtype=np.float64)]
         self.chunk_len = chunk_len
         self.num_inferences = 0
+        self.info = PolicyInfo(name="fixed-chunk", action_space=_DELTA_SPACE)
+        self.config = PolicyConfig()
+
+    def reset(self, scene: Scene) -> None:
+        return None
 
     def act(self, observation: Observation) -> ActionChunk:
         self.num_inferences += 1
@@ -85,10 +91,7 @@ def test_rejects_unaverageable_semantics() -> None:
         )
 
 
-def test_warns_when_semantics_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    import inspect_robots.controller as ctrl_mod
-
-    monkeypatch.setattr(ctrl_mod, "_ENSEMBLE_WARNED", False)
+def test_warns_when_semantics_missing() -> None:
     with pytest.warns(RuntimeWarning, match="no semantics"):
         EnsemblingController(Box(shape=(2,)))
 

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -1,0 +1,320 @@
+"""eval() orchestration hardening: error-log survival, error-trial scoring,
+partial-record delivery, fail_on_error timing, embodiment lifecycle, seeding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from inspect_robots import eval
+from inspect_robots.errors import ConfigError, EmbodimentFault, PolicyError
+from inspect_robots.eval import _git_commit
+from inspect_robots.log import EvalLog
+from inspect_robots.logging.sink import NullSink
+from inspect_robots.mock import CubePickEmbodiment, ScriptedPolicy
+from inspect_robots.policy import PolicyConfig, PolicyInfo
+from inspect_robots.registry import embodiment as embodiment_decorator
+from inspect_robots.rollout import TrialRecord
+from inspect_robots.scene import Scene
+from inspect_robots.scorer import min_distance_to_goal, success_at_end
+from inspect_robots.spaces import ActionSemantics, Box
+from inspect_robots.task import Epochs, Task
+from inspect_robots.types import Action, ActionChunk, Observation, StepResult
+
+_BOX = Box(shape=(2,), semantics=ActionSemantics(control_mode="eef_delta_pos", frame="world"))
+
+
+def _task(*, epochs: int | Epochs = 1, max_steps: int = 60, scorer: object = None) -> Task:
+    return Task(
+        name="t",
+        scenes=[Scene(id="s0", instruction="reach", init_seed=0)],
+        scorer=scorer or success_at_end(),  # type: ignore[arg-type]
+        max_steps=max_steps,
+        epochs=epochs,
+    )
+
+
+class _RecordingSink(NullSink):
+    """Collects the records delivered via on_trial_end."""
+
+    def __init__(self) -> None:
+        self.records: list[TrialRecord] = []
+
+    def on_trial_end(self, record: TrialRecord) -> None:
+        self.records.append(record)
+
+
+class _FaultAfterEpochsEmbodiment(CubePickEmbodiment):
+    """Runs ``good_epochs`` full trials, then faults on the next step."""
+
+    def __init__(self, good_epochs: int) -> None:
+        super().__init__()
+        self.good_epochs = good_epochs
+        self._resets = 0
+
+    def reset(self, scene: Scene, *, seed: int | None = None) -> Observation:
+        self._resets += 1
+        return super().reset(scene, seed=seed)
+
+    def step(self, action: Action) -> StepResult:
+        if self._resets > self.good_epochs:
+            raise EmbodimentFault("motor stalled")
+        return super().step(action)
+
+
+class _BoomOnSecondEpochPolicy(ScriptedPolicy):
+    """Behaves normally on the first epoch, explodes on later epochs."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._resets = 0
+
+    def reset(self, scene: Scene) -> None:
+        self._resets += 1
+        super().reset(scene)
+
+    def act(self, observation: Observation) -> ActionChunk:
+        if self._resets > 1:
+            raise RuntimeError("inference exploded")
+        return super().act(observation)
+
+
+class _BoomPolicy:
+    def __init__(self) -> None:
+        self.info = PolicyInfo(name="boom", action_space=_BOX)
+        self.config = PolicyConfig()
+
+    def reset(self, scene: Scene) -> None:
+        return None
+
+    def act(self, observation: Observation) -> ActionChunk:
+        raise RuntimeError("inference exploded")
+
+
+# --------------------------------------------------------------------------- #
+# 1. A halted eval must still produce an error log, whatever the reducer.
+# --------------------------------------------------------------------------- #
+def test_halted_eval_with_pass_at_k_reducer_still_writes_log(tmp_path: Path) -> None:
+    # Fault at epoch 2 of 5 leaves fewer scores than k; pass_at_5 would raise.
+    task = _task(epochs=Epochs(count=5, reducer="pass_at_5"))
+    (log,) = eval(
+        task, ScriptedPolicy(), _FaultAfterEpochsEmbodiment(good_epochs=2), log_dir=str(tmp_path)
+    )
+    assert isinstance(log, EvalLog)
+    assert log.status == "error"
+    assert log.error is not None and "motor stalled" in log.error
+    assert log.samples[0].error is not None and "reducer" in log.samples[0].error
+    assert list(tmp_path.glob("*.json"))  # the log reached disk
+
+
+def test_categorical_scorer_with_mean_reducer_degrades_to_error_log(tmp_path: Path) -> None:
+    class _CategoricalScorer:
+        name = "direction"
+
+        def __call__(self, record: TrialRecord, target: object) -> object:
+            from inspect_robots.scorer import Score
+
+            return Score(value="left")
+
+    task = _task(epochs=2, scorer=_CategoricalScorer())
+    (log,) = eval(task, ScriptedPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path))
+    assert log.status == "error"
+    assert log.error is not None and "reducer 'mean' failed" in log.error
+    assert log.results.metrics == {}  # the failed reducer contributes no metric
+
+
+# --------------------------------------------------------------------------- #
+# 2. Errored trials are never scored and cannot poison metrics.
+# --------------------------------------------------------------------------- #
+def test_errored_trials_are_not_scored(tmp_path: Path) -> None:
+    task = _task(epochs=2, scorer=min_distance_to_goal())
+    (log,) = eval(task, _BoomOnSecondEpochPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path))
+    scene = log.samples[0]
+    assert scene.status == "error"  # the failed epoch is visible...
+    assert scene.epochs[1] == {}  # ...as an empty (unscored) epoch entry
+    # ...but the metric comes from the good epoch only: finite, not inf.
+    assert np.isfinite(log.results.metrics["min_distance_to_goal"])
+
+
+# --------------------------------------------------------------------------- #
+# 3. Partial records reach the sinks (forensics survive errors).
+# --------------------------------------------------------------------------- #
+def test_policy_error_partial_record_reaches_sinks() -> None:
+    class _BoomLaterPolicy(_BoomPolicy):
+        def __init__(self) -> None:
+            super().__init__()
+            self._calls = 0
+
+        def act(self, observation: Observation) -> ActionChunk:
+            self._calls += 1
+            if self._calls > 1:
+                raise RuntimeError("inference exploded later")
+            return ActionChunk(actions=[Action(data=np.zeros(2)) for _ in range(4)])
+
+    sink = _RecordingSink()
+    (log,) = eval(_task(), _BoomLaterPolicy(), CubePickEmbodiment(), sinks=[sink])
+    assert log.status == "success"  # fail_on_error=False: the eval itself ran
+    (record,) = sink.records
+    assert record.status == "error"
+    assert len(record.steps) == 4  # the steps walked before the failure survive
+    assert log.stats.total_steps == 4
+
+
+def test_halt_without_attached_record_still_produces_error_log(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Defensive path: a halting error raised without rollout's record attachment
+    # (e.g. from third-party middleware) must still yield an error log.
+    def fake_rollout(*args: object, **kwargs: object) -> TrialRecord:
+        raise EmbodimentFault("fault with no record")
+
+    import sys
+
+    # inspect_robots.eval the *module* is shadowed by the eval() function on the
+    # package, so fetch it from sys.modules.
+    monkeypatch.setattr(sys.modules["inspect_robots.eval"], "rollout", fake_rollout)
+    (log,) = eval(_task(), ScriptedPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path))
+    assert log.status == "error"
+    assert log.results.total_trials == 0  # nothing to count or deliver
+
+
+def test_halt_delivers_partial_record_and_counts_trial() -> None:
+    sink = _RecordingSink()
+    (log,) = eval(
+        _task(), ScriptedPolicy(), _FaultAfterEpochsEmbodiment(good_epochs=0), sinks=[sink]
+    )
+    assert log.status == "error"
+    assert log.results.total_trials == 1  # the aborted trial is counted...
+    (record,) = sink.records  # ...and its record delivered to sinks
+    assert record.status == "error"
+    assert record.error is not None and "motor stalled" in record.error
+
+
+# --------------------------------------------------------------------------- #
+# 4. fail_on_error is evaluated after every trial, not per scene.
+# --------------------------------------------------------------------------- #
+def test_fail_on_error_true_stops_at_first_error(tmp_path: Path) -> None:
+    task = _task(epochs=3)
+    (log,) = eval(
+        task, _BoomPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path), fail_on_error=True
+    )
+    assert log.status == "error"
+    assert log.results.total_trials == 1  # stopped immediately, not after 3 epochs
+
+
+# --------------------------------------------------------------------------- #
+# 5. Embodiment lifecycle: eval closes what it resolves, and only that.
+# --------------------------------------------------------------------------- #
+_CLOSED: list[str] = []
+
+
+class _ClosableEmbodiment(CubePickEmbodiment):
+    def close(self) -> None:
+        _CLOSED.append("closed")
+
+
+embodiment_decorator("closable-cubepick")(_ClosableEmbodiment)
+
+
+def test_eval_closes_string_resolved_embodiment(tmp_path: Path) -> None:
+    _CLOSED.clear()
+    eval(_task(max_steps=5), ScriptedPolicy(), "closable-cubepick", log_dir=str(tmp_path))
+    assert _CLOSED == ["closed"]
+
+
+def test_eval_does_not_close_caller_owned_embodiment(tmp_path: Path) -> None:
+    _CLOSED.clear()
+    eval(_task(max_steps=5), ScriptedPolicy(), _ClosableEmbodiment(), log_dir=str(tmp_path))
+    assert _CLOSED == []  # the caller owns the object's lifecycle
+
+
+def test_eval_closes_resolved_embodiment_even_on_failure(tmp_path: Path) -> None:
+    _CLOSED.clear()
+    wide_policy_info = PolicyInfo(
+        name="wide",
+        action_space=Box(shape=(7,), semantics=ActionSemantics("eef_delta_pos", frame="world")),
+    )
+
+    class _WidePolicy:
+        info = wide_policy_info
+        config = PolicyConfig()
+
+        def reset(self, scene: Scene) -> None:
+            return None
+
+        def act(self, observation: Observation) -> ActionChunk:
+            return ActionChunk(actions=[Action(data=np.zeros(7))])
+
+    from inspect_robots.errors import CompatibilityError
+
+    with pytest.raises(CompatibilityError):
+        eval(_task(), _WidePolicy(), "closable-cubepick", log_dir=str(tmp_path))
+    assert _CLOSED == ["closed"]  # released even though the run failed fast
+
+
+# --------------------------------------------------------------------------- #
+# 6. seed=None draws recorded OS entropy; bad reducers fail fast.
+# --------------------------------------------------------------------------- #
+def test_seed_none_draws_recorded_entropy(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("os.urandom", lambda n: b"\x2a" + b"\x00" * (n - 1))
+    (log,) = eval(
+        _task(max_steps=5), ScriptedPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path), seed=None
+    )
+    assert log.eval.seed == 42  # the drawn seed is recorded, not None
+
+
+def test_unknown_reducer_fails_fast_as_config_error(tmp_path: Path) -> None:
+    task = _task(epochs=Epochs(count=2, reducer="bogus"))
+    with pytest.raises(ConfigError, match="unknown epoch reducer"):
+        eval(task, ScriptedPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path))
+
+
+def test_policy_error_without_attached_record_synthesizes_one(tmp_path: Path) -> None:
+    # A PolicyError raised outside the rollout internals (no record attached)
+    # still yields a scored-as-error trial rather than a crash.
+    class _EagerErrorController:
+        def next_action(self, policy: object, obs: object, t: int, store: object) -> Action:
+            raise PolicyError("controller-level failure")
+
+    sink = _RecordingSink()
+    (log,) = eval(
+        _task(),
+        ScriptedPolicy(),
+        CubePickEmbodiment(),
+        sinks=[sink],
+        controller=_EagerErrorController(),
+    )
+    assert log.status == "success"  # fail_on_error=False
+    (record,) = sink.records
+    assert record.status == "error"
+
+
+# --------------------------------------------------------------------------- #
+# 7. _git_commit: dirty suffix, deterministic via a fake git.
+# --------------------------------------------------------------------------- #
+class _FakeCompleted:
+    def __init__(self, stdout: str, returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+def test_git_commit_appends_dirty_suffix(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(cmd: list[str], **kwargs: object) -> _FakeCompleted:
+        if "rev-parse" in cmd:
+            return _FakeCompleted("abc123\n")
+        return _FakeCompleted(" M file.py\n")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert _git_commit() == "abc123-dirty"
+
+
+def test_git_commit_clean_tree_has_no_suffix(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(cmd: list[str], **kwargs: object) -> _FakeCompleted:
+        if "rev-parse" in cmd:
+            return _FakeCompleted("abc123\n")
+        return _FakeCompleted("")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert _git_commit() == "abc123"

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -78,7 +78,37 @@ def test_cli_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     out = capsys.readouterr().out
     assert "status: success" in out
     assert "success_at_end" in out
-    assert list(tmp_path.glob("*.json"))
+    (written,) = tmp_path.glob("*.json")
+    assert f"log: {written}" in out  # the CLI tells the user where the log went
+
+
+def test_cli_run_epochs_fail_on_error_store_frames(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = main(
+        [
+            "run",
+            "--task",
+            "cubepick-reach",
+            "--policy",
+            "scripted",
+            "--embodiment",
+            "cubepick",
+            "-T",
+            "num_scenes=1",
+            "--epochs",
+            "2",
+            "--fail-on-error",
+            "1",
+            "--store-frames",
+            "--log-dir",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "trials: 2" in out  # --epochs overrode the task's epoch count
+    assert list((tmp_path / "frames").glob("*.npy"))  # --store-frames streamed
 
 
 def test_cli_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-import inspect_robots.logging.rerun_sink as rerun_mod
 from inspect_robots import eval
 from inspect_robots.logging import RerunSink
 from inspect_robots.mock import CubePickEmbodiment, ScriptedPolicy
@@ -33,11 +32,15 @@ def test_rerun_sink_registered() -> None:
 
 
 @pytest.mark.skipif(_RERUN_INSTALLED, reason="rerun installed; testing the absent path")
-def test_noop_and_warns_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(rerun_mod, "_WARNED", False)
+def test_noop_and_warns_when_absent() -> None:
     sink = RerunSink()
     with pytest.warns(RuntimeWarning, match="rerun-sdk is not installed"):
         assert sink.available is False
+    # Warned once per instance; a second check stays quiet.
+    assert sink.available is False
+    # ...but a fresh instance warns again (no hidden module-global state).
+    with pytest.warns(RuntimeWarning, match="rerun-sdk is not installed"):
+        assert RerunSink().available is False
 
 
 @pytest.mark.skipif(_RERUN_INSTALLED, reason="rerun installed; testing the absent path")

--- a/tests/test_rollout_hardening.py
+++ b/tests/test_rollout_hardening.py
@@ -2,20 +2,21 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 import numpy as np
 import pytest
 
 from inspect_robots import eval
-from inspect_robots.approver import AutoApprover, ClampApprover
+from inspect_robots.approver import Approver, AutoApprover, ClampApprover
 from inspect_robots.controller import DefaultController
 from inspect_robots.errors import EmbodimentFault, PolicyError, SafetyAbort
 from inspect_robots.frames import FrameStore
 from inspect_robots.logging.sink import NullSink
 from inspect_robots.mock import CubePickEmbodiment, ScriptedPolicy
 from inspect_robots.policy import PolicyConfig, PolicyInfo
-from inspect_robots.rollout import derive_seed, rollout
+from inspect_robots.rollout import TrialRecord, derive_seed, rollout
 from inspect_robots.scene import Scene
 from inspect_robots.scorer import success_at_end
 from inspect_robots.spaces import ActionSemantics, Box
@@ -26,7 +27,13 @@ _SCENE = Scene(id="s", instruction="reach", init_seed=0)
 _BOX = Box(shape=(2,), semantics=ActionSemantics(control_mode="eef_delta_pos", frame="world"))
 
 
-def _run(policy: object, embodiment: object, *, approver: object = None, frame_store=None):  # type: ignore[no-untyped-def]
+def _run(
+    policy: object,
+    embodiment: object,
+    *,
+    approver: Approver | None = None,
+    frame_store: FrameStore | None = None,
+) -> TrialRecord:
     return rollout(
         policy,  # type: ignore[arg-type]
         embodiment,  # type: ignore[arg-type]
@@ -98,6 +105,15 @@ def test_clamp_approver_bounds_action() -> None:
     assert out.meta.get("clamped") is True
 
 
+def test_frame_store_sanitizes_without_collisions(tmp_path: Path) -> None:
+    store = FrameStore(str(tmp_path / "frames"))
+    img = np.zeros((2, 2, 3), dtype=np.uint8)
+    a = store.put("a/b", 0, "cam", img)
+    b = store.put("a-b", 0, "cam", img)
+    assert a.path != b.path  # sanitization must not introduce collisions
+    assert Path(a.path).exists() and Path(b.path).exists()
+
+
 def test_frame_store_streams_to_disk(tmp_path: Path) -> None:
     store = FrameStore(str(tmp_path / "frames"))
     record = _run(ScriptedPolicy(), CubePickEmbodiment(), frame_store=store)
@@ -115,6 +131,168 @@ def test_per_trial_seed_varies_by_epoch() -> None:
     assert s0 != s1
     # deterministic
     assert derive_seed(7, 3, 0) == s0
+
+
+def test_derive_seed_distinguishes_none_from_zero() -> None:
+    # "unseeded" must not silently alias seed=0.
+    assert derive_seed(None, 3, 0) != derive_seed(0, 3, 0)
+    assert derive_seed(7, None, 0) != derive_seed(7, 0, 0)
+
+
+# --------------------------------------------------------------------------- #
+# Partial-record preservation: every in-trial error carries the forensic record.
+# --------------------------------------------------------------------------- #
+class _BoomLaterPolicy:
+    """Delivers one good chunk, then explodes on the second inference."""
+
+    def __init__(self) -> None:
+        self.info = PolicyInfo(name="boom-later", action_space=_BOX)
+        self.config = PolicyConfig()
+        self._calls = 0
+
+    def reset(self, scene: Scene) -> None:
+        return None
+
+    def act(self, observation: Observation) -> ActionChunk:
+        self._calls += 1
+        if self._calls > 1:
+            raise RuntimeError("inference exploded later")
+        return ActionChunk(actions=[Action(data=np.zeros(2)) for _ in range(4)])
+
+
+def test_policy_error_carries_partial_record() -> None:
+    with pytest.raises(PolicyError, match="exploded later") as excinfo:
+        _run(_BoomLaterPolicy(), CubePickEmbodiment())
+    rec = excinfo.value.record
+    assert rec is not None
+    assert rec.status == "error"
+    assert rec.error is not None and "exploded later" in rec.error
+    assert len(rec.steps) == 4  # the first chunk executed before the failure
+    assert rec.events[-1].kind == "error"
+
+
+def test_embodiment_fault_carries_partial_record() -> None:
+    with pytest.raises(EmbodimentFault, match="motor stalled") as excinfo:
+        _run(ScriptedPolicy(), _FaultyEmbodiment())
+    rec = excinfo.value.record
+    assert rec is not None and rec.status == "error"
+    kinds = [e.kind for e in rec.events]
+    assert kinds[0] == "reset" and kinds[-1] == "error"
+
+
+def test_safety_abort_carries_partial_record() -> None:
+    with pytest.raises(SafetyAbort, match="e-stop") as excinfo:
+        _run(ScriptedPolicy(), CubePickEmbodiment(), approver=_VetoApprover())
+    rec = excinfo.value.record
+    assert rec is not None and rec.status == "error"
+
+
+class _CrashingApprover:
+    def review(self, action: Action, store: dict[str, object]) -> Action:
+        raise ZeroDivisionError("approver crashed")
+
+
+def test_approver_crash_wrapped_as_safety_abort() -> None:
+    # An approver that crashed cannot vouch for safety: treat it as an abort.
+    with pytest.raises(SafetyAbort, match="approver crashed") as excinfo:
+        _run(ScriptedPolicy(), CubePickEmbodiment(), approver=_CrashingApprover())
+    assert excinfo.value.record is not None
+
+
+# --------------------------------------------------------------------------- #
+# Reset failures are wrapped/attributed like in-loop failures.
+# --------------------------------------------------------------------------- #
+class _ResetBoomPolicy(_BoomLaterPolicy):
+    def reset(self, scene: Scene) -> None:
+        raise RuntimeError("policy reset failed")
+
+
+class _TypedResetPolicy(_BoomLaterPolicy):
+    def reset(self, scene: Scene) -> None:
+        raise PolicyError("typed reset failure")
+
+
+class _ResetFaultEmbodiment(CubePickEmbodiment):
+    def reset(self, scene: Scene, *, seed: int | None = None) -> Observation:
+        raise RuntimeError("homing failed")
+
+
+class _TypedResetEmbodiment(CubePickEmbodiment):
+    def reset(self, scene: Scene, *, seed: int | None = None) -> Observation:
+        raise EmbodimentFault("e-stop during reset")
+
+
+def test_policy_reset_exception_wrapped() -> None:
+    with pytest.raises(PolicyError, match="policy reset failed") as excinfo:
+        _run(_ResetBoomPolicy(), CubePickEmbodiment())
+    assert excinfo.value.record is not None
+
+
+def test_policy_reset_typed_error_propagates() -> None:
+    with pytest.raises(PolicyError, match="typed reset failure") as excinfo:
+        _run(_TypedResetPolicy(), CubePickEmbodiment())
+    assert excinfo.value.record is not None
+
+
+def test_embodiment_reset_exception_wrapped() -> None:
+    with pytest.raises(EmbodimentFault, match="homing failed") as excinfo:
+        _run(ScriptedPolicy(), _ResetFaultEmbodiment())
+    assert excinfo.value.record is not None
+
+
+def test_embodiment_reset_typed_error_propagates() -> None:
+    with pytest.raises(EmbodimentFault, match="e-stop during reset") as excinfo:
+        _run(ScriptedPolicy(), _TypedResetEmbodiment())
+    assert excinfo.value.record is not None
+
+
+# --------------------------------------------------------------------------- #
+# Runtime action-shape validation: a malformed action is a PolicyError, not a
+# halting EmbodimentFault misattributed to the robot.
+# --------------------------------------------------------------------------- #
+class _WrongDimPolicy:
+    def __init__(self) -> None:
+        self.info = PolicyInfo(name="wrong-dim", action_space=_BOX)  # declares 2-D
+        self.config = PolicyConfig()
+
+    def reset(self, scene: Scene) -> None:
+        return None
+
+    def act(self, observation: Observation) -> ActionChunk:
+        return ActionChunk(actions=[Action(data=np.zeros(3))])  # emits 3-D
+
+
+def test_wrong_dim_action_attributed_to_policy() -> None:
+    with pytest.raises(PolicyError, match="expects 2-D") as excinfo:
+        _run(_WrongDimPolicy(), CubePickEmbodiment())
+    rec = excinfo.value.record
+    assert rec is not None and rec.status == "error"
+
+
+# --------------------------------------------------------------------------- #
+# Approval events: a modified action is recorded in the transcript.
+# --------------------------------------------------------------------------- #
+def test_clamp_approver_records_approval_event() -> None:
+    space = Box(shape=(2,), low=np.array([-0.05, -0.05]), high=np.array([0.05, 0.05]))
+    record = _run(ScriptedPolicy(), CubePickEmbodiment(), approver=ClampApprover(space))
+    approvals = [e for e in record.events if e.kind == "approval"]
+    assert approvals
+    assert approvals[0].data["modified"] is True
+    assert approvals[0].data["detail"] == "clamped"
+
+
+class _HalvingApprover:
+    """Modifies the action without setting the ``clamped`` meta flag."""
+
+    def review(self, action: Action, store: dict[str, object]) -> Action:
+        return replace(action, data=np.asarray(action.data, dtype=np.float64) * 0.5)
+
+
+def test_modified_action_records_approval_event_without_detail() -> None:
+    record = _run(ScriptedPolicy(), CubePickEmbodiment(), approver=_HalvingApprover())
+    approvals = [e for e in record.events if e.kind == "approval"]
+    assert approvals
+    assert approvals[0].data["detail"] is None
 
 
 def test_fail_on_error_proportion_halts(tmp_path: Path) -> None:

--- a/tests/test_types_spaces.py
+++ b/tests/test_types_spaces.py
@@ -25,7 +25,7 @@ def test_core_types_are_frozen() -> None:
     step = StepResult(observation=obs)
     for frozen in (obs, act, chunk, step):
         with pytest.raises(dataclasses.FrozenInstanceError):
-            frozen.foo = 1  # type: ignore[attr-defined]
+            frozen.foo = 1  # type: ignore[union-attr]
 
 
 def test_action_chunk_rejects_empty() -> None:
@@ -43,6 +43,11 @@ def test_box_dim_and_bounds_validation() -> None:
     assert box.dim == 6
     with pytest.raises(ValueError, match="shape"):
         Box(shape=(6,), low=np.zeros(3))
+
+
+def test_box_rejects_inverted_bounds() -> None:
+    with pytest.raises(ValueError, match="low must be elementwise"):
+        Box(shape=(2,), low=np.array([0.0, 1.0]), high=np.array([1.0, 0.5]))
 
 
 def test_action_semantics_defaults() -> None:
@@ -65,3 +70,38 @@ def test_observation_space_derives_state_keys_from_spec() -> None:
     )
     assert space.state_keys == {"joint_pos", "gripper"}
     assert space.camera_names == {"wrist"}
+
+
+def test_observation_space_rejects_inconsistent_state_keys() -> None:
+    spec = StateSpec(fields=(StateField(key="joint_pos", shape=(7,)),))
+    # Consistent duplication is allowed...
+    ObservationSpace(state_keys=frozenset({"joint_pos"}), state=spec)
+    # ...but a silent disagreement is not.
+    with pytest.raises(ValueError, match="inconsistent"):
+        ObservationSpace(state_keys=frozenset({"eef_pos"}), state=spec)
+
+
+def test_task_validation_and_scorer_names() -> None:
+    from inspect_robots.errors import ConfigError
+    from inspect_robots.scene import Scene
+    from inspect_robots.task import Epochs, Task
+
+    scene = Scene(id="s", instruction="x")
+    with pytest.raises(ConfigError, match="max_steps"):
+        Task(name="t", scenes=[scene], scorer="success_at_end", max_steps=0)
+    with pytest.raises(ConfigError, match="Epochs count"):
+        Task(name="t", scenes=[scene], scorer="success_at_end", max_steps=5, epochs=0)
+    with pytest.raises(ConfigError, match="Epochs count"):
+        Epochs(count=0)
+
+    # A scorer registry name resolves to one scorer, never to a sequence of
+    # one-character "scorers" (str is a Sequence).
+    task = Task(name="t", scenes=[scene], scorer="success_at_end", max_steps=5)
+    (scorer,) = task.scorers
+    assert scorer.name == "success_at_end"
+
+    # Sequences may mix objects and names.
+    from inspect_robots.scorer import episode_length
+
+    mixed = Task(name="t", scenes=[scene], scorer=[episode_length(), "success_at_end"], max_steps=5)
+    assert [s.name for s in mixed.scorers] == ["episode_length", "success_at_end"]


### PR DESCRIPTION
## Problem

PR #1 (`review-fixes`, 7 commits `499aa12..ee0cccb`) fixes ~12 verified-still-present bugs — reset failures losing the whole EvalLog, scorer/reducer exceptions losing the run, partial `TrialRecord`s discarded on faults, crashing approvers escaping raw, `derive_seed` `None`/`0` aliasing, `chunk_len` overstatement, collision-prone frame slugs, swallowed entry-point failures, missing `Task` validation, rerun new-SDK compat, and untyped tests — but it branched from pre-rename `a420bfd` (`src/robolens/`) and was never ported through the `robolens` → `roboinspect` → `inspect-robots` renames, so it no longer applies to main.

## What changed

Forward-ports all 7 original commits onto current main, rewriting old names with three context-scoped rules (identifiers `RoboLens*` → `InspectRobots*`; CLI/pip/prose `robolens` → `inspect-robots` / `Inspect Robots` at the enumerated sites only; module refs `robolens` → `inspect_robots`):

1. `499aa12` rollout: preserve partial records on failure, attribute errors correctly (crashing approver → `SafetyAbort`; `approval_event` emitted; `seed=None` no longer aliases `seed=0`)
2. `bd41180` eval: never lose the log, never score errored trials, own the lifecycle (`eval()` closes registry-resolved embodiments; `fail_on_error` checked after every trial; scorer/reducer failures degrade to an error log)
3. `e908481` task/spaces: validate configuration at construction, resolve scorer names
4. `fb5a370` frames/registry/mock: collision-safe slugs, loud plugin failures, honest names
5. `41be976` rerun sink: namespace trials, per-instance warning, new-SDK (>=0.23) compatibility
6. `6161d89` cli/json sink: print the log path, expose run knobs (`--epochs`, `--fail-on-error`, `--store-frames`), drop dead counter
7. `ee0cccb` tooling/docs: type-check tests under strict mypy (`mypy` now covers `tests/`)

Port deviations from the original branch:
- The `JsonLogSink` docstring conflict (main had re-wrapped it) was resolved in favor of the branch's fuller docstring.
- The original branch predates `docs/`: this PR also sweeps `docs/guide/` (fail_on_error table, seed=None, errored-trials-never-scored, ownership-based close, new CLI flags) and updates the isaacsim plugin README/`close()` docstring to the ownership rule ("`eval()` closes what it resolves; you close what you construct").
- CHANGELOG gains a `[Unreleased]` section for the port (existing content preserved).
- No pyproject version changes ported.

Supersedes #1 (left open for the owner to close).

## How verified

- Ported tree proven to equal `main` + the renamed branch changes exactly (line-multiset diff comparison against the renamed original), then each of the 7 commits reviewed semantically.
- `grep -r 'robolens|roboinspect|RoboLens|Inspect RobotsError'` over `src`/`tests`/`docs`/`plugins`: zero hits.
- Gates: `ruff check` / `ruff format --check` / `mypy` (src **and** tests) all clean; `pytest --cov` 143 passed at **100% coverage**; isaacsim plugin 13 passed; `examples/quickstart.py` smoke run: status `success`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)