### PR TITLE
isaacsim: headless debug_vis + named observation terms

### DIFF
--- a/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
+++ b/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
@@ -208,8 +208,13 @@ class IsaacSimEmbodiment:
         # Importing the tasks registers the gym ids; must happen AFTER the app boots.
         import gymnasium as gym
         import isaaclab_tasks  # noqa: F401  (registers Isaac-* gym ids)
+        from isaaclab_tasks.utils import parse_env_cfg
 
-        self._env = gym.make(self.task_id, num_envs=1, render_mode="rgb_array")
+        # Isaac Lab envs take a mandatory cfg object (gym.make(task_id) alone
+        # raises "missing 1 required positional argument: 'cfg'"); parse_env_cfg
+        # is Isaac Lab's own task-id -> config resolution.
+        env_cfg = parse_env_cfg(self.task_id, device=self.device, num_envs=1)
+        self._env = gym.make(self.task_id, cfg=env_cfg, render_mode="rgb_array")
         return self._env
 
     # ------------------------------------------------------------------ #

--- a/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
+++ b/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
@@ -102,6 +102,21 @@ def _disable_debug_vis(cfg: Any) -> None:
                 stack.append(value)
 
 
+def _request_named_obs_terms(env_cfg: Any, obs_group: str) -> None:
+    """Ask Isaac Lab to keep the observation group as a named dict.
+
+    Manager-based envs concatenate a group's terms into one flat tensor by
+    default (``concatenate_terms=True``), which would leave ``_to_observation``
+    with nothing to map onto the adapter's *named* state fields — policies
+    would see an empty ``Observation.state``. The adapter's contract is named
+    proprioception, so request named terms.
+    """
+    groups = getattr(env_cfg, "observations", None)
+    group_cfg = getattr(groups, obs_group, None)
+    if group_cfg is not None and hasattr(group_cfg, "concatenate_terms"):
+        group_cfg.concatenate_terms = False
+
+
 def _default_state_fields(num_arm_joints: int) -> tuple[StateField, ...]:
     """Canonical proprioception for a Franka-like arm (keys/units from Inspect Robots)."""
 
@@ -250,6 +265,7 @@ class IsaacSimEmbodiment:
         env_cfg = parse_env_cfg(self.task_id, device=self.device, num_envs=1)
         if self.headless:
             _disable_debug_vis(env_cfg)
+        _request_named_obs_terms(env_cfg, self.obs_group)
         self._env = gym.make(self.task_id, cfg=env_cfg, render_mode="rgb_array")
         return self._env
 

--- a/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
+++ b/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
@@ -68,6 +68,40 @@ def _missing_isaac(exc: ImportError) -> RuntimeError:
     )
 
 
+def _disable_debug_vis(cfg: Any) -> None:
+    """Recursively switch every ``debug_vis`` flag off on an Isaac Lab env cfg.
+
+    Debug-visualization markers exist for a human watching a viewport — a
+    headless eval has none. Spawning their prototype prims also drags in the
+    shader/material machinery (``Sdr.Registry()`` / MDL discovery), which can
+    hang env creation outright on hosts whose render stack is unhealthy
+    (observed live: a missing ``libGLU.so.1`` killed ``omni.iray.libs`` and
+    the marker's preview-surface material spun forever). Never creating the
+    markers is both faster and more robust.
+    """
+    seen: set[int] = set()
+    stack: list[Any] = [cfg]
+    while stack:
+        obj = stack.pop()
+        if id(obj) in seen or isinstance(obj, type):
+            continue
+        seen.add(id(obj))
+        if isinstance(obj, dict):
+            stack.extend(obj.values())
+            continue
+        if isinstance(obj, (list, tuple, set)):
+            stack.extend(obj)
+            continue
+        obj_vars = getattr(obj, "__dict__", None)
+        if obj_vars is None:
+            continue
+        for key, value in obj_vars.items():
+            if key == "debug_vis" and value is True:
+                setattr(obj, "debug_vis", False)
+            elif isinstance(value, (dict, list, tuple, set)) or hasattr(value, "__dict__"):
+                stack.append(value)
+
+
 def _default_state_fields(num_arm_joints: int) -> tuple[StateField, ...]:
     """Canonical proprioception for a Franka-like arm (keys/units from Inspect Robots)."""
 
@@ -214,6 +248,8 @@ class IsaacSimEmbodiment:
         # raises "missing 1 required positional argument: 'cfg'"); parse_env_cfg
         # is Isaac Lab's own task-id -> config resolution.
         env_cfg = parse_env_cfg(self.task_id, device=self.device, num_envs=1)
+        if self.headless:
+            _disable_debug_vis(env_cfg)
         self._env = gym.make(self.task_id, cfg=env_cfg, render_mode="rgb_array")
         return self._env
 

--- a/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
+++ b/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
@@ -278,3 +278,23 @@ def test_disable_debug_vis_walks_nested_configs() -> None:
     assert cfg.not_a_flag.debug_vis is False
     assert cfg.scene.debug_vis is False
     assert cfg.debug_vis == "keep"
+
+
+def test_request_named_obs_terms_flips_concatenate_flag() -> None:
+    from inspect_robots_isaacsim.embodiment import _request_named_obs_terms
+
+    class _Group:
+        concatenate_terms = True
+
+    class _Obs:
+        policy = _Group()
+
+    class _Cfg:
+        observations = _Obs()
+
+    cfg = _Cfg()
+    _request_named_obs_terms(cfg, "policy")
+    assert cfg.observations.policy.concatenate_terms is False
+    # Unknown group / missing attrs: silently a no-op, never raises.
+    _request_named_obs_terms(cfg, "nonexistent")
+    _request_named_obs_terms(object(), "policy")

--- a/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
+++ b/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
@@ -244,3 +244,37 @@ def test_no_ram_leak_over_many_steps() -> None:
     assert fake.step_calls == 3200
     for value in vars(emb).values():
         assert not isinstance(value, (list, dict)) or len(value) <= 1
+
+
+def test_disable_debug_vis_walks_nested_configs() -> None:
+    from inspect_robots_isaacsim.embodiment import _disable_debug_vis
+
+    class _Term:
+        def __init__(self, debug_vis: bool) -> None:
+            self.debug_vis = debug_vis
+
+    class _Commands:
+        def __init__(self) -> None:
+            self.object_pose = _Term(True)
+            self.extra = [_Term(True), {"nested": _Term(True)}]
+
+    class _EnvCfg:
+        def __init__(self) -> None:
+            self.commands = _Commands()
+            self.scene = _Term(False)  # already off: stays off
+            self.not_a_flag = _Term(True)
+            self.debug_vis = "keep"  # non-bool sentinel: must not be touched
+
+    cfg = _EnvCfg()
+    cfg.commands.object_pose.debug_vis = True
+    # A reference cycle must not hang the walk.
+    cfg.commands.parent = cfg  # type: ignore[attr-defined]
+
+    _disable_debug_vis(cfg)
+
+    assert cfg.commands.object_pose.debug_vis is False
+    assert cfg.commands.extra[0].debug_vis is False
+    assert cfg.commands.extra[1]["nested"].debug_vis is False
+    assert cfg.not_a_flag.debug_vis is False
+    assert cfg.scene.debug_vis is False
+    assert cfg.debug_vis == "keep"


### PR DESCRIPTION
Two isaacsim plugin fixes that were stranded on a local branch when #15 (env creation) was merged independently:

- **Disable `debug_vis` in headless env configs** — headless runs crashed/warned trying to build debug visualization.
- **Request named observation terms (`concatenate_terms=False`)** — the embodiment needs per-term observations rather than one concatenated tensor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)