### PR TITLE
README lockfile note + weekly fresh-resolution canary

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,46 @@
+name: Canary
+
+# Weekly fresh-resolution test. Regular CI installs from uv.lock, so it can't
+# see that a new release of an allowed dependency breaks us — this job can:
+# it resolves the latest versions the pyproject ranges allow (ignoring the
+# lockfile) and runs the test suite. On failure it opens an issue, like the
+# red-main alert. A green canary is also the signal that it's safe to refresh
+# the lockfile (`uv lock --upgrade`).
+on:
+  schedule:
+    - cron: "23 5 * * 1"  # Mondays 05:23 UTC
+  workflow_dispatch:
+
+jobs:
+  fresh-deps:
+    name: fresh resolution (latest allowed deps)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write  # open the failure alert
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # hatch-vcs derives the version from git tags
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Create venv
+        run: uv venv --python 3.12
+      - name: Install latest allowed deps (unlocked)
+        run: uv pip install -e ".[dev]"
+      - name: Pytest
+        run: uv run --no-sync pytest -q
+      - name: Open an issue on failure (unless one is already open)
+        if: ${{ failure() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          existing=$(gh issue list -R "$GITHUB_REPOSITORY" --state open --search "Canary in:title" --json number --jq length)
+          if [ "$existing" = "0" ]; then
+            gh issue create -R "$GITHUB_REPOSITORY" \
+              --title "Canary: latest allowed dependencies break the build" \
+              --body "The weekly fresh-resolution canary failed: $RUN_URL — a new release of an allowed dependency likely breaks us. Fix: cap the offending dependency in pyproject.toml (then uv lock), or adapt the code and refresh the lock with uv lock --upgrade."
+          else
+            echo "an open canary issue already exists; not filing another"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,10 @@ and its 100% coverage gate; `plugins/inspect-robots-isaacsim/` is the reference 
 - **CI installs from `uv.lock`** (`uv sync --locked`). After changing
   dependencies in `pyproject.toml`, run `uv lock` and commit the lockfile —
   otherwise CI fails with "the lockfile needs to be updated".
+- A weekly **canary** (`canary.yml`) does the opposite: it installs the latest
+  dependency versions the pyproject ranges allow (ignoring the lockfile), runs
+  the tests, and opens an issue on failure — catching ecosystem breakage that
+  locked CI can't see. A green canary means `uv lock --upgrade` is safe.
 - The `test-extra` tier stays advisory: `continue-on-error: true` means it
   reports success to `ci-ok` even when its steps fail — listing it in `needs`
   does not make it blocking.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ and [`llms-full.txt`](https://inspectrobots.org/llms-full.txt).
 
 ## Development
 
+> **Dependency changes:** after editing dependencies in `pyproject.toml`, run
+> `uv lock` and commit the updated lockfile — CI installs with
+> `uv sync --locked` and fails with "the lockfile needs to be updated" if you
+> forget. Day-to-day conventions (PR-only `main`, the required `ci-ok` check,
+> one-click releases) are documented in [`CLAUDE.md`](CLAUDE.md).
+
 ```bash
 uv venv && uv pip install -e ".[dev]"
 uv run pre-commit install          # ruff + mypy on commit, 100% coverage on push


### PR DESCRIPTION
Two related changes:

1. **README**: a Development-section callout — after editing dependencies in `pyproject.toml`, run `uv lock` and commit the lockfile (CI installs with `uv sync --locked` and fails otherwise), with a pointer to CLAUDE.md.
2. **Weekly canary** (`canary.yml`, Mondays + manual dispatch): locked CI can't see that a new release of an allowed dependency breaks fresh installs — the canary installs the latest allowed versions (ignoring `uv.lock`), runs the tests, and opens a deduped issue on failure. A green canary is the signal that `uv lock --upgrade` is safe. Documented in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)