### PR TITLE
Add PyPI release workflow (trusted publishing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+# Publishes to PyPI via trusted publishing (OIDC) — no API tokens.
+# Each job authenticates against its own PyPI trusted-publisher entry,
+# distinguished by the GitHub environment name (pypi / pypi-isaacsim).
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-core:
+    name: publish inspect-robots
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # OIDC token for PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # hatch-vcs derives the version from git tags
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Build sdist + wheel
+        run: uv build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-isaacsim:
+    name: publish inspect-robots-isaacsim
+    runs-on: ubuntu-latest
+    environment: pypi-isaacsim
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Build sdist + wheel
+        run: uv build --package inspect-robots-isaacsim
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # The plugin is versioned independently (static version in its
+          # pyproject); a repo release that doesn't bump it should not fail
+          # on the already-uploaded file.
+          skip-existing: true


### PR DESCRIPTION
Adds `.github/workflows/release.yml`, which publishes to PyPI on every published GitHub release via OIDC trusted publishing (no API tokens).

Two jobs, matching the two pending trusted publishers registered on PyPI:
- **publish-core** (`environment: pypi`) — builds and publishes `inspect-robots`. Uses `fetch-depth: 0` so hatch-vcs can derive the version from the release tag.
- **publish-isaacsim** (`environment: pypi-isaacsim`) — builds and publishes `plugins/inspect-robots-isaacsim` (static version). `skip-existing: true` so a repo release that doesn't bump the plugin version doesn't fail on re-upload.

Both `uv build` invocations were smoke-tested locally and produce correct sdists/wheels. Note: a `0.3.0` tag already exists, so the first PyPI release should be tagged `v0.3.1` or higher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)