### PR TITLE
Strict-JSON eval logs + ClampApprover NaN/one-sided hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **Eval logs are strict RFC 8259 JSON.** Non-finite floats (e.g. an inf
+  `min_distance_to_goal` when no distance was ever recorded) are mapped to
+  `null` at the JSON boundary, so `jq` and other conforming parsers accept the
+  file; `json.dump(..., allow_nan=False)` stays on as a regression backstop.
+  In-memory scores keep the inf sentinel.
+- **`ClampApprover` hardening:** a NaN action raises `SafetyAbort` (a NaN has
+  no meaningful clamp and must never reach hardware) while `±inf` clamps to the
+  finite bound like any out-of-range value; one-sided boxes (`low`-only /
+  `high`-only) are honored instead of ignored; an unmodified action is returned
+  as the *same* object so the rollout's identity-based `approval_event` stays
+  accurate.
 - **Never lose the log.** `eval()` always produces and persists an `EvalLog`
   once rollouts have started: scorer/reducer failures degrade the run to an
   error log instead of crashing; `policy.reset`/`embodiment.reset` failures are

--- a/src/inspect_robots/approver.py
+++ b/src/inspect_robots/approver.py
@@ -14,6 +14,7 @@ from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
 
+from inspect_robots.errors import SafetyAbort
 from inspect_robots.spaces import Box
 from inspect_robots.types import Action
 
@@ -39,18 +40,31 @@ class AutoApprover:
 class ClampApprover:
     """Clamp actions to a box's ``low``/``high`` bounds before they reach hardware.
 
-    A modified action is flagged via ``action.meta["clamped"]`` so the rollout can
-    record an approval event.
+    One-sided boxes are honored: a ``low``-only box clamps from below, a
+    ``high``-only box from above. A modified action is flagged via
+    ``action.meta["clamped"]`` so the rollout can record an approval event;
+    when nothing clamps, the *same* action object is returned (the rollout
+    detects modification by identity).
+
+    Non-finite values are the safety cases: ``NaN`` anywhere in the action
+    raises [`SafetyAbort`][inspect_robots.errors.SafetyAbort] — a NaN is a
+    poisonous value with no meaningful clamp, and it must never reach hardware.
+    ``±inf`` is *not* an abort: it clamps to the finite bound on that side like
+    any other out-of-range value (and passes through if that side is
+    unbounded).
     """
 
     def __init__(self, action_space: Box):
         self._space = action_space
 
     def review(self, action: Action, store: dict[str, Any]) -> Action:
+        data = np.asarray(action.data, dtype=np.float64)
+        if bool(np.isnan(data).any()):
+            raise SafetyAbort("ClampApprover: action contains NaN; refusing to pass it on")
         low, high = self._space.low, self._space.high
-        if low is None or high is None:
+        if low is None and high is None:
             return action
-        clamped = np.clip(np.asarray(action.data, dtype=np.float64), low, high)
-        if np.array_equal(clamped, action.data):
+        clamped = np.clip(data, low, high)
+        if np.array_equal(clamped, data):
             return action
         return replace(action, data=clamped, meta={**dict(action.meta), "clamped": True})

--- a/src/inspect_robots/logging/json_log.py
+++ b/src/inspect_robots/logging/json_log.py
@@ -3,11 +3,20 @@
 Writes the immutable [`EvalLog`][inspect_robots.log.EvalLog] to ``log_dir`` once the run
 finishes. The write is atomic (temp file + ``os.replace``) so an interrupted
 overnight run never leaves a half-written log.
