### PR TITLE
Zero-config CLI: inspect-robots "place the spoon on the plate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ inspect-robots run --task cubepick-reach --policy scripted --embodiment cubepick
 inspect-robots inspect logs/cubepick-reach_*.json            # results table
 ```
 
+…or, with a default policy/embodiment configured once in
+`~/.config/inspect-robots/config.ini`, just tell the robot what to do:
+
+```bash
+inspect-robots "place the spoon on the plate"                # zero-config ad-hoc eval
+```
+
 ## Why Inspect Robots
 
 - 🌍 **Real-world first.** Interfaces assume real-robot reality — human-in-the-loop

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -2,6 +2,71 @@
 
 The `inspect_robots` CLI wraps the registry and [`eval`][inspect_robots.eval.eval].
 
+## Zero-config: `inspect-robots "<instruction>"`
+
+Once you have configured a default policy and embodiment (below), giving the
+robot a command is a one-liner:
+
+```bash
+inspect-robots "place the spoon on the plate"
+```
+
+This runs a single **ad-hoc scene** built from that language instruction on
+your default policy/embodiment — sugar for
+`inspect-robots run --instruction "..."`. The resolved components and where
+they came from are printed before the robot moves. Two flags exist only for
+instruction runs: `--max-steps N` (horizon, default 300) and `--scorer NAME`
+(default `operator`).
+
+The sugar only fires when the first argument contains whitespace, so a
+mistyped subcommand (`inspect-robots isnpect`) errors out instead of starting
+a rollout; a single-word instruction needs the explicit
+`run --instruction "wipe"` form.
+
+### Default policy and embodiment
+
+Resolved in order — first hit wins:
+
+1. explicit flags: `--policy` / `--embodiment`
+2. environment: `INSPECT_ROBOTS_POLICY` / `INSPECT_ROBOTS_EMBODIMENT`
+3. the user config file `~/.config/inspect-robots/config.ini`
+   (`$XDG_CONFIG_HOME` is honored):
+
+```ini
+[defaults]
+policy = molmoact2-yam
+embodiment = yam-bimanual
+scorer = operator      ; optional, ad-hoc runs only
+max_steps = 300        ; optional, ad-hoc runs only
+
+[policy.args]          ; default -P key=value pairs
+checkpoint = ~/ckpts/molmoact2-yam.pt
+
+[embodiment.args]      ; default -E key=value pairs
+cameras = wrist,front
+```
+
+Values parse like `-P/-E` args (bool/int/float/None/str), `~` expands in
+`[*.args]` values, and an explicit `-P/-E key=value` flag overrides the
+same-named config key. There is deliberately **no project-local config file**:
+a checked-in file choosing which policy drives your hardware would be a trust
+footgun.
+
+### Operator scoring
+
+An arbitrary instruction has no success oracle, so ad-hoc runs default to the
+`operator` scorer: when run on an interactive terminal, the CLI asks after
+each trial —
+
+```text
+did the robot succeed? [y/n/partial/skip] (partial scores as failure)
+```
+
+— and records the verdict in the log (`skip` records nothing). Piped/CI
+stdin, `--no-prompt`, or a registered `--task` run never prompt: unattended
+runs stay non-blocking, and an unjudged trial honestly scores as failure with
+"no operator judgement recorded".
+
 ## `inspect-robots list`
 
 Show registered components (builtins + installed plugins):
@@ -28,6 +93,10 @@ inspect-robots run --task cubepick-reach -T num_scenes=10 --policy scripted -P c
 `PolicyError`s (`1` = first error, `0<X<1` = proportion, `X>1` = count), and
 `--store-frames` streams camera frames to `<log-dir>/frames`. When the run
 finishes, the path of the written log is printed.
+
+`--policy`/`--embodiment` may be omitted when defaults are configured (see
+the zero-config section above); `--instruction "..."` replaces `--task` to
+run a single ad-hoc scene.
 
 The exit code is `0` on a successful eval, `1` otherwise.
 

--- a/plans/0005-zero-config-cli.md
+++ b/plans/0005-zero-config-cli.md
@@ -1,0 +1,357 @@
+# 0005 — Zero-config CLI: `inspect-robots "place the spoon on the plate"`
+
+## 1. Goal & motivation
+
+Today the only way to run an eval from the CLI is the fully explicit form:
+
+```bash
+inspect-robots run --task cubepick-reach --policy scripted --embodiment cubepick
+```
+
+The target UX is the `ollama run`-style one-liner for robotics:
+
+```bash
+inspect-robots "place the spoon on the plate"
+```
+
+which runs a **single ad-hoc scene** built from that language instruction using a
+**default policy and embodiment** the user configured once (e.g. a MolmoAct2-YAM
+checkpoint on a bimanual YAM rig, installed as plugins). The value is demo/
+smoke-test velocity: "point the framework at my robot and give it a command"
+without writing a Task or memorizing registry names.
+
+Non-goals (YAGNI):
+
+- No new benchmark semantics — an ad-hoc run is a normal `Task` with one `Scene`.
+- No plugin auto-selection magic ("if exactly one policy is installed, use it").
+  Defaults are explicit, user-set configuration.
+- No natural-language → Target/scorer synthesis. The instruction is passed to the
+  policy verbatim; success judgement comes from the operator (or an explicitly
+  chosen scorer).
+- No changes to plugin packaging or entry points.
+
+## 2. What exists today (grounding)
+
+- `cli.py`: argparse subcommands `list` / `run` / `inspect`; `run` requires
+  `--task/--policy/--embodiment` (registry names) and passes `-T/-P/-E k=v`
+  constructor args (`_parse_kvs`/`_parse_value`).
+- `Scene` already carries `instruction: str` (`scene.py`). `Task` is
+  `name + scenes + scorer + max_steps [+ epochs/control_hz/metadata]` (`task.py`).
+- Registry (`registry.py`) resolves by `(kind, name)` from builtins + entry
+  points. No notion of "default" components.
+- `TrialRecord.operator_judgement` exists (R6) and `operator_scorer` **reads** it,
+  but nothing in core ever *sets* it. Scoring happens inline in `eval.py`'s run
+  loop immediately after each trial (~L303–308); **errored trials are recorded
+  but never scored** (~L297–301, a CLAUDE.md invariant); the `LogSink.on_trial_end`
+  hook fires *after* scoring (~L309). `transcript.operator_event(t, verdict)`
+  exists, unused.
+- The persisted `EvalLog` (`log.py`) contains only `EvalSpec` (names/config/seed),
+  `EvalResults`, `EvalStats`, and per-scene `SceneResult(scene_id, status,
+  reduced, epochs, error)`. **Neither the scene instruction nor
+  `operator_judgement` is persisted today**; `JsonLogSink.on_trial_end` is a
+  no-op. `EvalLog.from_dict` constructs dataclasses with `**kwargs`, so adding
+  defaulted fields keeps the "newer reads older" guarantee at `SCHEMA_VERSION=1`.
+- Binding constraints: plan 0001 §9 — especially **R6** (operator judgement is
+  captured once during rollout as a recorded event; scorers only read it; v0
+  keeps CI/unattended runs non-blocking) and **R10** (YAGNI reservations).
+- Core is NumPy-only; py3.10–3.13 claimed (so **no `tomllib`**, which is 3.11+).
+- Gates: ruff, mypy `--strict` (src+tests), pytest at **100 % coverage**.
+
+## 3. Design
+
+### 3.1 CLI surface
+
+```bash
+# zero-config form (positional instruction; sugar for `run --instruction`)
+inspect-robots "place the spoon on the plate"
+
+# explicit form, mixable with any run flag
+inspect-robots run --instruction "place the spoon on the plate" \
+    --policy molmoact2-yam --embodiment yam-bimanual --max-steps 400
+```
+
+- **Bare-instruction sugar** lives in `main()`: let `tok = argv[0].strip()`;
+  if `argv` is non-empty, `tok` is not a known subcommand (`list`/`run`/
+  `inspect`), does not start with `-`, **and contains interior whitespace**,
+  rewrite to `["run", "--instruction", argv[0], *argv[1:]]`. The whitespace
+  requirement is a safety gate: a mistyped subcommand (`inspect-robots
+  isnpect`, `runs`) is a single token and must *not* silently start a robot
+  rollout — it falls through to argparse's normal "invalid choice" error.
+  Stripping before both checks means a whitespace-padded subcommand
+  (`inspect-robots " list "`, e.g. from a shell variable with a stray space)
+  is still treated as the subcommand, not as an instruction. Single-word
+  instructions use the explicit `run --instruction` form (documented). `build_parser()` stays
+  untouched; `--help`/`--version` behave as before.
+- **`run` changes** (all backward compatible):
+  - `--task` is no longer `required=True`. Exactly one of `--task` /
+    `--instruction` must be given (checked in `_cmd_run`, clear `SystemExit`
+    message otherwise — argparse mutually-exclusive groups can't express
+    "required XOR" across an option that used to be required, so validate
+    manually).
+  - `--policy` / `--embodiment` are no longer `required=True`; when omitted they
+    resolve through the defaults chain (§3.2). If the chain produces nothing →
+    `SystemExit` with a message that lists registered policies/embodiments and
+    shows both remedies (flag and config file).
+  - New flags `--max-steps` and `--scorer` (registry name), **`default=None`
+    sentinels** so "was it passed?" is detectable: with `--instruction` the
+    effective value is `flag | config | fallback` (fallbacks: 300 / `operator`).
+    Flag/argument validity is symmetric and explicit — with `--task`, passing
+    `--max-steps` or `--scorer` is a `SystemExit` error (a registered Task owns
+    its horizon and scorers); with `--instruction`, passing `-T k=v` is a
+    `SystemExit` error (the ad-hoc Task is constructed directly — there is no
+    task factory to receive `-T`). Silently ignoring flags would be a lie.
+    `-T` with `--task` keeps working exactly as today (backward compatible).
+  - New flag `--no-prompt`: disables the operator prompt (§3.4).
+- The run header prints what was resolved and from where **before** the eval
+  starts (i.e. before the embodiment resets), so defaults are never silent:
+  `policy: molmoact2-yam (from $XDG_CONFIG_HOME/inspect-robots/config.ini)`.
+
+### 3.2 Defaults resolution (new `src/inspect_robots/_defaults.py`)
+
+Precedence, first hit wins, per component kind:
+
+1. explicit CLI flag (`--policy` / `--embodiment`)
+2. environment: `INSPECT_ROBOTS_POLICY`, `INSPECT_ROBOTS_EMBODIMENT`
+3. user config file `<config-home>/inspect-robots/config.ini`, where
+   `<config-home>` = `env["XDG_CONFIG_HOME"]` if set, else `env["HOME"]/.config`
+   if `HOME` is set, else no config file. Derived **only from the injected env
+   mapping** — never `Path.home()` — so the fallback branch is testable without
+   touching the real home directory (and behaves predictably on Windows CI).
+4. nothing → caller raises the guidance error (§3.1)
+
+There is **no project-local config file**. A `./inspect-robots.ini` outranking
+user config would mean `cd untrusted-checkout && inspect-robots "..."` runs
+repo-chosen policy/embodiment/constructor args on the user's hardware — a
+`.envrc`-class footgun unacceptable for a tool that moves physical robots.
+(Revisit only with an explicit trust/allowlist mechanism.)
+
+Config file format is **INI via stdlib `configparser`** (works on py3.10; TOML
+would need `tomllib`≥3.11 or a new dep — rejected to keep the core NumPy-only).
+The parser is constructed with `inline_comment_prefixes=(";", "#")` so the
+documented examples with trailing comments parse as expected.
+
+```ini
+[defaults]
+policy = molmoact2-yam
+embodiment = yam-bimanual
+scorer = operator      ; optional, ad-hoc runs only
+max_steps = 300        ; optional, ad-hoc runs only
+
+[policy.args]          ; default -P k=v pairs, same value parsing as the CLI
+checkpoint = ~/ckpts/molmoact2-yam.pt
+
+[embodiment.args]      ; default -E k=v pairs
+cameras = wrist,front
+```
+
+- Values go through the existing `_parse_value` scalar parsing; additionally,
+  string values in `[policy.args]`/`[embodiment.args]` that start with `~` get
+  `os.path.expanduser` applied (checkpoint paths are the flagship use case and a
+  literal `~/...` string would fail silently deep inside a plugin).
+- Explicit `-P/-E k=v` flags **override** same-named config args (dict merge,
+  CLI wins); other config args still apply.
+- `_defaults.py` exposes one function:
+  `load_defaults(env: Mapping[str, str]) -> Defaults` (a frozen dataclass:
+  per-kind name + human-readable source description + args dicts). "Never a
+  traceback" covers value validation too, not just parse errors: malformed INI,
+  a non-integer or `< 1` `[defaults] max_steps`, and any other type-invalid
+  `[defaults]` value → `SystemExit` naming the file, key, and problem. Unknown
+  sections/keys are ignored (forward compatibility). Registry-name resolution
+  failures (unknown policy/embodiment/scorer, whether from flags, env, or
+  config) are caught in `_cmd_run` and re-raised as `SystemExit` listing the
+  available names — no raw `KeyError` traceback from the zero-config path.
+- **Not public API**: module is underscore-private, nothing added to
+  `inspect_robots.__all__` (no API-snapshot change — the snapshot is name-based).
+
+### 3.3 Ad-hoc task synthesis (in `cli.py`)
+
+```python
+Task(
+    name="adhoc",
+    scenes=[Scene(id="scene-0", instruction=<text>)],
+    scorer=<--scorer | config | "operator">,
+    max_steps=<--max-steps | config | 300>,
+    metadata={"instruction": <text>, "adhoc": True},
+)
+```
+
+`--epochs`, `--seed`, `--log-dir`, `--fail-on-error`, `--store-frames` all keep
+working — the ad-hoc task flows through the same `_cmd_run` path and produces a
+normal immutable `EvalLog` (log file name derives from the task name, `adhoc_*`).
+An ad-hoc `Scene` has `target=None`/`setup=None`, so it passes R7 realizability
+checks on any embodiment.
+
+### 3.4 Operator verdict capture
+
+Default scorer `operator` is useless unless something records the judgement. Per
+R6 the verdict must be captured before scoring, recorded on the trial, and merely
+read by the scorer. Today there is no seam. Add one:
+
+- `eval(..., before_scoring: Callable[[TrialRecord, Scene], None] | None = None)`
+  — keyword-only, default `None` → zero behavior change for every existing
+  caller. Named `before_scoring` (not `on_trial_end`) because a `LogSink` hook of
+  that name already exists and fires on the *other* side of scoring. **Firing
+  rule: invoked exactly once per trial that will be scored** — i.e. only for
+  trials with `record.status == "success"`. Errored trials (continuing
+  `PolicyError`, halting `EmbodimentFault`/`SafetyAbort`) are recorded but never
+  scored (existing invariant), so prompting a human for a verdict no scorer can
+  read would be dead data and a blocked terminal on a crashed trial. An exception
+  raised by the hook is not swallowed (caller-owned code; wrapping it would hide
+  bugs). `eval_set` forwards it.
+- The CLI passes a prompt hook **only on the ad-hoc (`--instruction`) path**,
+  and only when the resolved scorers include the `operator` scorer, stdin is a
+  TTY, and `--no-prompt` was not given. Registered `--task` runs are never
+  prompted — R6's binding "non-blocking, unattended-safe" property for benchmark
+  runs is untouched (a 50-scene × 5-epoch task must not produce 250 modal
+  prompts because its scorer list mentions `operator`). `--no-prompt` recovers
+  unattended behavior for ad-hoc runs left in a tmux TTY.
+- **Prompt contract**: `did the robot succeed? [y/n/partial/skip]` via
+  `input()`; answers are stripped/lower-cased; re-prompt on anything not in
+  `{y, yes, n, no, partial, skip}` (a typo like `yse` must not be recorded as a
+  failing verdict). `EOFError` counts as `skip`. `skip` → `operator_judgement`
+  stays `None` (scores as "no operator judgement recorded") and **no** operator
+  event is appended (`operator_event` requires a `str` verdict). Any other
+  answer is recorded verbatim (normalized) via `record.operator_judgement` plus
+  `transcript.operator_event(t=len(record.steps), verdict=...)` appended to
+  `record.events`. The prompt text notes that `partial` counts as failure in the
+  binary success metric (existing `_OPERATOR_SUCCESS` semantics; richer partial
+  credit is R10-reserved).
+
+### 3.5 Log persistence (small additive schema change)
+
+The persisted log today records neither what the robot was asked nor what the
+operator answered — which would make the ad-hoc log unreproducible and the
+operator flow untestable end-to-end. Two **additive, defaulted** fields on
+`SceneResult` (schema stays `SCHEMA_VERSION=1`; `from_dict` fills missing keys
+with defaults, so newer-reads-older still holds; the golden read-back test in
+`tests/test_eval_log.py` and the strict-JSON round-trips in
+`tests/test_strict_json.py` are updated):
+
+- `instruction: str | None = None` — copied from the `Scene` by `eval()` for
+  every task (useful beyond ad-hoc: a benchmark log becomes self-describing).
+- `operator_judgements: list[str | None] = field(default_factory=list)` —
+  **always strictly parallel to `epochs`** in newly written logs: exactly one
+  entry per recorded trial, `None` for a trial that was errored/unscored *or*
+  scored-but-unjudged (skip / no prompt), the verdict string otherwise. (Note
+  `epochs` itself gets `{}` for errored trials — eval.py appends per *recorded*
+  trial.) The `[]` default exists only so old logs without the field read back;
+  a mixed errored/judged scene is pinned by a test.
+
+Defaults *provenance* (flag vs env vs config) is printed in the run header but
+deliberately **not** persisted: the log already records the resolved
+policy/embodiment names and configs in `EvalSpec`, which is what reproduction
+needs; where the name came from is session UX.
+
+### 3.6 Alternatives considered
+
+- **Plugin-declared defaults** (entry-point group `inspect_robots.defaults`):
+  rejected — two installed plugins fight over the default, and "install changes
+  behavior" is spooky action.
+- **Auto-pick the only installed non-mock policy/embodiment**: rejected — adding
+  a second plugin silently changes what `inspect-robots "..."` does.
+- **TOML config**: rejected for py3.10 support without new deps (revisit when
+  the floor moves to 3.11).
+- **Default scorer `success_at_end`**: rejected as the ad-hoc default — real
+  robots have no success oracle for an arbitrary instruction, so it would report
+  a confident-looking `0.0` forever. `operator` is honest in both modes.
+- **Project-local config**: rejected (trust footgun, §3.2).
+
+## 4. File-level changes
+
+```
+inspect-robots/
+├── plans/0005-zero-config-cli.md            (this doc)
+├── src/inspect_robots/
+│   ├── _defaults.py                         (new: Defaults dataclass + load_defaults)
+│   ├── cli.py                               (argv sugar; run: instruction path,
+│   │                                         defaults chain, operator prompt hook)
+│   ├── eval.py                              (eval/eval_set: before_scoring param;
+│   │                                         populate SceneResult.instruction /
+│   │                                         operator_judgements)
+│   ├── log.py                               (SceneResult: two additive fields)
+│   └── CLAUDE.md                            (module map rows for _defaults/cli)
+├── tests/
+│   ├── test_defaults.py                     (new: precedence, INI parsing, errors)
+│   ├── test_registry_cli.py                 (extend: sugar, ad-hoc run e2e on mock,
+│   │                                         operator prompt, flag validation)
+│   ├── test_eval_orchestration.py           (extend: before_scoring hook)
+│   ├── test_eval_log.py                     (extend: golden read-back with and
+│   │                                         without the new SceneResult fields)
+│   └── test_strict_json.py                  (extend: round-trip new fields)
+├── docs/guide/cli.md                        (zero-config section + config file)
+├── README.md                                (one-liner in the CLI example block)
+└── CLAUDE.md                                (mention zero-config CLI where apt)
+```
+
+## 5. Testing (TDD; 100 % coverage; no vacuous tests)
+
+Every test asserts observable behavior (exit codes, stdout, written logs,
+recorded judgements) — not merely "function returns without raising".
+
+- **argv sugar**: `main(["place the spoon"])` runs the ad-hoc path (assert via
+  the written `adhoc_*` log); `main(["isnpect"])` (single token, no whitespace)
+  → argparse invalid-choice error, **no** eval runs; `main([])` prints help,
+  exit 0; `main(["list"])` still lists; `--version` unaffected.
+- **defaults precedence** (`test_defaults.py`, all through the injected `env`
+  mapping — no real `$HOME`/`$XDG_CONFIG_HOME` reads): flag > env > user INI >
+  error; `XDG_CONFIG_HOME` set / unset-with-`HOME` / neither (no config read);
+  args merge (CLI `-P` overrides same key from `[policy.args]`, non-colliding
+  config keys survive); `~` expansion on arg values; inline comments parse;
+  malformed INI → `SystemExit` naming the file; missing file → empty defaults;
+  value parsing (bool/int/none/str) matches `-P` parsing.
+- **run validation**: `--task` + `--instruction` together → error; neither →
+  error; `--max-steps` / `--scorer` / `-T` with `--task`+ad-hoc mismatches →
+  error (each direction); omitted policy/embodiment with no defaults → error
+  message lists registered names; sentinel logic: config `max_steps` wins when
+  the flag is omitted, flag wins when passed (including `--max-steps 300`
+  passed explicitly with a different config value — distinguishable only via
+  the `None` sentinel).
+- **ad-hoc e2e on the mock** (no hardware): env or flags select
+  `scripted`/`cubepick`; `inspect-robots "reach the cube" --scorer
+  success_at_end` runs, writes an `adhoc_*` log, exit code reflects status;
+  the written log's `samples[0].instruction` equals the CLI text;
+  `--max-steps`/`--epochs` honored (assert in the written log); resolved-
+  defaults header printed before the run with the correct source label.
+- **operator flow** (ad-hoc path): TTY + `operator` scorer → prompt called
+  (monkeypatched `input` and `isatty`), judgement lands in the written log's
+  `operator_judgements` and the `operator` scorer scores it; transcript
+  `operator` event appended with `t == len(record.steps)`; re-prompt on invalid
+  input (`yse` → re-ask, then `y` recorded); `skip` and `EOFError` → judgement
+  `None`, no event; non-TTY or `--no-prompt` → no prompt, score `False` with
+  the existing explanation; `--task` path never prompts even on a TTY with
+  `operator` scorer.
+- **`before_scoring` hook** (eval-level, independent of CLI): called exactly
+  once per **scored** trial with the record and scene, before scorers run
+  (observable: hook sets `operator_judgement`, operator scorer sees it); not
+  called for errored trials (continuing `PolicyError` path); default `None`
+  unchanged; hook exception propagates (not swallowed); `eval_set` forwards it.
+- **log schema**: old-format log JSON (without the new fields) still reads via
+  `read_eval_log` (defaults fill in); new fields serialize; goldens updated;
+  mixed-status scene (epoch 0 errors, epoch 1 scored and judged) pins
+  `operator_judgements == [None, "yes"]` parallel to `epochs == [{}, {...}]`.
+- **config validation**: `[defaults] max_steps = lots` (and `= 0`) →
+  `SystemExit` naming file/key, no traceback; unknown scorer/policy/embodiment
+  name from any source → `SystemExit` listing available names.
+- **Test-quality gate**: after implementation, a reviewer subagent audits the
+  new tests for vacuousness (assertions that cannot fail, mocks asserting on
+  themselves, coverage-only tests) and findings are fixed before the PR.
+
+## 6. Milestones (each = focused commit, gates green)
+
+1. `log.py` additive `SceneResult` fields + `eval()` populates `instruction` +
+   read-back tests.
+2. `eval()`/`eval_set()` `before_scoring` hook (+ `operator_judgements`
+   persistence) + orchestration tests.
+3. `_defaults.py` (load/merge/precedence) + `test_defaults.py`.
+4. `cli.py`: run-path rework (instruction XOR task, defaults chain, ad-hoc task,
+   operator prompt, resolved-defaults header) + argv sugar + CLI tests.
+5. Docs: `docs/guide/cli.md` zero-config section, README one-liner,
+   `src/inspect_robots/CLAUDE.md` module map.
+
+## 7. Out of scope / follow-ups
+
+- A first-party MolmoAct2/YAM plugin (separate package; this plan only makes the
+  configured-defaults UX possible for it).
+- `inspect-robots configure` interactive setup; VLM scoring of ad-hoc runs
+  (R10 reserved); TOML config once py3.10 support is dropped; project-local
+  config with a trust mechanism.

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -25,7 +25,8 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `log.py` | immutable, schema-versioned `EvalLog` + `read_eval_log` |
 | `logging/` | `LogSink` protocol, `JsonLogSink` (atomic), optional `RerunSink` |
 | `registry.py` | decorators + entry-point discovery; `_builtins.py` registers in-tree components |
-| `cli.py` | `inspect-robots list` / `inspect-robots run` / `inspect-robots inspect` |
+| `cli.py` | `inspect-robots list` / `run` / `inspect`, plus the zero-config form `inspect-robots "<instruction>"` (ad-hoc single-scene task; operator prompt on TTY) |
+| `_defaults.py` | user default policy/embodiment for the zero-config CLI: env vars > `~/.config/inspect-robots/config.ini` (INI — py3.10 has no tomllib; deliberately no project-local file) |
 | `mock/` | dependency-free `CubePick` world + scripted/random/noop policies |
 
 ## Key invariants

--- a/src/inspect_robots/_defaults.py
+++ b/src/inspect_robots/_defaults.py
@@ -1,0 +1,138 @@
+"""User-level default components for the zero-config CLI (plan 0005).
+
+``inspect-robots "place the spoon on the plate"`` needs a policy and an
+embodiment without flags. They come from, in order: explicit CLI flags
+(handled in ``cli.py``), the ``INSPECT_ROBOTS_POLICY`` /
+``INSPECT_ROBOTS_EMBODIMENT`` environment variables, then the user config
+file ``<config-home>/inspect-robots/config.ini`` (INI via stdlib
+``configparser`` — the core supports py3.10, which has no ``tomllib``).
+
+There is deliberately **no project-local config file**: a checked-in
+``./inspect-robots.ini`` choosing which policy runs on the user's hardware
+would be a trust footgun for a tool that moves physical robots.
+"""
+
+from __future__ import annotations
+
+import configparser
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+ENV_POLICY = "INSPECT_ROBOTS_POLICY"
+ENV_EMBODIMENT = "INSPECT_ROBOTS_EMBODIMENT"
+
+# Fallbacks for ad-hoc (instruction) runs when neither flag nor config decides.
+ADHOC_SCORER_FALLBACK = "operator"
+ADHOC_MAX_STEPS_FALLBACK = 300
+
+
+def parse_value(text: str) -> Any:
+    """Best-effort scalar parse for ``k=v`` args (bool/int/float/None/str)."""
+    low = text.lower()
+    if low in ("true", "false"):
+        return low == "true"
+    if low in ("none", "null"):
+        return None
+    for caster in (int, float):
+        try:
+            return caster(text)
+        except ValueError:
+            continue
+    return text
+
+
+@dataclass(frozen=True)
+class Defaults:
+    """Resolved user defaults, each with a human-readable source for the run header."""
+
+    policy: str | None = None
+    policy_source: str | None = None
+    embodiment: str | None = None
+    embodiment_source: str | None = None
+    scorer: str | None = None
+    max_steps: int | None = None
+    policy_args: dict[str, Any] = field(default_factory=dict)
+    embodiment_args: dict[str, Any] = field(default_factory=dict)
+
+
+def _config_path(env: Mapping[str, str]) -> Path | None:
+    """The user config file location, derived from ``env`` only (testable)."""
+    if xdg := env.get("XDG_CONFIG_HOME"):
+        home = Path(xdg)
+    elif user_home := env.get("HOME"):
+        home = Path(user_home) / ".config"
+    else:
+        return None
+    return home / "inspect-robots" / "config.ini"
+
+
+def _die(path: Path, problem: str) -> SystemExit:
+    return SystemExit(f"error in {path}: {problem}")
+
+
+def _parse_args_section(parser: configparser.ConfigParser, section: str) -> dict[str, Any]:
+    """An ``[<kind>.args]`` section as parsed kwargs, with ``~`` paths expanded."""
+    if not parser.has_section(section):
+        return {}
+    out: dict[str, Any] = {}
+    for key, raw in parser.items(section):
+        value = parse_value(raw)
+        if isinstance(value, str) and value.startswith("~"):
+            # Checkpoint paths are the flagship use; a literal "~/..." string
+            # would fail silently deep inside a plugin.
+            value = os.path.expanduser(value)
+        out[key] = value
+    return out
+
+
+def _read_config(path: Path) -> Defaults:
+    parser = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+    try:
+        with path.open(encoding="utf-8") as fh:
+            parser.read_file(fh)
+    except (configparser.Error, UnicodeDecodeError) as exc:
+        raise _die(path, f"malformed config: {exc}") from exc
+
+    source = str(path)
+    max_steps: int | None = None
+    if raw_steps := parser.get("defaults", "max_steps", fallback=None):
+        parsed = parse_value(raw_steps)
+        if not isinstance(parsed, int) or isinstance(parsed, bool) or parsed < 1:
+            raise _die(path, f"[defaults] max_steps must be an integer >= 1, got {raw_steps!r}")
+        max_steps = parsed
+
+    policy = parser.get("defaults", "policy", fallback=None)
+    embodiment = parser.get("defaults", "embodiment", fallback=None)
+    return Defaults(
+        policy=policy,
+        policy_source=source if policy else None,
+        embodiment=embodiment,
+        embodiment_source=source if embodiment else None,
+        scorer=parser.get("defaults", "scorer", fallback=None),
+        max_steps=max_steps,
+        policy_args=_parse_args_section(parser, "policy.args"),
+        embodiment_args=_parse_args_section(parser, "embodiment.args"),
+    )
+
+
+def load_defaults(env: Mapping[str, str]) -> Defaults:
+    """Load user defaults: environment variables override the config file.
+
+    ``env`` is injected (pass ``os.environ``) so tests never touch the real
+    home directory. A missing config file yields empty defaults; a malformed
+    or type-invalid one raises ``SystemExit`` naming the file — the
+    zero-config path must never print a traceback at the user.
+    """
+    from dataclasses import replace
+
+    path = _config_path(env)
+    defaults = _read_config(path) if path is not None and path.is_file() else Defaults()
+
+    if policy := env.get(ENV_POLICY):
+        defaults = replace(defaults, policy=policy, policy_source=f"${ENV_POLICY}")
+    if embodiment := env.get(ENV_EMBODIMENT):
+        defaults = replace(defaults, embodiment=embodiment, embodiment_source=f"${ENV_EMBODIMENT}")
+    return defaults

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -9,15 +9,37 @@ Subcommands:
   ``--epochs``, ``--fail-on-error``, and ``--store-frames`` tune the run. The
   written log's path is printed at the end.
 - ``inspect-robots inspect LOG.json`` — print a saved eval log.
+
+Zero-config form (plan 0005): ``inspect-robots "place the spoon on the plate"``
+is sugar for ``run --instruction "..."`` — a single ad-hoc scene on the user's
+default policy/embodiment (flags > ``INSPECT_ROBOTS_POLICY``/``_EMBODIMENT``
+env vars > ``~/.config/inspect-robots/config.ini``). The sugar only fires for
+a first argument with interior whitespace, so a mistyped subcommand
+(``inspect-robots isnpect``) errors instead of starting a robot rollout;
+single-word instructions use the explicit ``run --instruction`` form.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
+import sys
 from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from inspect_robots import __version__
+from inspect_robots._defaults import (
+    ADHOC_MAX_STEPS_FALLBACK,
+    ADHOC_SCORER_FALLBACK,
+    ENV_EMBODIMENT,
+    ENV_POLICY,
+    load_defaults,
+    parse_value,
+)
+
+if TYPE_CHECKING:
+    from inspect_robots.rollout import TrialRecord
+    from inspect_robots.scene import Scene
 
 _KIND_BY_PLURAL = {
     "tasks": "task",
@@ -27,20 +49,11 @@ _KIND_BY_PLURAL = {
     "sinks": "sink",
 }
 
+_PLURAL_BY_KIND = {kind: plural for plural, kind in _KIND_BY_PLURAL.items()}
 
-def _parse_value(text: str) -> Any:
-    """Best-effort scalar parse for ``k=v`` CLI args (bool/int/float/None/str)."""
-    low = text.lower()
-    if low in ("true", "false"):
-        return low == "true"
-    if low in ("none", "null"):
-        return None
-    for caster in (int, float):
-        try:
-            return caster(text)
-        except ValueError:
-            continue
-    return text
+_SUBCOMMANDS = ("list", "run", "inspect")
+
+_ENV_BY_KIND = {"policy": ENV_POLICY, "embodiment": ENV_EMBODIMENT}
 
 
 def _parse_kvs(pairs: Sequence[str] | None) -> dict[str, Any]:
@@ -49,7 +62,7 @@ def _parse_kvs(pairs: Sequence[str] | None) -> dict[str, Any]:
         if "=" not in pair:
             raise SystemExit(f"expected key=value, got {pair!r}")
         key, _, value = pair.partition("=")
-        out[key] = _parse_value(value)
+        out[key] = parse_value(value)
     return out
 
 
@@ -70,15 +83,38 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     p_run = sub.add_parser("run", help="run an evaluation")
-    p_run.add_argument("--task", required=True, help="registered task name")
-    p_run.add_argument("--policy", required=True, help="registered policy name")
-    p_run.add_argument("--embodiment", required=True, help="registered embodiment name")
+    p_run.add_argument("--task", help="registered task name")
+    p_run.add_argument(
+        "--instruction",
+        help="run a single ad-hoc scene with this language instruction "
+        "(instead of a registered --task)",
+    )
+    p_run.add_argument("--policy", help="registered policy name (default: user config)")
+    p_run.add_argument("--embodiment", help="registered embodiment name (default: user config)")
     p_run.add_argument("-T", dest="task_args", action="append", metavar="k=v")
     p_run.add_argument("-P", dest="policy_args", action="append", metavar="k=v")
     p_run.add_argument("-E", dest="embodiment_args", action="append", metavar="k=v")
     p_run.add_argument("--log-dir", default="logs")
     p_run.add_argument("--seed", type=int, default=0)
     p_run.add_argument("--epochs", type=int, default=None, help="override the task's epoch count")
+    p_run.add_argument(
+        "--max-steps",
+        type=int,
+        default=None,
+        help="horizon of an --instruction run (default: config or "
+        f"{ADHOC_MAX_STEPS_FALLBACK}); invalid with --task",
+    )
+    p_run.add_argument(
+        "--scorer",
+        default=None,
+        help="scorer for an --instruction run (default: config or "
+        f"{ADHOC_SCORER_FALLBACK!r}); invalid with --task",
+    )
+    p_run.add_argument(
+        "--no-prompt",
+        action="store_true",
+        help="never ask the terminal operator for a success verdict",
+    )
     p_run.add_argument(
         "--fail-on-error",
         type=float,
@@ -112,18 +148,133 @@ def _cmd_list(what: str | None) -> int:
     return 0
 
 
+def _pick_component(
+    kind: str, flag_value: str | None, default: str | None, source: str | None
+) -> tuple[str, str]:
+    """Resolve a component name via flag > defaults, or exit with guidance."""
+    if flag_value:
+        return flag_value, f"--{kind}"
+    if default:
+        return default, f"from {source}"
+    from inspect_robots.registry import registered
+
+    names = ", ".join(sorted(registered(kind))) or "(none)"
+    raise SystemExit(
+        f"no {kind} given and no default configured.\n"
+        f"registered {_PLURAL_BY_KIND[kind]}: {names}\n"
+        f"fix: pass --{kind} NAME, set ${_ENV_BY_KIND[kind]}, or add "
+        f"'{kind} = NAME' under [defaults] in ~/.config/inspect-robots/config.ini"
+    )
+
+
+def _resolve_or_exit(kind: str, name: str, /, **kwargs: Any) -> Any:
+    """Registry resolution with a clean error instead of a KeyError traceback."""
+    from inspect_robots.registry import resolve
+
+    try:
+        return resolve(kind, name, **kwargs)
+    except KeyError as exc:
+        raise SystemExit(str(exc.args[0])) from exc
+
+
+_PROMPT = "did the robot succeed? [y/n/partial/skip] (partial scores as failure) "
+_PROMPT_ANSWERS = frozenset({"y", "yes", "n", "no", "partial", "skip"})
+
+
+def _prompt_operator(record: TrialRecord, scene: Scene) -> None:
+    """Capture the terminal operator's verdict on the record (R6)."""
+    from inspect_robots.transcript import operator_event
+
+    del scene
+    while True:
+        try:
+            answer = input(_PROMPT).strip().lower()
+        except EOFError:
+            answer = "skip"
+        if answer in _PROMPT_ANSWERS:
+            break
+        print(f"unrecognized answer {answer!r}; expected one of y/n/partial/skip")
+    if answer == "skip":
+        return
+    record.operator_judgement = answer
+    record.events.append(operator_event(t=len(record.steps), verdict=answer))
+
+
 def _cmd_run(args: argparse.Namespace) -> int:
     from dataclasses import replace
 
     from inspect_robots import eval
     from inspect_robots.logging import JsonLogSink
-    from inspect_robots.registry import resolve
+    from inspect_robots.scene import Scene
+    from inspect_robots.task import Task
 
-    task = resolve("task", args.task, **_parse_kvs(args.task_args))
-    policy = resolve("policy", args.policy, **_parse_kvs(args.policy_args))
-    embodiment = resolve("embodiment", args.embodiment, **_parse_kvs(args.embodiment_args))
+    is_adhoc = args.instruction is not None
+    if is_adhoc and args.task:
+        raise SystemExit("pass exactly one of --task or --instruction, not both")
+    if not is_adhoc and not args.task:
+        raise SystemExit("pass a registered --task name or an --instruction to run")
+    if not is_adhoc:
+        if args.max_steps is not None:
+            raise SystemExit(
+                "--max-steps only applies to --instruction runs; a registered task owns its horizon"
+            )
+        if args.scorer is not None:
+            raise SystemExit(
+                "--scorer only applies to --instruction runs; a registered task owns its scorers"
+            )
+    elif args.task_args:
+        raise SystemExit(
+            "-T only applies to --task runs; an ad-hoc instruction task takes no constructor args"
+        )
+
+    defaults = load_defaults(os.environ)
+    policy_name, policy_source = _pick_component(
+        "policy", args.policy, defaults.policy, defaults.policy_source
+    )
+    embodiment_name, embodiment_source = _pick_component(
+        "embodiment", args.embodiment, defaults.embodiment, defaults.embodiment_source
+    )
+    # Config-file args apply to whichever component is selected; explicit
+    # -P/-E flags override same-named keys.
+    policy_kvs = {**defaults.policy_args, **_parse_kvs(args.policy_args)}
+    embodiment_kvs = {**defaults.embodiment_args, **_parse_kvs(args.embodiment_args)}
+
+    if is_adhoc:
+        scorer_name = args.scorer or defaults.scorer or ADHOC_SCORER_FALLBACK
+        max_steps = (
+            args.max_steps
+            if args.max_steps is not None
+            else (defaults.max_steps or ADHOC_MAX_STEPS_FALLBACK)
+        )
+        task = Task(
+            name="adhoc",
+            scenes=[Scene(id="scene-0", instruction=args.instruction)],
+            scorer=_resolve_or_exit("scorer", scorer_name),
+            max_steps=max_steps,
+            metadata={"instruction": args.instruction, "adhoc": True},
+        )
+    else:
+        task = _resolve_or_exit("task", args.task, **_parse_kvs(args.task_args))
+
+    policy = _resolve_or_exit("policy", policy_name, **policy_kvs)
+    embodiment = _resolve_or_exit("embodiment", embodiment_name, **embodiment_kvs)
     if args.epochs is not None:
         task = replace(task, epochs=args.epochs)
+
+    # Defaults must never be silent: say what runs, and why, before it moves.
+    print(f"policy: {policy_name} ({policy_source})")
+    print(f"embodiment: {embodiment_name} ({embodiment_source})")
+
+    before_scoring = None
+    if (
+        is_adhoc
+        and not args.no_prompt
+        and sys.stdin.isatty()
+        and any(s.name == "operator" for s in task.scorers)
+    ):
+        # Ad-hoc runs only: a registered task with an operator scorer keeps
+        # R6's non-blocking, unattended-safe behavior (judgement stays None).
+        before_scoring = _prompt_operator
 
     # Construct the sink explicitly so we can tell the user where the log went.
     sink = JsonLogSink(args.log_dir)
@@ -136,6 +287,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         sinks=[sink],
         fail_on_error=args.fail_on_error if args.fail_on_error is not None else False,
         store_frames=args.store_frames,
+        before_scoring=before_scoring,
     )
     log = logs[0]
     print(f"status: {log.status}")
@@ -169,9 +321,26 @@ def _cmd_inspect(path: str) -> int:
     return 0 if log.status == "success" else 1
 
 
+def _apply_instruction_sugar(argv: list[str]) -> list[str]:
+    """``inspect-robots "wipe the table"`` → ``run --instruction "wipe the table"``.
+
+    Fires only for a first argument that is not a subcommand or flag AND has
+    interior whitespace after stripping: a mistyped subcommand
+    (``inspect-robots isnpect``) or a whitespace-padded one
+    (``inspect-robots " list "``) must never silently start a rollout.
+    """
+    if not argv:
+        return argv
+    tok = argv[0].strip()
+    if tok in _SUBCOMMANDS or tok.startswith("-") or not any(ch.isspace() for ch in tok):
+        return argv
+    return ["run", "--instruction", argv[0], *argv[1:]]
+
+
 def main(argv: Sequence[str] | None = None) -> int:
+    argv_list = list(argv) if argv is not None else sys.argv[1:]
     parser = build_parser()
-    args = parser.parse_args(argv)
+    args = parser.parse_args(_apply_instruction_sugar(argv_list))
     if args.command == "list":
         return _cmd_list(args.what)
     if args.command == "run":

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import os
 import subprocess
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -29,6 +29,7 @@ from inspect_robots.frames import FrameStore
 from inspect_robots.log import EvalLog, EvalResults, EvalSpec, EvalStats, SceneResult
 from inspect_robots.policy import Policy
 from inspect_robots.rollout import TrialRecord, derive_seed, rollout
+from inspect_robots.scene import Scene
 from inspect_robots.scorer import Score, get_reducer, reduce_scores, value_to_float
 from inspect_robots.task import Task
 
@@ -113,6 +114,7 @@ def eval(
     approver: Approver | None = None,
     remap: dict[str, str] | None = None,
     store_frames: bool = False,
+    before_scoring: Callable[[TrialRecord, Scene], None] | None = None,
 ) -> list[EvalLog]:
     """Run ``task`` with ``policy`` on ``embodiment``; return ``[EvalLog]``.
 
@@ -137,6 +139,13 @@ def eval(
 
     When ``store_frames`` is set, camera frames are streamed to
     ``<log_dir>/frames`` as binary side-cars (R5) rather than kept in memory.
+
+    ``before_scoring`` is called exactly once per trial that will be scored
+    (never for errored trials, which are recorded but not scored), after the
+    rollout returns and before the scorers run. It may mutate the record —
+    e.g. capture ``TrialRecord.operator_judgement`` (R6) so the ``operator``
+    scorer can read it. Exceptions it raises propagate to the caller. Note
+    this fires on the *other* side of scoring from ``LogSink.on_trial_end``.
 
     Raises [`CompatibilityError`][inspect_robots.errors.CompatibilityError] (fail fast, before any
     rollout) if the policy and embodiment are incompatible, and
@@ -165,6 +174,7 @@ def eval(
             approver=approver,
             remap=remap,
             store_frames=store_frames,
+            before_scoring=before_scoring,
         )
     finally:
         # Close what we opened: a registry-resolved embodiment is released even
@@ -186,6 +196,7 @@ def _run_eval(
     approver: Approver | None,
     remap: dict[str, str] | None,
     store_frames: bool,
+    before_scoring: Callable[[TrialRecord, Scene], None] | None,
 ) -> list[EvalLog]:
     """The body of [`eval`][inspect_robots.eval.eval], after resolution/ownership."""
     from inspect_robots.logging.json_log import JsonLogSink
@@ -248,6 +259,7 @@ def _run_eval(
     for scene in task.scenes:
         per_scorer_scores: dict[str, list[Score]] = {s.name: [] for s in scorers}
         epoch_dicts: list[dict[str, float]] = []
+        judgements: list[str | None] = []
         scene_status = "success"
         scene_error: str | None = None
 
@@ -299,13 +311,20 @@ def _run_eval(
                     # masquerade as data (e.g. an inf min-distance poisoning
                     # the metric mean). It stays visible via scene status.
                     epoch_dicts.append({})
+                    judgements.append(None)
                 else:
+                    if before_scoring is not None:
+                        # The only trials the hook sees are the ones scorers
+                        # will read — an operator verdict on a crashed trial
+                        # would be dead data (errored trials are never scored).
+                        before_scoring(record, scene)
                     epoch_values: dict[str, float] = {}
                     for scorer in scorers:
                         score = scorer(record, scene.target)
                         per_scorer_scores[scorer.name].append(score)
                         epoch_values[scorer.name] = value_to_float(score.value)
                     epoch_dicts.append(epoch_values)
+                    judgements.append(record.operator_judgement)
                 bus.on_trial_end(record)
 
             if halted:
@@ -345,6 +364,8 @@ def _run_eval(
                 reduced=reduced,
                 epochs=epoch_dicts,
                 error=scene_error,
+                instruction=scene.instruction,
+                operator_judgements=judgements,
             )
         )
         if stopped:
@@ -404,6 +425,7 @@ def eval_set(
     approver: Approver | None = None,
     remap: dict[str, str] | None = None,
     store_frames: bool = False,
+    before_scoring: Callable[[TrialRecord, Scene], None] | None = None,
     retry_attempts: int = 0,
 ) -> tuple[bool, list[EvalLog]]:
     """Run a set of tasks and return ``(success, logs)`` (mirrors Inspect AI).
@@ -429,6 +451,7 @@ def eval_set(
                 approver=approver,
                 remap=remap,
                 store_frames=store_frames,
+                before_scoring=before_scoring,
             )
         )
     success = all(log.status == "success" for log in logs)

--- a/src/inspect_robots/log.py
+++ b/src/inspect_robots/log.py
@@ -53,6 +53,12 @@ class SceneResult:
     reduced: dict[str, float] = field(default_factory=dict)
     epochs: list[dict[str, float]] = field(default_factory=list)
     error: str | None = None
+    # What the scene asked the policy to do — makes a log self-describing.
+    instruction: str | None = None
+    # Strictly parallel to ``epochs``: the operator's verdict per recorded
+    # trial, ``None`` when the trial errored or no judgement was captured.
+    # Defaults keep logs written before these fields existed readable.
+    operator_judgements: list[str | None] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/test_coverage_completion.py
+++ b/tests/test_coverage_completion.py
@@ -17,8 +17,9 @@ import pytest
 import inspect_robots.controller as controller_mod
 import inspect_robots.registry as reg
 from inspect_robots import eval
+from inspect_robots._defaults import parse_value as _parse_value
 from inspect_robots.approver import AutoApprover, ClampApprover
-from inspect_robots.cli import _parse_kvs, _parse_value, main
+from inspect_robots.cli import _parse_kvs, main
 from inspect_robots.compat import check_compatibility
 from inspect_robots.controller import DefaultController, EnsemblingController, SmoothingController
 from inspect_robots.embodiment import EmbodimentInfo

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,128 @@
+"""User defaults for the zero-config CLI: config-file parsing and precedence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from inspect_robots._defaults import (
+    ENV_EMBODIMENT,
+    ENV_POLICY,
+    Defaults,
+    load_defaults,
+    parse_value,
+)
+
+
+def _write_config(config_home: Path, body: str) -> Path:
+    path = config_home / "inspect-robots" / "config.ini"
+    path.parent.mkdir(parents=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+_FULL_CONFIG = """
+[defaults]
+policy = molmoact2-yam
+embodiment = yam-bimanual
+scorer = operator      ; ad-hoc runs only
+max_steps = 450
+
+[policy.args]
+checkpoint = ~/ckpts/molmoact2-yam.pt
+temperature = 0.5
+verbose = true
+
+[embodiment.args]
+cameras = wrist,front
+port = none
+"""
+
+
+def test_full_config_parses_with_inline_comments_and_expansion(tmp_path: Path) -> None:
+    _write_config(tmp_path, _FULL_CONFIG)
+    d = load_defaults({"XDG_CONFIG_HOME": str(tmp_path)})
+    assert d.policy == "molmoact2-yam"
+    assert d.embodiment == "yam-bimanual"
+    assert d.scorer == "operator"  # inline comment stripped
+    assert d.max_steps == 450
+    assert d.policy_source == str(tmp_path / "inspect-robots" / "config.ini")
+    assert d.embodiment_source == d.policy_source
+    # ~ expanded, and value parsing matches the CLI's -P/-E parsing.
+    checkpoint = d.policy_args["checkpoint"]
+    assert isinstance(checkpoint, str) and not checkpoint.startswith("~")
+    assert checkpoint.endswith("ckpts/molmoact2-yam.pt")
+    assert d.policy_args["temperature"] == 0.5
+    assert d.policy_args["verbose"] is True
+    assert d.embodiment_args == {"cameras": "wrist,front", "port": None}
+
+
+def test_env_vars_override_config_names_but_not_args(tmp_path: Path) -> None:
+    _write_config(tmp_path, _FULL_CONFIG)
+    d = load_defaults(
+        {
+            "XDG_CONFIG_HOME": str(tmp_path),
+            ENV_POLICY: "other-policy",
+            ENV_EMBODIMENT: "other-arm",
+        }
+    )
+    assert d.policy == "other-policy"
+    assert d.policy_source == f"${ENV_POLICY}"
+    assert d.embodiment == "other-arm"
+    assert d.embodiment_source == f"${ENV_EMBODIMENT}"
+    # Config-file args still apply to whatever component ends up selected.
+    assert d.policy_args["temperature"] == 0.5
+
+
+def test_env_vars_work_without_any_config_file(tmp_path: Path) -> None:
+    d = load_defaults({"XDG_CONFIG_HOME": str(tmp_path), ENV_POLICY: "p1"})
+    assert d.policy == "p1"
+    assert d.embodiment is None
+    assert d.policy_args == {}
+
+
+def test_home_fallback_when_xdg_unset(tmp_path: Path) -> None:
+    _write_config(tmp_path / ".config", "[defaults]\npolicy = from-home\n")
+    d = load_defaults({"HOME": str(tmp_path)})
+    assert d.policy == "from-home"
+    assert d.embodiment is None  # unset keys stay None
+
+
+def test_no_home_and_no_xdg_means_no_config(tmp_path: Path) -> None:
+    assert load_defaults({}) == Defaults()
+
+
+def test_missing_config_file_means_empty_defaults(tmp_path: Path) -> None:
+    assert load_defaults({"XDG_CONFIG_HOME": str(tmp_path)}) == Defaults()
+
+
+def test_unknown_sections_and_keys_are_ignored(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        "[defaults]\npolicy = p\nfuture_knob = 7\n\n[future.section]\nx = 1\n",
+    )
+    d = load_defaults({"XDG_CONFIG_HOME": str(tmp_path)})
+    assert d.policy == "p"
+
+
+def test_malformed_ini_raises_system_exit_naming_file(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, "not an ini file [\n===\n")
+    with pytest.raises(SystemExit, match=str(path)):
+        load_defaults({"XDG_CONFIG_HOME": str(tmp_path)})
+
+
+@pytest.mark.parametrize("bad", ["lots", "0", "-3", "true", "2.5"])
+def test_invalid_max_steps_raises_system_exit(tmp_path: Path, bad: str) -> None:
+    _write_config(tmp_path, f"[defaults]\nmax_steps = {bad}\n")
+    with pytest.raises(SystemExit, match="max_steps"):
+        load_defaults({"XDG_CONFIG_HOME": str(tmp_path)})
+
+
+def test_parse_value_scalars() -> None:
+    assert parse_value("true") is True
+    assert parse_value("False") is False
+    assert parse_value("none") is None
+    assert parse_value("42") == 42
+    assert parse_value("2.5") == 2.5
+    assert parse_value("hello") == "hello"

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -98,12 +98,13 @@ def test_missing_config_file_means_empty_defaults(tmp_path: Path) -> None:
 
 
 def test_unknown_sections_and_keys_are_ignored(tmp_path: Path) -> None:
-    _write_config(
+    path = _write_config(
         tmp_path,
         "[defaults]\npolicy = p\nfuture_knob = 7\n\n[future.section]\nx = 1\n",
     )
     d = load_defaults({"XDG_CONFIG_HOME": str(tmp_path)})
-    assert d.policy == "p"
+    # Full equality: the unknown key and section contributed nothing at all.
+    assert d == Defaults(policy="p", policy_source=str(path))
 
 
 def test_malformed_ini_raises_system_exit_naming_file(tmp_path: Path) -> None:

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -109,7 +110,8 @@ def test_unknown_sections_and_keys_are_ignored(tmp_path: Path) -> None:
 
 def test_malformed_ini_raises_system_exit_naming_file(tmp_path: Path) -> None:
     path = _write_config(tmp_path, "not an ini file [\n===\n")
-    with pytest.raises(SystemExit, match=str(path)):
+    # re.escape: a Windows path's backslashes are not a regex.
+    with pytest.raises(SystemExit, match=re.escape(str(path))):
         load_defaults({"XDG_CONFIG_HOME": str(tmp_path)})
 
 

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -42,7 +42,16 @@ def _golden_log() -> EvalLog:
             duration_s=1.0,
             total_steps=12,
         ),
-        samples=[SceneResult(scene_id="s0", status="success", reduced={"success_at_end": 1.0})],
+        samples=[
+            SceneResult(
+                scene_id="s0",
+                status="success",
+                reduced={"success_at_end": 1.0},
+                epochs=[{"success_at_end": 1.0}],
+                instruction="reach the cube",
+                operator_judgements=["yes"],
+            )
+        ],
     )
 
 
@@ -61,6 +70,23 @@ def test_golden_log_reads_back(tmp_path: Path) -> None:
     assert restored.version == SCHEMA_VERSION
     assert restored.eval.git_commit == "deadbeef"
     assert restored.samples[0].scene_id == "s0"
+    assert restored.samples[0].instruction == "reach the cube"
+    assert restored.samples[0].operator_judgements == ["yes"]
+
+
+def test_pre_instruction_log_without_new_scene_fields_reads_back(tmp_path: Path) -> None:
+    # Logs written before SceneResult grew instruction/operator_judgements
+    # must stay readable at the same schema version (newer reads older).
+    data = _golden_log().to_dict()
+    for sample in data["samples"]:
+        del sample["instruction"]
+        del sample["operator_judgements"]
+    path = tmp_path / "old.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    restored = read_eval_log(str(path))
+    assert restored.samples[0].reduced == {"success_at_end": 1.0}
+    assert restored.samples[0].instruction is None
+    assert restored.samples[0].operator_judgements == []
 
 
 def test_unsupported_schema_version_rejected() -> None:

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from inspect_robots import eval
+from inspect_robots import eval, eval_set
 from inspect_robots.errors import ConfigError, EmbodimentFault, PolicyError
 from inspect_robots.eval import _git_commit
 from inspect_robots.log import EvalLog
@@ -18,7 +18,7 @@ from inspect_robots.policy import PolicyConfig, PolicyInfo
 from inspect_robots.registry import embodiment as embodiment_decorator
 from inspect_robots.rollout import TrialRecord
 from inspect_robots.scene import Scene
-from inspect_robots.scorer import min_distance_to_goal, success_at_end
+from inspect_robots.scorer import min_distance_to_goal, operator_scorer, success_at_end
 from inspect_robots.spaces import ActionSemantics, Box
 from inspect_robots.task import Epochs, Task
 from inspect_robots.types import Action, ActionChunk, Observation, StepResult
@@ -318,3 +318,83 @@ def test_git_commit_clean_tree_has_no_suffix(monkeypatch: pytest.MonkeyPatch) ->
 
     monkeypatch.setattr("subprocess.run", fake_run)
     assert _git_commit() == "abc123"
+
+
+# --------------------------------------------------------------------------- #
+# 8. before_scoring hook: the R6 seam for capturing operator judgements.
+# --------------------------------------------------------------------------- #
+def test_before_scoring_runs_before_scorers_and_persists_judgement(tmp_path: Path) -> None:
+    task = _task(scorer=operator_scorer())
+    seen: list[tuple[str, int]] = []
+
+    def judge(record: TrialRecord, scene: Scene) -> None:
+        seen.append((scene.id, record.epoch))
+        record.operator_judgement = "yes"
+
+    (log,) = eval(
+        task, ScriptedPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path), before_scoring=judge
+    )
+    assert seen == [("s0", 0)]
+    # The operator scorer read the verdict, so the hook ran before scoring.
+    assert log.results.metrics["operator"] == 1.0
+    assert log.samples[0].operator_judgements == ["yes"]
+    assert log.samples[0].instruction == "reach"
+
+
+def test_before_scoring_skipped_for_errored_trials(tmp_path: Path) -> None:
+    # Epoch 0 succeeds and is judged; epoch 1 errors (PolicyError) and must
+    # neither be scored nor prompt the hook — its judgement slot stays None,
+    # parallel to the empty epochs entry.
+    task = _task(epochs=2, scorer=operator_scorer())
+    calls: list[int] = []
+
+    def judge(record: TrialRecord, scene: Scene) -> None:
+        calls.append(record.epoch)
+        record.operator_judgement = "yes"
+
+    (log,) = eval(
+        task,
+        _BoomOnSecondEpochPolicy(),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+        before_scoring=judge,
+    )
+    assert calls == [0]
+    scene = log.samples[0]
+    assert scene.epochs == [{"operator": 1.0}, {}]
+    assert scene.operator_judgements == ["yes", None]
+
+
+def test_before_scoring_exception_propagates(tmp_path: Path) -> None:
+    def bad_hook(record: TrialRecord, scene: Scene) -> None:
+        raise RuntimeError("hook exploded")
+
+    with pytest.raises(RuntimeError, match="hook exploded"):
+        eval(
+            _task(),
+            ScriptedPolicy(),
+            CubePickEmbodiment(),
+            log_dir=str(tmp_path),
+            before_scoring=bad_hook,
+        )
+
+
+def test_before_scoring_default_none_records_no_judgements(tmp_path: Path) -> None:
+    (log,) = eval(_task(epochs=2), ScriptedPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path))
+    assert log.samples[0].operator_judgements == [None, None]
+
+
+def test_eval_set_forwards_before_scoring(tmp_path: Path) -> None:
+    def judge(record: TrialRecord, scene: Scene) -> None:
+        record.operator_judgement = "pass"
+
+    success, logs = eval_set(
+        _task(scorer=operator_scorer()),
+        ScriptedPolicy(),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+        before_scoring=judge,
+    )
+    assert success
+    assert logs[0].samples[0].operator_judgements == ["pass"]
+    assert logs[0].results.metrics["operator"] == 1.0

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -7,9 +7,29 @@ from pathlib import Path
 import pytest
 
 import inspect_robots.registry as reg
+from inspect_robots._defaults import ENV_EMBODIMENT, ENV_POLICY
 from inspect_robots.cli import main
+from inspect_robots.log import EvalLog
 from inspect_robots.mock import ScriptedPolicy
 from inspect_robots.registry import registered, resolve
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_defaults(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Keep CLI runs blind to the developer's real config file and env vars."""
+    config_home = tmp_path / "config-home"
+    config_home.mkdir()
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+    monkeypatch.delenv(ENV_POLICY, raising=False)
+    monkeypatch.delenv(ENV_EMBODIMENT, raising=False)
+    return config_home
+
+
+def _write_config(config_home: Path, body: str) -> Path:
+    path = config_home / "inspect-robots" / "config.ini"
+    path.parent.mkdir()
+    path.write_text(body, encoding="utf-8")
+    return path
 
 
 def test_builtins_are_registered() -> None:
@@ -114,3 +134,292 @@ def test_cli_run_epochs_fail_on_error_store_frames(
 def test_cli_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
     assert main([]) == 0
     assert "Inspect Robots" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# Zero-config CLI (plan 0005): instruction sugar, defaults chain, operator flow.
+# --------------------------------------------------------------------------- #
+def _read_only_log(log_dir: Path) -> EvalLog:
+    from inspect_robots import read_eval_log
+
+    (path,) = log_dir.glob("*.json")
+    return read_eval_log(str(path))
+
+
+def test_bare_instruction_runs_adhoc_task_from_env_defaults(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv(ENV_POLICY, "scripted")
+    monkeypatch.setenv(ENV_EMBODIMENT, "cubepick")
+    log_dir = tmp_path / "logs"
+    rc = main(["reach the cube", "--scorer", "success_at_end", "--log-dir", str(log_dir)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"policy: scripted (from ${ENV_POLICY})" in out
+    assert f"embodiment: cubepick (from ${ENV_EMBODIMENT})" in out
+    log = _read_only_log(log_dir)
+    assert log.eval.task == "adhoc"
+    assert log.samples[0].instruction == "reach the cube"
+    assert log.results.metrics["success_at_end"] == 1.0
+
+
+def test_config_file_supplies_defaults_and_adhoc_settings(
+    _hermetic_defaults: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config = _write_config(
+        _hermetic_defaults,
+        "[defaults]\n"
+        "policy = scripted\n"
+        "embodiment = cubepick\n"
+        "scorer = success_at_end\n"
+        "max_steps = 50\n"
+        "[policy.args]\n"
+        "chunk_size = 6\n",
+    )
+    log_dir = tmp_path / "logs"
+    rc = main(["reach the cube", "--log-dir", str(log_dir)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"policy: scripted (from {config})" in out
+    log = _read_only_log(log_dir)
+    assert log.samples[0].instruction == "reach the cube"
+    # [policy.args] chunk_size=6 reached the policy constructor (recorded in
+    # the log as the policy's action_horizon).
+    assert log.eval.policy_config["action_horizon"] == 6
+
+
+def test_cli_flags_beat_config_defaults_and_args(
+    _hermetic_defaults: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\n"
+        "policy = noop\n"
+        "embodiment = cubepick\n"
+        "scorer = success_at_end\n"
+        "[policy.args]\n"
+        "chunk_size = 6\n",
+    )
+    log_dir = tmp_path / "logs"
+    rc = main(
+        [
+            "run",
+            "--instruction",
+            "reach the cube",
+            "--policy",
+            "scripted",
+            "-P",
+            "chunk_size=4",
+            "--log-dir",
+            str(log_dir),
+        ]
+    )
+    assert rc == 0
+    assert "policy: scripted (--policy)" in capsys.readouterr().out
+    # The -P flag's chunk_size=4 overrode the same-named [policy.args] key.
+    assert _read_only_log(log_dir).eval.policy_config["action_horizon"] == 4
+
+
+def test_mistyped_subcommand_never_starts_a_rollout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Even with defaults fully configured, a single-token typo (no interior
+    # whitespace) and a whitespace-padded subcommand both error out.
+    monkeypatch.setenv(ENV_POLICY, "scripted")
+    monkeypatch.setenv(ENV_EMBODIMENT, "cubepick")
+    for argv in (["isnpect"], ["runs"], [" list "]):
+        with pytest.raises(SystemExit) as excinfo:
+            main(argv)
+        assert excinfo.value.code == 2  # argparse invalid-choice, not a run
+    capsys.readouterr()
+
+
+def test_run_requires_exactly_one_of_task_or_instruction() -> None:
+    with pytest.raises(SystemExit, match="not both"):
+        main(["run", "--task", "cubepick-reach", "--instruction", "reach it"])
+    with pytest.raises(SystemExit, match="--task name or an --instruction"):
+        main(["run", "--policy", "scripted", "--embodiment", "cubepick"])
+
+
+def test_adhoc_only_flags_rejected_with_task() -> None:
+    base = ["run", "--task", "cubepick-reach", "--policy", "scripted", "--embodiment", "cubepick"]
+    with pytest.raises(SystemExit, match="--max-steps only applies"):
+        main([*base, "--max-steps", "10"])
+    with pytest.raises(SystemExit, match="--scorer only applies"):
+        main([*base, "--scorer", "operator"])
+
+
+def test_task_args_rejected_with_instruction() -> None:
+    with pytest.raises(SystemExit, match="-T only applies"):
+        main(["run", "--instruction", "reach it", "-T", "num_scenes=1"])
+
+
+def test_missing_defaults_error_lists_registered_components() -> None:
+    with pytest.raises(SystemExit, match=r"registered policies: .*scripted") as excinfo:
+        main(["run", "--instruction", "reach the cube"])
+    assert ENV_POLICY in str(excinfo.value)  # the message shows the remedies
+
+
+def test_unknown_scorer_name_exits_cleanly(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_POLICY, "scripted")
+    monkeypatch.setenv(ENV_EMBODIMENT, "cubepick")
+    with pytest.raises(SystemExit, match="no scorer named 'nope'"):
+        main(["run", "--instruction", "reach it", "--scorer", "nope"])
+
+
+def test_adhoc_flags_override_config(
+    _hermetic_defaults: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\npolicy = scripted\nembodiment = cubepick\nscorer = operator\nmax_steps = 7\n",
+    )
+    log_dir = tmp_path / "logs"
+    rc = main(
+        [
+            "run",
+            "--instruction",
+            "reach the cube",
+            "--scorer",
+            "success_at_end",
+            "--max-steps",
+            "60",
+            "--log-dir",
+            str(log_dir),
+        ]
+    )
+    assert rc == 0
+    log = _read_only_log(log_dir)
+    # config max_steps=7 would truncate before success; the flag's 60 won.
+    assert log.results.metrics["success_at_end"] == 1.0
+    assert "operator" not in log.results.metrics  # --scorer replaced the config scorer
+    capsys.readouterr()
+
+
+def _tty_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+
+def test_operator_prompt_records_verdict_and_reprompts_on_typos(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv(ENV_POLICY, "scripted")
+    monkeypatch.setenv(ENV_EMBODIMENT, "cubepick")
+    _tty_stdin(monkeypatch)
+    answers = iter(["yse", "y"])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+    log_dir = tmp_path / "logs"
+    rc = main(["reach the cube", "--log-dir", str(log_dir)])  # default scorer: operator
+    assert rc == 0
+    assert "unrecognized answer 'yse'" in capsys.readouterr().out
+    log = _read_only_log(log_dir)
+    assert log.samples[0].operator_judgements == ["y"]
+    assert log.results.metrics["operator"] == 1.0
+
+
+def test_operator_prompt_suppressed_without_tty_or_with_no_prompt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv(ENV_POLICY, "scripted")
+    monkeypatch.setenv(ENV_EMBODIMENT, "cubepick")
+    monkeypatch.setattr(
+        "builtins.input", lambda _prompt: pytest.fail("operator prompt must not fire")
+    )
+
+    # Non-TTY stdin (the pytest default): never prompts.
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    log_dir_a = tmp_path / "a"
+    assert main(["reach the cube", "--log-dir", str(log_dir_a)]) == 0
+    assert _read_only_log(log_dir_a).samples[0].operator_judgements == [None]
+
+    # TTY but --no-prompt: never prompts either.
+    _tty_stdin(monkeypatch)
+    log_dir_b = tmp_path / "b"
+    assert main(["reach the cube", "--no-prompt", "--log-dir", str(log_dir_b)]) == 0
+    log = _read_only_log(log_dir_b)
+    assert log.samples[0].operator_judgements == [None]
+    assert log.results.metrics["operator"] == 0.0  # unjudged scores honestly as failure
+    capsys.readouterr()
+
+
+def test_registered_task_never_prompts_even_with_operator_scorer_on_tty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from inspect_robots.registry import task as task_decorator
+    from inspect_robots.scene import Scene
+    from inspect_robots.scorer import operator_scorer
+    from inspect_robots.task import Task
+
+    @task_decorator("operator-task-for-test")
+    def _operator_task() -> Task:
+        return Task(
+            name="operator-task-for-test",
+            scenes=[Scene(id="s0", instruction="reach", init_seed=0)],
+            scorer=operator_scorer(),
+            max_steps=40,
+        )
+
+    _tty_stdin(monkeypatch)
+    monkeypatch.setattr(
+        "builtins.input", lambda _prompt: pytest.fail("R6: --task runs must not block")
+    )
+    log_dir = tmp_path / "logs"
+    rc = main(
+        [
+            "run",
+            "--task",
+            "operator-task-for-test",
+            "--policy",
+            "scripted",
+            "--embodiment",
+            "cubepick",
+            "--log-dir",
+            str(log_dir),
+        ]
+    )
+    assert rc == 0
+    assert _read_only_log(log_dir).samples[0].operator_judgements == [None]
+    capsys.readouterr()
+
+
+def test_prompt_operator_unit_semantics(monkeypatch: pytest.MonkeyPatch) -> None:
+    from inspect_robots.cli import _prompt_operator
+    from inspect_robots.rollout import TrialRecord
+    from inspect_robots.scene import Scene
+
+    scene = Scene(id="s0", instruction="reach")
+
+    def _record() -> TrialRecord:
+        record = TrialRecord(scene_id="s0", epoch=0, seed=0)
+        record.steps = [None, None, None]  # type: ignore[list-item]
+        return record
+
+    # A verdict is recorded verbatim with an operator event at the final step.
+    record = _record()
+    monkeypatch.setattr("builtins.input", lambda _prompt: "Partial")
+    _prompt_operator(record, scene)
+    assert record.operator_judgement == "partial"
+    (event,) = record.events
+    assert event.kind == "operator"
+    assert event.t == 3
+    assert event.data["verdict"] == "partial"
+
+    # skip: no judgement, no event.
+    record = _record()
+    monkeypatch.setattr("builtins.input", lambda _prompt: "skip")
+    _prompt_operator(record, scene)
+    assert record.operator_judgement is None
+    assert record.events == []
+
+    # EOF (operator hit Ctrl-D): treated as skip.
+    def _eof(_prompt: str) -> str:
+        raise EOFError
+
+    record = _record()
+    monkeypatch.setattr("builtins.input", _eof)
+    _prompt_operator(record, scene)
+    assert record.operator_judgement is None
+    assert record.events == []

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -183,9 +183,31 @@ def test_config_file_supplies_defaults_and_adhoc_settings(
     assert f"policy: scripted (from {config})" in out
     log = _read_only_log(log_dir)
     assert log.samples[0].instruction == "reach the cube"
+    # The config's scorer (not the "operator" fallback) actually scored the run.
+    assert log.results.metrics == {"success_at_end": 1.0}
     # [policy.args] chunk_size=6 reached the policy constructor (recorded in
     # the log as the policy's action_horizon).
     assert log.eval.policy_config["action_horizon"] == 6
+
+
+def test_config_max_steps_truncates_adhoc_run(
+    _hermetic_defaults: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\n"
+        "policy = scripted\n"
+        "embodiment = cubepick\n"
+        "scorer = success_at_end\n"
+        "max_steps = 3\n",
+    )
+    log_dir = tmp_path / "logs"
+    rc = main(["reach the cube", "--log-dir", str(log_dir)])
+    assert rc == 0  # truncation is not an error; the eval itself succeeded
+    # Three steps cannot reach the cube: the config horizon (not the 300
+    # fallback, which would succeed) governed the rollout.
+    assert _read_only_log(log_dir).results.metrics["success_at_end"] == 0.0
+    capsys.readouterr()
 
 
 def test_cli_flags_beat_config_defaults_and_args(
@@ -367,19 +389,23 @@ def test_registered_task_never_prompts_even_with_operator_scorer_on_tty(
         "builtins.input", lambda _prompt: pytest.fail("R6: --task runs must not block")
     )
     log_dir = tmp_path / "logs"
-    rc = main(
-        [
-            "run",
-            "--task",
-            "operator-task-for-test",
-            "--policy",
-            "scripted",
-            "--embodiment",
-            "cubepick",
-            "--log-dir",
-            str(log_dir),
-        ]
-    )
+    try:
+        rc = main(
+            [
+                "run",
+                "--task",
+                "operator-task-for-test",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(log_dir),
+            ]
+        )
+    finally:
+        # Don't leak the ad-hoc registration into later tests' registry views.
+        reg._FACTORIES["task"].pop("operator-task-for-test", None)
     assert rc == 0
     assert _read_only_log(log_dir).samples[0].operator_judgements == [None]
     capsys.readouterr()

--- a/tests/test_strict_json.py
+++ b/tests/test_strict_json.py
@@ -120,3 +120,18 @@ def test_json_dump_backstop_rejects_unsanitized_non_finite(tmp_path: Path) -> No
         (tmp_path / "x.json").open("w", encoding="utf-8") as fh,
     ):
         json.dump({"bad": float("inf")}, fh, allow_nan=False)
+
+
+def test_scene_instruction_and_judgements_serialize_strict(tmp_path: Path) -> None:
+    # The new SceneResult fields reach disk as strict JSON: the instruction
+    # verbatim, and one judgement slot per epoch (None when nobody judged).
+    (log,) = eval(_task(), ScriptedPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path))
+    assert log.status == "success"
+    (path,) = tmp_path.glob("*.json")
+    data = _read_strict(path)
+    samples = data["samples"]
+    assert isinstance(samples, list)
+    sample = samples[0]
+    assert isinstance(sample, dict)
+    assert sample["instruction"] == "reach"
+    assert sample["operator_judgements"] == [None]


### PR DESCRIPTION
## Summary

Adds the `ollama run`-style one-liner for robotics: with a default policy and embodiment configured once, `inspect-robots "place the spoon on the plate"` runs a single ad-hoc scene, captures the operator's success verdict on a TTY, and writes a normal immutable `EvalLog`. Design doc: `plans/0005-zero-config-cli.md` (survived three subagent critique rounds, 16 issues addressed before implementation).

## What's in it

- **Bare-instruction sugar** → `run --instruction "..."`. Gated on interior whitespace after stripping, so a mistyped subcommand (`inspect-robots isnpect`) or a padded one (`" list "`) can never silently start a robot rollout.
- **Defaults chain** (flags > `INSPECT_ROBOTS_POLICY`/`_EMBODIMENT` env > `~/.config/inspect-robots/config.ini`), implemented in a new private `_defaults.py`. INI via stdlib `configparser` (py3.10 has no `tomllib`; core stays NumPy-only). Deliberately **no project-local config** — a checked-in file choosing what runs on the user's hardware is a trust footgun. Resolved names + their sources print before the embodiment moves; config `[policy.args]`/`[embodiment.args]` merge under explicit `-P`/`-E`.
- **Operator verdict capture (R6)**: new keyword-only `before_scoring` hook on `eval()`/`eval_set()` — fires once per trial that will be scored, never for errored trials, before scorers run. The CLI uses it only on the ad-hoc path, only on a TTY, and only when the `operator` scorer is in play (`--no-prompt` opts out); registered `--task` runs stay non-blocking per R6. Prompt re-asks on typos; `skip`/EOF records nothing.
- **Log schema (additive, still v1)**: `SceneResult.instruction` and `SceneResult.operator_judgements` (strictly parallel to `epochs`) — logs become self-describing and old logs read back unchanged.
- Registry `KeyError`s on the CLI path surface as clean `SystemExit` messages; mode-mismatched flags (`--max-steps`/`--scorer` with `--task`, `-T` with `--instruction`) error instead of being silently ignored.
- Docs: README one-liner, `docs/guide/cli.md` zero-config section, module map.

## Test plan

- 188 tests, **100% coverage**, mypy `--strict` (src+tests), ruff clean.
- A subagent **mutation audit** verified the tests actually discriminate: 7 targeted mutations (hook removal, sugar-gate removal, merge-direction swap, env-precedence swap, prompt-gate drops, fallback-chain drops) — the one survivor exposed a real gap, now closed with two tests that observably pin config scorer/max_steps at the CLI layer.
- Manual end-to-end smoke test of the installed binary: zero-config run from a config file succeeds and writes `adhoc_*.json`; typo guard exits 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)