### PR TITLE
--sim: run the zero-config CLI on your configured sim embodiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,25 @@ pip install "inspect-robots[rerun]"   # + Rerun visualization
 
 ## Quickstart
 
-No hardware or simulator needed — the dependency-free `CubePick` mock world
-exercises the whole stack:
+With a default policy/embodiment configured once in
+`~/.config/inspect-robots/config.ini`, just tell the robot what to do:
+
+```bash
+inspect-robots "place the spoon on the plate"                # zero-config ad-hoc eval
+inspect-robots "place the spoon on the plate" --sim          # same, on your configured sim
+```
+
+The full command line resolves any registered task/policy/embodiment
+(builtins + installed plugins):
+
+```bash
+inspect-robots list                                          # registered components
+inspect-robots run --task cubepick-reach --policy scripted --embodiment cubepick
+inspect-robots inspect logs/cubepick-reach_*.json            # results table
+```
+
+And everything is a Python API. No hardware or simulator needed — the
+dependency-free `CubePick` mock world exercises the whole stack:
 
 ```python
 from inspect_robots import eval
@@ -70,21 +87,6 @@ task = Task(
 # The two swappable inputs: a policy (VLA) and an embodiment (robot/sim).
 (log,) = eval(task, ScriptedPolicy(), CubePickEmbodiment())
 print(log.status, log.results.metrics)   # success {'success_at_end': 1.0}
-```
-
-…or from the command line (components resolve from a registry):
-
-```bash
-inspect-robots list                                          # registered components
-inspect-robots run --task cubepick-reach --policy scripted --embodiment cubepick
-inspect-robots inspect logs/cubepick-reach_*.json            # results table
-```
-
-…or, with a default policy/embodiment configured once in
-`~/.config/inspect-robots/config.ini`, just tell the robot what to do:
-
-```bash
-inspect-robots "place the spoon on the plate"                # zero-config ad-hoc eval
 ```
 
 ## Why Inspect Robots

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -35,7 +35,8 @@ Resolved in order — first hit wins:
 ```ini
 [defaults]
 policy = molmoact2-yam
-embodiment = yam-bimanual
+embodiment = yam-bimanual            ; the default: real hardware
+sim_embodiment = yam-bimanual-isaac  ; what --sim swaps in
 scorer = operator      ; optional, ad-hoc runs only
 max_steps = 300        ; optional, ad-hoc runs only
 
@@ -44,6 +45,9 @@ checkpoint = ~/ckpts/molmoact2-yam.pt
 
 [embodiment.args]      ; default -E key=value pairs
 cameras = wrist,front
+
+[sim_embodiment.args]  ; -E pairs used only under --sim
+headless = true
 ```
 
 Values parse like `-P/-E` args (bool/int/float/None/str), `~` expands in
@@ -51,6 +55,26 @@ Values parse like `-P/-E` args (bool/int/float/None/str), `~` expands in
 same-named config key. There is deliberately **no project-local config file**:
 a checked-in file choosing which policy drives your hardware would be a trust
 footgun.
+
+### Running in simulation: `--sim`
+
+Real hardware is the default (it is whatever you configured as `embodiment`).
+`--sim` swaps in your configured sim counterpart for one invocation:
+
+```bash
+inspect-robots "place the spoon on the plate" --sim
+inspect-robots run --task my-benchmark --policy molmoact2-yam --sim
+```
+
+The sim embodiment resolves as `$INSPECT_ROBOTS_SIM_EMBODIMENT` > config
+`sim_embodiment`, with constructor args from `[sim_embodiment.args]` only —
+real-rig args (`[embodiment.args]`: serial ports, camera IDs) never leak into
+a sim run, and vice versa. `--sim` together with an explicit `--embodiment`
+is an error (they both pick the embodiment); an exported
+`$INSPECT_ROBOTS_EMBODIMENT` is simply not consulted under `--sim` — it's a
+persistent default for real runs, not a per-invocation intent. The mapping is
+explicit configuration: the framework never guesses which sim matches your
+robot.
 
 ### Operator scoring
 