+
+The file is strict RFC 8259 JSON: non-finite floats (``nan``, ``±inf``, e.g. a
+``min_distance_to_goal`` score when no distance was ever recorded) are mapped
+to ``null`` before serialization, so any conforming parser (``jq``, browsers,
+non-Python tooling) can read the log. ``allow_nan=False`` is kept on the
+``json.dump`` call as a regression backstop: if a non-finite value ever slips
+past the sanitizer, writing fails loudly instead of emitting ``Infinity``/
+``NaN`` literals.
 """
 
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import uuid
@@ -24,6 +33,22 @@ _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
 def _slug(name: str) -> str:
     return _SLUG_RE.sub("-", name.lower()).strip("-") or "eval"
+
+
+def _sanitize(obj: object) -> object:
+    """Recursively map non-finite floats to ``None`` (JSON ``null``).
+
+    ``json.dump`` would happily emit the non-standard ``Infinity``/``NaN``
+    literals for them (``default=`` never fires for floats), which RFC 8259
+    parsers reject.
+    """
+    if isinstance(obj, float):
+        return obj if math.isfinite(obj) else None
+    if isinstance(obj, dict):
+        return {key: _sanitize(value) for key, value in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_sanitize(value) for value in obj]
+    return obj
 
 
 class JsonLogSink:
@@ -57,7 +82,7 @@ class JsonLogSink:
         self.path = self.log_dir / filename
         tmp = self.path.with_suffix(".json.tmp")
         with tmp.open("w", encoding="utf-8") as fh:
-            json.dump(log.to_dict(), fh, indent=2, sort_keys=True)
+            json.dump(_sanitize(log.to_dict()), fh, indent=2, sort_keys=True, allow_nan=False)
             fh.flush()
             os.fsync(fh.fileno())
         os.replace(tmp, self.path)

--- a/tests/test_rollout_hardening.py
+++ b/tests/test_rollout_hardening.py
@@ -105,6 +105,48 @@ def test_clamp_approver_bounds_action() -> None:
     assert out.meta.get("clamped") is True
 
 
+def test_clamp_approver_nan_raises_safety_abort() -> None:
+    # A NaN has no meaningful clamp; it must never reach hardware.
+    space = Box(shape=(2,), low=np.array([-1.0, -1.0]), high=np.array([1.0, 1.0]))
+    approver = ClampApprover(space)
+    with pytest.raises(SafetyAbort, match="NaN"):
+        approver.review(Action(data=np.array([0.0, float("nan")])), {})
+
+
+def test_clamp_approver_nan_aborts_even_without_bounds() -> None:
+    approver = ClampApprover(Box(shape=(2,)))  # no low/high
+    with pytest.raises(SafetyAbort, match="NaN"):
+        approver.review(Action(data=np.array([float("nan"), 0.0])), {})
+
+
+def test_clamp_approver_inf_clamps_without_abort() -> None:
+    # ±inf is out-of-range, not poisonous: it clamps to the finite bound.
+    space = Box(shape=(2,), low=np.array([-1.0, -1.0]), high=np.array([1.0, 1.0]))
+    approver = ClampApprover(space)
+    out = approver.review(Action(data=np.array([float("inf"), float("-inf")])), {})
+    assert np.allclose(out.data, [1.0, -1.0])
+    assert out.meta.get("clamped") is True
+
+
+def test_clamp_approver_low_only_bound() -> None:
+    approver = ClampApprover(Box(shape=(2,), low=np.array([0.0, 0.0])))
+    out = approver.review(Action(data=np.array([-0.5, 0.5])), {})
+    assert np.allclose(out.data, [0.0, 0.5])
+    assert out.meta.get("clamped") is True
+    in_bounds = Action(data=np.array([0.5, 0.5]))
+    assert approver.review(in_bounds, {}) is in_bounds  # identity pass-through
+
+
+def test_clamp_approver_high_only_bound() -> None:
+    approver = ClampApprover(Box(shape=(2,), high=np.array([1.0, 1.0])))
+    out = approver.review(Action(data=np.array([2.0, 0.5])), {})
+    assert np.allclose(out.data, [1.0, 0.5])
+    assert out.meta.get("clamped") is True
+    # inf on the unbounded side has nothing to clamp against: pass-through.
+    unbounded_side = Action(data=np.array([float("-inf"), 0.0]))
+    assert approver.review(unbounded_side, {}) is unbounded_side
+
+
 def test_frame_store_sanitizes_without_collisions(tmp_path: Path) -> None:
     store = FrameStore(str(tmp_path / "frames"))
     img = np.zeros((2, 2, 3), dtype=np.uint8)

--- a/tests/test_strict_json.py
+++ b/tests/test_strict_json.py
@@ -1,0 +1,122 @@
+"""Strict RFC 8259 JSON logs and the ClampApprover NaN gate, end to end.
+
+The written eval log must be parseable by any conforming JSON parser: no
+``Infinity``/``NaN`` literals (non-finite floats become ``null``). A NaN action
+caught by the ClampApprover halts the eval as ``SafetyAbort`` — and the log
+still reaches disk.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from inspect_robots import eval, read_eval_log
+from inspect_robots.approver import ClampApprover
+from inspect_robots.logging.json_log import _sanitize
+from inspect_robots.mock import CubePickEmbodiment, ScriptedPolicy
+from inspect_robots.scene import Scene
+from inspect_robots.scorer import min_distance_to_goal, success_at_end
+from inspect_robots.task import Task
+from inspect_robots.types import Action, ActionChunk, Observation, StepResult
+
+
+def _task(scorer: object = None) -> Task:
+    return Task(
+        name="strict-json",
+        scenes=[Scene(id="s0", instruction="reach", init_seed=0)],
+        scorer=scorer or success_at_end(),  # type: ignore[arg-type]
+        max_steps=40,
+    )
+
+
+def _forbid_constants(name: str) -> float:
+    raise AssertionError(f"non-RFC-8259 constant in log: {name}")
+
+
+def _read_strict(path: Path) -> dict[str, object]:
+    """Parse with a ``parse_constant`` that rejects Infinity/NaN literals."""
+    data = json.loads(path.read_text(encoding="utf-8"), parse_constant=_forbid_constants)
+    assert isinstance(data, dict)
+    return data
+
+
+class _NoDistanceEmbodiment(CubePickEmbodiment):
+    """Reports no distance signal, so min_distance_to_goal scores inf."""
+
+    def step(self, action: Action) -> StepResult:
+        result = super().step(action)
+        return replace(result, info={"success": result.info.get("success", False)})
+
+
+class _NaNPolicy(ScriptedPolicy):
+    """Emits a NaN action on the first inference."""
+
+    def act(self, observation: Observation) -> ActionChunk:
+        chunk = super().act(observation)
+        return ActionChunk(actions=[Action(data=np.full(2, np.nan)), *chunk.actions])
+
+
+def test_sanitize_maps_non_finite_floats_to_none() -> None:
+    dirty = {
+        "inf": float("inf"),
+        "ninf": float("-inf"),
+        "nan": float("nan"),
+        "fine": 1.5,
+        "int": 3,
+        "flag": True,
+        "nested": [float("inf"), {"d": float("nan")}, (2.0, float("-inf"))],
+    }
+    clean = _sanitize(dirty)
+    assert clean == {
+        "inf": None,
+        "ninf": None,
+        "nan": None,
+        "fine": 1.5,
+        "int": 3,
+        "flag": True,
+        "nested": [None, {"d": None}, [2.0, None]],
+    }
+
+
+def test_inf_metric_written_as_null(tmp_path: Path) -> None:
+    task = _task(scorer=min_distance_to_goal())
+    (log,) = eval(task, ScriptedPolicy(), _NoDistanceEmbodiment(), log_dir=str(tmp_path))
+    assert log.results.metrics["min_distance_to_goal"] == float("inf")  # in-memory sentinel
+
+    (path,) = tmp_path.glob("*.json")
+    text = path.read_text(encoding="utf-8")
+    assert "Infinity" not in text and "NaN" not in text
+    data = _read_strict(path)  # a strict parser accepts the whole file
+    results = data["results"]
+    assert isinstance(results, dict)
+    metrics = results["metrics"]
+    assert isinstance(metrics, dict)
+    assert metrics["min_distance_to_goal"] is None  # inf → null at the JSON boundary
+
+
+def test_nan_action_halts_as_safety_abort_and_log_reaches_disk(tmp_path: Path) -> None:
+    embodiment = CubePickEmbodiment()
+    approver = ClampApprover(embodiment.info.action_space)
+    (log,) = eval(_task(), _NaNPolicy(), embodiment, approver=approver, log_dir=str(tmp_path))
+    assert log.status == "error"
+    assert log.error is not None and "NaN" in log.error
+
+    (path,) = tmp_path.glob("*.json")
+    restored = read_eval_log(str(path))
+    assert restored.status == "error"
+    _read_strict(path)  # strict parseable even for a halted run
+
+
+def test_json_dump_backstop_rejects_unsanitized_non_finite(tmp_path: Path) -> None:
+    # The allow_nan=False regression backstop: if a non-finite value ever
+    # slipped past _sanitize, the write would fail loudly.
+    with (
+        pytest.raises(ValueError),
+        (tmp_path / "x.json").open("w", encoding="utf-8") as fh,
+    ):
+        json.dump({"bad": float("inf")}, fh, allow_nan=False)


