### PR TITLE
build: render README alerts as bold notes on PyPI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,3 +85,7 @@ and its 100% coverage gate; `plugins/inspect-robots-isaacsim/` is the reference 
   patch/minor/major. The version is derived from the git tag by hatch-vcs —
   never add a static `version =` back to pyproject (`__version__` comes from importlib.metadata. Exception: `plugins/*` packages keep static versions in their own pyprojects; bump one in a PR and it publishes alongside the next core release via its `publish-<name>` job in `release.yml` (`skip-existing` makes unchanged versions a no-op). A new plugin needs its own `publish-<name>` job and PyPI trusted-publisher environment). The same
   run publishes to PyPI via trusted publishing; nothing is pushed to main.
+- **PyPI readme is transformed at build time** — `hatch-fancy-pypi-readme`
+  rewrites GitHub-only alert syntax (`> [!NOTE]` etc.) in README.md into bold
+  blockquotes (`> **Note:**`) that PyPI renders; keep using alert syntax in the
+  README itself. Config lives at the bottom of pyproject.toml.

--- a/plugins/inspect-robots-isaacsim/pyproject.toml
+++ b/plugins/inspect-robots-isaacsim/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = ["hatchling>=1.18"]
+requires = ["hatchling>=1.18", "hatch-fancy-pypi-readme>=24.1"]
 build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-isaacsim"
 version = "0.1.0"
 description = "IsaacSim / Isaac Lab embodiment adapter for Inspect Robots — run Inspect Robots evals against an Isaac Lab simulation."
-readme = "README.md"
+dynamic = ["readme"]
 requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "Inspect Robots contributors" }]
@@ -61,3 +61,31 @@ strict = true
 [[tool.mypy.overrides]]
 module = ["isaaclab.*", "isaaclab_tasks.*", "gymnasium.*", "torch.*"]
 ignore_missing_imports = true
+
+# PyPI readme: identical to README.md except GitHub-only alert syntax
+# (e.g. `> [!NOTE]`) is rewritten to bold blockquotes, which PyPI renders.
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!NOTE\][ \t]*$'
+replacement = '> **Note:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!TIP\][ \t]*$'
+replacement = '> **Tip:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!IMPORTANT\][ \t]*$'
+replacement = '> **Important:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!WARNING\][ \t]*$'
+replacement = '> **Warning:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!CAUTION\][ \t]*$'
+replacement = '> **Caution:**'

--- a/plugins/inspect-robots-xpolicylab/pyproject.toml
+++ b/plugins/inspect-robots-xpolicylab/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = ["hatchling>=1.18"]
+requires = ["hatchling>=1.18", "hatch-fancy-pypi-readme>=24.1"]
 build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-xpolicylab"
 version = "0.1.0"
 description = "XPolicyLab policy adapter for Inspect Robots — evaluate any XPolicyLab-served VLA policy (π0, GR00T, OpenVLA-OFT, RDT, ACT, ...) with Inspect Robots."
-readme = "README.md"
+dynamic = ["readme"]
 requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "Inspect Robots contributors" }]
@@ -70,3 +70,31 @@ strict = true
 [[tool.mypy.overrides]]
 module = ["msgpack.*", "msgpack_numpy.*"]
 ignore_missing_imports = true
+
+# PyPI readme: identical to README.md except GitHub-only alert syntax
+# (e.g. `> [!NOTE]`) is rewritten to bold blockquotes, which PyPI renders.
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!NOTE\][ \t]*$'
+replacement = '> **Note:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!TIP\][ \t]*$'
+replacement = '> **Tip:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!IMPORTANT\][ \t]*$'
+replacement = '> **Important:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!WARNING\][ \t]*$'
+replacement = '> **Warning:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!CAUTION\][ \t]*$'
+replacement = '> **Caution:**'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,11 @@
 [build-system]
-requires = ["hatchling>=1.18", "hatch-vcs>=0.3"]
+requires = ["hatchling>=1.18", "hatch-vcs>=0.3", "hatch-fancy-pypi-readme>=24.1"]
 build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots"
-dynamic = ["version"]
+dynamic = ["version", "readme"]
 description = "An evaluation framework for VLA (vision-language-action) models across real robots and simulators — the Inspect AI for robotics."
-readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 license-files = ["LICENSE"]
@@ -151,3 +150,31 @@ exclude_also = [
 # plugin editable into one shared environment.
 [tool.uv.workspace]
 members = ["plugins/*"]
+
+# PyPI readme: identical to README.md except GitHub-only alert syntax
+# (e.g. `> [!NOTE]`) is rewritten to bold blockquotes, which PyPI renders.
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!NOTE\][ \t]*$'
+replacement = '> **Note:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!TIP\][ \t]*$'
+replacement = '> **Tip:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!IMPORTANT\][ \t]*$'
+replacement = '> **Important:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!WARNING\][ \t]*$'
+replacement = '> **Warning:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!CAUTION\][ \t]*$'
+replacement = '> **Caution:**'


### PR DESCRIPTION
GitHub's `> [!NOTE]` alert syntax renders as a callout on github.com but shows up as literal `[!NOTE]` text on PyPI project pages (PyPI's renderer doesn't support the alerts extension). With the early-development note now in the README, the next release would have shipped that literal text to PyPI.

This PR adds [`hatch-fancy-pypi-readme`](https://github.com/hynek/hatch-fancy-pypi-readme) so the PyPI long description is generated from `README.md` with alert markers rewritten to portable bold blockquotes (`> [!NOTE]` → `> **Note:**`; TIP/IMPORTANT/WARNING/CAUTION likewise). The README itself is unchanged — GitHub keeps rendering the nice callout.

Why here and not a sed step in `release.yml`: rewriting the README mid-workflow would dirty the tag checkout and make hatch-vcs emit a `+dYYYYMMDD` local version, which PyPI rejects. The metadata-hook approach keeps the tree clean and also fixes local `uv build`.

- `uv.lock` unchanged — build-system requirements aren't part of the dependency lock.
- Verified locally: `uv build` sdist PKG-INFO and a wheel built *from* the extracted sdist both contain `> **Note:**` and no literal `[!NOTE]` (README.md was already in the sdist include list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
