### PR TITLE
Docs & packaging hygiene: broken snippet, sink semantics, URLs, CHANGELOG backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Changed
+
+- **Documentation site moved to a custom domain:** <https://inspectrobots.org/>.
+
+## [0.3.0] - 2026-07-01
+
+### Changed
+
+- **Renamed the framework RoboInspect → Inspect Robots.** The import package is
+  now `inspect_robots`, the distribution/CLI `inspect-robots`, the error base
+  class `InspectRobotsError`, the log field `inspect_robots_version`, and the
+  plugin entry-point groups `inspect_robots.*`. The Isaac Sim plugin follows as
+  `inspect-robots-isaacsim` (import package `inspect_robots_isaacsim`, entry
+  point group `inspect_robots.embodiments`).
+
+## [0.2.0] - 2026-06-30
+
+### Added
+
+- **Isaac Sim / Isaac Lab plugin** as an in-repo uv-workspace package
+  (`plugins/`): an `Embodiment` adapter backed by an Isaac Lab physics
+  simulation (default profile: 7-DoF Franka Panda under joint-position control
+  with a binary gripper), registered via entry point, with Isaac imported
+  lazily so the plugin installs anywhere and the core stays NumPy-only.
+  First-party plugins live as their own packages with their own pyproject,
+  tests, and coverage scope; `uv sync --all-packages --extra dev` installs
+  core + plugins editable.
+
+### Changed
+
+- Renamed the package RoboLens → RoboInspect (superseded by the 0.3.0 rename).
+
+## [0.1.0] - 2026-06-27
+
 ### Added
 
 - **Widened the public API for plugin authors.** `inspect_robots.__all__` now exports
@@ -57,4 +91,7 @@ All notable changes to this project are documented here. The format is based on
   strict mypy on commit, the 100% coverage gate on push. Install with
   `uv run pre-commit install`. Documented in `CONTRIBUTING.md`.
 
-[Unreleased]: https://github.com/robocurve/inspect-robots/commits/main
+[Unreleased]: https://github.com/robocurve/inspect-robots/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/robocurve/inspect-robots/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/robocurve/inspect-robots/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/robocurve/inspect-robots/releases/tag/v0.1.0

--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -24,8 +24,11 @@ A [`LogSink`][inspect_robots.logging.LogSink] observes the run lifecycle
 (`on_eval_start` → per trial `on_trial_start`/`log_step`/`on_trial_end` →
 `on_eval_end`). Builtins:
 
-- [`JsonLogSink`][inspect_robots.logging.JsonLogSink] — always on; the canonical JSON record.
+- [`JsonLogSink`][inspect_robots.logging.JsonLogSink] — the default; the canonical JSON record.
 - [`RerunSink`][inspect_robots.logging.RerunSink] — optional, lazily imported.
+
+Passing `sinks=` **replaces** the default `JsonLogSink`, it does not add to it —
+so include one in the list if you still want the JSON log:
 
 ```python
 from inspect_robots.logging import JsonLogSink, RerunSink

--- a/docs/guide/scoring.md
+++ b/docs/guide/scoring.md
@@ -31,7 +31,7 @@ class SmoothMotion:
     name: str = "smooth_motion"
 
     def __call__(self, record, target) -> Score:
-        deltas = [abs(float(s.action.data).sum()) for s in record.steps]
+        deltas = [abs(float(s.action.data.sum())) for s in record.steps]
         return Score(value=-sum(deltas), explanation="negative total command magnitude")
 ```
 

--- a/plugins/inspect-robots-isaacsim/pyproject.toml
+++ b/plugins/inspect-robots-isaacsim/pyproject.toml
@@ -35,8 +35,8 @@ dev = ["pytest>=8.0", "pytest-cov>=5.0", "mypy>=1.11", "ruff>=0.6"]
 isaacsim = "inspect_robots_isaacsim:isaacsim_embodiment"
 
 [project.urls]