### PR DESCRIPTION
**Stacked on #9** (`port/review-fixes`) — the base branch is set to `port/review-fixes` so the diff shows only this change. Merge after #9, then retarget this PR's base to `main`.

## Problem

- The JSON eval log is not strict RFC 8259: an inf score (e.g. `min_distance_to_goal` when no distance signal was ever recorded) serializes as the non-standard `Infinity` literal, which `jq`, browsers, and most non-Python parsers reject.
- `ClampApprover` passed NaN actions straight to hardware (while falsely flagging them `clamped`), and silently ignored one-sided boxes (`low`-only or `high`-only bounds).

## What changed

- `logging/json_log.py`: a recursive pre-serialization sanitizer maps non-finite floats to `null` over `log.to_dict()`; `json.dump(..., allow_nan=False)` is kept as a regression backstop (not the mechanism — `default=` never fires for floats). Documented in the module docstring. `min_distance_to_goal` keeps returning inf in memory (semantically "never got close"); only the JSON boundary nulls it.
- `approver.py` `ClampApprover`:
  - NaN anywhere in the action → `SafetyAbort` (a poisonous value with no meaningful clamp must never reach a hardware gate). `±inf` is **not** an abort — it clamps to the finite bound; the distinction is documented.
  - One-sided bounds honored via `np.clip`'s native `None` handling.
  - Pass-through returns the **same** object — the rollout (from #9) emits `approval_event` on `reviewed is not action`, so identity is part of the contract (tested).

## How verified

- New tests: sanitizer unit test; inf metric → `null` in the file with a `json.loads(parse_constant=<raiser>)` strict read-back; NaN action halts as `SafetyAbort` **and** the log still reaches disk (via #9's never-lose-the-log semantics); `+inf`/`-inf` clamp to bounds without abort; one-sided low-only/high-only clamping; pass-through object identity; `allow_nan=False` backstop.
- Gates: `ruff check` / `ruff format --check` / `mypy` (src + tests) clean; `pytest --cov` 152 passed at **100% coverage**; isaacsim plugin 13 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)