### PR TITLE
CLI: add inspect-robot as an alias for the common typo

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1,6 +1,8 @@
 # Command-line interface
 
 The `inspect_robots` CLI wraps the registry and [`eval`][inspect_robots.eval.eval].
+The command is installed as `inspect-robots`, with `inspect-robot` as an alias
+for the common typo; both run the same CLI.
 
 ## Zero-config: `inspect-robots "<instruction>"`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,8 @@ all = ["inspect-robots[rerun]"]
 
 [project.scripts]
 inspect-robots = "inspect_robots.cli:main"
+# Alias so the common typo `inspect-robot` still works.
+inspect-robot = "inspect_robots.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/robocurve/inspect-robots"


### PR DESCRIPTION
Typing `uv run inspect-robot` (singular) instead of `inspect-robots` currently fails with "command not found", which is an easy mistake to make and a frustrating first experience.

This adds a second console-script entry point, `inspect-robot`, pointing at the same `inspect_robots.cli:main`. Since `build_parser` hardcodes `prog="inspect-robots"`, help and version output still show the canonical name, so the alias quietly teaches the right spelling.

Verified locally after `uv sync`: both `uv run inspect-robot --version` and `uv run inspect-robots --version` print `inspect-robots <version>`. `uv lock` produced no lockfile changes (entry points do not affect resolution). Also noted the alias in `docs/guide/cli.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)