-Homepage = "https://github.com/robocurve/inspect-robots-isaacsim"
-Repository = "https://github.com/robocurve/inspect-robots-isaacsim"
+Homepage = "https://github.com/robocurve/inspect-robots/tree/main/plugins/inspect-robots-isaacsim"
+Repository = "https://github.com/robocurve/inspect-robots"
 
 # In the Inspect Robots monorepo this resolves the `inspect_robots` dependency to the in-repo
 # core package instead of PyPI. Harmless in a standalone checkout (uv ignores a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ inspect-robots = "inspect_robots.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/robocurve/inspect-robots"
+Documentation = "https://inspectrobots.org/"
 Repository = "https://github.com/robocurve/inspect-robots"
 Issues = "https://github.com/robocurve/inspect-robots/issues"
 
@@ -74,6 +75,9 @@ source = "vcs"
 # Before the first tag exists, fall back to a sensible dev version instead of failing.
 version_scheme = "guess-next-dev"
 fallback_version = "0.0.0"
+
+[tool.hatch.build]
+exclude = ["src/inspect_robots/CLAUDE.md"]  # agent docs; not for the wheel/sdist
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/inspect_robots"]

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -25,7 +25,7 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `log.py` | immutable, schema-versioned `EvalLog` + `read_eval_log` |
 | `logging/` | `LogSink` protocol, `JsonLogSink` (atomic), optional `RerunSink` |
 | `registry.py` | decorators + entry-point discovery; `_builtins.py` registers in-tree components |
-| `cli.py` | `inspect-robots list` / `inspect-robots run` |
+| `cli.py` | `inspect-robots list` / `inspect-robots run` / `inspect-robots inspect` |
 | `mock/` | dependency-free `CubePick` world + scripted/random/noop policies |
 
 ## Key invariants


### PR DESCRIPTION
Independent of #9/#10 — docs and metadata only, no behavior changes.

## Problem / What changed

- **`docs/guide/scoring.md` snippet raised `TypeError`:** `abs(float(s.action.data).sum())` calls `float()` on an array and then `.sum()` on a float. Fixed to `abs(float(s.action.data.sum()))`.
- **`docs/guide/logging-and-rerun.md` claimed `JsonLogSink` is "always on":** in fact `sinks=` *replaces* the default. Now says so explicitly and the example keeps a `JsonLogSink` in the list alongside `RerunSink`.
- **`src/inspect_robots/CLAUDE.md` module map:** `cli.py` also implements `inspect-robots inspect`.
- **CHANGELOG backfill:** everything sat under `[Unreleased]` despite three tagged releases. Foundation content → `v0.1.0` (2026-06-27), isaacsim plugin + RoboInspect rename → `v0.2.0` (2026-06-30), Inspect Robots rename → `v0.3.0` (2026-07-01); `[Unreleased]` keeps the post-tag custom-domain move; compare links added. (Note: #9 adds its own `[Unreleased]` entries — whichever merges second takes a trivial CHANGELOG conflict.)
- **Plugin `[project.urls]`** pointed at a nonexistent standalone repo (`robocurve/inspect-robots-isaacsim`); Homepage now deep-links to the plugin subtree in the monorepo, Repository points at the monorepo.
- **Root `[project.urls]`:** added `Documentation = "https://inspectrobots.org/"`.
- **Build artifacts no longer ship agent docs:** `src/inspect_robots/CLAUDE.md` is excluded via a target-agnostic `[tool.hatch.build]` exclude (the sdist include list only pulls `src`/`tests`/README/LICENSE, so this single exclusion covers both wheel and sdist).

## How verified

- `uv build`: neither the wheel nor the sdist contains any `CLAUDE.md` (checked with `unzip -l` / `tar tzf`).
- Gates: `ruff check` / `ruff format --check` / `mypy` clean; `pytest --cov` 109 passed at **100% coverage**; isaacsim plugin 13 passed.
- CHANGELOG sections cross-checked against `git log v0.1.0`, `v0.1.0..v0.2.0`, `v0.2.0..v0.3.0`, `v0.3.0..main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)