### PR TITLE
isaacsim: pass parse_env_cfg result to gym.make (env creation was broken)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **isaacsim plugin: real env creation was broken.** `_ensure_env` called
+  `gym.make(task_id)` without the mandatory Isaac Lab `cfg` object, so every
+  live run failed with `missing 1 required positional argument: 'cfg'`; the
+  config is now resolved via Isaac Lab's own `parse_env_cfg`. Alongside it:
+  observation groups are requested as *named* dicts (`concatenate_terms=False`
+  — a flat tensor left `Observation.state` empty; a warning fires when the
+  request can't be honored), and headless runs disable every `debug_vis` flag
+  (markers exist for a viewport nobody has, and their material machinery can
+  hang env creation on hosts with a broken render stack).
 - **Eval logs are strict RFC 8259 JSON.** Non-finite floats (e.g. an inf
   `min_distance_to_goal` when no distance was ever recorded) are mapped to
   `null` at the JSON boundary, so `jq` and other conforming parsers accept the

--- a/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
+++ b/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
@@ -208,8 +208,13 @@ class IsaacSimEmbodiment:
         # Importing the tasks registers the gym ids; must happen AFTER the app boots.
         import gymnasium as gym
         import isaaclab_tasks  # noqa: F401  (registers Isaac-* gym ids)
+        from isaaclab_tasks.utils import parse_env_cfg
 
-        self._env = gym.make(self.task_id, num_envs=1, render_mode="rgb_array")
+        # Isaac Lab envs take a mandatory cfg object (gym.make(task_id) alone
+        # raises "missing 1 required positional argument: 'cfg'"); parse_env_cfg
+        # is Isaac Lab's own task-id -> config resolution.
+        env_cfg = parse_env_cfg(self.task_id, device=self.device, num_envs=1)
+        self._env = gym.make(self.task_id, cfg=env_cfg, render_mode="rgb_array")
         return self._env
 
     # ------------------------------------------------------------------ #

--- a/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
+++ b/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
@@ -102,6 +102,21 @@ def _disable_debug_vis(cfg: Any) -> None:
                 stack.append(value)
 
 
+def _request_named_obs_terms(env_cfg: Any, obs_group: str) -> None:
+    """Ask Isaac Lab to keep the observation group as a named dict.
+
+    Manager-based envs concatenate a group's terms into one flat tensor by
+    default (``concatenate_terms=True``), which would leave ``_to_observation``
+    with nothing to map onto the adapter's *named* state fields — policies
+    would see an empty ``Observation.state``. The adapter's contract is named
+    proprioception, so request named terms.
+    """
+    groups = getattr(env_cfg, "observations", None)
+    group_cfg = getattr(groups, obs_group, None)
+    if group_cfg is not None and hasattr(group_cfg, "concatenate_terms"):
+        group_cfg.concatenate_terms = False
+
+
 def _default_state_fields(num_arm_joints: int) -> tuple[StateField, ...]:
     """Canonical proprioception for a Franka-like arm (keys/units from Inspect Robots)."""
 
@@ -250,6 +265,7 @@ class IsaacSimEmbodiment:
         env_cfg = parse_env_cfg(self.task_id, device=self.device, num_envs=1)
         if self.headless:
             _disable_debug_vis(env_cfg)
+        _request_named_obs_terms(env_cfg, self.obs_group)
         self._env = gym.make(self.task_id, cfg=env_cfg, render_mode="rgb_array")
         return self._env
 

--- a/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
+++ b/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
@@ -68,6 +68,40 @@ def _missing_isaac(exc: ImportError) -> RuntimeError:
     )
 
 
+def _disable_debug_vis(cfg: Any) -> None:
+    """Recursively switch every ``debug_vis`` flag off on an Isaac Lab env cfg.
+
+    Debug-visualization markers exist for a human watching a viewport — a
+    headless eval has none. Spawning their prototype prims also drags in the
+    shader/material machinery (``Sdr.Registry()`` / MDL discovery), which can
+    hang env creation outright on hosts whose render stack is unhealthy
+    (observed live: a missing ``libGLU.so.1`` killed ``omni.iray.libs`` and
+    the marker's preview-surface material spun forever). Never creating the
+    markers is both faster and more robust.
+    """
+    seen: set[int] = set()
+    stack: list[Any] = [cfg]
+    while stack:
+        obj = stack.pop()
+        if id(obj) in seen or isinstance(obj, type):
+            continue
+        seen.add(id(obj))
+        if isinstance(obj, dict):
+            stack.extend(obj.values())
+            continue
+        if isinstance(obj, (list, tuple, set)):
+            stack.extend(obj)
+            continue
+        obj_vars = getattr(obj, "__dict__", None)
+        if obj_vars is None:
+            continue
+        for key, value in obj_vars.items():
+            if key == "debug_vis" and value is True:
+                setattr(obj, "debug_vis", False)
+            elif isinstance(value, (dict, list, tuple, set)) or hasattr(value, "__dict__"):
+                stack.append(value)
+
+
 def _default_state_fields(num_arm_joints: int) -> tuple[StateField, ...]:
     """Canonical proprioception for a Franka-like arm (keys/units from Inspect Robots)."""
 
