### PR TITLE
CLI closes resolved embodiments; store_frames config default + per-run frame dirs

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -39,6 +39,7 @@ embodiment = yam-bimanual            ; the default: real hardware
 sim_embodiment = yam-bimanual-isaac  ; what --sim swaps in
 scorer = operator      ; optional, ad-hoc runs only
 max_steps = 300        ; optional, ad-hoc runs only
+store_frames = true    ; optional, capture frames on every run
 
 [policy.args]          ; default -P key=value pairs
 checkpoint = ~/ckpts/molmoact2-yam.pt
@@ -115,8 +116,12 @@ inspect-robots run --task cubepick-reach -T num_scenes=10 --policy scripted -P c
 
 `--epochs N` overrides the task's epoch count, `--fail-on-error X` halts on
 `PolicyError`s (`1` = first error, `0<X<1` = proportion, `X>1` = count), and
-`--store-frames` streams camera frames to `<log-dir>/frames`. When the run
-finishes, the path of the written log is printed.
+`--store-frames` streams camera frames to a per-run subdirectory of
+`<log-dir>/frames` (trial ids repeat across runs, so each run gets its own
+directory; the log's `stats.frames_dir` records the exact path). A
+`store_frames = true` config default enables capture on every run;
+`--no-store-frames` disables it for one invocation. When the run finishes,
+the path of the written log is printed.
 
 `--policy`/`--embodiment` may be omitted when defaults are configured (see
 the zero-config section above); `--instruction "..."` replaces `--task` to

--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -46,9 +46,12 @@ no-ops, so core never depends on it. Install with `pip install "inspect-robots[r
 ## Frame side-cars
 
 Camera frames are large. With `store_frames=True`, the rollout streams frames to
-`<log_dir>/frames` through a [`FrameStore`][inspect_robots.frames.FrameStore] and the
-`TrialRecord` keeps lightweight [`FrameRef`][inspect_robots.frames.FrameRef] handles — so
-long, multi-camera episodes stay memory-safe and remain scorable from disk.
+a per-run subdirectory of `<log_dir>/frames` through a
+[`FrameStore`][inspect_robots.frames.FrameStore] and the `TrialRecord` keeps lightweight
+[`FrameRef`][inspect_robots.frames.FrameRef] handles — so long, multi-camera episodes stay
+memory-safe and remain scorable from disk. Trial ids repeat across runs, so
+each eval gets its own directory; read the exact path from the log's
+`stats.frames_dir` rather than globbing `<log_dir>/frames` directly.
 
 ```python
 eval(task, policy, embodiment, log_dir="logs", store_frames=True)

--- a/src/inspect_robots/_defaults.py
+++ b/src/inspect_robots/_defaults.py
@@ -60,6 +60,7 @@ class Defaults:
     sim_embodiment_source: str | None = None
     scorer: str | None = None
     max_steps: int | None = None
+    store_frames: bool = False
     policy_args: dict[str, Any] = field(default_factory=dict)
     embodiment_args: dict[str, Any] = field(default_factory=dict)
     sim_embodiment_args: dict[str, Any] = field(default_factory=dict)
@@ -111,6 +112,13 @@ def _read_config(path: Path) -> Defaults:
             raise _die(path, f"[defaults] max_steps must be an integer >= 1, got {raw_steps!r}")
         max_steps = parsed
 
+    store_frames = False
+    if raw_frames := parser.get("defaults", "store_frames", fallback=None):
+        parsed_frames = parse_value(raw_frames)
+        if not isinstance(parsed_frames, bool):
+            raise _die(path, f"[defaults] store_frames must be true or false, got {raw_frames!r}")
+        store_frames = parsed_frames
+
     policy = parser.get("defaults", "policy", fallback=None)
     embodiment = parser.get("defaults", "embodiment", fallback=None)
     sim_embodiment = parser.get("defaults", "sim_embodiment", fallback=None)
@@ -123,6 +131,7 @@ def _read_config(path: Path) -> Defaults:
         sim_embodiment_source=source if sim_embodiment else None,
         scorer=parser.get("defaults", "scorer", fallback=None),
         max_steps=max_steps,
+        store_frames=store_frames,
         policy_args=_parse_args_section(parser, "policy.args"),
         embodiment_args=_parse_args_section(parser, "embodiment.args"),
         sim_embodiment_args=_parse_args_section(parser, "sim_embodiment.args"),

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -299,27 +299,27 @@ def _cmd_run(args: argparse.Namespace) -> int:
 
     policy = _resolve_or_exit("policy", policy_name, **policy_kvs)
     embodiment = _resolve_or_exit("embodiment", embodiment_name, **embodiment_kvs)
-    if args.epochs is not None:
-        task = replace(task, epochs=args.epochs)
-
-    # Defaults must never be silent: say what runs, and why, before it moves.
-    print(f"policy: {policy_name} ({policy_source})")
-    print(f"embodiment: {embodiment_name} ({embodiment_source})")
-
-    before_scoring = None
-    if (
-        is_adhoc
-        and not args.no_prompt
-        and sys.stdin.isatty()
-        and any(s.name == "operator" for s in task.scorers)
-    ):
-        # Ad-hoc runs only: a registered task with an operator scorer keeps
-        # R6's non-blocking, unattended-safe behavior (judgement stays None).
-        before_scoring = _prompt_operator
-
-    # Construct the sink explicitly so we can tell the user where the log went.
-    sink = JsonLogSink(args.log_dir)
     try:
+        if args.epochs is not None:
+            task = replace(task, epochs=args.epochs)
+
+        # Defaults must never be silent: say what runs, and why, before it moves.
+        print(f"policy: {policy_name} ({policy_source})")
+        print(f"embodiment: {embodiment_name} ({embodiment_source})")
+
+        before_scoring = None
+        if (
+            is_adhoc
+            and not args.no_prompt
+            and sys.stdin.isatty()
+            and any(s.name == "operator" for s in task.scorers)
+        ):
+            # Ad-hoc runs only: a registered task with an operator scorer keeps
+            # R6's non-blocking, unattended-safe behavior (judgement stays None).
+            before_scoring = _prompt_operator
+
+        # Construct the sink explicitly so we can tell the user where the log went.
+        sink = JsonLogSink(args.log_dir)
         logs = eval(
             task,
             policy,
@@ -336,7 +336,9 @@ def _cmd_run(args: argparse.Namespace) -> int:
     finally:
         # The CLI resolved the embodiment itself, so eval() does not own it
         # ("close what we open"). Real-hardware embodiments release motor
-        # torque in close(); skipping this leaves a robot energized.
+        # torque in close(); skipping this leaves a robot energized. The span
+        # starts right after resolution: --epochs/scorer validation between
+        # here and eval() can raise, and that must not leak the embodiment.
         embodiment.close()
     log = logs[0]
     print(f"status: {log.status}")

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -325,7 +325,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
             seed=args.seed,
             sinks=[sink],
             fail_on_error=args.fail_on_error if args.fail_on_error is not None else False,
-            store_frames=args.store_frames,
+            store_frames=args.store_frames or defaults.store_frames,
             before_scoring=before_scoring,
         )
     finally:

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -132,8 +132,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_run.add_argument(
         "--store-frames",
-        action="store_true",
-        help="stream camera frames to <log-dir>/frames instead of keeping them in memory",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="stream camera frames to a per-run directory under <log-dir>/frames "
+        "instead of keeping them in memory (--no-store-frames overrides a "
+        "store_frames config default)",
     )
 
     p_inspect = sub.add_parser("inspect", help="print a saved eval log")
@@ -325,7 +328,9 @@ def _cmd_run(args: argparse.Namespace) -> int:
             seed=args.seed,
             sinks=[sink],
             fail_on_error=args.fail_on_error if args.fail_on_error is not None else False,
-            store_frames=args.store_frames or defaults.store_frames,
+            store_frames=(
+                args.store_frames if args.store_frames is not None else defaults.store_frames
+            ),
             before_scoring=before_scoring,
         )
     finally:

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -316,17 +316,23 @@ def _cmd_run(args: argparse.Namespace) -> int:
 
     # Construct the sink explicitly so we can tell the user where the log went.
     sink = JsonLogSink(args.log_dir)
