### PR TITLE
Docs: retry Pages deploy on transient failures

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,8 +48,26 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps.retry1.outputs.page_url || steps.retry2.outputs.page_url }}
     steps:
+      # The Pages API intermittently rejects deployments with a transient
+      # "Deployment failed, try again later" — retry twice with backoff.
       - name: Deploy
         id: deployment
+        continue-on-error: true
+        uses: actions/deploy-pages@v4
+      - name: Wait before retry
+        if: steps.deployment.outcome == 'failure'
+        run: sleep 30
+      - name: Deploy (retry 1)
+        id: retry1
+        if: steps.deployment.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/deploy-pages@v4
+      - name: Wait before second retry
+        if: steps.deployment.outcome == 'failure' && steps.retry1.outcome == 'failure'
+        run: sleep 60
+      - name: Deploy (retry 2)
+        id: retry2
+        if: steps.deployment.outcome == 'failure' && steps.retry1.outcome == 'failure'
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
The `deploy-pages` step intermittently fails with GitHub's transient **"Deployment failed, try again later"** (seen on main 2026-07-06, fixed by manual re-run; worldevals hit it 3× the same day). This adds two in-job retries with 30s/60s backoff so deploys self-heal. No third-party actions; the environment URL falls back across attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)