@@ -214,6 +248,8 @@ class IsaacSimEmbodiment:
         # raises "missing 1 required positional argument: 'cfg'"); parse_env_cfg
         # is Isaac Lab's own task-id -> config resolution.
         env_cfg = parse_env_cfg(self.task_id, device=self.device, num_envs=1)
+        if self.headless:
+            _disable_debug_vis(env_cfg)
         self._env = gym.make(self.task_id, cfg=env_cfg, render_mode="rgb_array")
         return self._env
 

--- a/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
+++ b/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
@@ -25,6 +25,7 @@ without editing this file.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -56,6 +57,8 @@ _DEFAULT_CAPABILITIES = frozenset({"seedable", "resettable", "privileged_success
 # second embodiment instance reuses the live app instead of launching a duplicate
 # (which crashes) or leaking one. Cleared by close().
 _ACTIVE_APP: Any | None = None
+
+logger = logging.getLogger(__name__)
 
 
 def _missing_isaac(exc: ImportError) -> RuntimeError:
@@ -115,6 +118,15 @@ def _request_named_obs_terms(env_cfg: Any, obs_group: str) -> None:
     group_cfg = getattr(groups, obs_group, None)
     if group_cfg is not None and hasattr(group_cfg, "concatenate_terms"):
         group_cfg.concatenate_terms = False
+    else:
+        # Without named terms the group arrives as one flat tensor and
+        # _to_observation maps nothing -> policies see an empty state.
+        logger.warning(
+            "could not request named observation terms for group %r "
+            "(missing group or no concatenate_terms attribute); "
+            "Observation.state may be empty",
+            obs_group,
+        )
 
 
 def _default_state_fields(num_arm_joints: int) -> tuple[StateField, ...]:

--- a/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
+++ b/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
@@ -278,3 +278,23 @@ def test_disable_debug_vis_walks_nested_configs() -> None:
     assert cfg.not_a_flag.debug_vis is False
     assert cfg.scene.debug_vis is False
     assert cfg.debug_vis == "keep"
+
+
+def test_request_named_obs_terms_flips_concatenate_flag() -> None:
+    from inspect_robots_isaacsim.embodiment import _request_named_obs_terms
+
+    class _Group:
+        concatenate_terms = True
+
+    class _Obs:
+        policy = _Group()
+
+    class _Cfg:
+        observations = _Obs()
+
+    cfg = _Cfg()
+    _request_named_obs_terms(cfg, "policy")
+    assert cfg.observations.policy.concatenate_terms is False
+    # Unknown group / missing attrs: silently a no-op, never raises.
+    _request_named_obs_terms(cfg, "nonexistent")
+    _request_named_obs_terms(object(), "policy")

--- a/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
+++ b/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
@@ -280,7 +280,11 @@ def test_disable_debug_vis_walks_nested_configs() -> None:
     assert cfg.debug_vis == "keep"
 
 
-def test_request_named_obs_terms_flips_concatenate_flag() -> None:
+def test_request_named_obs_terms_flips_concatenate_flag(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import logging
+
     from inspect_robots_isaacsim.embodiment import _request_named_obs_terms
 
     class _Group:
@@ -293,8 +297,14 @@ def test_request_named_obs_terms_flips_concatenate_flag() -> None:
         observations = _Obs()
 
     cfg = _Cfg()
-    _request_named_obs_terms(cfg, "policy")
-    assert cfg.observations.policy.concatenate_terms is False
-    # Unknown group / missing attrs: silently a no-op, never raises.
-    _request_named_obs_terms(cfg, "nonexistent")
-    _request_named_obs_terms(object(), "policy")
+    with caplog.at_level(logging.WARNING, logger="inspect_robots_isaacsim.embodiment"):
+        _request_named_obs_terms(cfg, "policy")
+        assert cfg.observations.policy.concatenate_terms is False
+        assert not caplog.records  # success path stays quiet
+
+        # Unknown group / missing attrs: a warned no-op, never raises — a
+        # silently-flat group would mean an empty Observation.state.
+        _request_named_obs_terms(cfg, "nonexistent")
+        _request_named_obs_terms(object(), "policy")
+    assert len(caplog.records) == 2
+    assert all("named observation terms" in r.message for r in caplog.records)

--- a/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
+++ b/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
@@ -244,3 +244,37 @@ def test_no_ram_leak_over_many_steps() -> None:
     assert fake.step_calls == 3200
     for value in vars(emb).values():
         assert not isinstance(value, (list, dict)) or len(value) <= 1
+
+
+def test_disable_debug_vis_walks_nested_configs() -> None:
+    from inspect_robots_isaacsim.embodiment import _disable_debug_vis
+
+    class _Term:
+        def __init__(self, debug_vis: bool) -> None:
+            self.debug_vis = debug_vis
+
+    class _Commands:
+        def __init__(self) -> None:
+            self.object_pose = _Term(True)
+            self.extra = [_Term(True), {"nested": _Term(True)}]
+
+    class _EnvCfg:
+        def __init__(self) -> None:
+            self.commands = _Commands()
+            self.scene = _Term(False)  # already off: stays off
+            self.not_a_flag = _Term(True)
+            self.debug_vis = "keep"  # non-bool sentinel: must not be touched
+
+    cfg = _EnvCfg()
+    cfg.commands.object_pose.debug_vis = True
+    # A reference cycle must not hang the walk.
+    cfg.commands.parent = cfg  # type: ignore[attr-defined]
+
+    _disable_debug_vis(cfg)
+
+    assert cfg.commands.object_pose.debug_vis is False
+    assert cfg.commands.extra[0].debug_vis is False
+    assert cfg.commands.extra[1]["nested"].debug_vis is False
+    assert cfg.not_a_flag.debug_vis is False
+    assert cfg.scene.debug_vis is False
+    assert cfg.debug_vis == "keep"


### PR DESCRIPTION
## Summary

Three fixes that make the isaacsim plugin actually work on a live Isaac Lab install. Found and verified end-to-end on an RTX 5090 (Isaac Sim 5.0.0/5.1.0, Isaac Lab 2.2.0/2.3.2, `Isaac-Lift-Cube-Franka-v0`) while exercising the zero-config `--sim` path (#14).

1. **Env creation was unconditionally broken.** `_ensure_env` called `gym.make(self.task_id, num_envs=1, render_mode="rgb_array")` — but every Isaac Lab env takes a **mandatory `cfg` object**, so real env creation always failed with:

   ```
   EmbodimentFault: ManagerBasedRLEnv.__init__() missing 1 required positional argument: 'cfg'
   ```

   Fix: resolve the config with Isaac Lab's own `parse_env_cfg(task_id, device, num_envs=1)` and pass it as `cfg=`. (The plugin's CI tests run without Isaac by design — they inject a fake env — so only a live GPU run could catch this.)

2. **Named observation terms.** Manager-based envs concatenate a group's terms into one flat tensor by default (`concatenate_terms=True`), which leaves `_to_observation` with nothing to map onto the adapter's *named* state fields — policies would see an empty `Observation.state`. `_request_named_obs_terms` flips the group's `concatenate_terms` to `False`, and warns if it can't (missing group / renamed flag), so a silently-flat group is at least loud.

3. **Headless runs disable `debug_vis`.** Debug-visualization markers exist for a human watching a viewport — a headless eval has none. Spawning their prototype prims also drags in the shader/material machinery (`Sdr.Registry()` / MDL discovery), which can hang env creation outright on hosts whose render stack is unhealthy (observed live: a missing `libGLU.so.1` killed `omni.iray.libs` and the marker's preview-surface material spun forever). `_disable_debug_vis` walks the resolved env cfg (cycle-safe) and switches every `debug_vis=True` off.

Silver lining from the original failed run: the framework's error contract held — the `EmbodimentFault` halted the eval and the error `EvalLog` still reached disk with the fault recorded on the scene.

## Test plan

- Plugin suite (no-Isaac, fake-env): 15 passed, including new tests for the debug-vis walk (nesting, cycles, non-bool sentinels) and the named-obs request (success path quiet, no-op path warns); ruff + strict mypy (CI's exact invocation) green.
- Live verification on the 5090 box: **passed** on CPU physics (Isaac Sim 5.0.0) and GPU physics (5.1.0) — see comments below.
- `CHANGELOG.md` entry under "Unreleased".

🤖 Generated with [Claude Code](https://claude.com/claude-code)