-    logs = eval(
-        task,
-        policy,
-        embodiment,
-        log_dir=args.log_dir,
-        seed=args.seed,
-        sinks=[sink],
-        fail_on_error=args.fail_on_error if args.fail_on_error is not None else False,
-        store_frames=args.store_frames,
-        before_scoring=before_scoring,
-    )
+    try:
+        logs = eval(
+            task,
+            policy,
+            embodiment,
+            log_dir=args.log_dir,
+            seed=args.seed,
+            sinks=[sink],
+            fail_on_error=args.fail_on_error if args.fail_on_error is not None else False,
+            store_frames=args.store_frames,
+            before_scoring=before_scoring,
+        )
+    finally:
+        # The CLI resolved the embodiment itself, so eval() does not own it
+        # ("close what we open"). Real-hardware embodiments release motor
+        # torque in close(); skipping this leaves a robot energized.
+        embodiment.close()
     log = logs[0]
     print(f"status: {log.status}")
     print(f"scenes: {log.results.total_scenes}  trials: {log.results.total_trials}")

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import os
 import subprocess
 import time
+import uuid
 from collections.abc import Callable, Sequence
 from dataclasses import asdict
 from datetime import datetime, timezone
@@ -224,7 +225,13 @@ def _run_eval(
 
     frame_store: FrameStore | None = None
     if store_frames:
-        frame_store = FrameStore(str(Path(log_dir) / "frames"))
+        # One subdirectory per run: trial ids repeat across runs (scene-epoch),
+        # so a shared directory would silently overwrite the previous run's
+        # frames. The log's stats.frames_dir records the exact directory.
+        run_stamp = (
+            datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S") + f"_{uuid.uuid4().hex[:8]}"
+        )
+        frame_store = FrameStore(str(Path(log_dir) / "frames" / run_stamp))
 
     spec = EvalSpec(
         task=task.name,

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -173,3 +173,23 @@ def test_env_sim_embodiment_overrides_config_but_not_real(tmp_path: Path) -> Non
     assert d.sim_embodiment_args["headless"] is True
     scene_file = d.sim_embodiment_args["scene_file"]
     assert isinstance(scene_file, str) and scene_file.endswith("scenes/kitchen.usd")
+
+
+def test_config_store_frames_parses_bool(tmp_path: Path) -> None:
+    config_home = tmp_path / "cfg"
+    _write_config(config_home, "[defaults]\nstore_frames = true\n")
+    defaults = load_defaults({"XDG_CONFIG_HOME": str(config_home)})
+    assert defaults.store_frames is True
+
+
+def test_config_store_frames_defaults_false(tmp_path: Path) -> None:
+    config_home = tmp_path / "cfg"
+    _write_config(config_home, "[defaults]\npolicy = x\n")
+    assert load_defaults({"XDG_CONFIG_HOME": str(config_home)}).store_frames is False
+
+
+def test_config_store_frames_rejects_non_bool(tmp_path: Path) -> None:
+    config_home = tmp_path / "cfg"
+    _write_config(config_home, "[defaults]\nstore_frames = 12\n")
+    with pytest.raises(SystemExit, match="store_frames"):
+        load_defaults({"XDG_CONFIG_HOME": str(config_home)})

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -145,7 +145,7 @@ def test_store_frames_writes_side_cars(tmp_path: Path) -> None:
         task, ScriptedPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path), store_frames=True
     )
     assert logs[0].stats.frames_dir is not None
