### PR TITLE
Release prep: 0.4.0 (isaacsim 0.1.1, changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). While the version is
 `0.x`, breaking changes may occur on any minor release.
 
-## [Unreleased]
+## [0.4.0] - 2026-07-09
+
+Plugin releases alongside this version: `inspect-robots-xpolicylab` 0.1.0
+(first release) and `inspect-robots-isaacsim` 0.1.1 (ships the env-creation
+fix below).
 
 ### Added
 

--- a/plugins/inspect-robots-isaacsim/pyproject.toml
+++ b/plugins/inspect-robots-isaacsim/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-isaacsim"
-version = "0.1.0"
+version = "0.1.1"
 description = "IsaacSim / Isaac Lab embodiment adapter for Inspect Robots — run Inspect Robots evals against an Isaac Lab simulation."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/__init__.py
+++ b/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/__init__.py
@@ -24,7 +24,7 @@ from inspect_robots_isaacsim.embodiment import IsaacSimEmbodiment
 
 __all__ = ["IsaacSimEmbodiment", "isaacsim_embodiment"]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 def isaacsim_embodiment(**kwargs: Any) -> IsaacSimEmbodiment:

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-isaacsim"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "plugins/inspect-robots-isaacsim" }
 dependencies = [
     { name = "inspect-robots" },


### PR DESCRIPTION
Pre-release housekeeping for v0.4.0:

- **isaacsim plugin → 0.1.1** so the [env-creation fix](https://github.com/robocurve/inspect-robots/blob/main/CHANGELOG.md) actually publishes — `skip-existing: true` makes an unbumped version a silent no-op.
- **CHANGELOG**: `Unreleased` → `[0.4.0] - 2026-07-09`, with a note that this release ships `inspect-robots-xpolicylab` 0.1.0 (first release) and `inspect-robots-isaacsim` 0.1.1.
- `uv.lock` refreshed for the version bump.

After merge: Actions → Release → **minor** publishes core 0.4.0 + both plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)