--- a/plans/0006-sim-flag.md
+++ b/plans/0006-sim-flag.md
@@ -1,0 +1,175 @@
+# 0006 — `--sim`: swap the default embodiment for its sim counterpart
+
+## 1. Goal
+
+Plan 0005 gave us `inspect-robots "place the spoon on the plate"` running on
+the user's configured default embodiment — typically real hardware. This plan
+adds the one-flag escape hatch to run the same command in simulation:
+
+```bash
+inspect-robots "place the spoon on the plate" --sim
+```
+
+Real hardware stays the default (it is whatever the user configured as
+`embodiment`); `--sim` swaps in a second, separately configured embodiment.
+The framework cannot guess that `yam-bimanual` maps to
+`yam-bimanual-isaacsim` — per 0005's no-magic stance, the mapping is explicit
+user configuration:
+
+```ini
+[defaults]
+embodiment = yam-bimanual            ; the default: real hardware
+sim_embodiment = yam-bimanual-isaac  ; what --sim swaps in
+
+[sim_embodiment.args]                ; default -E pairs for the sim embodiment
+headless = true
+```
+
+Non-goals (YAGNI): no auto-discovery of sim counterparts, no per-task sim
+mapping, no `--real` flag (real is the absence of `--sim`), no change to the
+ad-hoc default scorer under `--sim` (a sim may have a success oracle, but
+which scorer that is stays the user's choice — set `scorer =` in config or
+pass `--scorer`).
+
+## 2. Grounding (state after plan 0005)
+
+- `_defaults.py`: `Defaults` frozen dataclass with `policy`/`embodiment`
+  (+ `_source` strings), `scorer`, `max_steps`, `policy_args`,
+  `embodiment_args`; `load_defaults(env)` reads
+  `<config-home>/inspect-robots/config.ini` then applies
+  `INSPECT_ROBOTS_POLICY`/`INSPECT_ROBOTS_EMBODIMENT` env overrides;
+  value/type validation raises `SystemExit` naming the file/key.
+- `cli.py`: `_cmd_run` validates mode flags, resolves names via
+  `_pick_component(kind, flag, default, source)` (guidance `SystemExit` when
+  nothing is configured), merges `defaults.embodiment_args` under explicit
+  `-E` pairs, prints the resolved header before the embodiment moves.
+- Tests: `tests/test_defaults.py` (pure `load_defaults`),
+  `tests/test_registry_cli.py` (CLI e2e on the mock, hermetic
+  `_hermetic_defaults` autouse fixture).
+
+## 3. Design
+
+### 3.1 Semantics
+
+- `--sim` is a `run` flag (`store_true`). It applies to **both** `--task` and
+  `--instruction` runs — it only changes which embodiment default is used, and
+  is orthogonal to task selection. The bare-instruction sugar already passes
+  trailing flags through (`inspect-robots "wipe table" --sim` →
+  `run --instruction "wipe table" --sim`).
+- Resolution for the embodiment name becomes:
+  - without `--sim`: `--embodiment` flag > `$INSPECT_ROBOTS_EMBODIMENT` >
+    config `embodiment` (unchanged from 0005)
+  - with `--sim`: `$INSPECT_ROBOTS_SIM_EMBODIMENT` > config `sim_embodiment`
+- `--sim` **conflicts with an explicit `--embodiment`**: `SystemExit` ("--sim
+  selects your configured sim_embodiment; passing --embodiment already picks
+  the embodiment — drop one"). Silently letting the flag win would make `--sim`
+  a no-op lie in scripts.
+- `--sim` with `$INSPECT_ROBOTS_EMBODIMENT` set is **not** an error: the sim
+  chain simply doesn't consult that variable. This asymmetry with the
+  `--embodiment` conflict is deliberate: the env var is a persistent default
+  (a shell profile), not a per-invocation intent — erroring would make
+  `--sim` unusable for anyone who exports it. Pinned by a test (env real
+  embodiment set + `--sim` → sim embodiment used, no error) and documented.
+- `--sim` with nothing configured → guidance `SystemExit` mirroring
+  `_pick_component`'s message: list registered embodiments, show the env var
+  and the `sim_embodiment = NAME` config line.
+- Embodiment args under `--sim` come from `[sim_embodiment.args]` (NOT
+  `[embodiment.args]` — args tuned for a real rig, e.g. a serial port, are
+  wrong for a sim and vice versa). Explicit `-E k=v` still overrides.
+- The run header keeps its contract: `embodiment: yam-bimanual-isaac (--sim,
+  from <config path>)` or `(--sim, from $INSPECT_ROBOTS_SIM_EMBODIMENT)`.
+- The operator-prompt gating is unchanged (a TTY ad-hoc run with the
+  `operator` scorer still prompts under `--sim`; skip or configure a scorer).
+
+### 3.2 Changes
+
+`_defaults.py`:
+
+- `ENV_SIM_EMBODIMENT = "INSPECT_ROBOTS_SIM_EMBODIMENT"`.
+- `Defaults` grows `sim_embodiment`, `sim_embodiment_source`,
+  `sim_embodiment_args` (same shapes as their non-sim twins).
+- `_read_config` reads `[defaults] sim_embodiment` and
+  `[sim_embodiment.args]`; `load_defaults` applies the env override with
+  source `$INSPECT_ROBOTS_SIM_EMBODIMENT`.
+
+`cli.py`:
+
+- `build_parser`: add `--sim` to `run`.
+- `_cmd_run`: the `--sim`/`--embodiment` conflict check joins the existing
+  mode validation block; embodiment name/args selection branches on
+  `args.sim` as specced above. The sim chain gets its own small
+  `_pick_sim_embodiment(defaults)` helper rather than routing through
+  `_pick_component` (whose reuse would be partial anyway: its guidance
+  message and `f"from {source}"` format are wrong for sim): the helper
+  returns `(name, f"--sim, from {source}")` on success — satisfying the
+  header contract — and on the empty path raises the sim-flavored guidance
+  `SystemExit` (registered embodiments + `$INSPECT_ROBOTS_SIM_EMBODIMENT` +
+  the `sim_embodiment = NAME` config line). `_pick_component` stays untouched.
+
+Docs: the config example + a `--sim` paragraph in `docs/guide/cli.md`'s
+zero-config section; one line in the README block; module-map row already
+covers `_defaults.py` (update its blurb to mention sim).
+
+### 3.3 Alternatives considered
+
+- **`--embodiment` + `--sim` = flag wins silently**: rejected — `--sim`
+  becoming a no-op depending on other flags is exactly the silent-ignore
+  pattern 0005 rejected for `-T`/`--max-steps`.
+- **Fallback of `[embodiment.args]` onto the sim embodiment**: rejected —
+  real-rig args (ports, camera serials) are wrong for a sim; empty-by-default
+  is safer than wrong-by-default.
+- **`--sim` flips the ad-hoc scorer to `success_at_end`**: rejected — whether
+  the sim has a success oracle depends on the embodiment; guessing wrong
+  silently reports 0.0 forever. Config's `scorer =` already covers it.
+
+## 4. Tests (TDD; 100 % coverage; no vacuous tests)
+
+`test_defaults.py`:
+
+- config `sim_embodiment` + `[sim_embodiment.args]` parse (with `~` expansion
+  and source path), and are independent of `embodiment`/`[embodiment.args]`
+  (full-equality assertion on `Defaults`).
+- `$INSPECT_ROBOTS_SIM_EMBODIMENT` overrides config `sim_embodiment` and sets
+  the env source; does not touch `embodiment`.
+
+`test_registry_cli.py` (e2e on the mock; `cubepick` plays the "sim").
+**Prerequisite: extend the `_hermetic_defaults` autouse fixture to also
+`delenv` `ENV_SIM_EMBODIMENT`** — no failing test forces this, but without it
+a developer with the var exported gets flaky CLI tests, defeating the
+fixture's purpose. Then:
+
+- `--sim` swaps the embodiment: config `embodiment = missing-real-arm`,
+  `sim_embodiment = cubepick` → bare instruction + `--sim` runs green
+  (proving the real-arm default was NOT used), header shows
+  `(--sim, from <config>)`; the same command **without** `--sim` exits with
+  the unknown-embodiment `SystemExit` (proving `--sim` was load-bearing).
+- `[sim_embodiment.args]` reach the constructor and `-E` overrides them.
+  NOTE: the log's `embodiment_info` records only
+  `control_hz`/`is_simulated`/`capabilities` (eval.py), none of which depend
+  on `CubePickEmbodiment` constructor args — so assert **behaviorally**:
+  `[sim_embodiment.args] max_step = 0.001` makes the run too slow to succeed
+  (`success_at_end == 0.0`), and an explicit `-E max_step=0.1` restores
+  success (`== 1.0`). Non-leakage: put a key in `[embodiment.args]` that
+  `CubePickEmbodiment.__init__` rejects (`port = 1`) — the sim run still
+  constructs fine, proving real-rig args never touch the sim path.
+- `--sim --embodiment cubepick` → conflict `SystemExit` (match on "drop one").
+- `--sim` with no `sim_embodiment` configured → guidance `SystemExit` naming
+  `INSPECT_ROBOTS_SIM_EMBODIMENT` and `sim_embodiment`.
+- `--sim` works with `--task` too (registered task + `--sim` resolves the sim
+  embodiment).
+- env `$INSPECT_ROBOTS_SIM_EMBODIMENT` beats config `sim_embodiment` at the
+  CLI layer (header source assertion).
+- asymmetry pin: `$INSPECT_ROBOTS_EMBODIMENT` set (to a bogus name) + `--sim`
+  → the sim embodiment runs, no error and no use of the bogus real default.
+
+Post-implementation: subagent mutation audit (drop the `--sim` branch, swap
+sim/real chains, leak `[embodiment.args]` into sim runs — each must be killed
+by a test) before the PR.
+
+## 5. Milestones
+
+1. `_defaults.py` sim fields + tests.
+2. `cli.py` `--sim` + tests.
+3. Docs + README — including reordering the README quickstart simple→complex
+   per user request: zero-config one-liner first, then the CLI block, then
+   the CubePick Python example.

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -26,7 +26,7 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `logging/` | `LogSink` protocol, `JsonLogSink` (atomic), optional `RerunSink` |
 | `registry.py` | decorators + entry-point discovery; `_builtins.py` registers in-tree components |
 | `cli.py` | `inspect-robots list` / `run` / `inspect`, plus the zero-config form `inspect-robots "<instruction>"` (ad-hoc single-scene task; operator prompt on TTY) |
-| `_defaults.py` | user default policy/embodiment for the zero-config CLI: env vars > `~/.config/inspect-robots/config.ini` (INI — py3.10 has no tomllib; deliberately no project-local file) |
+| `_defaults.py` | user default policy/embodiment (+ `--sim` counterpart) for the zero-config CLI: env vars > `~/.config/inspect-robots/config.ini` (INI — py3.10 has no tomllib; deliberately no project-local file) |
 | `mock/` | dependency-free `CubePick` world + scripted/random/noop policies |
 
 ## Key invariants

--- a/src/inspect_robots/_defaults.py
+++ b/src/inspect_robots/_defaults.py
@@ -23,6 +23,7 @@ from typing import Any
 
 ENV_POLICY = "INSPECT_ROBOTS_POLICY"
 ENV_EMBODIMENT = "INSPECT_ROBOTS_EMBODIMENT"
+ENV_SIM_EMBODIMENT = "INSPECT_ROBOTS_SIM_EMBODIMENT"
 
 # Fallbacks for ad-hoc (instruction) runs when neither flag nor config decides.
 ADHOC_SCORER_FALLBACK = "operator"
@@ -52,10 +53,16 @@ class Defaults:
     policy_source: str | None = None
     embodiment: str | None = None
     embodiment_source: str | None = None
+    # The sim counterpart --sim swaps in; real hardware is just the default
+    # `embodiment`. Args are kept separate: real-rig args (ports, camera
+    # serials) are wrong for a sim and vice versa.
+    sim_embodiment: str | None = None
+    sim_embodiment_source: str | None = None
     scorer: str | None = None
     max_steps: int | None = None
     policy_args: dict[str, Any] = field(default_factory=dict)
     embodiment_args: dict[str, Any] = field(default_factory=dict)
+    sim_embodiment_args: dict[str, Any] = field(default_factory=dict)
 
 
 def _config_path(env: Mapping[str, str]) -> Path | None:
@@ -106,15 +113,19 @@ def _read_config(path: Path) -> Defaults:
 
     policy = parser.get("defaults", "policy", fallback=None)
     embodiment = parser.get("defaults", "embodiment", fallback=None)
+    sim_embodiment = parser.get("defaults", "sim_embodiment", fallback=None)
     return Defaults(
         policy=policy,
         policy_source=source if policy else None,
         embodiment=embodiment,
         embodiment_source=source if embodiment else None,
+        sim_embodiment=sim_embodiment,
+        sim_embodiment_source=source if sim_embodiment else None,
         scorer=parser.get("defaults", "scorer", fallback=None),
         max_steps=max_steps,
         policy_args=_parse_args_section(parser, "policy.args"),
         embodiment_args=_parse_args_section(parser, "embodiment.args"),
+        sim_embodiment_args=_parse_args_section(parser, "sim_embodiment.args"),
     )
 
 
@@ -135,4 +146,8 @@ def load_defaults(env: Mapping[str, str]) -> Defaults:
         defaults = replace(defaults, policy=policy, policy_source=f"${ENV_POLICY}")
     if embodiment := env.get(ENV_EMBODIMENT):
         defaults = replace(defaults, embodiment=embodiment, embodiment_source=f"${ENV_EMBODIMENT}")
+    if sim := env.get(ENV_SIM_EMBODIMENT):
+        defaults = replace(
+            defaults, sim_embodiment=sim, sim_embodiment_source=f"${ENV_SIM_EMBODIMENT}"
+        )
     return defaults

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -33,6 +33,8 @@ from inspect_robots._defaults import (
     ADHOC_SCORER_FALLBACK,
     ENV_EMBODIMENT,
     ENV_POLICY,
+    ENV_SIM_EMBODIMENT,
+    Defaults,
     load_defaults,
     parse_value,
 )
@@ -111,6 +113,12 @@ def build_parser() -> argparse.ArgumentParser:
         f"{ADHOC_SCORER_FALLBACK!r}); invalid with --task",
     )
     p_run.add_argument(
+        "--sim",
+        action="store_true",
+        help="run on the configured sim_embodiment instead of the default "
+        "(real-hardware) embodiment",
+    )
+    p_run.add_argument(
         "--no-prompt",
         action="store_true",
         help="never ask the terminal operator for a success verdict",
@@ -164,6 +172,26 @@ def _pick_component(
         f"registered {_PLURAL_BY_KIND[kind]}: {names}\n"
         f"fix: pass --{kind} NAME, set ${_ENV_BY_KIND[kind]}, or add "
         f"'{kind} = NAME' under [defaults] in ~/.config/inspect-robots/config.ini"
+    )
+
+
+def _pick_sim_embodiment(defaults: Defaults) -> tuple[str, str]:
+    """The --sim chain: env var > config ``sim_embodiment``, or exit with guidance.
+
+    Deliberately does NOT consult ``--embodiment``/``$INSPECT_ROBOTS_EMBODIMENT``
+    (those pick the *real* default; an exported env var is a persistent
+    preference, not per-invocation intent, so --sim simply ignores it).
+    """
+    if defaults.sim_embodiment:
+        return defaults.sim_embodiment, f"--sim, from {defaults.sim_embodiment_source}"
+    from inspect_robots.registry import registered
+
+    names = ", ".join(sorted(registered("embodiment"))) or "(none)"
+    raise SystemExit(
+        "--sim given but no sim embodiment configured.\n"
+        f"registered embodiments: {names}\n"
+        f"fix: set ${ENV_SIM_EMBODIMENT}, or add 'sim_embodiment = NAME' under "
+        "[defaults] in ~/.config/inspect-robots/config.ini"
     )
 
 
@@ -226,18 +254,28 @@ def _cmd_run(args: argparse.Namespace) -> int:
         raise SystemExit(
             "-T only applies to --task runs; an ad-hoc instruction task takes no constructor args"
         )
+    if args.sim and args.embodiment:
+        raise SystemExit(
+            "--sim selects your configured sim_embodiment; "
+            "passing --embodiment already picks the embodiment — drop one"
+        )
 
     defaults = load_defaults(os.environ)
     policy_name, policy_source = _pick_component(
         "policy", args.policy, defaults.policy, defaults.policy_source
     )
-    embodiment_name, embodiment_source = _pick_component(
-        "embodiment", args.embodiment, defaults.embodiment, defaults.embodiment_source
-    )
+    if args.sim:
+        embodiment_name, embodiment_source = _pick_sim_embodiment(defaults)
+        embodiment_defaults = defaults.sim_embodiment_args
+    else:
+        embodiment_name, embodiment_source = _pick_component(
+            "embodiment", args.embodiment, defaults.embodiment, defaults.embodiment_source
+        )
+        embodiment_defaults = defaults.embodiment_args
     # Config-file args apply to whichever component is selected; explicit
     # -P/-E flags override same-named keys.
     policy_kvs = {**defaults.policy_args, **_parse_kvs(args.policy_args)}
-    embodiment_kvs = {**defaults.embodiment_args, **_parse_kvs(args.embodiment_args)}
+    embodiment_kvs = {**embodiment_defaults, **_parse_kvs(args.embodiment_args)}
 
     if is_adhoc:
         scorer_name = args.scorer or defaults.scorer or ADHOC_SCORER_FALLBACK

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -10,6 +10,7 @@ import pytest
 from inspect_robots._defaults import (
     ENV_EMBODIMENT,
     ENV_POLICY,
+    ENV_SIM_EMBODIMENT,
     Defaults,
     load_defaults,
     parse_value,
@@ -129,3 +130,46 @@ def test_parse_value_scalars() -> None:
     assert parse_value("42") == 42
     assert parse_value("2.5") == 2.5
     assert parse_value("hello") == "hello"
+
+
+_SIM_CONFIG = """
+[defaults]
+embodiment = yam-bimanual
+sim_embodiment = yam-bimanual-isaac
+
+[embodiment.args]
+port = /dev/ttyUSB0
+
+[sim_embodiment.args]
+headless = true
+scene_file = ~/scenes/kitchen.usd
+"""
+
+
+def test_sim_embodiment_config_is_independent_of_real(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, _SIM_CONFIG)
+    d = load_defaults({"XDG_CONFIG_HOME": str(tmp_path)})
+    scene_file = d.sim_embodiment_args["scene_file"]
+    assert isinstance(scene_file, str) and not scene_file.startswith("~")  # ~ expanded
+    # Full equality: sim and real defaults live side by side without bleed.
+    assert d == Defaults(
+        embodiment="yam-bimanual",
+        embodiment_source=str(path),
+        sim_embodiment="yam-bimanual-isaac",
+        sim_embodiment_source=str(path),
+        embodiment_args={"port": "/dev/ttyUSB0"},
+        sim_embodiment_args={"headless": True, "scene_file": scene_file},
+    )
+
+
+def test_env_sim_embodiment_overrides_config_but_not_real(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, _SIM_CONFIG)
+    d = load_defaults({"XDG_CONFIG_HOME": str(tmp_path), ENV_SIM_EMBODIMENT: "other-sim"})
+    assert d.sim_embodiment == "other-sim"
+    assert d.sim_embodiment_source == f"${ENV_SIM_EMBODIMENT}"
+    assert d.embodiment == "yam-bimanual"  # the real default is untouched
+    assert d.embodiment_source == str(path)
+    # The env var overrides only the *name*; config-file sim args still apply.
+    assert d.sim_embodiment_args["headless"] is True
+    scene_file = d.sim_embodiment_args["scene_file"]
+    assert isinstance(scene_file, str) and scene_file.endswith("scenes/kitchen.usd")

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 import inspect_robots.registry as reg
-from inspect_robots._defaults import ENV_EMBODIMENT, ENV_POLICY
+from inspect_robots._defaults import ENV_EMBODIMENT, ENV_POLICY, ENV_SIM_EMBODIMENT
 from inspect_robots.cli import main
 from inspect_robots.log import EvalLog
 from inspect_robots.mock import ScriptedPolicy
@@ -22,6 +22,7 @@ def _hermetic_defaults(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
     monkeypatch.delenv(ENV_POLICY, raising=False)
     monkeypatch.delenv(ENV_EMBODIMENT, raising=False)
+    monkeypatch.delenv(ENV_SIM_EMBODIMENT, raising=False)
     return config_home
 
 
@@ -449,3 +450,114 @@ def test_prompt_operator_unit_semantics(monkeypatch: pytest.MonkeyPatch) -> None
     _prompt_operator(record, scene)
     assert record.operator_judgement is None
     assert record.events == []
+
+
+# --------------------------------------------------------------------------- #
+# --sim (plan 0006): swap the default embodiment for its sim counterpart.
+# --------------------------------------------------------------------------- #
+_SIM_SWAP_CONFIG = (
+    "[defaults]\n"
+    "policy = scripted\n"
+    "embodiment = missing-real-arm\n"  # would explode if ever resolved
+    "sim_embodiment = cubepick\n"
+    "scorer = success_at_end\n"
+    "[embodiment.args]\n"
+    "port = 1\n"  # real-rig arg cubepick would reject
+)
+
+
+def test_sim_flag_swaps_embodiment_and_is_load_bearing(
+    _hermetic_defaults: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config = _write_config(_hermetic_defaults, _SIM_SWAP_CONFIG)
+    log_dir = tmp_path / "logs"
+
+    # With --sim: runs green on cubepick — the real default (which does not
+    # exist) was never resolved, and [embodiment.args] port=1 never leaked
+    # into the sim constructor (it would TypeError).
+    rc = main(["reach the cube", "--sim", "--log-dir", str(log_dir)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"embodiment: cubepick (--sim, from {config})" in out
+    assert _read_only_log(log_dir).results.metrics["success_at_end"] == 1.0
+
+    # Without --sim the same command dies resolving the real default,
+    # proving --sim was load-bearing.
+    with pytest.raises(SystemExit, match="no embodiment named 'missing-real-arm'"):
+        main(["reach the cube", "--log-dir", str(log_dir)])
+
+
+def test_sim_embodiment_args_reach_constructor_and_e_flag_overrides(
+    _hermetic_defaults: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\n"
+        "policy = scripted\n"
+        "sim_embodiment = cubepick\n"
+        "scorer = success_at_end\n"
+        "[sim_embodiment.args]\n"
+        "max_step = 0.001\n",  # crawls: cube is >=0.5 away, 300 steps max
+    )
+    log_dir_a = tmp_path / "a"
+    assert main(["reach the cube", "--sim", "--log-dir", str(log_dir_a)]) == 0
+    assert _read_only_log(log_dir_a).results.metrics["success_at_end"] == 0.0
+
+    # An explicit -E overrides the same-named [sim_embodiment.args] key.
+    log_dir_b = tmp_path / "b"
+    assert main(["reach the cube", "--sim", "-E", "max_step=0.1", "--log-dir", str(log_dir_b)]) == 0
+    assert _read_only_log(log_dir_b).results.metrics["success_at_end"] == 1.0
+    capsys.readouterr()
+
+
+def test_sim_conflicts_with_explicit_embodiment() -> None:
+    with pytest.raises(SystemExit, match="drop one"):
+        main(["run", "--instruction", "reach it", "--sim", "--embodiment", "cubepick"])
+
+
+def test_sim_without_configuration_exits_with_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(ENV_POLICY, "scripted")
+    with pytest.raises(SystemExit, match="no sim embodiment configured") as excinfo:
+        main(["run", "--instruction", "reach it", "--sim"])
+    message = str(excinfo.value)
+    assert ENV_SIM_EMBODIMENT in message and "sim_embodiment = NAME" in message
+
+
+def test_sim_works_with_registered_task(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv(ENV_SIM_EMBODIMENT, "cubepick")
+    log_dir = tmp_path / "logs"
+    rc = main(
+        [
+            "run",
+            "--task",
+            "cubepick-reach",
+            "--policy",
+            "scripted",
+            "--sim",
+            "--log-dir",
+            str(log_dir),
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    # env beats config for the sim chain, and the header says so.
+    assert f"embodiment: cubepick (--sim, from ${ENV_SIM_EMBODIMENT})" in out
+    assert "status: success" in out
+
+
+def test_sim_ignores_real_embodiment_env_var(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A persistent real-embodiment env var must not break (or leak into)
+    # --sim runs: the sim chain simply doesn't consult it.
+    monkeypatch.setenv(ENV_POLICY, "scripted")
+    monkeypatch.setenv(ENV_EMBODIMENT, "bogus-real-arm")
+    monkeypatch.setenv(ENV_SIM_EMBODIMENT, "cubepick")
+    log_dir = tmp_path / "logs"
+    rc = main(["reach the cube", "--sim", "--scorer", "success_at_end", "--log-dir", str(log_dir)])
+    assert rc == 0
+    assert "embodiment: cubepick" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Stacked on #13. Real hardware stays the default; `--sim` swaps in a user-configured sim counterpart for one invocation:

```bash
inspect-robots "place the spoon on the plate" --sim
inspect-robots run --task my-benchmark --sim
```

Design doc: `plans/0006-sim-flag.md` (two subagent critique rounds before implementation).

## Semantics

- Sim chain: `$INSPECT_ROBOTS_SIM_EMBODIMENT` > config `sim_embodiment` — the framework never guesses which sim matches your robot; the mapping is explicit configuration.
- Constructor args come from `[sim_embodiment.args]` only: real-rig args (serial ports, camera IDs) never leak into a sim run and vice versa. Explicit `-E k=v` still overrides.
- `--sim` + explicit `--embodiment` errors (both pick the embodiment; silent-ignore would make `--sim` a no-op lie). An exported `$INSPECT_ROBOTS_EMBODIMENT` is deliberately *not* consulted under `--sim` — it's a persistent default for real runs, not per-invocation intent (documented + pinned by a test).
- Works for both `--instruction` and `--task` runs; the run header shows `embodiment: <name> (--sim, from <source>)` before the embodiment moves.
- Also: README quickstart reordered simple→complex (zero-config one-liner → CLI → Python example), per request.

## Test plan

- 196 tests, 100% coverage, mypy `--strict`, ruff — all green.
- Subagent mutation audit: **7/7 mutations killed** (branch drop, chain swap, real-arg leak, env-override drop, conflict-check removal, header regression, `-E` precedence swap), every kill via behavioral assertions through the real constructor.
- Real-binary smoke test: config with a nonexistent real arm + `sim_embodiment = cubepick` — `--sim` runs green with the correct header; without `--sim` it errors, proving the flag is load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)