-    assert list((tmp_path / "frames").glob("*.npy"))
+    assert list((tmp_path / "frames").rglob("*.npy"))
 
 
 def test_eval_set_runs_multiple_tasks(tmp_path: Path) -> None:
@@ -166,3 +166,25 @@ def test_eval_set_runs_multiple_tasks(tmp_path: Path) -> None:
     assert success is True
     assert len(logs) == 2
     assert {log.eval.task for log in logs} == {"a", "b"}
+
+
+def test_store_frames_runs_do_not_overwrite_each_other(tmp_path: Path) -> None:
+    """Each eval gets its own frames subdir; a second run must not clobber the first."""
+    from inspect_robots import eval
+
+    task = Task(
+        name="demo",
+        scenes=[Scene(id="s0", instruction="reach", init_seed=0)],
+        scorer=success_at_end(),
+        max_steps=5,
+    )
+    dirs = set()
+    for _ in range(2):
+        logs = eval(
+            task, ScriptedPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path), store_frames=True
+        )
+        assert logs[0].stats.frames_dir is not None
+        dirs.add(logs[0].stats.frames_dir)
+    assert len(dirs) == 2  # distinct per-run directories
+    for d in dirs:
+        assert list(Path(d).glob("*.npy"))  # both runs' frames still on disk

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -600,3 +600,19 @@ def test_config_store_frames_enables_frame_capture(
     assert rc == 0
     assert list((log_dir / "frames").rglob("*.npy"))
     assert _read_only_log(log_dir).stats.frames_dir is not None
+
+
+def test_no_store_frames_flag_overrides_config_default(
+    _hermetic_defaults: Path, tmp_path: Path
+) -> None:
+    """--no-store-frames must win over store_frames = true in the config file."""
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\npolicy = scripted\nembodiment = cubepick\n"
+        "scorer = success_at_end\nstore_frames = true\n",
+    )
+    log_dir = tmp_path / "logs"
+    rc = main(["reach the cube", "--no-store-frames", "--log-dir", str(log_dir)])
+    assert rc == 0
+    assert not (log_dir / "frames").exists()
+    assert _read_only_log(log_dir).stats.frames_dir is None

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -561,3 +561,26 @@ def test_sim_ignores_real_embodiment_env_var(
     rc = main(["reach the cube", "--sim", "--scorer", "success_at_end", "--log-dir", str(log_dir)])
     assert rc == 0
     assert "embodiment: cubepick" in capsys.readouterr().out
+
+
+def test_cli_run_closes_the_embodiment_it_resolved(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The CLI resolves the embodiment itself (so eval() does not own it); it
+    must close what it opened — real-hardware embodiments release motor torque
+    in close(), and skipping it leaves arms energized after the run."""
+    from inspect_robots.mock import CubePickEmbodiment
+
+    closed: list[bool] = []
+
+    class _Tracked(CubePickEmbodiment):
+        def close(self) -> None:
+            closed.append(True)
+            super().close()
+
+    monkeypatch.setitem(reg._FACTORIES["embodiment"], "tracked-cubepick", _Tracked)
+    monkeypatch.setenv(ENV_POLICY, "scripted")
+    monkeypatch.setenv(ENV_EMBODIMENT, "tracked-cubepick")
+    rc = main(["reach the cube", "--scorer", "success_at_end", "--log-dir", str(tmp_path / "logs")])
+    assert rc == 0
+    assert closed == [True]

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -586,6 +586,40 @@ def test_cli_run_closes_the_embodiment_it_resolved(
     assert closed == [True]
 
 
+def test_cli_run_closes_embodiment_when_validation_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failure between resolving the embodiment and eval() (here: --epochs 0
+    raising ConfigError) must still close the embodiment — otherwise a bad flag
+    leaves real arms energized."""
+    from inspect_robots.errors import ConfigError
+    from inspect_robots.mock import CubePickEmbodiment
+
+    closed: list[bool] = []
+
+    class _Tracked(CubePickEmbodiment):
+        def close(self) -> None:
+            closed.append(True)
+            super().close()
+
+    monkeypatch.setitem(reg._FACTORIES["embodiment"], "tracked-cubepick", _Tracked)
+    monkeypatch.setenv(ENV_POLICY, "scripted")
+    monkeypatch.setenv(ENV_EMBODIMENT, "tracked-cubepick")
+    with pytest.raises(ConfigError):
+        main(
+            [
+                "reach the cube",
+                "--scorer",
+                "success_at_end",
+                "--epochs",
+                "0",
+                "--log-dir",
+                str(tmp_path / "logs"),
+            ]
+        )
+    assert closed == [True]
+
+
 def test_config_store_frames_enables_frame_capture(
     _hermetic_defaults: Path, tmp_path: Path
 ) -> None:

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -129,7 +129,7 @@ def test_cli_run_epochs_fail_on_error_store_frames(
     assert rc == 0
     out = capsys.readouterr().out
     assert "trials: 2" in out  # --epochs overrode the task's epoch count
-    assert list((tmp_path / "frames").glob("*.npy"))  # --store-frames streamed
+    assert list((tmp_path / "frames").rglob("*.npy"))  # --store-frames streamed (per-run subdir)
 
 
 def test_cli_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
@@ -584,3 +584,19 @@ def test_cli_run_closes_the_embodiment_it_resolved(
     rc = main(["reach the cube", "--scorer", "success_at_end", "--log-dir", str(tmp_path / "logs")])
     assert rc == 0
     assert closed == [True]
+
+
+def test_config_store_frames_enables_frame_capture(
+    _hermetic_defaults: Path, tmp_path: Path
+) -> None:
+    """store_frames = true in the config file captures frames with no CLI flag."""
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\npolicy = scripted\nembodiment = cubepick\n"
+        "scorer = success_at_end\nstore_frames = true\n",
+    )
+    log_dir = tmp_path / "logs"
+    rc = main(["reach the cube", "--log-dir", str(log_dir)])
+    assert rc == 0
+    assert list((log_dir / "frames").rglob("*.npy"))
+    assert _read_only_log(log_dir).stats.frames_dir is not None


### PR DESCRIPTION
Two hardening changes for real-hardware runs, stacked (second builds on the first):

**1. CLI closes the embodiment it resolved** — `_cmd_run` resolves the embodiment into an object, so `eval()`'s "close what we open" ownership rule never applied and nothing closed it. Harmless for sims, but a real-hardware embodiment releases motor torque (and parks the arms) in `close()`; skipping it leaves the robot energized after the run. The close lives in a `finally` so a halting eval can't skip it. Found driving real YAM arms via the zero-config CLI.

**2. `store_frames` as a config default + per-run frame directories** — `[defaults] store_frames = true` in config.ini enables frame capture on every run without the flag. Frame side-cars now land in a per-run subdirectory of `<log_dir>/frames`: trial ids repeat across runs (scene-epoch), so the old shared directory silently overwrote the previous run's frames — unacceptable once capture is a default. `stats.frames_dir` records the exact directory.

Both TDD'd; ruff/mypy-strict/pytest green, coverage untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)