### PR TITLE
docs: de-dash site_description

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Inspect Robots
 site_description: >-
-  The Inspect AI for robotics — an evaluation framework for physical AI and VLA
+  The Inspect AI for robotics: an evaluation framework for physical AI and VLA
   (vision-language-action) models.
 site_url: https://inspectrobots.org/
 repo_url: https://github.com/robocurve/inspect-robots


### PR DESCRIPTION
One-character follow-up to #32: the mkdocs site_description (rendered into every page's meta description) still had the em dash. Colon now, matching worldevals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)