### PR TITLE
README: lead with what the project is, keep Inspect AI as a nod

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # 🤖 Inspect Robots
 
-### The [Inspect AI](https://inspect.aisi.org.uk/) for robotics
-
-**An open-source evaluation framework for physical AI and VLA (vision-language-action) models.**
+### An open-source evaluation framework for physical AI and VLA (vision-language-action) models
 
 Define a robotics benchmark once, then run *any* policy against *any* compatible
 embodiment — a real robot or a simulator — with reproducible logs and first-class
 [Rerun](https://github.com/rerun-io/rerun) visualization.
+
+If you know [Inspect AI](https://inspect.aisi.org.uk/), this is that for robotics.
 
 [![CI](https://github.com/robocurve/inspect-robots/actions/workflows/ci.yml/badge.svg)](https://github.com/robocurve/inspect-robots/actions/workflows/ci.yml)
 [![Docs](https://github.com/robocurve/inspect-robots/actions/workflows/docs.yml/badge.svg)](https://inspectrobots.org/)
@@ -122,9 +122,9 @@ If you know [Inspect AI](https://inspect.aisi.org.uk/), you already know Inspect
 | `eval()` → `EvalLog` | `eval()` → `EvalLog` |
 | `@task` / `@solver` / `@scorer` + registry | `@task` / `@policy` / `@embodiment` / `@scorer` + entry points |
 
-This repository is the **framework** (the "Inspect AI for robotics"). Concrete
-benchmarks (the "Inspect Evals for robotics") and backend adapters live in
-separate plugin packages.
+This repository is the **framework**. Concrete benchmarks live in
+[WorldEvals](https://github.com/robocurve/worldevals), the benchmark catalog,
+and backend adapters live in separate plugin packages.
 
 ## Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "inspect-robots"
 dynamic = ["version"]
-description = "The Inspect AI for robotics — an evaluation framework for VLA (vision-language-action) models across real robots and simulators."
+description = "An evaluation framework for VLA (vision-language-action) models across real robots and simulators — the Inspect AI for robotics."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
Robotics folks generally don't know Inspect AI, so the framing inverts to describe-first, analogize-second:

- Tagline is now the plain-language description; the Inspect AI reference becomes a follow-up line: "If you know Inspect AI, this is that for robotics."
- The ecosystem paragraph explains framework vs. benchmarks in its own terms (naming WorldEvals directly) instead of via the two Inspect analogies.
- PyPI summary (pyproject `description`) inverted the same way.
- The "How it maps to Inspect AI" section is untouched — it's already gated on knowing Inspect AI and sits appropriately deep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)