### PR TITLE
docs: remove AI-writing tells from doc site; codify style rule in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,3 +89,21 @@ and its 100% coverage gate; `plugins/inspect-robots-isaacsim/` is the reference 
   rewrites GitHub-only alert syntax (`> [!NOTE]` etc.) in README.md into bold
   blockquotes (`> **Note:**`) that PyPI renders; keep using alert syntax in the
   README itself. Config lives at the bottom of pyproject.toml.
+
+## Writing style (public-facing text)
+
+READMEs, docs pages, repo/collection descriptions, and HF model cards must
+avoid AI-writing tells. The full rule with the gating checklist lives in
+[worldevals docs/model-cards.md, "Writing style"](https://github.com/robocurve/worldevals/blob/main/docs/model-cards.md);
+short version:
+
+- No em dashes in prose. Use periods, colons, commas, or parentheses (`—` is
+  fine as an empty table cell and inside code blocks).
+- Bold only for definition-list lead-ins (`**term:**`) and at most one critical
+  imperative per safety bullet. Never mid-sentence for emphasis.
+- No decorative emoji (functional ✅/⚠️ marks and 🤗 for Hugging Face are fine),
+  no slogans or chiasmus, no "not just X, but Y".
+- Headers use colons, never em dashes or italics.
+
+Style-only edits must never touch YAML frontmatter, code blocks, numbers,
+links, or safety qualifiers.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -11,8 +11,8 @@ robot a command is a one-liner:
 inspect-robots "place the spoon on the plate"
 ```
 
-This runs a single **ad-hoc scene** built from that language instruction on
-your default policy/embodiment — sugar for
+This runs a single ad-hoc scene built from that language instruction on
+your default policy/embodiment: sugar for
 `inspect-robots run --instruction "..."`. The resolved components and where
 they came from are printed before the robot moves. Two flags exist only for
 instruction runs: `--max-steps N` (horizon, default 300) and `--scorer NAME`
@@ -25,7 +25,7 @@ a rollout; a single-word instruction needs the explicit
 
 ### Default policy and embodiment
 
-Resolved in order — first hit wins:
+Resolved in order (first hit wins):
 
 1. explicit flags: `--policy` / `--embodiment`
 2. environment: `INSPECT_ROBOTS_POLICY` / `INSPECT_ROBOTS_EMBODIMENT`
@@ -53,7 +53,7 @@ headless = true
 
 Values parse like `-P/-E` args (bool/int/float/None/str), `~` expands in
 `[*.args]` values, and an explicit `-P/-E key=value` flag overrides the
-same-named config key. There is deliberately **no project-local config file**:
+same-named config key. There is deliberately no project-local config file:
 a checked-in file choosing which policy drives your hardware would be a trust
 footgun.
 
@@ -68,11 +68,11 @@ inspect-robots run --task my-benchmark --policy molmoact2-yam --sim
 ```
 
 The sim embodiment resolves as `$INSPECT_ROBOTS_SIM_EMBODIMENT` > config
-`sim_embodiment`, with constructor args from `[sim_embodiment.args]` only —
+`sim_embodiment`, with constructor args from `[sim_embodiment.args]` only:
 real-rig args (`[embodiment.args]`: serial ports, camera IDs) never leak into
 a sim run, and vice versa. `--sim` together with an explicit `--embodiment`
 is an error (they both pick the embodiment); an exported
-`$INSPECT_ROBOTS_EMBODIMENT` is simply not consulted under `--sim` — it's a
+`$INSPECT_ROBOTS_EMBODIMENT` is simply not consulted under `--sim`: it's a
 persistent default for real runs, not a per-invocation intent. The mapping is
 explicit configuration: the framework never guesses which sim matches your
 robot.
@@ -81,13 +81,13 @@ robot.
 
 An arbitrary instruction has no success oracle, so ad-hoc runs default to the
 `operator` scorer: when run on an interactive terminal, the CLI asks after
-each trial —
+each trial
 
 ```text
 did the robot succeed? [y/n/partial/skip] (partial scores as failure)
 ```
 
-— and records the verdict in the log (`skip` records nothing). Piped/CI
+and records the verdict in the log (`skip` records nothing). Piped/CI
 stdin, `--no-prompt`, or a registered `--task` run never prompt: unattended
 runs stay non-blocking, and an unjudged trial honestly scores as failure with
 "no operator judgement recorded".

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -81,7 +81,7 @@ robot.
 
 An arbitrary instruction has no success oracle, so ad-hoc runs default to the
 `operator` scorer: when run on an interactive terminal, the CLI asks after
-each trial
+each trial,
 
 ```text
 did the robot succeed? [y/n/partial/skip] (partial scores as failure)

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -4,15 +4,15 @@ Inspect Robots factors a robotics evaluation into a few small, orthogonal pieces
 
 ## The two inputs
 
-Unlike LLM evals (one swappable input, the model), a robotics eval has **two**:
+Unlike LLM evals (one swappable input, the model), a robotics eval has two:
 
-- [`Policy`][inspect_robots.policy.Policy] — the VLA "brain". Given an
+- [`Policy`][inspect_robots.policy.Policy]: the VLA "brain". Given an
   [`Observation`][inspect_robots.types.Observation], returns an
   [`ActionChunk`][inspect_robots.types.ActionChunk]: a horizon of actions executed open-loop
   (because VLA inference is slower than the control rate). `H = 1` is the
   degenerate reactive case.
-- [`Embodiment`][inspect_robots.embodiment.Embodiment] — the "body + world": a real robot or
-  a simulator. It produces observations, executes actions, and owns the
+- [`Embodiment`][inspect_robots.embodiment.Embodiment]: the "body + world" (a real robot or
+  a simulator). It produces observations, executes actions, and owns the
   action/observation spaces, the native control rate, and reset/safety machinery.
 
 Both are runtime-checkable Protocols, so you can wrap an existing model or sim
@@ -21,9 +21,9 @@ without inheriting anything. Convenience base classes (`PolicyBase`,
 
 ## Tasks and scenes
 
-A [`Task`][inspect_robots.task.Task] is an **embodiment-agnostic** benchmark: a dataset
+A [`Task`][inspect_robots.task.Task] is an embodiment-agnostic benchmark: a dataset
 of [`Scene`][inspect_robots.scene.Scene]s plus scorer(s), a step horizon, and an epoch
-count. A `Scene` is the robotics analog of Inspect AI's `Sample` — one initial
+count. A `Scene` is the robotics analog of Inspect AI's `Sample`, one initial
 condition: an instruction, an optional success [`Target`][inspect_robots.scene.Target],
 and a seed.
 
@@ -44,7 +44,7 @@ with a [`CompatibilityError`][inspect_robots.errors.CompatibilityError].
    calling `policy.act()` and buffering the chunk (so open-loop execution and
    temporal ensembling compose without forking the loop).
 2. An [`Approver`][inspect_robots.approver.Approver] reviews the action before it reaches
-   the embodiment — pass, clamp, or veto (a safety gate).
+   the embodiment: pass, clamp, or veto (a safety gate).
 3. `embodiment.step(action)` executes it; everything is logged to sinks and
    recorded in an immutable [`TrialRecord`][inspect_robots.rollout.TrialRecord] (steps, a typed
    transcript, inference latencies).
@@ -58,7 +58,7 @@ memory-safe.
 A [`Scorer`][inspect_robots.scorer.Scorer] maps a recorded `TrialRecord` (+ the scene's
 `Target`) to a [`Score`][inspect_robots.scorer.Score]. Because scorers consume the
 *recorded* trajectory (not a live environment), scoring is reproducible from a
-saved log. Across the `epochs` of a scene, an **epoch reducer** (`mean`, `max`,
+saved log. Across the `epochs` of a scene, an epoch reducer (`mean`, `max`,
 `pass_at_k`, …) collapses scores; metrics then aggregate across scenes.
 
 ## Errors and safety
@@ -69,14 +69,14 @@ The error taxonomy resolves the "fail fast vs never-crash-overnight" tension:
 |---|---|
 | [`CompatibilityError`][inspect_robots.errors.CompatibilityError], `ConfigError` | fail fast, before any rollout |
 | [`PolicyError`][inspect_robots.errors.PolicyError] | record the trial, then continue or halt per `fail_on_error` (`True` = first error, `0<x<1` = proportion, `x>1` = count), checked after every trial |
-| [`EmbodimentFault`][inspect_robots.errors.EmbodimentFault], [`SafetyAbort`][inspect_robots.errors.SafetyAbort] | **always halt** — a faulted/unsafe robot never auto-advances |
+| [`EmbodimentFault`][inspect_robots.errors.EmbodimentFault], [`SafetyAbort`][inspect_robots.errors.SafetyAbort] | **always halt**: a faulted/unsafe robot never auto-advances |
 
 Failures inside a trial (including `reset`) are wrapped into the taxonomy; a
 crashing approver becomes a `SafetyAbort` (it can no longer vouch for safety).
 Every error raised from inside a trial carries the partial
 [`TrialRecord`][inspect_robots.rollout.TrialRecord] on its `record` attribute, so the
 steps that did run are delivered to sinks. Errored trials are recorded but
-**never scored** — a failed trial cannot masquerade as data in the metrics.
+never scored: a failed trial cannot masquerade as data in the metrics.
 
 ## The eval log
 
@@ -87,10 +87,10 @@ guarantee. Once rollouts have started, an `EvalLog` is always produced and
 persisted: scorer or reducer failures degrade the run to an error log rather
 than crashing away the night's data.
 
-`eval()` also owns what it opens: an embodiment resolved from a **registry
-name** is closed when the run finishes (even on a halt), while a
-caller-constructed embodiment object stays open — its lifecycle belongs to the
-caller.
+`eval()` also owns what it opens: an embodiment resolved from a registry
+name is closed when the run finishes (even on a halt), while a
+caller-constructed embodiment object stays open (its lifecycle belongs to the
+caller).
 
 Passing `seed=None` draws a fresh seed from the OS and records it in the log,
 so an "unseeded" run remains reproducible after the fact (and is distinct from

--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -2,7 +2,7 @@
 
 ## The eval log
 
-Every run produces an immutable [`EvalLog`][inspect_robots.log.EvalLog] — the canonical,
+Every run produces an immutable [`EvalLog`][inspect_robots.log.EvalLog]: the canonical,
 reproducible record. It mirrors Inspect AI: `version`, `status`, an `eval` spec
 (task/policy/embodiment, created time, git revision, package versions), `results`
 (aggregate metrics), `stats` (timing, inference latency), per-scene `samples`, and
@@ -15,7 +15,7 @@ from inspect_robots import eval, read_eval_log
 again = read_eval_log("logs/cubepick-reach_xxxx.json")   # always re-readable
 ```
 
-Logs are written **atomically** (temp file + rename), schema-versioned, and carry
+Logs are written atomically (temp file + rename), schema-versioned, and carry
 a read-back guarantee: a newer Inspect Robots always reads an older log.
 
 ## Sinks
@@ -24,11 +24,11 @@ A [`LogSink`][inspect_robots.logging.LogSink] observes the run lifecycle
 (`on_eval_start` → per trial `on_trial_start`/`log_step`/`on_trial_end` →
 `on_eval_end`). Builtins:
 
-- [`JsonLogSink`][inspect_robots.logging.JsonLogSink] — the default; the canonical JSON record.
-- [`RerunSink`][inspect_robots.logging.RerunSink] — optional, lazily imported.
+- [`JsonLogSink`][inspect_robots.logging.JsonLogSink]: the default; the canonical JSON record.
+- [`RerunSink`][inspect_robots.logging.RerunSink]: optional, lazily imported.
 
-Passing `sinks=` **replaces** the default `JsonLogSink`, it does not add to it —
-so include one in the list if you still want the JSON log:
+Passing `sinks=` replaces the default `JsonLogSink`, it does not add to it.
+Include one in the list if you still want the JSON log:
 
 ```python
 from inspect_robots.logging import JsonLogSink, RerunSink
@@ -40,7 +40,7 @@ eval(task, policy, embodiment, sinks=[JsonLogSink("logs"), RerunSink("run.rrd")]
 
 `RerunSink` streams camera images, proprioception, action vectors, reward, and
 termination markers to a [Rerun](https://github.com/rerun-io/rerun) recording. It
-imports `rerun-sdk` lazily — if it isn't installed, the sink warns once and
+imports `rerun-sdk` lazily: if it isn't installed, the sink warns once and
 no-ops, so core never depends on it. Install with `pip install "inspect-robots[rerun]"`.
 
 ## Frame side-cars
@@ -48,7 +48,7 @@ no-ops, so core never depends on it. Install with `pip install "inspect-robots[r
 Camera frames are large. With `store_frames=True`, the rollout streams frames to
 a per-run subdirectory of `<log_dir>/frames` through a
 [`FrameStore`][inspect_robots.frames.FrameStore] and the `TrialRecord` keeps lightweight
-[`FrameRef`][inspect_robots.frames.FrameRef] handles — so long, multi-camera episodes stay
+[`FrameRef`][inspect_robots.frames.FrameRef] handles, so long, multi-camera episodes stay
 memory-safe and remain scorable from disk. Trial ids repeat across runs, so
 each eval gets its own directory; read the exact path from the log's
 `stats.frames_dir` rather than globbing `<log_dir>/frames` directly.

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -1,8 +1,8 @@
 # Plugins & the registry
 
-Inspect Robots components register by name and resolve from strings — the mechanism the
+Inspect Robots components register by name and resolve from strings: the mechanism the
 CLI and `eval("...", "...", "...")` use. In-tree builtins register via decorators;
-out-of-tree packages publish **entry points**, so an installed plugin appears in
+out-of-tree packages publish entry points, so an installed plugin appears in
 `inspect-robots list` without being imported first.
 
 ## Decorators
@@ -48,7 +48,7 @@ Groups: `inspect_robots.tasks`, `inspect_robots.policies`, `inspect_robots.embod
 `inspect_robots.scorers`, `inspect_robots.sinks`. After `pip install inspect-robots-maniskill`, it
 shows up in `inspect-robots list` and resolves by name in `eval()` and the CLI.
 
-This is how the ecosystem stays decoupled: this repository is the **framework**;
+This is how the ecosystem stays decoupled: this repository is the framework;
 specific simulators, VLA weights, and benchmarks live in their own packages.
 
 ## First-party plugins
@@ -56,7 +56,7 @@ specific simulators, VLA weights, and benchmarks live in their own packages.
 Two adapters ship from the Inspect Robots repo itself (as separate packages
 under `plugins/*`), covering both halves of an eval:
 
-### `inspect-robots-isaacsim` — the body
+### `inspect-robots-isaacsim`: the body
 
 Wraps an [Isaac Lab](https://isaac-sim.github.io/IsaacLab/) simulation as an
 embodiment. Installing it makes `isaacsim` resolvable; only `reset()`/`step()`
@@ -68,7 +68,7 @@ inspect-robots run --task my-task --policy my-vla --embodiment isaacsim \
     -E task_id=Isaac-Lift-Cube-Franka-v0
 ```
 
-### `inspect-robots-xpolicylab` — the brain
+### `inspect-robots-xpolicylab`: the brain
 
 Drives any [XPolicyLab](https://github.com/XPolicyLab/XPolicyLab)-served
 policy. XPolicyLab wraps 40+ VLA / imitation-learning policies (π0/π0.5,

--- a/docs/guide/policies-and-embodiments.md
+++ b/docs/guide/policies-and-embodiments.md
@@ -1,6 +1,6 @@
 # Policies and embodiments
 
-Both are runtime-checkable Protocols — implement the methods on any class (no
+Both are runtime-checkable Protocols: implement the methods on any class (no
 inheritance required), or subclass the convenience base classes.
 
 ## A policy (VLA)
@@ -88,14 +88,14 @@ class MyArm:
         ...
 ```
 
-Lifecycle: [`eval`][inspect_robots.eval.eval] closes what it resolves — an
-embodiment looked up by **registry name** is closed when the run finishes (even
+Lifecycle: [`eval`][inspect_robots.eval.eval] closes what it resolves. An
+embodiment looked up by registry name is closed when the run finishes (even
 on a halt). If you construct the embodiment object yourself, you own it: call
 `close()` yourself when you are done.
 
 ## Real-robot vs simulator
 
-The interfaces assume **real-robot reality**: no guaranteed privileged success,
+The interfaces assume real-robot reality: no guaranteed privileged success,
 human-in-the-loop reset, wall-clock control. Simulators opt into more via
 `capabilities` (`SEEDABLE`, `AUTO_RESET`, `PRIVILEGED_SUCCESS`, `RENDERABLE`, …).
 A sim may put privileged success into `StepResult.info` for a scorer to read; a

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -43,7 +43,7 @@ Inspect AI). Each log is immutable, schema-versioned, and written to `log_dir`.
 
 ## Use registry names
 
-`task`, `policy`, and `embodiment` may also be **registry names** — the same
+`task`, `policy`, and `embodiment` may also be registry names, the same
 mechanism the CLI uses:
 
 ```python
@@ -64,6 +64,6 @@ inspect-robots inspect logs/cubepick-reach_*.json            # print a saved log
 
 ## Next steps
 
-- [Concepts](concepts.md) — the core abstractions.
-- [Writing A Benchmark](writing-a-benchmark.md) — define your own `Task`.
-- [Policies And Embodiments](policies-and-embodiments.md) — plug in a real VLA or robot/sim.
+- [Concepts](concepts.md): the core abstractions.
+- [Writing A Benchmark](writing-a-benchmark.md): define your own `Task`.
+- [Policies And Embodiments](policies-and-embodiments.md): plug in a real VLA or robot/sim.

--- a/docs/guide/scoring.md
+++ b/docs/guide/scoring.md
@@ -3,8 +3,8 @@
 A [`Scorer`][inspect_robots.scorer.Scorer] maps a recorded
 [`TrialRecord`][inspect_robots.rollout.TrialRecord] (plus the scene's
 [`Target`][inspect_robots.scene.Target]) to a [`Score`][inspect_robots.scorer.Score]. Scorers
-read the *recorded* trajectory — never a live environment — so scoring is
-**reproducible from a saved log**.
+read the *recorded* trajectory (never a live environment), so scoring is
+reproducible from a saved log.
 
 ## Builtin scorers
 
@@ -39,7 +39,7 @@ Register it with [`scorer`][inspect_robots.registry.scorer] to resolve it by nam
 
 ## Epochs and reducers
 
-When a `Task` runs `epochs > 1`, an **epoch reducer** collapses the per-epoch
+When a `Task` runs `epochs > 1`, an epoch reducer collapses the per-epoch
 scores of a scene before metrics aggregate across scenes. Reducers are namespaced
 separately from metrics and are selected by name on
 [`Epochs`][inspect_robots.task.Epochs]:
@@ -57,8 +57,8 @@ Task(..., epochs=Epochs(count=5, reducer="pass_at_2"))
 
 ## Operator and VLM scoring (real world)
 
-Real robots have no privileged success oracle. The dominant method is a **human
-verdict**, captured *once* during the rollout (as a transcript event) and read
-back by [`operator_scorer`][inspect_robots.scorer.operator_scorer] — keeping scoring reproducible.
+Real robots have no privileged success oracle. The dominant method is a human
+verdict, captured *once* during the rollout (as a transcript event) and read
+back by [`operator_scorer`][inspect_robots.scorer.operator_scorer], keeping scoring reproducible.
 A [`VLMScorer`][inspect_robots.scorer.VLMScorer] interface is reserved for scoring final
 frames with a vision-language classifier.

--- a/docs/guide/writing-a-benchmark.md
+++ b/docs/guide/writing-a-benchmark.md
@@ -1,7 +1,7 @@
 # Writing a benchmark
 
 A benchmark is a [`Task`][inspect_robots.task.Task]: a dataset of scenes plus scorer(s).
-It is **embodiment-agnostic** — it describes *what* to evaluate, not *how* the
+It is embodiment-agnostic: it describes *what* to evaluate, not *how* the
 robot is built.
 
 ```python
@@ -31,15 +31,15 @@ task = Task(
 Each [`Scene`][inspect_robots.scene.Scene] is one initial condition (the Inspect `Sample`
 analog):
 
-- `id` — unique within the task.
-- `instruction` — the language goal handed to the policy.
-- `target` — an optional [`Target`][inspect_robots.scene.Target] the scorer reads; its
+- `id`: unique within the task.
+- `instruction`: the language goal handed to the policy.
+- `target`: an optional [`Target`][inspect_robots.scene.Target] the scorer reads; its
   `kind` is resolved in the *embodiment's* namespace (compatibility checking
   verifies the embodiment can realize it).
-- `init_seed` — combined with the eval seed and epoch index to seed each trial
+- `init_seed`: combined with the eval seed and epoch index to seed each trial
   deterministically. (An eval run with `seed=None` draws a fresh OS seed and
   records it in the log, so even "unseeded" runs are reproducible after the
-  fact — and distinct from `seed=0`.)
+  fact, and distinct from `seed=0`.)
 
 ## Epochs and reducers
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,12 @@
 # Inspect Robots
 
 <p style="font-size: 1.3rem; font-weight: 500; margin-bottom: 0.25rem;">
-The <strong>Inspect AI</strong> for robotics.
+The Inspect AI for robotics.
 </p>
 
-An open-source evaluation framework for **physical AI** and **VLA
-(vision-language-action)** models. Define a robotics benchmark once, then run
-*any* policy against *any* compatible embodiment — a real robot or a simulator —
+An open-source evaluation framework for physical AI and VLA
+(vision-language-action) models. Define a robotics benchmark once, then run
+*any* policy against *any* compatible embodiment (a real robot or a simulator)
 with reproducible logs and first-class [Rerun](https://github.com/rerun-io/rerun)
 visualization.
 
@@ -18,20 +18,20 @@ visualization.
 
 ## One framework, two swappable inputs
 
-LLM evals have a single swappable input: the model. **Robotics evals have two** —
+LLM evals have a single swappable input: the model. Robotics evals have two,
 and Inspect Robots makes both first-class and orthogonal.
 
 <div class="grid cards" markdown>
 
--   :material-brain:{ .lg .middle } __`Policy` — the VLA__
+-   :material-brain:{ .lg .middle } __`Policy`: the VLA__
 
     ---
 
-    The "brain". Maps an observation + a language instruction to an **action
-    chunk** (a horizon of actions executed open-loop, as π0 / ACT / diffusion
+    The "brain". Maps an observation + a language instruction to an action
+    chunk (a horizon of actions executed open-loop, as π0 / ACT / diffusion
     policies do).
 
--   :material-robot-industrial:{ .lg .middle } __`Embodiment` — the robot or sim__
+-   :material-robot-industrial:{ .lg .middle } __`Embodiment`: the robot or sim__
 
     ---
 
@@ -41,9 +41,9 @@ and Inspect Robots makes both first-class and orthogonal.
 
 </div>
 
-A **`Task`** — a dataset of `Scene`s (initial conditions, instructions, success
-targets) plus scorers — is defined *independently* of both. Before any rollout,
-Inspect Robots verifies the `(policy, embodiment)` pair is **compatible** and fails fast
+A **`Task`**, a dataset of `Scene`s (initial conditions, instructions, success
+targets) plus scorers, is defined *independently* of both. Before any rollout,
+Inspect Robots verifies the `(policy, embodiment)` pair is compatible and fails fast
 and loud if not.
 
 ---
@@ -55,7 +55,7 @@ pip install inspect-robots            # core (numpy only)
 pip install "inspect-robots[rerun]"   # + Rerun visualization
 ```
 
-No hardware or simulator required — the dependency-free `CubePick` mock world
+No hardware or simulator required. The dependency-free `CubePick` mock world
 exercises the whole stack:
 
 ```python
@@ -103,7 +103,7 @@ inspect-robots inspect logs/cubepick-reach_*.json     # results table
     ---
 
     Every run yields an immutable, schema-versioned `EvalLog` with the resolved
-    config, git revision, and package versions — re-readable across releases.
+    config, git revision, and package versions, re-readable across releases.
 
 -   :material-feather:{ .lg .middle } __Light core__
 
@@ -130,8 +130,8 @@ inspect-robots inspect logs/cubepick-reach_*.json     # results table
 
     ---
 
-    Ship `inspect-robots-maniskill` or `inspect-robots-openvla` as separate packages — entry
-    points make them appear in `inspect-robots list` automatically.
+    Ship `inspect-robots-maniskill` or `inspect-robots-openvla` as separate packages.
+    Entry points make them appear in `inspect-robots list` automatically.
 
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ and Inspect Robots makes both first-class and orthogonal.
 
 </div>
 
-A **`Task`**, a dataset of `Scene`s (initial conditions, instructions, success
+A `Task`, a dataset of `Scene`s (initial conditions, instructions, success
 targets) plus scorers, is defined *independently* of both. Before any rollout,
 Inspect Robots verifies the `(policy, embodiment)` pair is compatible and fails fast
 and loud if not.


### PR DESCRIPTION
## Part 1: docs style pass

- Applied the org README/docs style spec to all 9 pages under `docs/`: every prose em dash replaced with a period, colon, comma, or parentheses; the only remaining `—` in `docs/` are two bash comments inside a fenced code block in `guide/plugins.md`.
- Thinned rhetorical mid-sentence bold (kept definition lead-ins, table headers, and the single `**always halt**` safety phrase in the error-taxonomy table); headers and grid-card titles now use colons instead of em dashes.
- No technical content changed: code blocks, code spans, commands, links, numbers, and every claim/caveat are byte-identical in meaning.

## Part 2: CLAUDE.md

- Appended the shared "Writing style (public-facing text)" section verbatim as a new section at the end of `CLAUDE.md`, linking the full gating checklist in worldevals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)