### PR TITLE
LLM agent mode: frontier LLMs as first-class policies (plan 0008)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,12 +225,49 @@ jobs:
           uv run --no-sync python -m pytest plugins/inspect-robots-xpolicylab/tests -q
           --cov=inspect_robots_xpolicylab --cov-report=term-missing --cov-fail-under=0
 
+  # The agent plugin's suite needs no LLM: httpx.MockTransport scripts the
+  # OpenAI-compatible conversations, and the mock cubepick world stands in for
+  # hardware — provider resolution, tool/motion synthesis, and the full
+  # eval() loop are covered offline.
+  plugin-agent:
+    name: plugin · agent
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Sync workspace (core + plugins, dev extras)
+        run: uv sync --locked --python 3.11 --all-packages --extra dev
+      - name: Ruff (plugin, lint)
+        run: uv run --no-sync ruff check plugins/inspect-robots-agent
+      - name: Ruff (plugin, format check)
+        run: uv run --no-sync ruff format --check plugins/inspect-robots-agent
+      - name: Mypy (plugin, strict)
+        run: >
+          uv run --no-sync mypy
+          --config-file plugins/inspect-robots-agent/pyproject.toml
+          plugins/inspect-robots-agent/src/inspect_robots_agent
+      - name: Pytest (plugin, with coverage)
+        # Report-only, same rationale as plugin-isaacsim: no 100% gate for
+        # plugins, but the number should be visible. --cov-fail-under=0
+        # overrides the root pyproject's fail_under=100.
+        run: >
+          uv run --no-sync python -m pytest plugins/inspect-robots-agent/tests -q
+          --cov=inspect_robots_agent --cov-report=term-missing --cov-fail-under=0
+
   # Single required status check for branch protection: green iff every job
   # above is green. Add new jobs to 'needs' here or they won't gate merges.
   ci-ok:
     name: ci-ok
     if: ${{ always() }}
-    needs: [quality, test, test-rerun, test-extra, core-only-import, plugin-isaacsim, plugin-xpolicylab]
+    needs: [quality, test, test-rerun, test-extra, core-only-import, plugin-isaacsim, plugin-xpolicylab, plugin-agent]
     runs-on: ubuntu-latest
     steps:
       - name: Fail unless every needed job succeeded
@@ -243,7 +280,7 @@ jobs:
   alert-red-main:
     name: alert on red main
     if: ${{ failure() && github.event_name == 'push' }}
-    needs: [quality, test, test-rerun, test-extra, core-only-import, plugin-isaacsim, plugin-xpolicylab]
+    needs: [quality, test, test-rerun, test-extra, core-only-import, plugin-isaacsim, plugin-xpolicylab, plugin-agent]
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,3 +129,26 @@ jobs:
           # The plugin is versioned independently; a core release that doesn't
           # bump it must not fail on the already-uploaded file.
           skip-existing: true
+
+  publish-agent:
+    name: publish inspect-robots-agent
+    needs: [cut]
+    if: ${{ !cancelled() && (github.event_name == 'release' || needs.cut.result == 'success') }}
+    runs-on: ubuntu-latest
+    environment: pypi-agent
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.cut.outputs.tag || github.ref }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Build sdist + wheel
+        run: uv build --package inspect-robots-agent
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # The plugin is versioned independently; a core release that doesn't
+          # bump it must not fail on the already-uploaded file.
+          skip-existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). While the version is
 `0.x`, breaking changes may occur on any minor release.
 
+## [Unreleased]
+
+### Added
+
+- **New plugin: `inspect-robots-agent`** — frontier LLMs (Claude, GPT,
+  anything behind an OpenAI-compatible API) drive any registered embodiment
+  through tool calls, as the first-class policy `agent`
+  (`--policy agent -P model=anthropic/claude-fable-5`). Each tool call becomes
+  one smooth, approver-checked action chunk (`move_joints` with named partial
+  targets for absolute control, `move_by` for displacement control;
+  `done`/`give_up` end the trial). One `httpx` client speaks the wire format;
+  keys resolve from `$ANTHROPIC_API_KEY` / `$OPENAI_API_KEY` /
+  `$OPENROUTER_API_KEY` or a custom `base_url` (plan 0008).
+- Safety approvers: `DeltaLimitApprover` (semantics-aware "no wild swings"
+  per-step limiting) and `ChainApprover` (sequential composition) join
+  `ClampApprover` in `inspect_robots.approver`.
+- **CLI guardrails on by default**: every `run`/ad-hoc invocation wires
+  `ChainApprover(ClampApprover, DeltaLimitApprover)` from the embodiment's
+  action space; `--disable-guardrails` is the explicit, loudly-warned opt-out
+  and `--max-action-delta` tunes the per-step limit. The chain degrades per
+  component with stderr warnings (never blocking, never silent).
+- CLI: `inspect-robots config set KEY VALUE` / `config show` persist and
+  display `[defaults]` config keys; guided errors now point at `config set`.
+- `ActionSemantics.dim_labels` names action dimensions (validated against the
+  owning `Box`); `ControlMode` gains `"joint_delta"` for joint-space
+  displacement control.
+- Policies may define an optional `bind(embodiment_info)` hook — `eval()`
+  calls it after resolution and before the compatibility check, so
+  embodiment-adaptive policies (like the LLM agent) can adopt the
+  embodiment's spaces.
+- Rollout honors a policy-requested stop via the pre-review action's
+  `meta["request_stop"]` (ends the trial as a truncation; embodiment
+  termination wins; not preserved under ensembling).
+
+### Fixed
+
+- The CLI exits with the guided message (not a traceback) when a component
+  factory raises `ConfigError` during resolution.
+
 ## [0.4.0] - 2026-07-09
 
 Plugin releases alongside this version: `inspect-robots-xpolicylab` 0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,10 @@ rollout, scores it, and writes an immutable `EvalLog`. Mirrors Inspect AI's
   ties them in: `uv sync --all-packages --extra dev` installs core + all plugins
   editable. They never count toward the core 100% gate (coverage is scoped to
   `inspect_robots`). E.g. `plugins/inspect-robots-isaacsim/` (Isaac Lab
-  embodiment) and `plugins/inspect-robots-xpolicylab/` (policy adapter speaking
-  the XPolicyLab websocket protocol — 40+ served VLAs, no xpolicylab dep).
+  embodiment), `plugins/inspect-robots-xpolicylab/` (policy adapter speaking
+  the XPolicyLab websocket protocol — 40+ served VLAs, no xpolicylab dep), and
+  `plugins/inspect-robots-agent/` (LLMs as policies via the OpenAI-compatible
+  wire format — httpx only, no provider SDKs; registered as `agent`).
 
 ## Working here
 

--- a/README.md
+++ b/README.md
@@ -177,12 +177,29 @@ adapter shipped from this repo as separate packages:
   any [XPolicyLab](https://github.com/XPolicyLab/XPolicyLab)-served policy.
   One adapter puts its zoo of 40+ VLAs (π0/π0.5, GR00T, OpenVLA-OFT, RDT-1B,
   SmolVLA, ACT, …) behind `--policy xpolicylab -P url=ws://gpu-box:19000`.
+- **[inspect-robots-agent](plugins/inspect-robots-agent/)**: let a frontier
+  LLM (Claude, GPT, anything behind an OpenAI-compatible API) drive any
+  embodiment through tool calls, as a first-class policy. The same
+  `--policy agent` runs ad-hoc instructions and scores on registered tasks
+  next to fine-tuned VLAs.
 
 ```bash
 # Isaac Lab world + a π0 checkpoint served by XPolicyLab, evaluated end to end:
 inspect-robots run --task my-task --embodiment isaacsim \
     --policy xpolicylab -P url=ws://gpu-box:19000 -P cameras=cam_head:base_rgb
+
+# Claude driving the mock world, no hardware or GPU required:
+export ANTHROPIC_API_KEY=sk-ant-...
+inspect-robots "pick up the cube" --policy agent \
+    -P model=anthropic/claude-fable-5 --embodiment cubepick
 ```
+
+Safety guardrails (a bounds clamp plus a per-step delta limit derived from
+the embodiment's action space) are wired into every CLI run by default, for
+every policy. Turning them off requires an explicit `--disable-guardrails`.
+Persist your usual setup once with `inspect-robots config set embodiment NAME`
+and `inspect-robots config set policy NAME`, then a bare
+`inspect-robots "wipe the table"` does the rest.
 
 ## How it maps to Inspect AI
 

--- a/plans/0008-implementation.md
+++ b/plans/0008-implementation.md
@@ -1,0 +1,198 @@
+# 0008 Implementation Plan — LLMs as policies
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans
+> (inline). The authoritative design is `plans/0008-llm-agent-mode.md`
+> (referenced below as "spec §N"); this file sequences it into TDD tasks.
+> Steps use checkbox syntax for tracking.
+
+**Goal:** LLMs drive robots as a registered `Policy` (`agent`) with core
+safety guardrails on by default at the CLI.
+
+**Architecture:** Five core slices (vocabulary → approvers → bind →
+request_stop → CLI), then the `plugins/inspect-robots-agent` package
+(httpx client → tools/motion → policy e2e), then docs. Each task = one
+commit, gates green (`ruff check .`, `ruff format --check .`, `uv run mypy`,
+`uv run pytest --cov` at 100% for core).
+
+**Tech stack:** NumPy-only core; plugin adds `httpx`. uv workspace.
+
+## Global constraints (from spec + CLAUDE.md)
+
+- Core stays NumPy-only; plugin deps never imported by core.
+- 100% coverage on `inspect_robots`; mypy strict covers src and tests.
+- Public API fenced by `__all__` + `tests/test_api_snapshot.py` — update together.
+- Plugins: own pyproject (static version), own tests, outside core coverage.
+- README/docs prose: no em dashes, no mid-sentence bold, no decorative emoji.
+- Commit after every green task.
+
+---
+
+### Task 1: `spaces.py` vocabulary — `joint_delta` + `dim_labels` (spec §3b)
+
+**Files:** Modify `src/inspect_robots/spaces.py` (ControlMode at :23,
+ActionSemantics at :43, Box.__post_init__ at :62),
+`src/inspect_robots/controller.py:97` (`_AVERAGEABLE_MODES` gains
+`joint_delta`; pragma premise stays valid). Tests in
+`tests/test_types_spaces.py`; snapshot untouched unless `__all__` changes
+(it should not — both are attributes of existing exports).
+
+- [ ] Failing tests: `joint_delta` accepted as ControlMode; `dim_labels`
+  round-trips on ActionSemantics; Box with semantics whose
+  `len(dim_labels) != dim` raises ValueError; matching length passes;
+  `dim_labels=None` passes; ensembling accepts a `joint_delta` chunk pair
+  (tests/test_ensembling.py).
+- [ ] Implement; gates green; commit.
+
+### Task 2: approvers — `DeltaLimitApprover` + `ChainApprover` (spec §3a)
+
+**Files:** Modify `src/inspect_robots/approver.py`,
+`src/inspect_robots/rollout.py:216` (approval-event detail: surface
+`delta_clamped` alongside `clamped`), `src/inspect_robots/__init__.py`
+(+`__all__`), `tests/test_api_snapshot.py`. New `tests/test_approvers.py`
+(move/extend existing approver tests if any live elsewhere).
+
+**Interfaces (produced):**
+- `DeltaLimitApprover(action_space: Box, max_delta: float | ArrayLike | None = None)`
+  — `.review(action, store) -> Action`. Absolute modes {joint_pos,
+  eef_abs_pose}: clamp to ±max_delta around last approved action (store key
+  `"delta_limit:last"`), first action passes; derived default 5% of range.
+  Displacement/rate modes {eef_delta_pos, eef_delta_pose, joint_delta,
+  joint_vel}: clamp to box ∩ [-max_delta, +max_delta]; derived default =
+  box alone. Raises ValueError at construction: semantics None; needed
+  bound missing/non-finite without explicit max_delta; pose mode with
+  rotation_repr not in {none, rot6d}. NaN action → SafetyAbort. Modified
+  action → new object with meta `delta_clamped: True`.
+- `ChainApprover(*approvers: Approver)` — sequential review.
+
+- [ ] Failing tests: every constructor refusal; absolute clamp w/
+  reference update; first-action pass; displacement intersection incl.
+  asymmetric [0,1] dim; derived defaults both branches; NaN abort;
+  identity preserved when nothing clamps; per-trial store isolation;
+  chain order; rollout records delta_clamped detail (extend
+  tests/test_rollout_hardening.py).
+- [ ] Implement; gates green; commit.
+
+### Task 3: `Policy.bind()` hook (spec §3c)
+
+**Files:** Modify `src/inspect_robots/policy.py` (Protocol comment +
+`PolicyBase.bind` no-op), `src/inspect_robots/eval.py` (call between
+resolution and `assert_compatible` at ~:205). Tests in
+`tests/test_eval_orchestration.py`.
+
+**Interfaces (produced):** `def bind(self, embodiment_info: EmbodimentInfo) -> None`
+— optional; eval() invokes iff `hasattr(policy, "bind")`.
+
+- [ ] Failing tests: a recording policy's bind receives the resolved
+  embodiment's info before compat runs (adapting policy passes compat only
+  because bind ran); a bind-less minimal Protocol policy still works.
+- [ ] Implement; gates green; commit.
+
+### Task 4: policy-requested stop (spec §3d)
+
+**Files:** Modify `src/inspect_robots/rollout.py` (~:230, after step;
+pre-review action's meta; embodiment termination wins). Docstring notes
+the EnsemblingController limitation. Tests in
+`tests/test_rollout_hardening.py`.
+
+- [ ] Failing tests: chunk whose last action carries
+  `meta={"request_stop": True, "stop_reason": "done"}` → trial ends
+  truncated with reason "done"; default reason "policy_stop"; approver
+  rewrite does not erase intent; simultaneous embodiment `terminated=True`
+  wins; no stop flag → unchanged behavior.
+- [ ] Implement; gates green; commit.
+
+### Task 5: CLI guardrails-by-default + `config` (spec §3e)
+
+**Files:** Modify `src/inspect_robots/cli.py` (guardrail chain builder
+inside the existing close-embodiment try; `--disable-guardrails`,
+`--max-action-delta`; `config set/show` subcommand; guided-error fix line
+gains `inspect-robots config set …`), `src/inspect_robots/_defaults.py`
+(writer helper, atomic tmp+rename, preserves unknown sections/keys).
+Tests in `tests/test_registry_cli.py` + `tests/test_defaults.py`.
+
+- [ ] Failing tests: default run wires ChainApprover(Clamp, DeltaLimit)
+  (observable via a spy embodiment whose out-of-range scripted action gets
+  clamped); `--disable-guardrails` warns on stderr + AutoApprover;
+  degradation warnings for bounds-less absolute space, synthetic
+  semantics-less space, synthetic quat-pose space, fully-unlimitable
+  (each warning names the caught reason); `--max-action-delta` threads
+  through; `config set embodiment yam_arms` writes INI (tmp XDG), `config
+  set` rejects unknown keys, `config show` prints resolved defaults with
+  sources, unknown sections survive rewrite; guided error mentions config
+  set.
+- [ ] Implement; gates green; commit.
+
+### Task 6: plugin scaffold (spec §4 layout, §7)
+
+**Files:** Create `plugins/inspect-robots-agent/pyproject.toml`
+(deps `inspect-robots`, `httpx`; version 0.1.0; entry point
+`[project.entry-points."inspect_robots.policies"] agent = "inspect_robots_agent.policy:agent_policy"`),
+`src/inspect_robots_agent/__init__.py`, `py.typed`, stub `policy.py`,
+`tests/__init__.py` (+ trivial import test). Modify root `pyproject.toml`
+only if workspace members are enumerated (they are globbed — verify),
+run `uv lock`; `.github/workflows/ci.yml` (job `test-agent-plugin`
+mirroring `test-xpolicylab-plugin`, added to `ci-ok.needs`),
+`.github/workflows/release.yml` (`publish-inspect-robots-agent`,
+`skip-existing`, environment `pypi-agent`).
+
+- [ ] Scaffold; `uv sync --all-packages --extra dev`; plugin test green;
+  core gates untouched; commit.
+
+### Task 7: plugin `_llm.py` (spec §4a)
+
+**Interfaces (produced):**
+- `resolve_provider(model: str | None, base_url: str | None, api_key_env: str | None, env: Mapping[str, str]) -> Provider`
+  (dataclass: base_url, api_key, model) following spec §4a ladder; raises
+  `AgentConfigError` with guided message otherwise.
+- `ChatClient(provider, *, transport: httpx.BaseTransport | None = None)`
+  `.complete(messages: list[dict], tools: list[dict]) -> AssistantMessage`
+  (dataclass: content, tool_calls) with bounded retry/backoff on transient
+  HTTP, raise on persistent.
+
+- [ ] Failing tests (MockTransport): each ladder rule; missing-key guided
+  error; retry then success; retry exhaustion raises; request body carries
+  tools + model; Anthropic compat base URL for anthropic/*.
+- [ ] Implement; plugin tests green; commit.
+
+### Task 8: plugin `_tools.py` + `_motion.py` (spec §4b tools, §4c)
+
+**Interfaces (produced):**
+- `build_toolset(action_space: Box, state_spec, control_hz: float) -> Toolset`
+  — bind-time validation (mode support, rotation guard, absolute-mode
+  alignment rule: exactly one state field with shape == (dim,)); exposes
+  OpenAI tool JSON schemas (`move_joints` or `move_by`, `done`, `give_up`).
+- `Toolset.execute(tool_call, current_state: np.ndarray) -> ToolResult`
+  where ToolResult = chunk (ActionChunk) | error message (str, fed back to
+  LLM). Chunk cap ~10 s of steps; request_stop meta on done/give_up hold
+  action.
+
+- [ ] Failing tests: labeled partial targets (bimanual 14-D synthetic
+  space) interpolate correctly and hold unnamed dims; index fallback;
+  unknown label / non-finite / bad duration → error string; move_by splits
+  displacement; hold-still per mode; done/give_up meta; joint_vel and quat
+  pose rejected at build; alignment-rule failures (0 fields, 2 matching,
+  no StateSpec).
+- [ ] Implement; plugin tests green; commit.
+
+### Task 9: plugin `policy.py` e2e (spec §4b)
+
+**Interfaces (produced):** `agent_policy(**kwargs) -> LLMAgentPolicy`
+(registry factory); `LLMAgentPolicy.bind/reset/act`;
+`AgentPolicyConfig(PolicyConfig)` frozen with model, base_url,
+api_key_env, max_llm_calls, temperature.
+
+- [ ] Failing tests (scripted conversations through real `eval()` on
+  `cubepick`): goal runs to done → truncated "done" in log; wild-swing
+  script clamped by CLI-style chain, unclamped with AutoApprover; budget
+  exhaustion → give_up; malformed tool call retried then PolicyError;
+  images + labeled state in outbound messages; config lands in EvalLog.
+- [ ] Implement; plugin tests green; commit.
+
+### Task 10: docs (spec §9 step 10 core half)
+
+**Files:** Modify `README.md` (agent-policy section, style rules apply),
+`CLAUDE.md` (plugins list + new core seams), `plans/0008-llm-agent-mode.md`
+untouched, `src/inspect_robots/CLAUDE.md` module-map rows. Yam-repo PRs
+(spec §6) are follow-up work outside this repo/plan.
+
+- [ ] Write; gates green; commit.

--- a/plans/0008-llm-agent-mode.md
+++ b/plans/0008-llm-agent-mode.md
@@ -216,15 +216,15 @@ declare success.
   clamp already lands in the transcript/log as an approval event; a
   dedicated `EvalSpec` field is deferred (schema change, not needed for
   safety).
-- **The CLI closes what it constructs**: today the CLI resolves the
-  embodiment itself and passes the object to `eval()`, so `eval()`'s
-  close-what-we-open rule never fires and nothing closes it — acceptable for
-  mocks, not for hardware holding CAN channels. `_cmd_run` (both task and
-  ad-hoc paths) wraps the run in `try/finally: embodiment.close()`, covering
-  Ctrl-C. (The CLI must construct the embodiment anyway to build the
-  guardrail chain from its action space.)
+- **The CLI closes what it constructs** — already landed on main
+  independently of this plan (the `finally: embodiment.close()` in
+  `_cmd_run`, widened to cover post-resolution validation; see the PR #30
+  lead-up commits). Nothing to schedule; the guardrail-chain construction
+  simply slots inside that existing `try`. Noted here because an earlier
+  draft scheduled it and reviewers should not look for it in §9.
 - **`config set KEY VALUE` / `config show`**: writes `policy`, `embodiment`,
-  or `sim_embodiment` under `[defaults]` in
+  `sim_embodiment`, or `store_frames` (added to `[defaults]` on main by
+  PR #30) under `[defaults]` in
   `~/.config/inspect-robots/config.ini` (stdlib `configparser`, atomic
   write-temp-then-rename, unknown sections preserved); `show` prints resolved
   defaults with sources. The existing guided error's fix line gains the
@@ -353,8 +353,9 @@ than at runtime.
   `request_stop`
   (pre-review meta wins over approver rewrite; embodiment termination takes
   precedence; ensembling limitation documented), CLI guardrail default +
-  `--disable-guardrails` + `--max-action-delta`, CLI `finally: close()`
-  (asserted with a recording mock embodiment, including on error), and
+  `--disable-guardrails` + `--max-action-delta` (guardrail construction
+  must not escape the existing close-embodiment `try`, asserted with a
+  recording mock embodiment), and
   `config set/show` (tmp config home) — all pure NumPy/stdlib, straight into
   the 100% gate.
 - **Plugin**: `httpx.MockTransport` scripts LLM conversations (tool calls as
@@ -425,7 +426,8 @@ PyPI trusted-publisher environment for the package.
   shows first-step jumps.
 - **Arm behavior between chunks is an assumption, not a fact** — verified as
   YAM-repo work item §6.4 before any untethered run. Ctrl-C cleanup is now
-  guaranteed by the CLI's `finally: close()` (§3e), not assumed.
+  guaranteed by the CLI's existing `finally: close()` (on main since
+  PR #30's lead-ups; §3e), not assumed.
 - **Prompt injection / model misbehavior** — cannot bypass the approver
   chain (it sits below the model, in rollout); worst case is in-bounds,
   rate-limited motion until a budget trips.
@@ -457,8 +459,8 @@ PyPI trusted-publisher environment for the package.
 4. Core: `request_stop` in rollout (+ tests, docstring noting the ensembling
    limitation).
 5. Core: CLI guardrails-by-default (`--disable-guardrails`,
-   `--max-action-delta`), embodiment `finally: close()`, `config set/show`,
-   guided-error text update (+ tests).
+   `--max-action-delta`; construction inside the existing close-embodiment
+   `try`), `config set/show`, guided-error text update (+ tests).
 6. Plugin scaffold: pyproject, workspace membership, lockfile, CI job,
    release job.
 7. Plugin: `_llm.py` client + provider resolution (mock-transport tests).

--- a/plans/0008-llm-agent-mode.md
+++ b/plans/0008-llm-agent-mode.md
@@ -1,90 +1,236 @@
-# 0008 — Agent mode: LLMs drive robots through tool calls
+# 0008 — `LLMAgentPolicy`: frontier LLMs as first-class policies
 
 ## 1. Goal
 
 Let a frontier LLM (Claude, GPT, anything behind an OpenAI-compatible API)
-control a robot interactively — outside the eval loop — by calling tools
-against any registered `Embodiment`. Pilot target: the bimanual YAM arms.
+control a robot by emitting tool calls that become smooth, approver-checked
+action chunks — as a **registered `Policy`**, so the same agent that runs your
+ad-hoc "place the fork on the plate" also scores on real `Task`s next to VLAs.
+Pilot target: the bimanual YAM arms.
+
+Works out of the box, no hardware (`cubepick` is core's mock world):
 
 ```bash
-pip install inspect-robots inspect-robots-yam inspect-robots-agent
-inspect-robots config set embodiment yam        # once, per machine
+pip install inspect-robots inspect-robots-agent
 export ANTHROPIC_API_KEY=sk-ant-...
 
-inspect-robots agent "place the fork on the plate" --model anthropic/claude-fable-5
+inspect-robots "pick up the cube" --policy agent -P model=anthropic/claude-fable-5 \
+    --embodiment cubepick
 ```
 
-Same command with `--embodiment mock/cubepick` runs hardware-free, which is
-also how the whole feature is tested in CI.
+YAM pilot, after the yam-repo work in §6 lands (registry name is `yam_arms`):
 
-This is **not** a `Policy`. The eval loop's policy contract (observation →
-`ActionChunk` at control rate) is wrong for an LLM that thinks for seconds per
-decision. Agent mode is a separate vertical: an agentic tool-calling loop where
-each tool call executes a smooth, approver-checked motion primitive spanning
-many `embodiment.step()` calls. An LLM-backed `Policy` for scored evals can come
-later and is out of scope here.
+```bash
+pip install inspect-robots inspect-robots-agent "inspect-robots-yam[hardware]"
+inspect-robots config set embodiment yam_arms   # once, per machine
+inspect-robots config set policy agent          # once, per machine
+export ANTHROPIC_API_KEY=sk-ant-...
+export INSPECT_ROBOTS_MODEL=anthropic/claude-fable-5
+
+inspect-robots "place the fork on the plate"
+```
+
+Every flag still works for one-off overrides (`-P model=openai/gpt-5.2`,
+`--embodiment cubepick`), and the same policy drops into scored evals
+unchanged:
+
+```bash
+inspect-robots run --task kitchenbench/tidy --policy agent -P model=anthropic/claude-fable-5
+```
+
+That last line is the point of doing this as a `Policy`: LLMs become an
+evaluable policy family, comparable on any Task against fine-tuned VLAs,
+reusing the entire rollout/approver/transcript/`EvalLog` stack instead of
+growing a parallel vertical.
+
+**Feasibility precedent:** multi-second inference between chunks is already how
+this stack runs — the yam repo's MolmoAct client ships `timeout_s = 30.0`. An
+LLM thinking for seconds and returning an open-loop `ActionChunk` is the same
+shape, just slower and smarter.
+
+Out of scope: an interactive chat/REPL mode (later sugar on top), cartesian/IK
+primitives, and any non-OpenAI-compatible wire protocol.
 
 ## 2. Placement: what goes where
 
-Follows the family convention (hardware adapters in satellite repos, policy-side
+Follows the family convention (hardware adapters in satellite repos, policy
 adapters as in-repo plugins; `plugins/inspect-robots-xpolicylab` is the
 precedent — plan 0007).
 
 | Piece | Where | Why |
 |---|---|---|
-| Safety approvers (max-delta limiter, chaining) | core `approver.py` | NumPy-only; protects every action source; the `Approver` seam already exists and its docstring reserves exactly this hardening |
+| Safety approvers (`DeltaLimitApprover`, `ChainApprover`) | core `approver.py` | NumPy-only; the `Approver` seam already sits between every action and the embodiment, and its docstring reserves exactly this hardening |
 | `dim_labels` on `ActionSemantics` | core `spaces.py` | NumPy-only; lets the agent (and future logging/viz) name action dimensions |
-| Plugin CLI subcommands + `config set/show` | core `cli.py` / `_defaults.py` | tiny, dependency-free, benefits every plugin |
-| Agent loop, LLM client, tool surface, `agent` subcommand | new `plugins/inspect-robots-agent` | needs an HTTP client dep, so it cannot live in the NumPy-only core |
-| YAM pilot | `inspect-robots-yam` repo (docs/quickstart) | its bimanual `Embodiment` (two CAN channels, `can0`/`can1` defaults, flat 14-D action space) already exists; the pilot is documentation, not code |
+| `Policy.bind()` hook | core `policy.py` / `eval.py` | generic support for embodiment-adaptive policies |
+| Policy-requested stop | core `rollout.py` | generic: a policy may conclude "done" before the horizon |
+| `config set/show` subcommand | core `cli.py` / `_defaults.py` | dependency-free onboarding sugar; formalizes the config file `_defaults.py` already reads |
+| CLI guardrails-by-default + embodiment cleanup | core `cli.py` | the user-facing safety switch must live where runs are launched |
+| `LLMAgentPolicy`, LLM client, tool loop, motion primitives | new `plugins/inspect-robots-agent` | needs an HTTP client dep, so it cannot live in the NumPy-only core |
+| YAM pilot enablement | `inspect-robots-yam` repo | its bimanual `Embodiment` exists (two CAN channels, `can0`/`can1` defaults, flat 14-D action space) but needs the §6 items before the pilot can run |
+
+No new run-mode subcommand and no plugin-subcommand mechanism: the zero-config
+ad-hoc instruction path (plan 0005) is already the right front door. The only
+CLI addition is the `config` utility subcommand.
 
 ## 3. Core changes
 
+All NumPy-only, all inside the 100% gate, each with an API-snapshot update.
+
 ### 3a. Safety approvers (`approver.py`)
 
-- **`DeltaLimitApprover(max_delta, reference)`** — the "no wild swings" gate.
-  Clamps each action dimension to at most `max_delta` away from a reference
-  (last approved action, falling back to the current proprioceptive state on
-  the first action). Per-dimension `max_delta` array or scalar. NaN → `SafetyAbort`
-  (same contract as `ClampApprover`). A clamped action is flagged via
-  `action.meta["delta_clamped"]` so the transcript records an approval event.
-- **`ChainApprover(approvers)`** — runs approvers in sequence (bounds clamp,
-  then delta limit). Trivial, but gives "guardrails" one name.
+- **`DeltaLimitApprover(action_space, max_delta=None)`** — the "no wild
+  swings" gate, **semantics-aware** via the space's
+  `ActionSemantics.control_mode`. The classification is total over the
+  vocabulary (§3b adds `joint_delta`):
+  - **Absolute-target modes** — `joint_pos`, `eef_abs_pose`: clamps each
+    dimension to at most `max_delta[i]` away from the **last approved
+    action** of the trial. The first action of a trial passes through
+    un-delta-limited (documented: there is no trustworthy reference yet;
+    bounds clamping and the plugin's interpolation cover it — see §8).
+    Derived default: 5% of `(high - low)` per step — unit-agnostic (radians,
+    meters, and normalized grippers all get proportionate limits).
+  - **Displacement/rate modes** — `eef_delta_pos`, `eef_delta_pose`,
+    `joint_delta`, `joint_vel`: the action *is* the per-step displacement
+    (or rate), so limiting needs no reference. With an explicit `max_delta`,
+    each dimension clamps to the **intersection** of the box and
+    `[-max_delta[i], +max_delta[i]]` (well-defined for asymmetric boxes like
+    a `[0, 1]` gripper dim). The derived default is the box alone — i.e.
+    without an explicit override the limiter adds nothing beyond
+    `ClampApprover`. Deliberately: core cannot assume displacement bounds
+    are per-step-sized (that is an embodiment convention — true for
+    `cubepick`, whose box is ±max-step and whose scripted oracle must keep
+    passing; false for YAM's delta config today, which reuses absolute
+    joint limits — a §6 fix). The guardrail value in these modes therefore
+    depends on the embodiment declaring honest per-step bounds, or on
+    `--max-action-delta`; the docs say so.
+  - Constructing raises with a clear message when `semantics is None`, when
+    a needed bound is missing/non-finite and no explicit `max_delta` (scalar
+    or per-dimension array) is supplied, or when a pose mode
+    (`eef_abs_pose`, `eef_delta_pose`) carries a
+    `rotation_repr ∉ {none, rot6d}` — per-dimension clamping is invalid on
+    quaternion/axis-angle/euler components (it can move the rotation axis
+    arbitrarily), the same restriction `EnsemblingController` already
+    enforces for per-dimension averaging. This approver never guesses; the
+    CLI decides what to do about unlimitable spaces (§3e).
+  - NaN → `SafetyAbort` (same contract as `ClampApprover`). A modified action
+    is flagged `action.meta["delta_clamped"]` and returned as a new object so
+    the rollout's identity check records an approval event. Per-trial
+    reference state lives under a namespaced key in the rollout's `store`
+    (created fresh per trial, so nothing leaks across trials/epochs).
+- **`ChainApprover(*approvers)`** — runs approvers in sequence, feeding each
+  the previous result. Gives "guardrails" one composable name:
+  `ChainApprover(ClampApprover(space), DeltaLimitApprover(space))`.
+- Rollout's approval-event detail extraction currently hardwires
+  `meta.get("clamped")`; it is generalized to also surface `delta_clamped`
+  (same step, §8 step 1).
 
-Both are generic: they harden scored evals with VLA policies exactly as much as
-agent mode. Registered defaults change nothing for existing users — `eval()`
-keeps `AutoApprover` unless configured otherwise; **agent mode** is where the
-chain is on by default (§4d).
+Both approvers harden every policy — a fine-tuned VLA can wild-swing at least
+as hard as an LLM. Python-API behavior is unchanged (`eval()` still defaults
+to `AutoApprover`); the default flips at the CLI (§3e).
 
-### 3b. `ActionSemantics.dim_labels` (`spaces.py`)
+### 3b. `spaces.py` vocabulary: `dim_labels` + `joint_delta`
 
-Optional `dim_labels: tuple[str, ...] | None = None`; when present its length
-must equal the owning action `Box.dim` (validated in `Box.__post_init__`, which
-is where the semantics/shape pairing is visible). YAM will set
-`("left_j0", …, "left_j5", "left_gripper", "right_j0", …, "right_gripper")` in
-its repo. Embodiments without labels still work — the agent falls back to
-index-keyed targets (`"3": 0.4`).
+**`ControlMode` gains a `"joint_delta"` literal.** The current vocabulary
+(`joint_pos`, `joint_vel`, `eef_delta_pose`, `eef_abs_pose`, `eef_delta_pos`)
+cannot express joint-space displacement control — yet YAM's
+`joints_are_delta=True` config *is* that mode while its semantics constant
+declares `joint_pos` unconditionally. Misclassification is exactly the
+dangerous case (an absolute-branch limiter and "hold = repeat state" applied
+to a delta rig means `done()` commands a large motion), so the literal is
+added here and YAM's semantics fix is scheduled in §6.
 
-### 3c. CLI plugin subcommands + `config` (`cli.py`, `_defaults.py`)
+**`dim_labels`**: optional `dim_labels: tuple[str, ...] | None = None` on `ActionSemantics`.
+When an action `Box` carries semantics with labels, `Box.__post_init__`
+validates `len(dim_labels) == box.dim` (the pairing is only visible there).
+YAM's repo will set
+`("left_j0", …, "left_j5", "left_gripper", "right_j0", …, "right_gripper")`.
+Embodiments without labels still work — the agent falls back to index-keyed
+targets (`"3": 0.4`).
 
-- New entry-point group **`inspect_robots.cli`**: each entry point resolves to a
-  `register(subparsers) -> None` callable. Core loads the group after building
-  its own subparsers; a plugin that fails to import is skipped with a warning
-  (same tolerance the component registry uses).
-- New **`config`** subcommand in core: `config set KEY VALUE` writes
-  `[defaults]` keys (`policy`, `embodiment`, `sim_embodiment`, `model`) into
-  `~/.config/inspect-robots/config.ini` via `configparser` (atomic
-  write-temp-then-rename, preserving unknown sections); `config show` prints the
-  resolved defaults with their sources. `_defaults.py` gains `model` /
-  `INSPECT_ROBOTS_MODEL` alongside the existing keys so `--model` participates
-  in the same flag > env > config chain.
+### 3c. `Policy.bind()` — embodiment-adaptive policies (`policy.py`, `eval.py`)
 
-The unconfigured experience stays the existing guided `SystemExit` ("registered
-embodiments: …; fix: pass --embodiment, set $…, or run `inspect-robots config
-set embodiment NAME`" — the fix line gains the `config set` spelling). No
-shipped hardware default, deliberately: core cannot name an optional package,
-and a tool that moves physical robots must not pick its target implicitly
-(same trust stance as plan 0005's rejection of project-local config).
+Compat checking compares `policy.info.action_space` against the embodiment's,
+but a generic LLM policy has no fixed space — it adapts to whatever it drives.
+New optional hook:
+
+```python
+def bind(self, embodiment_info: EmbodimentInfo) -> None: ...
+```
+
+`eval()` (and therefore the ad-hoc CLI path, which calls `eval()`) invokes
+`bind` **after resolving both components and before `check_compatibility`**,
+only when the policy defines it (`hasattr` duck-typing, same spirit as the
+`Embodiment` Protocol; mypy narrows `hasattr` fine). `PolicyBase` gains a
+no-op default. `LLMAgentPolicy.bind` copies the embodiment's action space
+(with labels and semantics) and observation space into its own `PolicyInfo`,
+so compat passes by construction and the tool schema is generated from the
+true target.
+
+### 3d. Policy-requested stop (`rollout.py`)
+
+Today only the embodiment (`StepResult.terminated/truncated`) or the horizon
+ends a trial; a policy that knows it is done can only burn steps. New,
+policy-agnostic channel: after stepping an action, rollout checks the
+**pre-review** action's `meta["request_stop"]` (the policy's intent must
+survive any approver rewrite; the pre-review action is still in scope at that
+point in the loop); if truthy, the trial ends with `truncated=True,
+termination_reason=str(action.meta.get("stop_reason", "policy_stop"))`.
+Embodiment-reported termination on the same step wins (it is ground truth).
+
+Known limitation, documented on the feature: `EnsemblingController` rebuilds
+emitted actions with the *chunk's* meta, dropping per-action meta — so
+`request_stop` is honored under `DefaultController`/`SmoothingController`
+(which preserve action identity/meta) but not under ensembling. Ensembling a
+conversational agent policy is unsupported anyway; the docstring says so.
+
+The LLM's `done(summary)` / `give_up(reason)` tools map to a single
+hold-still action flagged `request_stop` (§4c defines hold-still per control
+mode) — no empty-chunk special case, no `ActionChunk` change, no `Controller`
+change. Scoring stays the scorer's job: `done()` ends the trial, it does not
+declare success.
+
+### 3e. CLI: guardrails by default, cleanup, `config` (`cli.py`, `_defaults.py`)
+
+- **Guardrails on by default at the CLI**: `run` and ad-hoc instruction runs
+  construct `ChainApprover(ClampApprover(space), DeltaLimitApprover(space))`
+  from the resolved embodiment's action space unless `--disable-guardrails`
+  is passed (which prints a prominent stderr warning and uses `AutoApprover`).
+  `--max-action-delta` overrides the derived per-step limit (scalar,
+  interpreted in the space's native units). The chain builder **degrades
+  per component with a loud stderr warning instead of blocking**: a space
+  with no bounds skips `ClampApprover`; a space where `DeltaLimitApprover`
+  refuses to construct — for *any* of its §3a reasons (no semantics,
+  unbounded dims without `--max-action-delta`, unsupported rotation repr,
+  …) — skips the delta limiter, with the CLI catching the constructor's
+  refusal generically rather than pre-checking an enumerated list; if
+  nothing is applicable the CLI says plainly that no guardrails are active,
+  names the actual refusal reason it caught, and states that reason's fix
+  (declare semantics/bounds, pass `--max-action-delta`, or — for rotation
+  reprs — fix the embodiment's declaration). Concretely: the isaacsim plugin's action box
+  (absolute `joint_pos` semantics but no bounds) keeps running, with the
+  warning, exactly as unprotected as it is today — never *less* protected
+  than the status quo, and never silently. This satisfies "guardrails on by default, explicit
+  flag to turn off" for **every** policy, not just LLMs, and sits below the
+  model — no prompt injection or model error can emit an unclamped action.
+  The run header states the active chain (or the degradation), and every
+  clamp already lands in the transcript/log as an approval event; a
+  dedicated `EvalSpec` field is deferred (schema change, not needed for
+  safety).
+- **The CLI closes what it constructs**: today the CLI resolves the
+  embodiment itself and passes the object to `eval()`, so `eval()`'s
+  close-what-we-open rule never fires and nothing closes it — acceptable for
+  mocks, not for hardware holding CAN channels. `_cmd_run` (both task and
+  ad-hoc paths) wraps the run in `try/finally: embodiment.close()`, covering
+  Ctrl-C. (The CLI must construct the embodiment anyway to build the
+  guardrail chain from its action space.)
+- **`config set KEY VALUE` / `config show`**: writes `policy`, `embodiment`,
+  or `sim_embodiment` under `[defaults]` in
+  `~/.config/inspect-robots/config.ini` (stdlib `configparser`, atomic
+  write-temp-then-rename, unknown sections preserved); `show` prints resolved
+  defaults with sources. The existing guided error's fix line gains the
+  `config set` spelling. No shipped hardware default, deliberately: core
+  cannot name an optional package, and a tool that moves physical robots must
+  not pick its target implicitly (plan 0005's trust stance).
 
 ## 4. The plugin: `inspect-robots-agent`
 
@@ -94,134 +240,229 @@ plugins/inspect-robots-agent/
   src/inspect_robots_agent/
     __init__.py
     _llm.py                 # OpenAI-compatible chat client (httpx), provider resolution
-    _tools.py               # tool schemas + dispatch over an Embodiment
-    _motion.py              # joint-space interpolation primitive
-    _loop.py                # the agentic loop (LLM ↔ tools ↔ embodiment)
-    _cli.py                 # registers the `agent` subcommand (entry point)
-  tests/                    # mock transport + mock/cubepick; no network, no hardware
+    _tools.py               # tool schemas + parsing over the bound action space
+    _motion.py              # control-mode-aware primitives → ActionChunk
+    policy.py               # LLMAgentPolicy (bind/reset/act), registry entry point
+  tests/                    # httpx.MockTransport + cubepick; no network, no hardware
 ```
+
+Registered under the existing `inspect_robots.policies` entry-point group as
+`agent` — exactly like the xpolicylab and yam policies. No new registry
+machinery.
 
 ### 4a. LLM client (`_llm.py`)
 
 Speaks the OpenAI chat-completions wire format (tools + tool_choice), which
 covers OpenRouter, OpenAI, local vLLM/Ollama, and Anthropic's OpenAI-compat
-endpoint. No provider SDKs — one `httpx` client, same "speak the protocol,
+endpoint. No provider SDKs — one `httpx` client; same "speak the protocol,
 don't import the package" doctrine as plan 0007.
 
-Model strings are OpenRouter-style `provider/model`. Key/base-url resolution,
-first match wins:
+Model strings are OpenRouter-style `provider/model`, resolved from
+`-P model=…` falling back to `$INSPECT_ROBOTS_MODEL`. Key/base-url
+resolution, first match wins:
 
-1. `--base-url` flag (+ `--api-key-env NAME`, default `OPENROUTER_API_KEY`) — any compatible endpoint
+1. `-P base_url=…` (+ `-P api_key_env=NAME`, default `OPENROUTER_API_KEY`) — any compatible endpoint
 2. `anthropic/*` model + `ANTHROPIC_API_KEY` → Anthropic compat endpoint
 3. `openai/*` model + `OPENAI_API_KEY` → OpenAI
 4. `OPENROUTER_API_KEY` → OpenRouter (any model string)
 
-No key that matches → guided `SystemExit` naming the env vars, mirroring the
+No model or no matching key → guided error naming the env vars, mirroring the
 embodiment error. This is the whole "works out of the box with an OpenRouter /
-Claude / OpenAI key" requirement.
+Claude / OpenAI key" requirement. Transient HTTP failures retry with backoff;
+persistent failure raises and is wrapped by the rollout as `PolicyError`.
 
-### 4b. Tool surface (`_tools.py`)
+### 4b. The policy (`policy.py`)
 
-Generated from the embodiment's spaces — the plugin never knows what a "YAM"
-or an "arm" is:
+`LLMAgentPolicy(PolicyBase)` — conversation state is per-trial:
 
-- `get_observation()` → proprioceptive state (labeled when `dim_labels` exist)
-  and camera frames, sent to the LLM as image content blocks.
-- `move_joints(targets: dict[str, float], duration_s: float)` — **named partial
-  targets**: unnamed joints hold position. `{"right_j2": 0.4, "right_gripper": 1.0}`
-  moves one arm of a bimanual robot; naming joints from both arms coordinates
-  them in one call. Falls back to index keys without labels. Unknown label,
-  out-of-bounds `duration_s` → structured tool error the LLM can react to,
-  never an exception.
-- `done(summary)` / `give_up(reason)` — terminate the loop.
+- **`bind(embodiment_info)`** adopts the embodiment's spaces (§3c) and builds
+  the tool schema from the action `Box` (bounds, `dim_labels`, semantics —
+  including which motion tool the control mode gets, §4c).
+- **`reset(scene)`** starts a fresh conversation: system prompt (embodiment
+  description, control mode, tool docs, safety notes, budget) + the scene's
+  instruction as the user goal.
+- **`act(observation)`** appends the observation (state fields with their
+  keys, camera frames as image content blocks) to the conversation, calls
+  the LLM until it produces a tool call (bounded retries on malformed output,
+  then `PolicyError`), and returns the resulting `ActionChunk`.
+- Tool errors (unknown label, non-finite value, bad `duration_s`) are
+  structured messages the LLM sees and can correct — never exceptions.
+- `-P` knobs: `model`, `base_url`, `api_key_env`, `max_llm_calls` (budget →
+  `give_up` when exhausted), `temperature`. Core `PolicyConfig` has no such
+  fields, so the plugin defines a frozen
+  `AgentPolicyConfig(PolicyConfig)` subclass — `eval()` serializes configs
+  with `dataclasses.asdict`, so the extra fields land in the log for free.
 
-The tool JSON schema embeds the action space's bounds, labels, and semantics
-(control mode, gripper kind), so the system prompt stays generic.
+The LLM never sees raw actuation: its tool calls are *requests* that the
+motion layer turns into bounded trajectories, and every emitted action still
+passes the rollout's approver chain — the plugin contains no safety-critical
+code path of its own.
 
-### 4c. Motion primitive (`_motion.py`)
+### 4c. Motion primitives (`_motion.py`) — control-mode-aware
 
-One tool call → one smooth trajectory: linear interpolation in joint space from
-current position to target over `duration_s` at the embodiment's control rate,
-each interpolated step passing through the approver chain, then
-`embodiment.step()`. Blocks until the trajectory finishes; returns the
-achieved state. This layer is what bridges "LLM thinks in seconds" to "robot
-steps at 10 Hz" — and interpolation itself is a guardrail (no teleports even if
-the target is far).
+The tool surface and action synthesis are selected by
+`ActionSemantics.control_mode` at bind time:
 
-### 4d. Guardrails-by-default (`_loop.py`, `_cli.py`)
+- **Absolute-target modes** (`joint_pos` — YAM's default — and
+  `eef_abs_pose`): tool is
+  `move_joints(targets: dict[str, float], duration_s: float)` with **named
+  partial targets** — unnamed dims hold their current observed value;
+  `{"right_j2": 0.4, "right_gripper": 1.0}` moves one arm of a bimanual
+  robot; naming joints from both arms coordinates them in one call. Synthesis:
+  linear interpolation from the current observed state to the target over
+  `duration_s` at the embodiment's control rate. **Hold-still = repeat the
+  current observed state.** Alignment rule (checked at `bind`): the
+  embodiment's `StateSpec` must contain **exactly one field with
+  `shape == (action_dim,)`** — that field is the proprioceptive reference
+  (YAM's single flat 14-D `joint_pos` field satisfies it). Zero or multiple
+  matching fields, or an embodiment without a `StateSpec`, is a bind error
+  naming this rule.
+- **Displacement modes** (`eef_delta_pos` — the mock `cubepick` world —
+  `eef_delta_pose`, and `joint_delta`): tool is
+  `move_by(deltas: dict[str, float], duration_s: float)` — the requested
+  displacement is split evenly across the chunk's steps (per-step deltas stay
+  small by construction). Unnamed dims get zero. **Hold-still = all-zeros
+  action.** No state/action alignment needed.
+- Pose modes additionally require `rotation_repr ∈ {none, rot6d}` — linear
+  per-dimension interpolation/splitting is invalid on quaternion, axis-angle,
+  or euler components (the same restriction `EnsemblingController` enforces
+  for per-dimension averaging). Other representations, `joint_vel`, and
+  anything else: unsupported at `bind` (clear message), until someone wants
+  it. No embodiment in the repo family declares a pose mode today, so
+  nothing regresses.
 
-The loop wires `ChainApprover(ClampApprover(action_space), DeltaLimitApprover(...))`
-between the primitive and the embodiment. **Always on.** `--disable-guardrails`
-is the explicit opt-out flag; it prints a prominent warning to stderr. There is
-no code path from the LLM to `embodiment.step()` that bypasses the approver —
-the safety boundary is below the model, so no prompt injection or model error
-can emit an unclamped action. Tunables: `--max-joint-delta` (rad/step, sane
-default), `--max-steps`, `--max-llm-calls`.
-
-Loop shape: system prompt (embodiment description, tool docs, safety notes) +
-user goal → LLM → tool calls executed sequentially → results (text + images)
-appended → repeat until `done`/`give_up`/budget. Every LLM call, tool call, and
-approval event is echoed to the console and written to a JSONL transcript under
-`logs/` (reusing core transcript event types where they fit).
-
-### 4e. CLI (`_cli.py`)
-
-```
-inspect-robots agent "GOAL" [--model P/M] [--embodiment NAME] [-E k=v]
-    [--base-url URL] [--api-key-env NAME] [--max-joint-delta R]
-    [--max-steps N] [--max-llm-calls N] [--disable-guardrails] [--log-dir D]
-```
-
-`--model` and `--embodiment` resolve through the §3c defaults chain; both
-unconfigured cases exit with the guided message. Registered via the
-`inspect_robots.cli` entry point, so the command appears whenever the plugin is
-installed.
+Either way, one tool call → one open-loop `ActionChunk` (`control_hz` from
+the embodiment), which bridges "LLM thinks in seconds" to "robot steps at
+10 Hz" — and per-step smallness is itself a guardrail before the approver
+chain ever sees the actions. Chunk length is capped (e.g. 10 s worth of
+steps); an over-long `duration_s` is a tool error, not a runaway chunk.
+`done`/`give_up` emit the mode's hold-still action flagged `request_stop`
+(§3d). Unsupported control modes fail at `bind` with a clear message rather
+than at runtime.
 
 ## 5. Testing (no network, no hardware)
 
-- Core: approvers and `dim_labels` are pure NumPy — straight into the 100%
-  gate. `config set/show` tested against a tmp `XDG_CONFIG_HOME`; the
-  entry-point hook tested with a synthetic entry point (same technique as
-  existing registry tests).
-- Plugin: `httpx.MockTransport` scripts LLM conversations (tool calls as
-  canned JSON) against `mock/cubepick`; asserts end-to-end that goals run,
-  guardrails clamp a scripted wild swing, `--disable-guardrails` doesn't, NaN
-  aborts, budgets terminate, and each provider resolution rule picks the right
-  base URL/key. Plugin keeps its own coverage scope outside the core gate,
-  like the other plugins.
+- **Core**: approvers (all six control modes' classification, derived and
+  explicit `max_delta`, every constructor refusal — `semantics=None`,
+  unbounded dims, unsupported rotation repr — NaN abort, first-action
+  pass-through, per-trial reference reset), CLI chain degradation warnings
+  (a bounds-less absolute space — isaacsim's shape; a synthetic
+  semantics-less space; a synthetic quat-repr pose space; a
+  fully-unlimitable one), `dim_labels` +
+  `joint_delta` (incl. the ensembling averageable-set update), `bind`,
+  `request_stop`
+  (pre-review meta wins over approver rewrite; embodiment termination takes
+  precedence; ensembling limitation documented), CLI guardrail default +
+  `--disable-guardrails` + `--max-action-delta`, CLI `finally: close()`
+  (asserted with a recording mock embodiment, including on error), and
+  `config set/show` (tmp config home) — all pure NumPy/stdlib, straight into
+  the 100% gate.
+- **Plugin**: `httpx.MockTransport` scripts LLM conversations (tool calls as
+  canned JSON) against `cubepick` end-to-end through real `eval()`:
+  goals run to `done`, a scripted wild swing is delta-clamped (and isn't with
+  guardrails disabled), budgets `give_up`, malformed tool calls retry then
+  fail as `PolicyError`, and each provider-resolution rule picks the right
+  base URL/key. The absolute-mode path (interpolation, named partial targets,
+  bimanual packing) is exercised against a labeled joint-space mock
+  embodiment defined in the plugin's tests. Plugin keeps its own coverage
+  scope outside the core gate, like the other plugins.
 
-## 6. CI, workspace, release
+## 6. YAM-repo enablement (separate repo, prerequisite for the pilot)
 
-Same integration as plan 0007 §8: uv workspace member; a `test-agent-plugin` CI
-job added to `ci-ok.needs`; core-only-import job already proves core never
-imports it; `publish-inspect-robots-agent` job in `release.yml` with
-`skip-existing`; PyPI trusted-publisher environment for the new package.
+The pilot cannot run on the yam adapter as it exists today; these land as
+`inspect-robots-yam` PRs alongside steps 7–9:
 
-## 7. Risks & mitigations
+1. **Semantics fixes** (once the core release carrying §3b is tagged):
+   `dim_labels` on its action space (14 labels, §3b order), and declare
+   `control_mode="joint_delta"` when `joints_are_delta=True` — today the
+   `joint_pos` constant is baked in regardless of the flag, which would send
+   both the delta limiter and the agent's motion layer down the absolute
+   branch on a delta-configured rig. Two coordinated consequences, both in
+   scope for this item:
+   - **Per-step displacement bounds**: the delta-mode action box currently
+     reuses the absolute joint limits (±π per joint, `[0, 1]` gripper) — so
+     the derived swing limit would be π/step, and `ClampApprover` on a
+     `[0, 1]` *delta* gripper dim clamps every negative delta to 0, making
+     the gripper impossible to open. Delta mode gets its own per-step box
+     (symmetric per joint and gripper, conservative defaults).
+   - **`MolmoAct2Policy` moves in lockstep**: it declares the same shared
+     `ACTION_SEMANTICS` constant, and a `control_mode` mismatch is a hard
+     compat error — the policy's declaration must become config-dependent
+     too, or the currently-working molmoact2-on-delta-YAM pairing breaks.
+2. **CLI-constructible cameras**: `YAMEmbodiment.reset()` currently raises
+   unless a `camera_reader` is injected programmatically — and the agent
+   policy needs frames. Add a camera factory configurable via scalar `-E`
+   args (e.g. `-E cameras=top:0,left:2` for local capture devices) behind an
+   optional extra.
+3. **Install story**: an extra (e.g. `inspect-robots-yam[hardware]`) or
+   documented step that pulls the i2rt driver — plain `pip install
+   inspect-robots-yam` deliberately doesn't.
+4. **Hold-behavior verification**: first hardware task is verifying that the
+   arms hold position between chunks with the chosen config —
+   `zero_gravity_mode` defaults to `True` (gravity-compensated/compliant),
+   which may need to be off for agent runs. Documented in the quickstart.
+5. **Quickstart** (§1's YAM block) in the README.
+
+## 7. CI, workspace, release
+
+Same integration as plan 0007 §8: uv workspace member (`uv lock` refreshed in
+the same PR); a `test-agent-plugin` CI job added to `ci-ok.needs`; the
+`core-only-import` job already proves core never imports it;
+`publish-inspect-robots-agent` job in `release.yml` with `skip-existing`; new
+PyPI trusted-publisher environment for the package.
+
+## 8. Risks & mitigations
 
 - **LLMs are poor low-level controllers.** Expected; the pilot's bar is
   "coherent, safe, visibly reasoned motion", not VLA-grade manipulation.
-  Named partial targets + images per step give the model its best shot;
-  budgets bound the failure mode.
-- **Latency between decisions** — the arm idles while the LLM thinks. Fine for
-  a pilot; hold-position is the safe idle.
-- **Prompt injection / model misbehavior** — cannot bypass the approver chain
-  (enforced below the model); worst case is in-bounds, rate-limited motion.
-  `--max-steps`/`--max-llm-calls` bound runaway loops; Ctrl-C must always
-  stop cleanly (`finally: embodiment.close()`).
+  Named partial targets + per-chunk images give the model its best shot;
+  budgets bound the failure mode — and because it's a `Policy`, "how bad is
+  it, exactly" is a scored, loggable question from day one.
+- **First action of a trial is not delta-limited** (no reference yet, §3a).
+  Accepted: bounds clamping still applies, the agent's interpolation starts
+  from the observed state (so its first action ≈ current pose), and this
+  matches the status quo for every existing policy. Revisit if the pilot
+  shows first-step jumps.
+- **Arm behavior between chunks is an assumption, not a fact** — verified as
+  YAM-repo work item §6.4 before any untethered run. Ctrl-C cleanup is now
+  guaranteed by the CLI's `finally: close()` (§3e), not assumed.
+- **Prompt injection / model misbehavior** — cannot bypass the approver
+  chain (it sits below the model, in rollout); worst case is in-bounds,
+  rate-limited motion until a budget trips.
+- **CLI guardrail default changes existing behavior**: out-of-bounds actions
+  now clamp, and on absolute-target embodiments in-bounds *jumps* larger than
+  the derived 5%-of-range step limit get rate-limited too — a real change for
+  fast VLAs on such rigs, tunable via `--max-action-delta`. Displacement-mode
+  embodiments are unaffected by default (derived limit = the bounds, §3a), so
+  builtin demos like `cubepick-reach` behave identically. Accepted and
+  deliberate (it is the safety requirement); release notes + run header make
+  it visible, `--disable-guardrails` restores the old behavior, and the
+  Python API is untouched.
 - **Anthropic compat-endpoint drift** — the client is plain OpenAI wire
   format; if the compat endpoint diverges, OpenRouter remains the universal
-  path and a native adapter can be added behind the same interface later.
+  path and a native adapter can slot behind the same client interface later.
 
-## 8. Execution steps (each a commit / PR-sized slice)
+## 9. Execution steps (each a commit / PR-sized slice)
 
-1. Core: `DeltaLimitApprover` + `ChainApprover` (+ tests, API snapshot).
-2. Core: `ActionSemantics.dim_labels` (+ validation, tests, snapshot).
-3. Core: `config set/show` subcommand; `model` default key; guided-error text
-   gains the `config set` fix line.
-4. Core: `inspect_robots.cli` entry-point group.
-5. Plugin scaffold: pyproject, workspace membership, CI job, release job.
-6. Plugin: `_llm.py` client + provider resolution (mock-transport tests).
-7. Plugin: `_tools.py` + `_motion.py` over mock/cubepick.
-8. Plugin: `_loop.py` + `_cli.py`; end-to-end scripted-conversation tests.
-9. Docs: core README section; yam repo quickstart PR (separate repo).
+1. Core: `ActionSemantics.dim_labels` + `ControlMode` `"joint_delta"`
+   literal (+ `Box` validation, tests, snapshot). Includes the knock-on in
+   `EnsemblingController`: add `joint_delta` to `_AVERAGEABLE_MODES` (it is
+   linearly averageable) — the rejection branch is `# pragma: no cover` on
+   the premise that every literal is averageable, and the new literal must
+   not silently invalidate that premise.
+2. Core: `DeltaLimitApprover` + `ChainApprover` (classification needs
+   step 1's vocabulary); generalize rollout's approval-event detail beyond
+   `clamped` (+ tests, API snapshot).
+3. Core: `Policy.bind()` hook in `eval()` (+ tests, snapshot).
+4. Core: `request_stop` in rollout (+ tests, docstring noting the ensembling
+   limitation).
+5. Core: CLI guardrails-by-default (`--disable-guardrails`,
+   `--max-action-delta`), embodiment `finally: close()`, `config set/show`,
+   guided-error text update (+ tests).
+6. Plugin scaffold: pyproject, workspace membership, lockfile, CI job,
+   release job.
+7. Plugin: `_llm.py` client + provider resolution (mock-transport tests).
+8. Plugin: `_tools.py` + `_motion.py`, both control modes (unit tests incl.
+   labeled bimanual space).
+9. Plugin: `LLMAgentPolicy` end-to-end through `eval()` on `cubepick`.
+10. Docs: core README section; yam-repo PRs per §6.

--- a/plans/0008-llm-agent-mode.md
+++ b/plans/0008-llm-agent-mode.md
@@ -1,0 +1,227 @@
+# 0008 — Agent mode: LLMs drive robots through tool calls
+
+## 1. Goal
+
+Let a frontier LLM (Claude, GPT, anything behind an OpenAI-compatible API)
+control a robot interactively — outside the eval loop — by calling tools
+against any registered `Embodiment`. Pilot target: the bimanual YAM arms.
+
+```bash
+pip install inspect-robots inspect-robots-yam inspect-robots-agent
+inspect-robots config set embodiment yam        # once, per machine
+export ANTHROPIC_API_KEY=sk-ant-...
+
+inspect-robots agent "place the fork on the plate" --model anthropic/claude-fable-5
+```
+
+Same command with `--embodiment mock/cubepick` runs hardware-free, which is
+also how the whole feature is tested in CI.
+
+This is **not** a `Policy`. The eval loop's policy contract (observation →
+`ActionChunk` at control rate) is wrong for an LLM that thinks for seconds per
+decision. Agent mode is a separate vertical: an agentic tool-calling loop where
+each tool call executes a smooth, approver-checked motion primitive spanning
+many `embodiment.step()` calls. An LLM-backed `Policy` for scored evals can come
+later and is out of scope here.
+
+## 2. Placement: what goes where
+
+Follows the family convention (hardware adapters in satellite repos, policy-side
+adapters as in-repo plugins; `plugins/inspect-robots-xpolicylab` is the
+precedent — plan 0007).
+
+| Piece | Where | Why |
+|---|---|---|
+| Safety approvers (max-delta limiter, chaining) | core `approver.py` | NumPy-only; protects every action source; the `Approver` seam already exists and its docstring reserves exactly this hardening |
+| `dim_labels` on `ActionSemantics` | core `spaces.py` | NumPy-only; lets the agent (and future logging/viz) name action dimensions |
+| Plugin CLI subcommands + `config set/show` | core `cli.py` / `_defaults.py` | tiny, dependency-free, benefits every plugin |
+| Agent loop, LLM client, tool surface, `agent` subcommand | new `plugins/inspect-robots-agent` | needs an HTTP client dep, so it cannot live in the NumPy-only core |
+| YAM pilot | `inspect-robots-yam` repo (docs/quickstart) | its bimanual `Embodiment` (two CAN channels, `can0`/`can1` defaults, flat 14-D action space) already exists; the pilot is documentation, not code |
+
+## 3. Core changes
+
+### 3a. Safety approvers (`approver.py`)
+
+- **`DeltaLimitApprover(max_delta, reference)`** — the "no wild swings" gate.
+  Clamps each action dimension to at most `max_delta` away from a reference
+  (last approved action, falling back to the current proprioceptive state on
+  the first action). Per-dimension `max_delta` array or scalar. NaN → `SafetyAbort`
+  (same contract as `ClampApprover`). A clamped action is flagged via
+  `action.meta["delta_clamped"]` so the transcript records an approval event.
+- **`ChainApprover(approvers)`** — runs approvers in sequence (bounds clamp,
+  then delta limit). Trivial, but gives "guardrails" one name.
+
+Both are generic: they harden scored evals with VLA policies exactly as much as
+agent mode. Registered defaults change nothing for existing users — `eval()`
+keeps `AutoApprover` unless configured otherwise; **agent mode** is where the
+chain is on by default (§4d).
+
+### 3b. `ActionSemantics.dim_labels` (`spaces.py`)
+
+Optional `dim_labels: tuple[str, ...] | None = None`; when present its length
+must equal the owning action `Box.dim` (validated in `Box.__post_init__`, which
+is where the semantics/shape pairing is visible). YAM will set
+`("left_j0", …, "left_j5", "left_gripper", "right_j0", …, "right_gripper")` in
+its repo. Embodiments without labels still work — the agent falls back to
+index-keyed targets (`"3": 0.4`).
+
+### 3c. CLI plugin subcommands + `config` (`cli.py`, `_defaults.py`)
+
+- New entry-point group **`inspect_robots.cli`**: each entry point resolves to a
+  `register(subparsers) -> None` callable. Core loads the group after building
+  its own subparsers; a plugin that fails to import is skipped with a warning
+  (same tolerance the component registry uses).
+- New **`config`** subcommand in core: `config set KEY VALUE` writes
+  `[defaults]` keys (`policy`, `embodiment`, `sim_embodiment`, `model`) into
+  `~/.config/inspect-robots/config.ini` via `configparser` (atomic
+  write-temp-then-rename, preserving unknown sections); `config show` prints the
+  resolved defaults with their sources. `_defaults.py` gains `model` /
+  `INSPECT_ROBOTS_MODEL` alongside the existing keys so `--model` participates
+  in the same flag > env > config chain.
+
+The unconfigured experience stays the existing guided `SystemExit` ("registered
+embodiments: …; fix: pass --embodiment, set $…, or run `inspect-robots config
+set embodiment NAME`" — the fix line gains the `config set` spelling). No
+shipped hardware default, deliberately: core cannot name an optional package,
+and a tool that moves physical robots must not pick its target implicitly
+(same trust stance as plan 0005's rejection of project-local config).
+
+## 4. The plugin: `inspect-robots-agent`
+
+```
+plugins/inspect-robots-agent/
+  pyproject.toml            # deps: inspect-robots, httpx; static version 0.1.0
+  src/inspect_robots_agent/
+    __init__.py
+    _llm.py                 # OpenAI-compatible chat client (httpx), provider resolution
+    _tools.py               # tool schemas + dispatch over an Embodiment
+    _motion.py              # joint-space interpolation primitive
+    _loop.py                # the agentic loop (LLM ↔ tools ↔ embodiment)
+    _cli.py                 # registers the `agent` subcommand (entry point)
+  tests/                    # mock transport + mock/cubepick; no network, no hardware
+```
+
+### 4a. LLM client (`_llm.py`)
+
+Speaks the OpenAI chat-completions wire format (tools + tool_choice), which
+covers OpenRouter, OpenAI, local vLLM/Ollama, and Anthropic's OpenAI-compat
+endpoint. No provider SDKs — one `httpx` client, same "speak the protocol,
+don't import the package" doctrine as plan 0007.
+
+Model strings are OpenRouter-style `provider/model`. Key/base-url resolution,
+first match wins:
+
+1. `--base-url` flag (+ `--api-key-env NAME`, default `OPENROUTER_API_KEY`) — any compatible endpoint
+2. `anthropic/*` model + `ANTHROPIC_API_KEY` → Anthropic compat endpoint
+3. `openai/*` model + `OPENAI_API_KEY` → OpenAI
+4. `OPENROUTER_API_KEY` → OpenRouter (any model string)
+
+No key that matches → guided `SystemExit` naming the env vars, mirroring the
+embodiment error. This is the whole "works out of the box with an OpenRouter /
+Claude / OpenAI key" requirement.
+
+### 4b. Tool surface (`_tools.py`)
+
+Generated from the embodiment's spaces — the plugin never knows what a "YAM"
+or an "arm" is:
+
+- `get_observation()` → proprioceptive state (labeled when `dim_labels` exist)
+  and camera frames, sent to the LLM as image content blocks.
+- `move_joints(targets: dict[str, float], duration_s: float)` — **named partial
+  targets**: unnamed joints hold position. `{"right_j2": 0.4, "right_gripper": 1.0}`
+  moves one arm of a bimanual robot; naming joints from both arms coordinates
+  them in one call. Falls back to index keys without labels. Unknown label,
+  out-of-bounds `duration_s` → structured tool error the LLM can react to,
+  never an exception.
+- `done(summary)` / `give_up(reason)` — terminate the loop.
+
+The tool JSON schema embeds the action space's bounds, labels, and semantics
+(control mode, gripper kind), so the system prompt stays generic.
+
+### 4c. Motion primitive (`_motion.py`)
+
+One tool call → one smooth trajectory: linear interpolation in joint space from
+current position to target over `duration_s` at the embodiment's control rate,
+each interpolated step passing through the approver chain, then
+`embodiment.step()`. Blocks until the trajectory finishes; returns the
+achieved state. This layer is what bridges "LLM thinks in seconds" to "robot
+steps at 10 Hz" — and interpolation itself is a guardrail (no teleports even if
+the target is far).
+
+### 4d. Guardrails-by-default (`_loop.py`, `_cli.py`)
+
+The loop wires `ChainApprover(ClampApprover(action_space), DeltaLimitApprover(...))`
+between the primitive and the embodiment. **Always on.** `--disable-guardrails`
+is the explicit opt-out flag; it prints a prominent warning to stderr. There is
+no code path from the LLM to `embodiment.step()` that bypasses the approver —
+the safety boundary is below the model, so no prompt injection or model error
+can emit an unclamped action. Tunables: `--max-joint-delta` (rad/step, sane
+default), `--max-steps`, `--max-llm-calls`.
+
+Loop shape: system prompt (embodiment description, tool docs, safety notes) +
+user goal → LLM → tool calls executed sequentially → results (text + images)
+appended → repeat until `done`/`give_up`/budget. Every LLM call, tool call, and
+approval event is echoed to the console and written to a JSONL transcript under
+`logs/` (reusing core transcript event types where they fit).
+
+### 4e. CLI (`_cli.py`)
+
+```
+inspect-robots agent "GOAL" [--model P/M] [--embodiment NAME] [-E k=v]
+    [--base-url URL] [--api-key-env NAME] [--max-joint-delta R]
+    [--max-steps N] [--max-llm-calls N] [--disable-guardrails] [--log-dir D]
+```
+
+`--model` and `--embodiment` resolve through the §3c defaults chain; both
+unconfigured cases exit with the guided message. Registered via the
+`inspect_robots.cli` entry point, so the command appears whenever the plugin is
+installed.
+
+## 5. Testing (no network, no hardware)
+
+- Core: approvers and `dim_labels` are pure NumPy — straight into the 100%
+  gate. `config set/show` tested against a tmp `XDG_CONFIG_HOME`; the
+  entry-point hook tested with a synthetic entry point (same technique as
+  existing registry tests).
+- Plugin: `httpx.MockTransport` scripts LLM conversations (tool calls as
+  canned JSON) against `mock/cubepick`; asserts end-to-end that goals run,
+  guardrails clamp a scripted wild swing, `--disable-guardrails` doesn't, NaN
+  aborts, budgets terminate, and each provider resolution rule picks the right
+  base URL/key. Plugin keeps its own coverage scope outside the core gate,
+  like the other plugins.
+
+## 6. CI, workspace, release
+
+Same integration as plan 0007 §8: uv workspace member; a `test-agent-plugin` CI
+job added to `ci-ok.needs`; core-only-import job already proves core never
+imports it; `publish-inspect-robots-agent` job in `release.yml` with
+`skip-existing`; PyPI trusted-publisher environment for the new package.
+
+## 7. Risks & mitigations
+
+- **LLMs are poor low-level controllers.** Expected; the pilot's bar is
+  "coherent, safe, visibly reasoned motion", not VLA-grade manipulation.
+  Named partial targets + images per step give the model its best shot;
+  budgets bound the failure mode.
+- **Latency between decisions** — the arm idles while the LLM thinks. Fine for
+  a pilot; hold-position is the safe idle.
+- **Prompt injection / model misbehavior** — cannot bypass the approver chain
+  (enforced below the model); worst case is in-bounds, rate-limited motion.
+  `--max-steps`/`--max-llm-calls` bound runaway loops; Ctrl-C must always
+  stop cleanly (`finally: embodiment.close()`).
+- **Anthropic compat-endpoint drift** — the client is plain OpenAI wire
+  format; if the compat endpoint diverges, OpenRouter remains the universal
+  path and a native adapter can be added behind the same interface later.
+
+## 8. Execution steps (each a commit / PR-sized slice)
+
+1. Core: `DeltaLimitApprover` + `ChainApprover` (+ tests, API snapshot).
+2. Core: `ActionSemantics.dim_labels` (+ validation, tests, snapshot).
+3. Core: `config set/show` subcommand; `model` default key; guided-error text
+   gains the `config set` fix line.
+4. Core: `inspect_robots.cli` entry-point group.
+5. Plugin scaffold: pyproject, workspace membership, CI job, release job.
+6. Plugin: `_llm.py` client + provider resolution (mock-transport tests).
+7. Plugin: `_tools.py` + `_motion.py` over mock/cubepick.
+8. Plugin: `_loop.py` + `_cli.py`; end-to-end scripted-conversation tests.
+9. Docs: core README section; yam repo quickstart PR (separate repo).

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -1,0 +1,47 @@
+# inspect-robots-agent
+
+LLM agent policy for [Inspect Robots](https://github.com/robocurve/inspect-robots):
+frontier LLMs (Claude, GPT, anything behind an OpenAI-compatible API) drive any
+registered embodiment through tool calls, as a first-class `Policy` named
+`agent`. The same policy runs ad-hoc instructions and scores on registered
+tasks next to fine-tuned VLAs.
+
+## Install
+
+```bash
+pip install inspect-robots inspect-robots-agent
+```
+
+## Quickstart (no hardware)
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+
+inspect-robots "pick up the cube" --policy agent \
+    -P model=anthropic/claude-fable-5 --embodiment cubepick
+```
+
+Model strings are OpenRouter-style `provider/model`, resolved from
+`-P model=...` or `$INSPECT_ROBOTS_MODEL`. API keys come from the environment:
+
+1. `-P base_url=...` (with `-P api_key_env=NAME`): any OpenAI-compatible endpoint
+2. `anthropic/*` model with `ANTHROPIC_API_KEY`: the Anthropic compat endpoint
+3. `openai/*` model with `OPENAI_API_KEY`: OpenAI
+4. `OPENROUTER_API_KEY`: OpenRouter, any model string
+
+## How it works
+
+Each LLM tool call becomes one smooth, open-loop action chunk: named partial
+joint targets are interpolated at the embodiment's control rate
+(`move_joints`), displacements are split across steps (`move_by`), and
+`done`/`give_up` end the trial through the core's policy-stop channel. Every
+action still passes the CLI's default safety approvers (bounds clamp plus
+per-step delta limit); the plugin contains no safety-critical code path of
+its own.
+
+> [!WARNING]
+> Guardrails are on by default at the CLI. **Never pass `--disable-guardrails`
+> on real hardware** unless you fully trust the policy and the rig.
+
+Configuration knobs (all `-P key=value`): `model`, `base_url`, `api_key_env`,
+`max_llm_calls`, `temperature`.

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -1,0 +1,90 @@
+[build-system]
+requires = ["hatchling>=1.18", "hatch-fancy-pypi-readme>=24.1"]
+build-backend = "hatchling.build"
+
+[project]
+name = "inspect-robots-agent"
+version = "0.1.0"
+description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
+dynamic = ["readme"]
+requires-python = ">=3.10"
+license = "MIT"
+authors = [{ name = "Inspect Robots contributors" }]
+keywords = ["robotics", "llm", "agent", "vla", "inspect_robots", "evaluation"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Typing :: Typed",
+]
+# NOTE: no provider SDKs. The adapter speaks the OpenAI chat-completions wire
+# format over one httpx client, which covers OpenRouter, OpenAI, local
+# vLLM/Ollama, and Anthropic's OpenAI-compat endpoint (plan 0008 §4a) — the
+# same "speak the protocol, don't import the package" doctrine as the
+# xpolicylab plugin.
+dependencies = [
+    "inspect-robots>=0.4",
+    "numpy>=1.24",
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "mypy>=1.11", "ruff>=0.6"]
+
+# Entry-point discovery: an installed inspect-robots-agent appears in
+# `inspect-robots list policies` without being imported first. The registry
+# calls this factory by the name `agent`.
+[project.entry-points."inspect_robots.policies"]
+agent = "inspect_robots_agent.policy:agent_policy"
+
+[project.urls]
+Homepage = "https://github.com/robocurve/inspect-robots/tree/main/plugins/inspect-robots-agent"
+Repository = "https://github.com/robocurve/inspect-robots"
+
+# In the Inspect Robots monorepo this resolves the `inspect_robots` dependency
+# to the in-repo core package instead of PyPI. Harmless in a standalone
+# checkout (uv ignores a workspace source when there is no workspace root).
+[tool.uv.sources]
+inspect-robots = { workspace = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/inspect_robots_agent"]
+
+[tool.hatch.build.targets.sdist]
+include = ["src/inspect_robots_agent", "tests", "README.md"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.mypy]
+strict = true
+
+# PyPI readme: identical to README.md except GitHub-only alert syntax
+# (e.g. `> [!NOTE]`) is rewritten to bold blockquotes, which PyPI renders.
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!NOTE\][ \t]*$'
+replacement = '> **Note:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!TIP\][ \t]*$'
+replacement = '> **Tip:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!IMPORTANT\][ \t]*$'
+replacement = '> **Important:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!WARNING\][ \t]*$'
+replacement = '> **Warning:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!CAUTION\][ \t]*$'
+replacement = '> **Caution:**'

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/__init__.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/__init__.py
@@ -1,0 +1,28 @@
+"""inspect-robots-agent — frontier LLMs as first-class Inspect Robots policies.
+
+An LLM behind any OpenAI-compatible API (OpenRouter, OpenAI, local
+vLLM/Ollama, Anthropic's compat endpoint) drives whatever embodiment it is
+paired with: each tool call becomes one smooth, approver-checked action
+chunk. Registered as the policy ``agent``::
+
+    inspect-robots "pick up the cube" --policy agent \
+        -P model=anthropic/claude-fable-5 --embodiment cubepick
+
+or programmatically::
+
+    from inspect_robots import eval
+    from inspect_robots_agent import LLMAgentPolicy
+
+    eval("my-task", LLMAgentPolicy(model="openai/gpt-5.2"), "cubepick")
+
+The policy is discovered via the ``inspect_robots.policies`` entry point, so
+it shows up in ``inspect-robots list policies`` without being imported first.
+"""
+
+from __future__ import annotations
+
+from inspect_robots_agent.policy import AgentPolicyConfig, LLMAgentPolicy, agent_policy
+
+__all__ = ["AgentPolicyConfig", "LLMAgentPolicy", "agent_policy"]
+
+__version__ = "0.1.0"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
@@ -1,0 +1,186 @@
+"""OpenAI-compatible chat client + provider resolution (plan 0008 §4a).
+
+No provider SDKs: one ``httpx`` client speaking the chat-completions wire
+format covers OpenRouter, OpenAI, local vLLM/Ollama, and Anthropic's
+OpenAI-compat endpoint — the same "speak the protocol, don't import the
+package" doctrine as the xpolicylab plugin.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from inspect_robots.errors import ConfigError
+
+ENV_MODEL = "INSPECT_ROBOTS_MODEL"
+
+_ANTHROPIC_BASE = "https://api.anthropic.com/v1"
+_OPENAI_BASE = "https://api.openai.com/v1"
+_OPENROUTER_BASE = "https://openrouter.ai/api/v1"
+_OPENROUTER_KEY = "OPENROUTER_API_KEY"
+
+
+@dataclass(frozen=True)
+class Provider:
+    """A resolved OpenAI-compatible endpoint: where, with which key, which model."""
+
+    base_url: str
+    api_key: str
+    model: str
+
+
+def resolve_provider(
+    model: str | None,
+    base_url: str | None,
+    api_key_env: str | None,
+    env: Mapping[str, str],
+) -> Provider:
+    """The key/base-url ladder (plan 0008 §4a); first match wins.
+
+    1. Explicit ``base_url`` — any OpenAI-compatible endpoint; the key comes
+       from ``api_key_env`` (default ``OPENROUTER_API_KEY``), and a missing
+       key is allowed (local vLLM/Ollama endpoints are typically keyless).
+    2. ``anthropic/*`` model + ``ANTHROPIC_API_KEY`` — the Anthropic compat
+       endpoint (provider prefix stripped from the model id).
+    3. ``openai/*`` model + ``OPENAI_API_KEY`` — OpenAI (prefix stripped).
+    4. ``OPENROUTER_API_KEY`` — OpenRouter, which takes the full
+       ``provider/model`` string.
+
+    Anything else is a guided [`ConfigError`][inspect_robots.errors.ConfigError]
+    naming the fixes — never a traceback at the user.
+    """
+    if not model:
+        raise ConfigError(
+            "no model configured for the agent policy.\n"
+            f"fix: pass -P model=provider/model (e.g. anthropic/claude-fable-5) "
+            f"or set ${ENV_MODEL}"
+        )
+    if base_url:
+        key_env = api_key_env or _OPENROUTER_KEY
+        return Provider(base_url=base_url.rstrip("/"), api_key=env.get(key_env, ""), model=model)
+    provider_prefix, _, bare_model = model.partition("/")
+    if provider_prefix == "anthropic" and (key := env.get("ANTHROPIC_API_KEY")):
+        return Provider(base_url=_ANTHROPIC_BASE, api_key=key, model=bare_model)
+    if provider_prefix == "openai" and (key := env.get("OPENAI_API_KEY")):
+        return Provider(base_url=_OPENAI_BASE, api_key=key, model=bare_model)
+    if key := env.get(_OPENROUTER_KEY):
+        return Provider(base_url=_OPENROUTER_BASE, api_key=key, model=model)
+    raise ConfigError(
+        f"no API key found for model {model!r}.\n"
+        f"fix: set ${_OPENROUTER_KEY} (works for any model), or the provider's "
+        "key ($ANTHROPIC_API_KEY for anthropic/*, $OPENAI_API_KEY for openai/*), "
+        "or pass -P base_url=... (+ -P api_key_env=NAME) for a custom endpoint"
+    )
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """One tool invocation the model asked for; ``arguments`` is raw JSON text."""
+
+    id: str
+    name: str
+    arguments: str
+
+
+@dataclass(frozen=True)
+class AssistantMessage:
+    """The parsed ``choices[0].message`` of a chat completion."""
+
+    content: str | None
+    tool_calls: tuple[ToolCall, ...]
+
+    def raw(self) -> dict[str, Any]:
+        """The wire-format dict to append back onto the conversation."""
+        message: dict[str, Any] = {"role": "assistant", "content": self.content}
+        if self.tool_calls:
+            message["tool_calls"] = [
+                {
+                    "id": c.id,
+                    "type": "function",
+                    "function": {"name": c.name, "arguments": c.arguments},
+                }
+                for c in self.tool_calls
+            ]
+        return message
+
+
+class ChatClient:
+    """Blocking chat-completions client with bounded retry on transient failures.
+
+    Retries 429/5xx and transport errors with exponential backoff; a 4xx is
+    our request's fault and fails immediately. Persistent failure raises
+    ``RuntimeError``, which the rollout wraps as ``PolicyError``.
+    """
+
+    def __init__(
+        self,
+        provider: Provider,
+        *,
+        timeout_s: float = 120.0,
+        max_retries: int = 3,
+        backoff_s: float = 1.0,
+        transport: httpx.BaseTransport | None = None,
+    ):
+        self._provider = provider
+        self._max_retries = max_retries
+        self._backoff_s = backoff_s
+        headers = {}
+        if provider.api_key:
+            headers["Authorization"] = f"Bearer {provider.api_key}"
+        self._http = httpx.Client(
+            base_url=provider.base_url,
+            headers=headers,
+            timeout=timeout_s,
+            transport=transport,
+        )
+
+    def complete(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        temperature: float | None = None,
+    ) -> AssistantMessage:
+        body: dict[str, Any] = {"model": self._provider.model, "messages": messages}
+        if tools:
+            body["tools"] = tools
+        if temperature is not None:
+            body["temperature"] = temperature
+
+        last_error = "unknown error"
+        for attempt in range(self._max_retries):
+            try:
+                response = self._http.post("/chat/completions", json=body)
+            except httpx.TransportError as exc:
+                last_error = str(exc)
+            else:
+                if response.status_code == 200:
+                    return _parse_message(response.json())
+                last_error = f"HTTP {response.status_code}: {response.text[:500]}"
+                if response.status_code not in (429,) and response.status_code < 500:
+                    # A 4xx is our request's fault; retrying cannot help.
+                    raise RuntimeError(f"LLM request rejected — {last_error}")
+            if attempt + 1 < self._max_retries:
+                time.sleep(self._backoff_s * 2**attempt)
+        raise RuntimeError(f"LLM request failed after {self._max_retries} attempts — {last_error}")
+
+    def close(self) -> None:
+        self._http.close()
+
+
+def _parse_message(payload: dict[str, Any]) -> AssistantMessage:
+    message = payload["choices"][0]["message"]
+    calls = tuple(
+        ToolCall(
+            id=str(c["id"]),
+            name=str(c["function"]["name"]),
+            arguments=str(c["function"]["arguments"]),
+        )
+        for c in message.get("tool_calls") or []
+    )
+    content = message.get("content")
+    return AssistantMessage(content=content if content is None else str(content), tool_calls=calls)

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_png.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_png.py
@@ -1,0 +1,50 @@
+"""Minimal stdlib PNG encoder for camera frames (no Pillow dependency).
+
+LLM APIs take images as base64 data URLs; this encodes an ``(H, W, C)``
+uint8/float array as an uncompressed-filter PNG using only zlib + struct.
+"""
+
+from __future__ import annotations
+
+import base64
+import struct
+import zlib
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+_COLOR_TYPE_BY_CHANNELS = {1: 0, 3: 2, 4: 6}
+
+
+def _chunk(tag: bytes, data: bytes) -> bytes:
+    return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", zlib.crc32(tag + data))
+
+
+def encode_png(image: npt.NDArray[Any]) -> bytes:
+    """Encode an ``(H, W)`` or ``(H, W, {1,3,4})`` array as PNG bytes.
+
+    Float arrays are assumed normalized to [0, 1] and scaled; everything else
+    is cast to uint8.
+    """
+    arr = np.asarray(image)
+    if np.issubdtype(arr.dtype, np.floating):
+        arr = (np.clip(arr, 0.0, 1.0) * 255.0).round()
+    arr = np.ascontiguousarray(arr.astype(np.uint8))
+    if arr.ndim == 2:
+        arr = arr[:, :, np.newaxis]
+    height, width, channels = arr.shape
+    color_type = _COLOR_TYPE_BY_CHANNELS[channels]
+    header = struct.pack(">IIBBBBB", width, height, 8, color_type, 0, 0, 0)
+    raw = b"".join(b"\x00" + arr[row].tobytes() for row in range(height))
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + _chunk(b"IHDR", header)
+        + _chunk(b"IDAT", zlib.compress(raw))
+        + _chunk(b"IEND", b"")
+    )
+
+
+def png_data_url(image: npt.NDArray[Any]) -> str:
+    """The ``data:image/png;base64,...`` form LLM APIs accept inline."""
+    return "data:image/png;base64," + base64.b64encode(encode_png(image)).decode("ascii")

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -1,0 +1,282 @@
+"""The agent's tool surface over a bound action space (plan 0008 §4b/§4c).
+
+Tools are generated from the embodiment's spaces — the plugin never knows
+what a "YAM" or an "arm" is. The control mode picks the motion tool:
+
+- Absolute-target modes (``joint_pos``, ``eef_abs_pose``): ``move_joints``
+  with named partial targets, linearly interpolated from the current
+  observed state; hold-still repeats the current state.
+- Displacement modes (``eef_delta_pos``, ``eef_delta_pose``,
+  ``joint_delta``): ``move_by`` splits the requested displacement evenly
+  across the chunk's steps; hold-still is all zeros.
+
+Tool mistakes (unknown label, non-finite value, bad duration, malformed
+JSON) come back as structured error strings the LLM sees and can correct —
+never exceptions. Unsupported configurations fail at build (= ``bind``)
+time with a clear message.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from inspect_robots.spaces import Box, ObservationSpace
+from inspect_robots.types import Action, ActionChunk, Observation
+
+_ABSOLUTE_MODES = frozenset({"joint_pos", "eef_abs_pose"})
+_DISPLACEMENT_MODES = frozenset({"eef_delta_pos", "eef_delta_pose", "joint_delta"})
+_POSE_MODES = frozenset({"eef_abs_pose", "eef_delta_pose"})
+_SAFE_ROT = frozenset({"none", "rot6d"})
+
+_FALLBACK_HZ = 10.0
+_MAX_DURATION_S = 10.0
+
+
+class ToolsetError(Exception):
+    """An action space / observation space this toolset cannot drive."""
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    """One executed tool call: an action chunk to play, or an error for the LLM.
+
+    Exactly one of ``chunk``/``error`` is set. ``note`` is the human/LLM-facing
+    confirmation text for successful calls.
+    """
+
+    chunk: ActionChunk | None = None
+    error: str | None = None
+    note: str = ""
+
+
+class Toolset:
+    """Schemas + execution for one bound embodiment. Built via ``build_toolset``."""
+
+    def __init__(
+        self,
+        *,
+        absolute: bool,
+        labels: tuple[str, ...],
+        state_key: str | None,
+        control_hz: float | None,
+        bounds_text: str,
+    ):
+        self._absolute = absolute
+        self._labels = labels
+        self._index_by_label = {label: i for i, label in enumerate(labels)}
+        self._state_key = state_key
+        self._hz = control_hz
+        self._move_tool = "move_joints" if absolute else "move_by"
+        self._bounds_text = bounds_text
+
+    # -- schemas ---------------------------------------------------------------
+
+    def schemas(self) -> list[dict[str, Any]]:
+        """OpenAI-format tool definitions for this embodiment."""
+        if self._absolute:
+            move_description = (
+                "Move to absolute joint/dimension targets, smoothly interpolated "
+                "from the current pose over duration_s. Unnamed dimensions hold "
+                "their current value. " + self._bounds_text
+            )
+            values_key = "targets"
+        else:
+            move_description = (
+                "Move BY the given displacement per dimension, split evenly over "
+                "duration_s. Unnamed dimensions do not move. " + self._bounds_text
+            )
+            values_key = "deltas"
+        move = {
+            "type": "function",
+            "function": {
+                "name": self._move_tool,
+                "description": move_description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        values_key: {
+                            "type": "object",
+                            "description": (
+                                "Map of dimension name to value. Valid names: "
+                                + ", ".join(self._labels)
+                            ),
+                        },
+                        "duration_s": {
+                            "type": "number",
+                            "description": f"Motion duration in seconds (0 < d <= {_MAX_DURATION_S})",
+                        },
+                    },
+                    "required": [values_key, "duration_s"],
+                },
+            },
+        }
+        done = {
+            "type": "function",
+            "function": {
+                "name": "done",
+                "description": "Declare the task finished. The trial ends; a scorer judges success.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"summary": {"type": "string"}},
+                    "required": ["summary"],
+                },
+            },
+        }
+        give_up = {
+            "type": "function",
+            "function": {
+                "name": "give_up",
+                "description": "Stop trying; the task cannot be completed. The trial ends.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"reason": {"type": "string"}},
+                    "required": ["reason"],
+                },
+            },
+        }
+        return [move, done, give_up]
+
+    # -- execution ---------------------------------------------------------------
+
+    def execute(self, call: Any, observation: Observation) -> ToolResult:
+        """Turn one tool call into an ActionChunk, or an error string for the LLM."""
+        try:
+            arguments = json.loads(call.arguments)
+        except (TypeError, ValueError):
+            return ToolResult(error=f"arguments for {call.name} are not valid JSON")
+        if not isinstance(arguments, dict):
+            return ToolResult(error=f"arguments for {call.name} must be a JSON object")
+        if call.name in ("done", "give_up"):
+            return self._stop(call.name, arguments, observation)
+        if call.name != self._move_tool:
+            return ToolResult(
+                error=f"unknown tool {call.name!r}; available: {self._move_tool}, done, give_up"
+            )
+        return self._move(arguments, observation)
+
+    def _current_state(self, observation: Observation) -> npt.NDArray[np.float64]:
+        if self._state_key is None:
+            return np.zeros(len(self._labels))
+        return np.asarray(observation.state[self._state_key], dtype=np.float64)
+
+    def _stop(self, name: str, arguments: dict[str, Any], observation: Observation) -> ToolResult:
+        # Hold still per control mode: repeat the pose (absolute) or move by
+        # nothing (displacement), flagged for rollout's policy-stop channel.
+        data = self._current_state(observation) if self._absolute else np.zeros(len(self._labels))
+        detail = str(arguments.get("summary") or arguments.get("reason") or "")
+        action = Action(
+            data=data,
+            meta={"request_stop": True, "stop_reason": name, "stop_detail": detail},
+        )
+        return ToolResult(
+            chunk=ActionChunk(actions=[action], control_hz=self._hz),
+            note=f"{name}: {detail}",
+        )
+
+    def _move(self, arguments: dict[str, Any], observation: Observation) -> ToolResult:
+        values_key = "targets" if self._absolute else "deltas"
+        values = arguments.get(values_key)
+        duration = arguments.get("duration_s")
+        if not isinstance(values, dict) or not values:
+            return ToolResult(error=f"{values_key} must be a non-empty object of name: value")
+        if not isinstance(duration, (int, float)) or isinstance(duration, bool):
+            return ToolResult(error="duration_s must be a number")
+        if not 0 < float(duration) <= _MAX_DURATION_S:
+            return ToolResult(
+                error=f"duration_s must be in (0, {_MAX_DURATION_S}] seconds, got {duration}"
+            )
+
+        vector = np.zeros(len(self._labels))
+        for label, raw in values.items():
+            index = self._index_by_label.get(str(label))
+            if index is None:
+                return ToolResult(
+                    error=f"unknown dimension {label!r}; valid names: {', '.join(self._labels)}"
+                )
+            if isinstance(raw, bool) or not isinstance(raw, (int, float)) or not np.isfinite(raw):
+                return ToolResult(error=f"value for {label!r} must be a finite number, got {raw!r}")
+            vector[index] = float(raw)
+
+        hz = self._hz if self._hz is not None else _FALLBACK_HZ
+        steps = max(1, round(float(duration) * hz))
+        if self._absolute:
+            current = self._current_state(observation)
+            target = current.copy()
+            for label in values:
+                target[self._index_by_label[str(label)]] = vector[self._index_by_label[str(label)]]
+            fractions = np.linspace(1.0 / steps, 1.0, steps)
+            actions = [Action(data=current + (target - current) * f) for f in fractions]
+        else:
+            per_step = vector / steps
+            actions = [Action(data=per_step.copy()) for _ in range(steps)]
+        return ToolResult(
+            chunk=ActionChunk(actions=actions, control_hz=self._hz),
+            note=f"executing {self._move_tool} over {steps} steps ({duration}s)",
+        )
+
+
+def build_toolset(
+    action_space: Box, observation_space: ObservationSpace, control_hz: float | None
+) -> Toolset:
+    """Validate a (action space, observation space) pairing and build its tools.
+
+    Raises [`ToolsetError`][inspect_robots_agent._tools.ToolsetError] with a
+    clear message for configurations the motion layer cannot drive — at bind
+    time, never mid-trial.
+    """
+    semantics = action_space.semantics
+    if semantics is None:
+        raise ToolsetError(
+            "the embodiment's action space declares no semantics; the agent cannot "
+            "tell absolute targets from displacements"
+        )
+    mode = semantics.control_mode
+    if mode in _POSE_MODES and semantics.rotation_repr not in _SAFE_ROT:
+        raise ToolsetError(
+            f"rotation_repr {semantics.rotation_repr!r} cannot be driven per-dimension; "
+            f"only {sorted(_SAFE_ROT)} are supported"
+        )
+    if mode not in _ABSOLUTE_MODES | _DISPLACEMENT_MODES:
+        raise ToolsetError(f"control_mode {mode!r} is not supported by the agent policy yet")
+
+    absolute = mode in _ABSOLUTE_MODES
+    dim = action_space.dim
+    state_key: str | None = None
+    if absolute:
+        spec = observation_space.state
+        if spec is None:
+            raise ToolsetError(
+                "absolute-target control needs a StateSpec on the embodiment's "
+                "observation space to locate the proprioceptive reference"
+            )
+        matching = [f.key for f in spec.fields if f.shape == (dim,)]
+        if len(matching) != 1:
+            raise ToolsetError(
+                f"absolute-target control needs exactly one state field with shape "
+                f"({dim},); found {matching or 'none'}"
+            )
+        state_key = matching[0]
+
+    labels = semantics.dim_labels or tuple(str(i) for i in range(dim))
+    low, high = action_space.low, action_space.high
+    if low is not None and high is not None:
+        pairs = ", ".join(
+            f"{label}: [{lo:.4g}, {hi:.4g}]"
+            for label, lo, hi in zip(labels, low.tolist(), high.tolist())
+        )
+        bounds_text = f"Per-dimension bounds: {pairs}."
+    else:
+        bounds_text = "The action space declares no bounds; move conservatively."
+
+    return Toolset(
+        absolute=absolute,
+        labels=labels,
+        state_key=state_key,
+        control_hz=control_hz,
+        bounds_text=bounds_text,
+    )

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -1,18 +1,52 @@
-"""LLMAgentPolicy — scaffold stub; the real implementation lands with the
-tool/motion/client modules (plan 0008 §4b)."""
+"""LLMAgentPolicy — a frontier LLM as a first-class Inspect Robots policy.
+
+The conversation loop lives inside ``act()``: observation in (labeled state
+text + camera frames), one validated tool call out, synthesized into an
+open-loop ``ActionChunk`` by the motion layer. The LLM never sees raw
+actuation, and every emitted action still passes the rollout's approver
+chain — this module contains no safety-critical code path of its own
+(plan 0008 §4b).
+"""
 
 from __future__ import annotations
 
+import json
+import os
 from dataclasses import dataclass
 from typing import Any
 
-from inspect_robots.policy import PolicyBase, PolicyConfig
+import httpx
+import numpy as np
+
+from inspect_robots.embodiment import EmbodimentInfo
+from inspect_robots.policy import PolicyBase, PolicyConfig, PolicyInfo
+from inspect_robots.scene import Scene
+from inspect_robots.spaces import Box
 from inspect_robots.types import ActionChunk, Observation
+from inspect_robots_agent._llm import ENV_MODEL, ChatClient, ToolCall, resolve_provider
+from inspect_robots_agent._png import png_data_url
+from inspect_robots_agent._tools import Toolset, build_toolset
+
+_MAX_CONSECUTIVE_FAILURES = 3
+
+_SYSTEM_TEMPLATE = """You are controlling a real robot embodiment named {name!r} \
+through tool calls. Each observation message gives you the current \
+proprioceptive state and camera images. Work toward the user's goal in \
+small, deliberate motions; re-check the observation after every motion. \
+Safety approvers clamp out-of-bounds and too-fast actions below you. \
+Respond with exactly one tool call per turn. When the goal is achieved call \
+done; if it cannot be achieved call give_up. You have a budget of \
+{budget} LLM calls for the whole trial."""
 
 
 @dataclass(frozen=True)
 class AgentPolicyConfig(PolicyConfig):
-    """Inference-time configuration recorded in the eval log."""
+    """Inference-time configuration recorded in the eval log.
+
+    Extends the core ``PolicyConfig``; ``eval()`` serializes configs with
+    ``dataclasses.asdict``, so these fields land in ``EvalSpec.policy_config``
+    for free.
+    """
 
     model: str | None = None
     base_url: str | None = None
@@ -21,15 +55,157 @@ class AgentPolicyConfig(PolicyConfig):
 
 
 class LLMAgentPolicy(PolicyBase):
-    """Placeholder that fails loudly until the agent loop lands."""
+    """Drives whatever embodiment it is bound to via LLM tool calls.
 
-    def __init__(self, **kwargs: Any):
-        raise NotImplementedError("inspect-robots-agent scaffold: policy lands in plan 0008 §4b")
+    Embodiment-adaptive: ``bind()`` (called by ``eval()`` before the
+    compatibility check) adopts the embodiment's spaces and builds the tool
+    surface from them. Conversation state is per-trial (``reset``).
+    """
 
-    def act(self, observation: Observation) -> ActionChunk:  # pragma: no cover
-        raise NotImplementedError
+    def __init__(
+        self,
+        model: str | None = None,
+        base_url: str | None = None,
+        api_key_env: str | None = None,
+        max_llm_calls: int = 50,
+        temperature: float | None = None,
+        transport: httpx.BaseTransport | None = None,
+        env: dict[str, str] | None = None,
+    ):
+        environ = dict(os.environ) if env is None else env
+        provider = resolve_provider(
+            model=model or environ.get(ENV_MODEL),
+            base_url=base_url,
+            api_key_env=api_key_env,
+            env=environ,
+        )
+        if max_llm_calls < 1:
+            raise ValueError("max_llm_calls must be >= 1")
+        self._client = ChatClient(provider, transport=transport)
+        self._max_llm_calls = max_llm_calls
+        self._temperature = temperature
+        self.config = AgentPolicyConfig(
+            temperature=temperature,
+            model=provider.model,
+            base_url=provider.base_url,
+            api_key_env=api_key_env,
+            max_llm_calls=max_llm_calls,
+        )
+        # Placeholder until bind(); eval() always binds before compat/rollout.
+        self.info = PolicyInfo(name="agent", action_space=Box(shape=(1,)))
+        self._toolset: Toolset | None = None
+        self._embodiment_name = "(unbound)"
+        self._messages: list[dict[str, Any]] = []
+        self._calls_used = 0
+
+    # -- lifecycle ---------------------------------------------------------------
+
+    def bind(self, embodiment_info: EmbodimentInfo) -> None:
+        """Adopt the embodiment's spaces and build the tool surface from them."""
+        self._toolset = build_toolset(
+            embodiment_info.action_space,
+            embodiment_info.observation_space,
+            embodiment_info.control_hz,
+        )
+        self._embodiment_name = embodiment_info.name
+        self.info = PolicyInfo(
+            name="agent",
+            action_space=embodiment_info.action_space,
+            observation_space=embodiment_info.observation_space,
+            control_hz=embodiment_info.control_hz,
+        )
+
+    def reset(self, scene: Scene) -> None:
+        self._messages = [
+            {
+                "role": "system",
+                "content": _SYSTEM_TEMPLATE.format(
+                    name=self._embodiment_name, budget=self._max_llm_calls
+                ),
+            },
+            {"role": "user", "content": f"Goal: {scene.instruction}"},
+        ]
+        self._calls_used = 0
+
+    # -- the loop ------------------------------------------------------------------
+
+    def act(self, observation: Observation) -> ActionChunk:
+        toolset = self._toolset
+        if toolset is None:
+            raise RuntimeError(
+                "LLMAgentPolicy.act() before bind(); run it through eval() or call "
+                "policy.bind(embodiment.info) first"
+            )
+        self._messages.append({"role": "user", "content": _observation_content(observation)})
+        failures = 0
+        while True:
+            if self._calls_used >= self._max_llm_calls:
+                return self._forced_give_up(toolset, observation, "LLM call budget exhausted")
+            message = self._client.complete(
+                self._messages, toolset.schemas(), temperature=self._temperature
+            )
+            self._calls_used += 1
+            self._messages.append(message.raw())
+
+            if not message.tool_calls:
+                failures += 1
+                if failures >= _MAX_CONSECUTIVE_FAILURES:
+                    raise RuntimeError(f"LLM produced no tool call in {failures} consecutive turns")
+                self._messages.append(
+                    {"role": "user", "content": "Respond with exactly one tool call."}
+                )
+                continue
+
+            call, *extras = message.tool_calls
+            for extra in extras:
+                # Every tool_call id needs an answer on the wire; only the
+                # first call per turn is executed.
+                self._messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": extra.id,
+                        "content": "ignored: one tool call per turn",
+                    }
+                )
+            result = toolset.execute(call, observation)
+            self._messages.append(
+                {"role": "tool", "tool_call_id": call.id, "content": result.error or result.note}
+            )
+            if result.error:
+                failures += 1
+                if failures >= _MAX_CONSECUTIVE_FAILURES:
+                    raise RuntimeError(f"LLM tool calls kept failing; last error: {result.error}")
+                continue
+            assert result.chunk is not None  # execute() sets exactly one of chunk/error
+            return result.chunk
+
+    def _forced_give_up(self, toolset: Toolset, observation: Observation, why: str) -> ActionChunk:
+        synthetic = ToolCall(id="budget", name="give_up", arguments=json.dumps({"reason": why}))
+        result = toolset.execute(synthetic, observation)
+        assert result.chunk is not None
+        return result.chunk
+
+
+def _observation_content(observation: Observation) -> list[dict[str, Any]]:
+    """State as readable text plus camera frames as inline PNG data URLs."""
+    lines = ["Current observation."]
+    if observation.instruction:
+        lines.append(f"Instruction: {observation.instruction}")
+    for key, value in observation.state.items():
+        rounded = np.round(np.asarray(value, dtype=np.float64), 4).tolist()
+        lines.append(f"state[{key}]: {rounded}")
+    parts: list[dict[str, Any]] = [{"type": "text", "text": "\n".join(lines)}]
+    for name, image in observation.images.items():
+        parts.append({"type": "text", "text": f"camera {name!r}:"})
+        parts.append({"type": "image_url", "image_url": {"url": png_data_url(image)}})
+    return parts
 
 
 def agent_policy(**kwargs: Any) -> LLMAgentPolicy:
-    """Factory the Inspect Robots registry calls (entry point ``agent``)."""
+    """Factory the Inspect Robots registry calls (entry point ``agent``).
+
+    Accepts the same keyword arguments as
+    [`LLMAgentPolicy`][inspect_robots_agent.policy.LLMAgentPolicy]; the CLI
+    forwards ``-P key=value`` pairs here.
+    """
     return LLMAgentPolicy(**kwargs)

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -1,0 +1,35 @@
+"""LLMAgentPolicy — scaffold stub; the real implementation lands with the
+tool/motion/client modules (plan 0008 §4b)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from inspect_robots.policy import PolicyBase, PolicyConfig
+from inspect_robots.types import ActionChunk, Observation
+
+
+@dataclass(frozen=True)
+class AgentPolicyConfig(PolicyConfig):
+    """Inference-time configuration recorded in the eval log."""
+
+    model: str | None = None
+    base_url: str | None = None
+    api_key_env: str | None = None
+    max_llm_calls: int = 50
+
+
+class LLMAgentPolicy(PolicyBase):
+    """Placeholder that fails loudly until the agent loop lands."""
+
+    def __init__(self, **kwargs: Any):
+        raise NotImplementedError("inspect-robots-agent scaffold: policy lands in plan 0008 §4b")
+
+    def act(self, observation: Observation) -> ActionChunk:  # pragma: no cover
+        raise NotImplementedError
+
+
+def agent_policy(**kwargs: Any) -> LLMAgentPolicy:
+    """Factory the Inspect Robots registry calls (entry point ``agent``)."""
+    return LLMAgentPolicy(**kwargs)

--- a/plugins/inspect-robots-agent/tests/test_llm.py
+++ b/plugins/inspect-robots-agent/tests/test_llm.py
@@ -1,0 +1,190 @@
+"""Provider resolution ladder + OpenAI-compatible chat client (plan 0008 §4a)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from inspect_robots.errors import ConfigError
+from inspect_robots_agent._llm import ChatClient, resolve_provider
+
+# --- provider resolution ladder ----------------------------------------------
+
+
+def test_explicit_base_url_wins_over_everything() -> None:
+    env = {"OPENROUTER_API_KEY": "or-key", "ANTHROPIC_API_KEY": "ant-key"}
+    p = resolve_provider(
+        model="anthropic/claude-fable-5",
+        base_url="http://localhost:8000/v1",
+        api_key_env=None,
+        env=env,
+    )
+    assert p.base_url == "http://localhost:8000/v1"
+    assert p.api_key == "or-key"  # default api_key_env is OPENROUTER_API_KEY
+    assert p.model == "anthropic/claude-fable-5"  # custom endpoints get the raw string
+
+
+def test_explicit_base_url_with_custom_key_env() -> None:
+    env = {"MY_KEY": "sk-mine"}
+    p = resolve_provider(
+        model="local/foo", base_url="http://box:1234/v1", api_key_env="MY_KEY", env=env
+    )
+    assert p.api_key == "sk-mine"
+
+
+def test_explicit_base_url_without_key_allows_keyless_endpoints() -> None:
+    p = resolve_provider(model="m", base_url="http://localhost:8000/v1", api_key_env=None, env={})
+    assert p.api_key == ""
+
+
+def test_anthropic_model_with_anthropic_key() -> None:
+    p = resolve_provider(
+        model="anthropic/claude-fable-5",
+        base_url=None,
+        api_key_env=None,
+        env={"ANTHROPIC_API_KEY": "ant-key", "OPENROUTER_API_KEY": "or-key"},
+    )
+    assert "api.anthropic.com" in p.base_url
+    assert p.api_key == "ant-key"
+    assert p.model == "claude-fable-5"  # provider prefix stripped for the compat endpoint
+
+
+def test_openai_model_with_openai_key() -> None:
+    p = resolve_provider(
+        model="openai/gpt-5.2", base_url=None, api_key_env=None, env={"OPENAI_API_KEY": "oai"}
+    )
+    assert "api.openai.com" in p.base_url
+    assert p.api_key == "oai"
+    assert p.model == "gpt-5.2"
+
+
+def test_openrouter_is_the_universal_fallback() -> None:
+    p = resolve_provider(
+        model="anthropic/claude-fable-5",
+        base_url=None,
+        api_key_env=None,
+        env={"OPENROUTER_API_KEY": "or-key"},  # no ANTHROPIC_API_KEY
+    )
+    assert "openrouter.ai" in p.base_url
+    assert p.model == "anthropic/claude-fable-5"  # OpenRouter takes the full string
+
+
+def test_missing_model_is_a_guided_error() -> None:
+    with pytest.raises(ConfigError, match="INSPECT_ROBOTS_MODEL"):
+        resolve_provider(model=None, base_url=None, api_key_env=None, env={})
+
+
+def test_no_matching_key_is_a_guided_error() -> None:
+    with pytest.raises(ConfigError, match="OPENROUTER_API_KEY") as excinfo:
+        resolve_provider(model="openai/gpt-5.2", base_url=None, api_key_env=None, env={})
+    assert "OPENAI_API_KEY" in str(excinfo.value)
+
+
+# --- chat client ---------------------------------------------------------------
+
+
+def _tool_call_response() -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "moving now",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "move_joints",
+                                "arguments": '{"targets": {"j0": 0.5}, "duration_s": 1.0}',
+                            },
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+
+def _client(handler: Any, **kwargs: Any) -> ChatClient:
+    provider = resolve_provider(
+        model="m", base_url="http://llm.test/v1", api_key_env="K", env={"K": "sk-test"}
+    )
+    return ChatClient(provider, transport=httpx.MockTransport(handler), **kwargs)
+
+
+def test_complete_sends_wire_format_and_parses_tool_calls() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json=_tool_call_response())
+
+    client = _client(handler)
+    msg = client.complete(
+        messages=[{"role": "user", "content": "go"}],
+        tools=[{"type": "function", "function": {"name": "move_joints"}}],
+        temperature=0.2,
+    )
+    (request,) = seen
+    assert request.url == httpx.URL("http://llm.test/v1/chat/completions")
+    assert request.headers["authorization"] == "Bearer sk-test"
+    body = json.loads(request.content)
+    assert body["model"] == "m"
+    assert body["tools"][0]["function"]["name"] == "move_joints"
+    assert body["temperature"] == 0.2
+    assert msg.content == "moving now"
+    (call,) = msg.tool_calls
+    assert call.id == "call_1"
+    assert call.name == "move_joints"
+    assert json.loads(call.arguments)["duration_s"] == 1.0
+
+
+def test_keyless_provider_sends_no_authorization_header() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "authorization" not in request.headers
+        return httpx.Response(200, json=_tool_call_response())
+
+    provider = resolve_provider(model="m", base_url="http://llm.test/v1", api_key_env=None, env={})
+    client = ChatClient(provider, transport=httpx.MockTransport(handler))
+    client.complete(messages=[], tools=[])
+
+
+def test_transient_errors_retry_then_succeed() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return httpx.Response(500, text="boom")
+        return httpx.Response(200, json=_tool_call_response())
+
+    client = _client(handler, backoff_s=0.0)
+    msg = client.complete(messages=[], tools=[])
+    assert calls["n"] == 3
+    assert msg.tool_calls
+
+
+def test_retries_exhausted_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="down")
+
+    client = _client(handler, backoff_s=0.0, max_retries=2)
+    with pytest.raises(RuntimeError, match="503"):
+        client.complete(messages=[], tools=[])
+
+
+def test_client_error_does_not_retry() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(400, json={"error": {"message": "bad tool schema"}})
+
+    client = _client(handler, backoff_s=0.0)
+    with pytest.raises(RuntimeError, match="bad tool schema"):
+        client.complete(messages=[], tools=[])
+    assert calls["n"] == 1  # 4xx is our bug, not weather; retrying can't help

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def test_package_imports_and_exports() -> None:
+    import inspect_robots_agent
+
+    assert inspect_robots_agent.__version__
+    assert callable(inspect_robots_agent.agent_policy)

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -1,0 +1,225 @@
+"""LLMAgentPolicy end-to-end through real eval() on the mock cubepick world.
+
+Conversations are scripted with httpx.MockTransport: no network, no LLM, no
+hardware — the whole loop (bind, observation payloads, tool synthesis,
+guardrails, policy-stop, budgets, error taxonomy) runs for real.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import numpy as np
+import pytest
+
+from inspect_robots import eval as ir_eval
+from inspect_robots.approver import ChainApprover, ClampApprover, DeltaLimitApprover
+from inspect_robots.logging.sink import NullSink
+from inspect_robots.mock import CubePickEmbodiment
+from inspect_robots.rollout import TrialRecord
+from inspect_robots.scene import Scene
+from inspect_robots.scorer import success_at_end
+from inspect_robots.task import Task
+from inspect_robots_agent import LLMAgentPolicy
+
+# --- scripted-conversation harness ---------------------------------------------
+
+
+def _tool_response(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": f"call_{name}",
+                            "type": "function",
+                            "function": {"name": name, "arguments": json.dumps(arguments)},
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+
+def _text_response(text: str) -> dict[str, Any]:
+    return {"choices": [{"message": {"role": "assistant", "content": text}}]}
+
+
+class _Script:
+    """Serves queued responses; repeats the last one when the queue runs dry."""
+
+    def __init__(self, responses: list[dict[str, Any]]):
+        self.queue = list(responses)
+        self.requests: list[dict[str, Any]] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(json.loads(request.content))
+        payload = self.queue.pop(0) if len(self.queue) > 1 else self.queue[0]
+        return httpx.Response(200, json=payload)
+
+
+def _policy(script: _Script, **kwargs: Any) -> LLMAgentPolicy:
+    return LLMAgentPolicy(
+        model="test/model",
+        base_url="http://llm.test/v1",
+        transport=httpx.MockTransport(script),
+        env={},
+        **kwargs,
+    )
+
+
+def _task(max_steps: int = 40) -> Task:
+    return Task(
+        name="t",
+        scenes=[Scene(id="s0", instruction="reach the cube", init_seed=0)],
+        scorer=success_at_end(),
+        max_steps=max_steps,
+    )
+
+
+class _RecordingSink(NullSink):
+    def __init__(self) -> None:
+        self.records: list[TrialRecord] = []
+
+    def on_trial_end(self, record: TrialRecord) -> None:
+        self.records.append(record)
+
+
+# --- tests -----------------------------------------------------------------------
+
+
+def test_goal_runs_to_done_and_config_lands_in_log(tmp_path: Path) -> None:
+    script = _Script(
+        [
+            _tool_response("move_by", {"deltas": {"0": 0.1, "1": 0.1}, "duration_s": 0.5}),
+            _tool_response("done", {"summary": "close enough"}),
+        ]
+    )
+    sink = _RecordingSink()
+    logs = ir_eval(
+        _task(), _policy(script), CubePickEmbodiment(), log_dir=str(tmp_path), sinks=[sink]
+    )
+    assert logs[0].status == "success"
+    (record,) = sink.records
+    assert record.truncated is True
+    assert record.termination_reason == "done"
+    # 5 interpolated steps + 1 hold-still stop action.
+    assert len(record.steps) == 6
+    assert logs[0].eval.policy_config["model"] == "test/model"
+    assert logs[0].eval.policy_config["max_llm_calls"] == 50
+
+
+def test_outbound_messages_carry_state_images_and_tools(tmp_path: Path) -> None:
+    script = _Script([_tool_response("done", {"summary": "looked around"})])
+    ir_eval(_task(), _policy(script), CubePickEmbodiment(), log_dir=str(tmp_path))
+    first = script.requests[0]
+    assert first["model"] == "test/model"
+    assert [t["function"]["name"] for t in first["tools"]] == ["move_by", "done", "give_up"]
+    system, goal, observation = first["messages"]
+    assert "cubepick" in system["content"]
+    assert goal["content"] == "Goal: reach the cube"
+    text_parts = [p["text"] for p in observation["content"] if p["type"] == "text"]
+    assert any("state[eef_pos]" in t for t in text_parts)
+    image_parts = [p for p in observation["content"] if p["type"] == "image_url"]
+    assert image_parts and image_parts[0]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+def test_wild_swing_is_clamped_by_guardrails_but_not_without(tmp_path: Path) -> None:
+    def run(approver: Any) -> TrialRecord:
+        script = _Script(
+            [
+                _tool_response("move_by", {"deltas": {"0": 5.0}, "duration_s": 0.5}),
+                _tool_response("done", {"summary": "stop"}),
+            ]
+        )
+        sink = _RecordingSink()
+        ir_eval(
+            _task(),
+            _policy(script),
+            CubePickEmbodiment(),
+            log_dir=str(tmp_path),
+            sinks=[sink],
+            approver=approver,
+        )
+        return sink.records[0]
+
+    space = CubePickEmbodiment().info.action_space
+    guarded = run(ChainApprover(ClampApprover(space), DeltaLimitApprover(space)))
+    approvals = [e for e in guarded.events if e.kind == "approval"]
+    assert approvals, "the 1.0-per-step swing must be clamped to the 0.1 bound"
+    assert all(abs(float(np.asarray(s.action.data)[0])) <= 0.1 for s in guarded.steps)
+
+    unguarded = run(None)  # eval()'s Python-API default is the permissive AutoApprover
+    assert not [e for e in unguarded.events if e.kind == "approval"]
+    assert any(abs(float(np.asarray(s.action.data)[0])) > 0.1 for s in unguarded.steps)
+
+
+def test_llm_call_budget_forces_give_up(tmp_path: Path) -> None:
+    script = _Script([_tool_response("move_by", {"deltas": {"0": 0.05}, "duration_s": 0.5})])
+    sink = _RecordingSink()
+    logs = ir_eval(
+        _task(),
+        _policy(script, max_llm_calls=1),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+        sinks=[sink],
+    )
+    assert logs[0].status == "success"
+    (record,) = sink.records
+    assert record.termination_reason == "give_up"
+
+
+def test_persistent_non_tool_output_becomes_policy_error(tmp_path: Path) -> None:
+    script = _Script([_text_response("I would rather write a poem about the cube.")])
+    sink = _RecordingSink()
+    logs = ir_eval(
+        _task(), _policy(script), CubePickEmbodiment(), log_dir=str(tmp_path), sinks=[sink]
+    )
+    # A PolicyError marks the trial errored (never scored); the eval survives.
+    (sample,) = logs[0].samples
+    assert sample.status == "error"
+    (record,) = sink.records
+    assert record.error is not None and "no tool call" in record.error
+
+
+def test_recoverable_tool_error_is_fed_back_and_corrected(tmp_path: Path) -> None:
+    script = _Script(
+        [
+            _tool_response("move_by", {"deltas": {"7": 0.1}, "duration_s": 0.5}),  # bad dim
+            _tool_response("move_by", {"deltas": {"0": 0.1}, "duration_s": 0.5}),
+            _tool_response("done", {"summary": "recovered"}),
+        ]
+    )
+    sink = _RecordingSink()
+    logs = ir_eval(
+        _task(), _policy(script), CubePickEmbodiment(), log_dir=str(tmp_path), sinks=[sink]
+    )
+    assert logs[0].status == "success"
+    assert sink.records[0].termination_reason == "done"
+    # The error went back to the model as a tool message naming the offender.
+    tool_messages = [
+        m for request in script.requests for m in request["messages"] if m.get("role") == "tool"
+    ]
+    assert any("unknown dimension '7'" in str(m["content"]) for m in tool_messages)
+
+
+def test_registry_resolves_agent_policy() -> None:
+    from inspect_robots.registry import resolve
+
+    policy = resolve("policy", "agent", model="m", base_url="http://x/v1")
+    assert isinstance(policy, LLMAgentPolicy)
+
+
+def test_unbound_act_raises_clear_error() -> None:
+    from inspect_robots.types import Observation
+
+    policy = _policy(_Script([_text_response("hi")]))
+    with pytest.raises(RuntimeError, match="bind"):
+        policy.act(Observation())

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -1,0 +1,198 @@
+"""Tool surface + control-mode-aware motion synthesis (plan 0008 §4b/§4c)."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from inspect_robots.spaces import ActionSemantics, Box, ObservationSpace, StateField, StateSpec
+from inspect_robots.types import Observation
+from inspect_robots_agent._llm import ToolCall
+from inspect_robots_agent._tools import ToolsetError, build_toolset
+
+_ARM_LABELS = tuple(
+    f"{side}_{part}"
+    for side in ("left", "right")
+    for part in (*[f"j{i}" for i in range(6)], "gripper")
+)
+
+
+def _bimanual_space() -> Box:
+    return Box(
+        shape=(14,),
+        low=np.array([-np.pi] * 6 + [0.0] + [-np.pi] * 6 + [0.0]),
+        high=np.array([np.pi] * 6 + [1.0] + [np.pi] * 6 + [1.0]),
+        semantics=ActionSemantics("joint_pos", dim_labels=_ARM_LABELS),
+    )
+
+
+def _bimanual_obs_space() -> ObservationSpace:
+    return ObservationSpace(state=StateSpec(fields=(StateField(key="joint_pos", shape=(14,)),)))
+
+
+def _delta_space() -> Box:
+    return Box(
+        shape=(2,),
+        low=np.array([-0.1, -0.1]),
+        high=np.array([0.1, 0.1]),
+        semantics=ActionSemantics("eef_delta_pos", frame="world"),
+    )
+
+
+def _call(name: str, **arguments: object) -> ToolCall:
+    return ToolCall(id="call_1", name=name, arguments=json.dumps(arguments))
+
+
+def _obs(state: dict[str, np.ndarray] | None = None) -> Observation:
+    return Observation(state=state or {"joint_pos": np.zeros(14)})
+
+
+# --- bind-time validation ------------------------------------------------------
+
+
+def test_build_refuses_unsupported_configurations() -> None:
+    no_sem = Box(shape=(2,), low=np.zeros(2), high=np.ones(2))
+    with pytest.raises(ToolsetError, match="semantics"):
+        build_toolset(no_sem, _bimanual_obs_space(), control_hz=10.0)
+
+    vel = Box(shape=(2,), semantics=ActionSemantics("joint_vel"))
+    with pytest.raises(ToolsetError, match="joint_vel"):
+        build_toolset(vel, _bimanual_obs_space(), control_hz=10.0)
+
+    quat = Box(shape=(7,), semantics=ActionSemantics("eef_abs_pose", rotation_repr="quat_wxyz"))
+    with pytest.raises(ToolsetError, match="rotation_repr"):
+        build_toolset(quat, _bimanual_obs_space(), control_hz=10.0)
+
+
+def test_absolute_mode_requires_exactly_one_aligned_state_field() -> None:
+    space = _bimanual_space()
+    with pytest.raises(ToolsetError, match="StateSpec"):
+        build_toolset(space, ObservationSpace(), control_hz=10.0)  # no StateSpec at all
+
+    none_match = ObservationSpace(state=StateSpec(fields=(StateField(key="eef", shape=(3,)),)))
+    with pytest.raises(ToolsetError, match="exactly one"):
+        build_toolset(space, none_match, control_hz=10.0)
+
+    two_match = ObservationSpace(
+        state=StateSpec(fields=(StateField(key="a", shape=(14,)), StateField(key="b", shape=(14,))))
+    )
+    with pytest.raises(ToolsetError, match="exactly one"):
+        build_toolset(space, two_match, control_hz=10.0)
+
+
+# --- schemas -------------------------------------------------------------------
+
+
+def test_schemas_match_control_mode_and_embed_labels() -> None:
+    absolute = build_toolset(_bimanual_space(), _bimanual_obs_space(), control_hz=10.0)
+    names = [t["function"]["name"] for t in absolute.schemas()]
+    assert names == ["move_joints", "done", "give_up"]
+    move_schema = json.dumps(absolute.schemas()[0])
+    assert "left_j0" in move_schema and "right_gripper" in move_schema
+
+    displacement = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+    names = [t["function"]["name"] for t in displacement.schemas()]
+    assert names == ["move_by", "done", "give_up"]
+
+
+# --- absolute-mode synthesis ---------------------------------------------------
+
+
+def test_move_joints_interpolates_named_partial_targets() -> None:
+    toolset = build_toolset(_bimanual_space(), _bimanual_obs_space(), control_hz=10.0)
+    result = toolset.execute(
+        _call("move_joints", targets={"right_j2": 0.4, "right_gripper": 1.0}, duration_s=1.0),
+        _obs(),
+    )
+    assert result.error is None and result.chunk is not None
+    chunk = result.chunk
+    assert len(chunk.actions) == 10
+    assert chunk.control_hz == 10.0
+    final = np.asarray(chunk.actions[-1].data)
+    assert final[9] == pytest.approx(0.4)  # right_j2 is dim 7 + 2
+    assert final[13] == pytest.approx(1.0)  # right_gripper
+    assert np.allclose(np.delete(final, [9, 13]), 0.0)  # unnamed dims hold
+    mid = np.asarray(chunk.actions[4].data)
+    assert mid[9] == pytest.approx(0.2)  # linear halfway
+
+
+def test_move_joints_index_fallback_without_labels() -> None:
+    space = Box(
+        shape=(2,), low=np.zeros(2), high=np.ones(2), semantics=ActionSemantics("joint_pos")
+    )
+    obs_space = ObservationSpace(state=StateSpec(fields=(StateField(key="q", shape=(2,)),)))
+    toolset = build_toolset(space, obs_space, control_hz=10.0)
+    result = toolset.execute(
+        _call("move_joints", targets={"1": 0.6}, duration_s=0.5),
+        Observation(state={"q": np.array([0.2, 0.2])}),
+    )
+    assert result.error is None and result.chunk is not None
+    final = np.asarray(result.chunk.actions[-1].data)
+    assert final[0] == pytest.approx(0.2) and final[1] == pytest.approx(0.6)
+
+
+# --- displacement-mode synthesis ------------------------------------------------
+
+
+def test_move_by_splits_displacement_across_steps() -> None:
+    toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+    result = toolset.execute(_call("move_by", deltas={"0": 0.1}, duration_s=0.5), _obs({}))
+    assert result.error is None and result.chunk is not None
+    actions = [np.asarray(a.data) for a in result.chunk.actions]
+    assert len(actions) == 5
+    for a in actions:
+        assert a[0] == pytest.approx(0.02) and a[1] == 0.0
+
+
+# --- done / give_up -------------------------------------------------------------
+
+
+def test_done_emits_hold_still_with_request_stop() -> None:
+    toolset = build_toolset(_bimanual_space(), _bimanual_obs_space(), control_hz=10.0)
+    state = np.full(14, 0.3)
+    result = toolset.execute(_call("done", summary="fork placed"), _obs({"joint_pos": state}))
+    assert result.error is None and result.chunk is not None
+    (action,) = result.chunk.actions
+    assert np.allclose(action.data, state)  # absolute hold = repeat current state
+    assert action.meta["request_stop"] is True
+    assert action.meta["stop_reason"] == "done"
+
+    displacement = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+    result = displacement.execute(_call("give_up", reason="cannot see the cube"), _obs({}))
+    assert result.chunk is not None
+    (action,) = result.chunk.actions
+    assert np.allclose(action.data, 0.0)  # displacement hold = zeros
+    assert action.meta["stop_reason"] == "give_up"
+
+
+# --- structured tool errors (fed back to the LLM, never exceptions) -------------
+
+
+def test_tool_errors_are_messages_not_exceptions() -> None:
+    toolset = build_toolset(_bimanual_space(), _bimanual_obs_space(), control_hz=10.0)
+    cases = [
+        _call("move_joints", targets={"left_elbow": 0.1}, duration_s=1.0),  # unknown label
+        _call("move_joints", targets={"left_j0": float("nan")}, duration_s=1.0),
+        _call("move_joints", targets={"left_j0": "fast"}, duration_s=1.0),  # non-numeric
+        _call("move_joints", targets={}, duration_s=1.0),  # nothing to do
+        _call("move_joints", targets={"left_j0": 0.1}, duration_s=0.0),  # bad duration
+        _call("move_joints", targets={"left_j0": 0.1}, duration_s=60.0),  # over the cap
+        _call("nonexistent_tool", x=1),
+        ToolCall(id="c", name="move_joints", arguments="{not json"),
+    ]
+    for call in cases:
+        result = toolset.execute(call, _obs())
+        assert result.chunk is None and result.error, f"expected error for {call}"
+    # Errors name the offender so the model can self-correct.
+    unknown = toolset.execute(cases[0], _obs())
+    assert unknown.error is not None and "left_elbow" in unknown.error
+
+
+def test_control_hz_none_falls_back_to_default() -> None:
+    toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=None)
+    result = toolset.execute(_call("move_by", deltas={"0": 0.05}, duration_s=1.0), _obs({}))
+    assert result.chunk is not None
+    assert len(result.chunk.actions) == 10  # 10 Hz fallback
+    assert result.chunk.control_hz is None  # defer to the embodiment's native rate

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -9,14 +9,14 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 |--------|----------------|
 | `types.py` | `Observation`, `Action`, `ActionChunk`, `StepResult` (frozen, NumPy-native) |
 | `spaces.py` | `Box`, `ObservationSpace`, `ActionSemantics`, `StateSpec` + canonical state vocab |
-| `policy.py` | `Policy` Protocol + `PolicyBase` ABC, `PolicyInfo`, `PolicyConfig` |
+| `policy.py` | `Policy` Protocol + `PolicyBase` ABC, `PolicyInfo`, `PolicyConfig`; optional duck-typed `bind(embodiment_info)` hook for embodiment-adaptive policies (called by `eval()` before compat) |
 | `embodiment.py` | `Embodiment` Protocol + `EmbodimentBase` ABC, `EmbodimentInfo`, capability flags |
 | `scene.py` | `Scene` (the Inspect `Sample` analog), `Target`, `ListSceneDataset` |
 | `task.py` | `Task` (scenes + scorer + horizon), `Epochs` |
 | `scorer.py` | `Score`/`Scorer`, epoch reducers, builtin scorers (incl. operator/VLM) |
 | `controller.py` | `Controller` middleware: `DefaultController` (open-loop chunking), `SmoothingController` |
-| `approver.py` | `Approver` safety gate: `AutoApprover`, `ClampApprover` |
-| `rollout.py` | `rollout()` closed loop, `TrialRecord`/`StepRecord`, per-trial seeding |
+| `approver.py` | `Approver` safety gate: `AutoApprover`, `ClampApprover`, `DeltaLimitApprover` (semantics-aware no-wild-swings limit), `ChainApprover` |
+| `rollout.py` | `rollout()` closed loop, `TrialRecord`/`StepRecord`, per-trial seeding; honors a policy-requested stop via pre-review `action.meta["request_stop"]` (truncation; embodiment termination wins; not preserved under ensembling) |
 | `frames.py` | `FrameStore`/`FrameRef` — stream camera frames to disk (R5) |
 | `transcript.py` | typed event stream (reset/inference/step/approval/operator/error) |
 | `compat.py` | `check_compatibility`/`assert_compatible` — fail-fast before rollout |
@@ -25,8 +25,8 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `log.py` | immutable, schema-versioned `EvalLog` + `read_eval_log` |
 | `logging/` | `LogSink` protocol, `JsonLogSink` (atomic), optional `RerunSink` |
 | `registry.py` | decorators + entry-point discovery; `_builtins.py` registers in-tree components |
-| `cli.py` | `inspect-robots list` / `run` / `inspect`, plus the zero-config form `inspect-robots "<instruction>"` (ad-hoc single-scene task; operator prompt on TTY) |
-| `_defaults.py` | user default policy/embodiment (+ `--sim` counterpart) for the zero-config CLI: env vars > `~/.config/inspect-robots/config.ini` (INI — py3.10 has no tomllib; deliberately no project-local file) |
+| `cli.py` | `inspect-robots list` / `run` / `inspect` / `config set|show`, plus the zero-config form `inspect-robots "<instruction>"` (ad-hoc single-scene task; operator prompt on TTY). Every run wires guardrails (Clamp + DeltaLimit) by default; `--disable-guardrails` is the loud opt-out and the chain degrades per component with stderr warnings |
+| `_defaults.py` | user default policy/embodiment (+ `--sim` counterpart) for the zero-config CLI: env vars > `~/.config/inspect-robots/config.ini` (INI — py3.10 has no tomllib; deliberately no project-local file); `set_default` backs `config set` |
 | `mock/` | dependency-free `CubePick` world + scripted/random/noop policies |
 
 ## Key invariants

--- a/src/inspect_robots/_defaults.py
+++ b/src/inspect_robots/_defaults.py
@@ -149,7 +149,15 @@ def _read_config(path: Path) -> Defaults:
 
 # [defaults] keys `inspect-robots config set` may write. Mirrors what
 # _read_config understands; argparse uses this for its choices list.
-CONFIG_KEYS = ("policy", "embodiment", "sim_embodiment", "scorer", "max_steps", "store_frames")
+CONFIG_KEYS = (
+    "policy",
+    "embodiment",
+    "sim_embodiment",
+    "scorer",
+    "max_steps",
+    "store_frames",
+    "rerun",
+)
 
 
 def set_default(env: Mapping[str, str], key: str, value: str) -> Path:
@@ -165,8 +173,8 @@ def set_default(env: Mapping[str, str], key: str, value: str) -> Path:
         parsed = parse_value(value)
         if not isinstance(parsed, int) or isinstance(parsed, bool) or parsed < 1:
             raise SystemExit(f"max_steps must be an integer >= 1, got {value!r}")
-    if key == "store_frames" and not isinstance(parse_value(value), bool):
-        raise SystemExit(f"store_frames must be true or false, got {value!r}")
+    if key in ("store_frames", "rerun") and not isinstance(parse_value(value), bool):
+        raise SystemExit(f"{key} must be true or false, got {value!r}")
 
     path = _config_path(env)
     if path is None:

--- a/src/inspect_robots/_defaults.py
+++ b/src/inspect_robots/_defaults.py
@@ -147,6 +147,49 @@ def _read_config(path: Path) -> Defaults:
     )
 
 
+# [defaults] keys `inspect-robots config set` may write. Mirrors what
+# _read_config understands; argparse uses this for its choices list.
+CONFIG_KEYS = ("policy", "embodiment", "sim_embodiment", "scorer", "max_steps", "store_frames")
+
+
+def set_default(env: Mapping[str, str], key: str, value: str) -> Path:
+    """Persist one ``[defaults]`` key to the user config file; return its path.
+
+    Values are validated with the same rules ``load_defaults`` applies on
+    read, so a bad ``config set`` fails now instead of poisoning every later
+    run. The write is atomic (temp file + rename) and round-trips unknown
+    sections and keys; configparser drops comments, which is the documented
+    trade-off of editing the file through the CLI.
+    """
+    if key == "max_steps":
+        parsed = parse_value(value)
+        if not isinstance(parsed, int) or isinstance(parsed, bool) or parsed < 1:
+            raise SystemExit(f"max_steps must be an integer >= 1, got {value!r}")
+    if key == "store_frames" and not isinstance(parse_value(value), bool):
+        raise SystemExit(f"store_frames must be true or false, got {value!r}")
+
+    path = _config_path(env)
+    if path is None:
+        raise SystemExit("cannot locate a config home: set $XDG_CONFIG_HOME or $HOME")
+    parser = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+    if path.is_file():
+        try:
+            with path.open(encoding="utf-8") as fh:
+                parser.read_file(fh)
+        except (configparser.Error, UnicodeDecodeError) as exc:
+            raise _die(path, f"malformed config: {exc}") from exc
+    if not parser.has_section("defaults"):
+        parser.add_section("defaults")
+    parser.set("defaults", key, value)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        parser.write(fh)
+    tmp.replace(path)
+    return path
+
+
 def load_defaults(env: Mapping[str, str]) -> Defaults:
     """Load user defaults: environment variables override the config file.
 

--- a/src/inspect_robots/approver.py
+++ b/src/inspect_robots/approver.py
@@ -13,6 +13,7 @@ from dataclasses import replace
 from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
+import numpy.typing as npt
 
 from inspect_robots.errors import SafetyAbort
 from inspect_robots.spaces import Box
@@ -68,3 +69,135 @@ class ClampApprover:
         if np.array_equal(clamped, data):
             return action
         return replace(action, data=clamped, meta={**dict(action.meta), "clamped": True})
+
+
+# Control modes whose actions are absolute targets (delta-limited against the
+# last approved action) vs displacements/rates (the action *is* the per-step
+# change, limited directly). Together these cover every ControlMode literal.
+_ABSOLUTE_MODES = frozenset({"joint_pos", "eef_abs_pose"})
+_POSE_MODES = frozenset({"eef_abs_pose", "eef_delta_pose"})
+# Rotation reps that survive independent per-dimension clamping (same set the
+# EnsemblingController accepts for per-dimension averaging).
+_LIMITABLE_ROT = frozenset({"none", "rot6d"})
+_LAST_APPROVED_KEY = "delta_limit:last"
+
+
+class DeltaLimitApprover:
+    """The "no wild swings" gate — semantics-aware per-step change limiting.
+
+    Absolute-target modes (``joint_pos``, ``eef_abs_pose``) clamp each
+    dimension to at most ``max_delta`` away from the **last approved action**
+    of the trial; the first action passes through un-delta-limited (there is
+    no trustworthy reference yet — bounds clamping still applies upstream).
+    The derived default is 5% of ``high - low`` per step.
+
+    Displacement/rate modes (``eef_delta_pos``, ``eef_delta_pose``,
+    ``joint_delta``, ``joint_vel``) *are* the per-step change, so each
+    dimension clamps to the intersection of the box and
+    ``[-max_delta, +max_delta]``. The derived default is the box alone —
+    core cannot assume displacement bounds are per-step-sized, so without an
+    explicit ``max_delta`` the limiter adds nothing beyond ``ClampApprover``.
+
+    Construction never guesses: missing semantics, a needed missing/non-finite
+    bound without an explicit ``max_delta``, or a pose mode whose rotation
+    representation cannot be clamped per-dimension all raise ``ValueError``.
+    ``NaN`` anywhere in a reviewed action raises
+    [`SafetyAbort`][inspect_robots.errors.SafetyAbort]. A modified action is
+    flagged ``meta["delta_clamped"]``; an unmodified one is returned as the
+    same object (rollout detects modification by identity). The reference
+    lives in the rollout ``store`` (fresh per trial) under a namespaced key.
+    """
+
+    def __init__(self, action_space: Box, max_delta: float | Any | None = None):
+        sem = action_space.semantics
+        if sem is None:
+            raise ValueError(
+                "DeltaLimitApprover: action space declares no semantics; the "
+                "limiter cannot tell absolute targets from displacements"
+            )
+        if sem.control_mode in _POSE_MODES and sem.rotation_repr not in _LIMITABLE_ROT:
+            raise ValueError(
+                f"DeltaLimitApprover: cannot clamp rotation_repr {sem.rotation_repr!r} "
+                f"per dimension; only {sorted(_LIMITABLE_ROT)} are safe"
+            )
+        self._absolute = sem.control_mode in _ABSOLUTE_MODES
+        dim = action_space.dim
+        low, high = action_space.low, action_space.high
+
+        explicit = _validate_max_delta(max_delta, dim) if max_delta is not None else None
+        if self._absolute:
+            if explicit is not None:
+                self._delta = explicit
+            else:
+                if low is None or high is None or not bool(np.all(np.isfinite(high - low))):
+                    raise ValueError(
+                        "DeltaLimitApprover: deriving a default needs finite low/high "
+                        "bounds; pass max_delta explicitly"
+                    )
+                self._delta = 0.05 * (high - low)
+        else:
+            if explicit is None and (low is None or high is None):
+                raise ValueError(
+                    "DeltaLimitApprover: a displacement-mode space without both "
+                    "bounds needs an explicit max_delta"
+                )
+            self._low = low if explicit is None else _intersect(low, -explicit, np.maximum)
+            self._high = high if explicit is None else _intersect(high, explicit, np.minimum)
+
+    def review(self, action: Action, store: dict[str, Any]) -> Action:
+        data = np.asarray(action.data, dtype=np.float64)
+        if bool(np.isnan(data).any()):
+            raise SafetyAbort("DeltaLimitApprover: action contains NaN; refusing to pass it on")
+        if self._absolute:
+            reference = store.get(_LAST_APPROVED_KEY)
+            if reference is None:
+                approved = data
+            else:
+                ref = np.asarray(reference, dtype=np.float64)
+                approved = np.clip(data, ref - self._delta, ref + self._delta)
+            store[_LAST_APPROVED_KEY] = approved
+        else:
+            approved = np.clip(data, self._low, self._high)
+        if np.array_equal(approved, data):
+            return action
+        return replace(action, data=approved, meta={**dict(action.meta), "delta_clamped": True})
+
+
+def _validate_max_delta(max_delta: float | Any, dim: int) -> npt.NDArray[np.float64]:
+    try:
+        arr = np.broadcast_to(np.asarray(max_delta, dtype=np.float64), (dim,))
+    except ValueError as exc:
+        raise ValueError(
+            f"DeltaLimitApprover: max_delta does not broadcast to {dim} dimensions"
+        ) from exc
+    if not bool(np.all(np.isfinite(arr))) or bool(np.any(arr <= 0)):
+        raise ValueError("DeltaLimitApprover: max_delta must be finite and > 0")
+    return arr
+
+
+def _intersect(
+    bound: npt.NDArray[np.floating[Any]] | None,
+    limit: npt.NDArray[np.float64],
+    tighter: Any,
+) -> npt.NDArray[np.float64]:
+    """Combine an optional box side with the symmetric limit, keeping the tighter."""
+    result: npt.NDArray[np.float64] = limit if bound is None else tighter(bound, limit)
+    return result
+
+
+class ChainApprover:
+    """Run approvers in sequence, feeding each the previous one's result.
+
+    Gives "guardrails" one composable name, e.g.
+    ``ChainApprover(ClampApprover(space), DeltaLimitApprover(space))``.
+    Identity is preserved end to end: if no approver modifies the action, the
+    original object comes back, so the rollout's modification check still works.
+    """
+
+    def __init__(self, *approvers: Approver):
+        self._approvers = approvers
+
+    def review(self, action: Action, store: dict[str, Any]) -> Action:
+        for approver in self._approvers:
+            action = approver.review(action, store)
+        return action

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -252,13 +252,21 @@ def _pick_sim_embodiment(defaults: Defaults) -> tuple[str, str]:
 
 
 def _resolve_or_exit(kind: str, name: str, /, **kwargs: Any) -> Any:
-    """Registry resolution with a clean error instead of a KeyError traceback."""
+    """Registry resolution with a clean error instead of a traceback.
+
+    Unknown names raise ``KeyError``; a factory that cannot construct itself
+    (e.g. the agent policy with no model/key configured) raises a guided
+    ``ConfigError``. Both are user-facing messages, not bugs.
+    """
+    from inspect_robots.errors import ConfigError
     from inspect_robots.registry import resolve
 
     try:
         return resolve(kind, name, **kwargs)
     except KeyError as exc:
         raise SystemExit(str(exc.args[0])) from exc
+    except ConfigError as exc:
+        raise SystemExit(str(exc)) from exc
 
 
 def _build_guardrails(

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -524,6 +524,7 @@ def _cmd_config(args: argparse.Namespace) -> int:
         ("scorer", defaults.scorer, None),
         ("max_steps", defaults.max_steps, None),
         ("store_frames", defaults.store_frames, None),
+        ("rerun", defaults.rerun, None),
     ]
     for key, value, source in rows:
         shown = "(unset)" if value is None else value

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -31,18 +31,22 @@ from inspect_robots import __version__
 from inspect_robots._defaults import (
     ADHOC_MAX_STEPS_FALLBACK,
     ADHOC_SCORER_FALLBACK,
+    CONFIG_KEYS,
     ENV_EMBODIMENT,
     ENV_POLICY,
     ENV_SIM_EMBODIMENT,
     Defaults,
     load_defaults,
     parse_value,
+    set_default,
 )
 
 if TYPE_CHECKING:
+    from inspect_robots.approver import Approver
     from inspect_robots.logging.sink import LogSink
     from inspect_robots.rollout import TrialRecord
     from inspect_robots.scene import Scene
+    from inspect_robots.spaces import Box
 
 
 def _styled(text: str, code: str) -> str:
@@ -73,7 +77,7 @@ _KIND_BY_PLURAL = {
 
 _PLURAL_BY_KIND = {kind: plural for plural, kind in _KIND_BY_PLURAL.items()}
 
-_SUBCOMMANDS = ("list", "run", "inspect")
+_SUBCOMMANDS = ("list", "run", "inspect", "config")
 
 _ENV_BY_KIND = {"policy": ENV_POLICY, "embodiment": ENV_EMBODIMENT}
 
@@ -166,9 +170,30 @@ def build_parser() -> argparse.ArgumentParser:
         "viewer window; needs rerun-sdk (--no-rerun overrides a rerun config "
         "default)",
     )
+    p_run.add_argument(
+        "--disable-guardrails",
+        action="store_true",
+        help="turn off the default safety approvers (bounds clamp + per-step "
+        "delta limit); actions reach the embodiment unchecked",
+    )
+    p_run.add_argument(
+        "--max-action-delta",
+        type=float,
+        default=None,
+        metavar="D",
+        help="per-step change limit for the default guardrails, in the action "
+        "space's native units (default: derived from the space's bounds)",
+    )
 
     p_inspect = sub.add_parser("inspect", help="print a saved eval log")
     p_inspect.add_argument("log", help="path to an EvalLog JSON file")
+
+    p_config = sub.add_parser("config", help="view or set user defaults (config.ini)")
+    config_sub = p_config.add_subparsers(dest="config_command", required=True)
+    p_set = config_sub.add_parser("set", help="persist a [defaults] key to the config file")
+    p_set.add_argument("key", choices=CONFIG_KEYS)
+    p_set.add_argument("value")
+    config_sub.add_parser("show", help="print resolved defaults and their sources")
     return parser
 
 
@@ -201,8 +226,8 @@ def _pick_component(
     raise SystemExit(
         f"no {kind} given and no default configured.\n"
         f"registered {_PLURAL_BY_KIND[kind]}: {names}\n"
-        f"fix: pass --{kind} NAME, set ${_ENV_BY_KIND[kind]}, or add "
-        f"'{kind} = NAME' under [defaults] in ~/.config/inspect-robots/config.ini"
+        f"fix: pass --{kind} NAME, set ${_ENV_BY_KIND[kind]}, or run "
+        f"'inspect-robots config set {kind} NAME'"
     )
 
 
@@ -221,8 +246,8 @@ def _pick_sim_embodiment(defaults: Defaults) -> tuple[str, str]:
     raise SystemExit(
         "--sim given but no sim embodiment configured.\n"
         f"registered embodiments: {names}\n"
-        f"fix: set ${ENV_SIM_EMBODIMENT}, or add 'sim_embodiment = NAME' under "
-        "[defaults] in ~/.config/inspect-robots/config.ini"
+        f"fix: set ${ENV_SIM_EMBODIMENT}, or run "
+        "'inspect-robots config set sim_embodiment NAME'"
     )
 
 
@@ -234,6 +259,48 @@ def _resolve_or_exit(kind: str, name: str, /, **kwargs: Any) -> Any:
         return resolve(kind, name, **kwargs)
     except KeyError as exc:
         raise SystemExit(str(exc.args[0])) from exc
+
+
+def _build_guardrails(
+    space: Box, max_action_delta: float | None
+) -> tuple[Approver, list[str], list[str]]:
+    """The default CLI safety chain for an action space (plan 0008 §3e).
+
+    Returns ``(approver, active, warnings)``. Degrades per component instead
+    of blocking: a component that cannot apply to this space is skipped with
+    a warning naming the actual refusal reason (the constructor's message),
+    so the CLI is never *less* protective than running without guardrails —
+    and never silently unprotected either.
+    """
+    from inspect_robots.approver import (
+        AutoApprover,
+        ChainApprover,
+        ClampApprover,
+        DeltaLimitApprover,
+    )
+
+    parts: list[Approver] = []
+    active: list[str] = []
+    warnings: list[str] = []
+    if space.low is None and space.high is None:
+        warnings.append("bounds clamp skipped: the action space declares no low/high bounds")
+    else:
+        parts.append(ClampApprover(space))
+        active.append("clamp")
+    try:
+        # Catch the constructor's refusal generically — whatever the §3a
+        # reason — rather than pre-checking an enumerated list.
+        parts.append(DeltaLimitApprover(space, max_delta=max_action_delta))
+        active.append("delta-limit")
+    except ValueError as exc:
+        warnings.append(f"delta limit skipped: {exc}")
+    if not parts:
+        warnings.append(
+            "no guardrails are active for this action space; declare bounds/semantics "
+            "on the embodiment or pass --max-action-delta"
+        )
+        return AutoApprover(), active, warnings
+    return ChainApprover(*parts), active, warnings
 
 
 _PROMPT = "did the robot succeed? [y/n/partial/skip] (partial scores as failure) "
@@ -290,6 +357,10 @@ def _cmd_run(args: argparse.Namespace) -> int:
             "--sim selects your configured sim_embodiment; "
             "passing --embodiment already picks the embodiment — drop one"
         )
+    if args.disable_guardrails and args.max_action_delta is not None:
+        raise SystemExit(
+            "--max-action-delta tunes the guardrails that --disable-guardrails turns off — drop one"
+        )
 
     defaults = load_defaults(os.environ)
     policy_name, policy_source = _pick_component(
@@ -335,6 +406,25 @@ def _cmd_run(args: argparse.Namespace) -> int:
         print(f"policy: {policy_name} ({policy_source})")
         print(f"embodiment: {embodiment_name} ({embodiment_source})")
 
+        # Guardrails are on by default (plan 0008 §3e): the approver chain
+        # sits below the policy in rollout, so nothing the policy emits — a
+        # wild VLA action or a misbehaving LLM — reaches hardware unchecked.
+        approver: Approver | None = None
+        if args.disable_guardrails:
+            print(
+                "WARNING: guardrails disabled (--disable-guardrails); actions "
+                "reach the embodiment unchecked.",
+                file=sys.stderr,
+            )
+            print("guardrails: disabled (--disable-guardrails)")
+        else:
+            approver, active, guard_warnings = _build_guardrails(
+                embodiment.info.action_space, args.max_action_delta
+            )
+            for warning in guard_warnings:
+                print(f"guardrails warning: {warning}", file=sys.stderr)
+            print(f"guardrails: {' + '.join(active) if active else 'none active'}")
+
         before_scoring = None
         if (
             is_adhoc
@@ -364,6 +454,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
             seed=args.seed,
             sinks=sinks,
             fail_on_error=args.fail_on_error if args.fail_on_error is not None else False,
+            approver=approver,
             store_frames=(
                 args.store_frames if args.store_frames is not None else defaults.store_frames
             ),
@@ -412,6 +503,27 @@ def _cmd_inspect(path: str) -> int:
     return 0 if log.status == "success" else 1
 
 
+def _cmd_config(args: argparse.Namespace) -> int:
+    if args.config_command == "set":
+        path = set_default(os.environ, args.key, args.value)
+        print(f"wrote {args.key} = {args.value} to {path}")
+        return 0
+    defaults = load_defaults(os.environ)
+    rows: list[tuple[str, object, str | None]] = [
+        ("policy", defaults.policy, defaults.policy_source),
+        ("embodiment", defaults.embodiment, defaults.embodiment_source),
+        ("sim_embodiment", defaults.sim_embodiment, defaults.sim_embodiment_source),
+        ("scorer", defaults.scorer, None),
+        ("max_steps", defaults.max_steps, None),
+        ("store_frames", defaults.store_frames, None),
+    ]
+    for key, value, source in rows:
+        shown = "(unset)" if value is None else value
+        suffix = f"  ({source})" if source else ""
+        print(f"{key}: {shown}{suffix}")
+    return 0
+
+
 def _apply_instruction_sugar(argv: list[str]) -> list[str]:
     """``inspect-robots "wipe the table"`` → ``run --instruction "wipe the table"``.
 
@@ -438,6 +550,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _cmd_run(args)
     if args.command == "inspect":
         return _cmd_inspect(args.log)
+    if args.command == "config":
+        return _cmd_config(args)
     parser.print_help()
     return 0
 

--- a/src/inspect_robots/controller.py
+++ b/src/inspect_robots/controller.py
@@ -95,7 +95,7 @@ class SmoothingController:
 _ENSEMBLE_KEY = "_ensemble_chunks"
 # Control modes whose actions live in a vector space and may be linearly averaged.
 _AVERAGEABLE_MODES = frozenset(
-    {"joint_pos", "joint_vel", "eef_delta_pos", "eef_abs_pose", "eef_delta_pose"}
+    {"joint_pos", "joint_vel", "joint_delta", "eef_delta_pos", "eef_abs_pose", "eef_delta_pose"}
 )
 # Rotation representations that survive linear averaging. "none" has no rotation;
 # "rot6d" is averaged un-normalized here on the assumption the consumer applies

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -202,6 +202,14 @@ def _run_eval(
     """The body of [`eval`][inspect_robots.eval.eval], after resolution/ownership."""
     from inspect_robots.logging.json_log import JsonLogSink
 
+    # Embodiment-adaptive policies (plan 0008 §3c): an optional bind() hook
+    # runs before the compatibility check so the policy can adopt the
+    # embodiment's spaces. Duck-typed — bind is not part of the Policy
+    # Protocol, so existing policies are untouched.
+    bind = getattr(policy, "bind", None)
+    if callable(bind):
+        bind(embodiment.info)
+
     # Fail fast on incompatible pairings before touching any hardware/sim.
     assert_compatible(policy, embodiment, task, remap=remap)
 

--- a/src/inspect_robots/policy.py
+++ b/src/inspect_robots/policy.py
@@ -16,11 +16,14 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from inspect_robots.scene import Scene
 from inspect_robots.spaces import Box, ObservationSpace
 from inspect_robots.types import ActionChunk, Observation
+
+if TYPE_CHECKING:
+    from inspect_robots.embodiment import EmbodimentInfo
 
 
 @dataclass(frozen=True)
@@ -49,7 +52,15 @@ class PolicyInfo:
 
 @runtime_checkable
 class Policy(Protocol):
-    """The VLA contract."""
+    """The VLA contract.
+
+    Policies may additionally define an **optional** ``bind(embodiment_info)``
+    hook (not part of this Protocol, so existing policies stay conformant):
+    ``eval()`` calls it after resolving both components and before the
+    compatibility check, letting embodiment-adaptive policies — e.g. an LLM
+    agent that drives whatever it is paired with — adopt the embodiment's
+    spaces. ``PolicyBase`` ships a no-op default.
+    """
 
     info: PolicyInfo
     config: PolicyConfig
@@ -64,6 +75,9 @@ class PolicyBase(ABC):
 
     info: PolicyInfo
     config: PolicyConfig = PolicyConfig()
+
+    def bind(self, embodiment_info: EmbodimentInfo) -> None:  # noqa: B027 - no-op default
+        """Default: fixed-space policies ignore the embodiment they run on."""
 
     def reset(self, scene: Scene) -> None:  # noqa: B027 - intentional no-op default
         """Default: stateless policies need no per-scene reset."""

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -213,7 +213,8 @@ def rollout(
             except Exception as exc:
                 raise _record_failure(record, SafetyAbort(str(exc)), t) from exc
             if reviewed is not action:
-                detail = "clamped" if reviewed.meta.get("clamped") else None
+                flags = [k for k in ("clamped", "delta_clamped") if reviewed.meta.get(k)]
+                detail = ", ".join(flags) or None
                 record.events.append(approval_event(t, modified=True, detail=detail))
             action = reviewed
 

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -205,6 +205,14 @@ def rollout(
                     t,
                 )
 
+            # Policy-requested stop (plan 0008 §3d), captured from the
+            # PRE-review action so an approver rewrite cannot erase the
+            # intent. Note: EnsemblingController rebuilds actions with chunk
+            # meta, so this channel works under Default/SmoothingController
+            # (which preserve per-action meta), not under ensembling.
+            requested_stop = bool(action.meta.get("request_stop"))
+            stop_reason = str(action.meta.get("stop_reason", "policy_stop"))
+
             try:
                 reviewed = approver.review(action, store)  # may raise SafetyAbort
             except InspectRobotsError as exc:
@@ -243,6 +251,13 @@ def rollout(
             if result.truncated:
                 record.truncated = True
                 record.termination_reason = result.termination_reason or "truncated"
+                break
+            if requested_stop:
+                # Embodiment-reported termination above wins (ground truth);
+                # otherwise the policy's stop ends the trial as a truncation —
+                # scoring stays the scorer's job, done() is not success.
+                record.truncated = True
+                record.termination_reason = stop_reason
                 break
             obs = result.observation
         else:

--- a/src/inspect_robots/spaces.py
+++ b/src/inspect_robots/spaces.py
@@ -23,6 +23,7 @@ import numpy.typing as npt
 ControlMode = Literal[
     "joint_pos",
     "joint_vel",
+    "joint_delta",
     "eef_delta_pose",
     "eef_abs_pose",
     "eef_delta_pos",
@@ -41,12 +42,20 @@ Frame = Literal["base", "world", "camera"]
 
 @dataclass(frozen=True)
 class ActionSemantics:
-    """What an action vector *means*. Attached to an action [`Box`][inspect_robots.spaces.Box]."""
+    """What an action vector *means*. Attached to an action [`Box`][inspect_robots.spaces.Box].
+
+    ``dim_labels`` optionally names each action dimension (e.g.
+    ``("left_j0", ..., "right_gripper")`` for a bimanual arm) so tooling —
+    LLM agent policies, logging, visualization — can address dimensions by
+    name. Length is validated against the owning box in ``Box.__post_init__``
+    (the semantics/shape pairing is only visible there).
+    """
 
     control_mode: ControlMode
     rotation_repr: RotationRepr = "none"
     gripper: GripperKind = "none"
     frame: Frame = "base"
+    dim_labels: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True, eq=False)
@@ -67,6 +76,12 @@ class Box:
                 )
         if self.low is not None and self.high is not None and bool(np.any(self.low > self.high)):
             raise ValueError("Box low must be elementwise <= high")
+        labels = self.semantics.dim_labels if self.semantics is not None else None
+        if labels is not None and len(labels) != self.dim:
+            raise ValueError(
+                f"ActionSemantics.dim_labels has {len(labels)} entries but the box "
+                f"has {self.dim} dimensions"
+            )
 
     @property
     def dim(self) -> int:

--- a/tests/test_approvers.py
+++ b/tests/test_approvers.py
@@ -1,0 +1,178 @@
+"""DeltaLimitApprover / ChainApprover tests (plan 0008 §3a).
+
+The delta limiter is semantics-aware: absolute-target modes clamp around the
+last approved action; displacement/rate modes clamp the action magnitude
+itself. Construction never guesses — missing semantics, missing needed
+bounds, or unaverageable rotation reps refuse loudly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from inspect_robots.approver import ChainApprover, ClampApprover, DeltaLimitApprover
+from inspect_robots.errors import SafetyAbort
+from inspect_robots.spaces import ActionSemantics, Box
+from inspect_robots.types import Action
+
+
+def _abs_space() -> Box:
+    return Box(
+        shape=(2,),
+        low=np.array([-1.0, 0.0]),
+        high=np.array([1.0, 1.0]),
+        semantics=ActionSemantics("joint_pos"),
+    )
+
+
+def _delta_space() -> Box:
+    # Asymmetric second dim ([0, 1]) mirrors a normalized-gripper delta dim.
+    return Box(
+        shape=(2,),
+        low=np.array([-0.1, 0.0]),
+        high=np.array([0.1, 1.0]),
+        semantics=ActionSemantics("joint_delta"),
+    )
+
+
+# --- construction refusals: never guess -------------------------------------
+
+
+def test_refuses_missing_semantics() -> None:
+    with pytest.raises(ValueError, match="semantics"):
+        DeltaLimitApprover(Box(shape=(2,), low=np.zeros(2), high=np.ones(2)))
+
+
+def test_refuses_pose_mode_with_unaverageable_rotation() -> None:
+    space = Box(
+        shape=(7,),
+        low=np.full(7, -1.0),
+        high=np.full(7, 1.0),
+        semantics=ActionSemantics("eef_abs_pose", rotation_repr="quat_wxyz"),
+    )
+    with pytest.raises(ValueError, match="rotation_repr"):
+        DeltaLimitApprover(space)
+
+
+def test_refuses_derived_default_without_bounds() -> None:
+    for mode in ("joint_pos", "joint_delta"):
+        unbounded = Box(shape=(2,), semantics=ActionSemantics(mode))
+        with pytest.raises(ValueError, match="bound"):
+            DeltaLimitApprover(unbounded)
+        # An explicit max_delta removes the bounds requirement.
+        DeltaLimitApprover(unbounded, max_delta=0.5)
+
+
+def test_refuses_nonpositive_or_nonfinite_max_delta() -> None:
+    with pytest.raises(ValueError, match="max_delta"):
+        DeltaLimitApprover(_abs_space(), max_delta=0.0)
+    with pytest.raises(ValueError, match="max_delta"):
+        DeltaLimitApprover(_abs_space(), max_delta=float("inf"))
+    with pytest.raises(ValueError, match="max_delta"):
+        DeltaLimitApprover(_abs_space(), max_delta=np.array([0.1, -0.1]))
+    with pytest.raises(ValueError, match="max_delta"):
+        DeltaLimitApprover(_abs_space(), max_delta=np.array([0.1, 0.1, 0.1]))
+
+
+# --- absolute-target modes ---------------------------------------------------
+
+
+def test_absolute_first_action_passes_then_limits() -> None:
+    approver = DeltaLimitApprover(_abs_space(), max_delta=0.1)
+    store: dict[str, object] = {}
+    first = Action(data=np.array([0.9, 0.9]))
+    assert approver.review(first, store) is first  # no reference yet
+    # Second action is limited to ±0.1 around the last approved one.
+    out = approver.review(Action(data=np.array([0.0, 1.0])), store)
+    assert np.allclose(out.data, [0.8, 1.0])
+    assert out.meta.get("delta_clamped") is True
+
+
+def test_absolute_identity_within_limit_and_reference_advances() -> None:
+    approver = DeltaLimitApprover(_abs_space(), max_delta=0.5)
+    store: dict[str, object] = {}
+    approver.review(Action(data=np.array([0.0, 0.0])), store)
+    small = Action(data=np.array([0.3, 0.4]))
+    assert approver.review(small, store) is small  # identity when nothing clamps
+    # Reference advanced to [0.3, 0.4]: a jump back to 0.9 clamps to 0.8.
+    out = approver.review(Action(data=np.array([0.9, 0.4])), store)
+    assert np.allclose(out.data, [0.8, 0.4])
+
+
+def test_absolute_reference_is_the_approved_action_not_the_request() -> None:
+    approver = DeltaLimitApprover(_abs_space(), max_delta=0.1)
+    store: dict[str, object] = {}
+    approver.review(Action(data=np.array([0.0, 0.0])), store)
+    approver.review(Action(data=np.array([1.0, 0.0])), store)  # approved as 0.1
+    out = approver.review(Action(data=np.array([1.0, 0.0])), store)
+    assert np.allclose(out.data, [0.2, 0.0])  # walks, one clamped step at a time
+
+
+def test_absolute_derived_default_is_five_percent_of_range() -> None:
+    approver = DeltaLimitApprover(_abs_space())  # ranges: 2.0 and 1.0
+    store: dict[str, object] = {}
+    approver.review(Action(data=np.array([0.0, 0.5])), store)
+    out = approver.review(Action(data=np.array([1.0, 0.0])), store)
+    assert np.allclose(out.data, [0.1, 0.45])  # 0.05 * (high - low) per dim
+
+
+def test_stores_are_isolated_per_trial() -> None:
+    approver = DeltaLimitApprover(_abs_space(), max_delta=0.1)
+    trial_a: dict[str, object] = {}
+    approver.review(Action(data=np.array([0.9, 0.9])), trial_a)
+    # A fresh store (new trial) has no reference: first action passes again.
+    trial_b: dict[str, object] = {}
+    big = Action(data=np.array([-0.9, 0.1]))
+    assert approver.review(big, trial_b) is big
+
+
+# --- displacement / rate modes ----------------------------------------------
+
+
+def test_displacement_explicit_limit_intersects_box() -> None:
+    approver = DeltaLimitApprover(_delta_space(), max_delta=0.05)
+    out = approver.review(Action(data=np.array([0.08, -0.5])), {})
+    # dim0: min(high=0.1, +0.05) → 0.05; dim1: max(low=0.0, -0.05) → 0.0.
+    assert np.allclose(out.data, [0.05, 0.0])
+    assert out.meta.get("delta_clamped") is True
+
+
+def test_displacement_derived_default_is_box_alone() -> None:
+    approver = DeltaLimitApprover(_delta_space())
+    inside = Action(data=np.array([0.1, 1.0]))  # at the box edge: untouched
+    assert approver.review(inside, {}) is inside
+    out = approver.review(Action(data=np.array([0.2, -0.2])), {})
+    assert np.allclose(out.data, [0.1, 0.0])
+
+
+def test_joint_vel_is_rate_limited_like_displacement() -> None:
+    space = Box(
+        shape=(1,),
+        low=np.array([-2.0]),
+        high=np.array([2.0]),
+        semantics=ActionSemantics("joint_vel"),
+    )
+    approver = DeltaLimitApprover(space, max_delta=1.0)
+    out = approver.review(Action(data=np.array([1.5])), {})
+    assert np.allclose(out.data, [1.0])
+
+
+# --- shared contracts ---------------------------------------------------------
+
+
+def test_nan_raises_safety_abort_in_both_branches() -> None:
+    for space in (_abs_space(), _delta_space()):
+        approver = DeltaLimitApprover(space, max_delta=0.1)
+        with pytest.raises(SafetyAbort, match="NaN"):
+            approver.review(Action(data=np.array([float("nan"), 0.0])), {})
+
+
+def test_chain_runs_approvers_in_order() -> None:
+    space = _delta_space()
+    chain = ChainApprover(ClampApprover(space), DeltaLimitApprover(space, max_delta=0.05))
+    out = chain.review(Action(data=np.array([5.0, 5.0])), {})
+    # Clamp to box ([0.1, 1.0]) first, then delta-limit to 0.05.
+    assert np.allclose(out.data, [0.05, 0.05])
+    inside = Action(data=np.array([0.01, 0.01]))
+    assert chain.review(inside, {}) is inside  # identity survives the chain

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -212,3 +212,20 @@ def test_config_rerun_rejects_non_bool(tmp_path: Path) -> None:
     _write_config(config_home, "[defaults]\nrerun = viewer\n")
     with pytest.raises(SystemExit, match="rerun"):
         load_defaults({"XDG_CONFIG_HOME": str(config_home)})
+
+
+def test_set_default_requires_config_home() -> None:
+    from inspect_robots._defaults import set_default
+
+    with pytest.raises(SystemExit, match="config home"):
+        set_default({}, "policy", "scripted")
+
+
+def test_set_default_rejects_malformed_existing_config(tmp_path: Path) -> None:
+    from inspect_robots._defaults import set_default
+
+    path = tmp_path / "inspect-robots" / "config.ini"
+    path.parent.mkdir(parents=True)
+    path.write_text("policy = dangling, no section header\n", encoding="utf-8")
+    with pytest.raises(SystemExit, match="malformed config"):
+        set_default({"XDG_CONFIG_HOME": str(tmp_path)}, "policy", "scripted")

--- a/tests/test_ensembling.py
+++ b/tests/test_ensembling.py
@@ -91,6 +91,11 @@ def test_rejects_unaverageable_semantics() -> None:
         )
 
 
+def test_accepts_joint_delta_semantics() -> None:
+    # joint_delta is linearly averageable; the constructor must not refuse it.
+    EnsemblingController(Box(shape=(2,), semantics=ActionSemantics("joint_delta")))
+
+
 def test_warns_when_semantics_missing() -> None:
     with pytest.warns(RuntimeWarning, match="no semantics"):
         EnsemblingController(Box(shape=(2,)))

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -218,6 +218,53 @@ class _ClosableEmbodiment(CubePickEmbodiment):
 embodiment_decorator("closable-cubepick")(_ClosableEmbodiment)
 
 
+def test_eval_binds_adaptive_policy_before_compat(tmp_path: Path) -> None:
+    """A bind() hook runs after resolution and before compat (plan 0008 §3c).
+
+    The policy starts with a deliberately incompatible action space; only the
+    bind() call adopting the embodiment's spaces lets compat pass, so a green
+    eval proves the ordering.
+    """
+    from inspect_robots.embodiment import EmbodimentInfo
+
+    class _AdaptivePolicy(ScriptedPolicy):
+        def __init__(self) -> None:
+            super().__init__()
+            self.bound_names: list[str] = []
+            self.info = PolicyInfo(
+                name="adaptive",
+                action_space=Box(shape=(9,), semantics=ActionSemantics("joint_pos")),
+            )
+
+        def bind(self, embodiment_info: EmbodimentInfo) -> None:
+            self.bound_names.append(embodiment_info.name)
+            self.info = PolicyInfo(
+                name="adaptive",
+                action_space=embodiment_info.action_space,
+                observation_space=embodiment_info.observation_space,
+            )
+
+    adaptive = _AdaptivePolicy()
+    logs = eval(_task(max_steps=60), adaptive, CubePickEmbodiment(), log_dir=str(tmp_path))
+    assert adaptive.bound_names == ["cubepick"]
+    assert logs[0].status == "success"
+
+
+def test_policy_base_bind_is_a_noop() -> None:
+    from inspect_robots.embodiment import EmbodimentInfo
+    from inspect_robots.policy import PolicyBase
+
+    class _Minimal(PolicyBase):
+        info = PolicyInfo(name="m", action_space=_BOX)
+
+        def act(self, observation: Observation) -> ActionChunk:
+            return ActionChunk(actions=[Action(data=np.zeros(2))])
+
+    obs_space = CubePickEmbodiment().info.observation_space
+    info = EmbodimentInfo(name="e", action_space=_BOX, observation_space=obs_space)
+    _Minimal().bind(info)  # must exist and do nothing
+
+
 def test_eval_closes_string_resolved_embodiment(tmp_path: Path) -> None:
     _CLOSED.clear()
     eval(_task(max_steps=5), ScriptedPolicy(), "closable-cubepick", log_dir=str(tmp_path))

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -962,3 +962,29 @@ def test_cli_config_set_validates_values(_hermetic_defaults: Path) -> None:
     # Valid values round-trip.
     assert main(["config", "set", "max_steps", "50"]) == 0
     assert main(["config", "set", "store_frames", "true"]) == 0
+
+
+def test_component_config_error_exits_cleanly(tmp_path: Path) -> None:
+    """A factory's guided ConfigError must exit cleanly, not print a traceback."""
+    from inspect_robots.errors import ConfigError
+    from inspect_robots.registry import policy as policy_decorator
+
+    @policy_decorator("misconfigured-policy")
+    def _factory(**kwargs: object) -> object:
+        raise ConfigError("no model configured.\nfix: set $SOME_KEY")
+
+    with pytest.raises(SystemExit, match="no model configured") as excinfo:
+        main(
+            [
+                "run",
+                "--instruction",
+                "reach it",
+                "--policy",
+                "misconfigured-policy",
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    assert "Traceback" not in str(excinfo.value)

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -524,7 +524,7 @@ def test_sim_without_configuration_exits_with_guidance(
     with pytest.raises(SystemExit, match="no sim embodiment configured") as excinfo:
         main(["run", "--instruction", "reach it", "--sim"])
     message = str(excinfo.value)
-    assert ENV_SIM_EMBODIMENT in message and "sim_embodiment = NAME" in message
+    assert ENV_SIM_EMBODIMENT in message and "config set sim_embodiment NAME" in message
 
 
 def test_sim_works_with_registered_task(
@@ -743,3 +743,222 @@ def test_styled_respects_no_color(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
     monkeypatch.setenv("NO_COLOR", "1")
     assert _styled("x", "1") == "x"
+
+
+# --- guardrails by default (plan 0008 §3e) -----------------------------------
+
+
+def _guard_space(**kwargs: object) -> object:
+    from inspect_robots.spaces import Box
+
+    return Box(**kwargs)  # type: ignore[arg-type]
+
+
+def test_build_guardrails_full_chain_on_bounded_displacement_space() -> None:
+    import numpy as np
+
+    from inspect_robots.cli import _build_guardrails
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.types import Action
+
+    space = CubePickEmbodiment().info.action_space
+    approver, active, warnings = _build_guardrails(space, None)
+    assert active == ["clamp", "delta-limit"]
+    assert warnings == []
+    out = approver.review(Action(data=np.array([5.0, 5.0])), {})
+    assert out.meta.get("clamped") is True  # box bounds enforced
+
+
+def test_build_guardrails_threads_max_action_delta() -> None:
+    import numpy as np
+
+    from inspect_robots.cli import _build_guardrails
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.types import Action
+
+    approver, _, _ = _build_guardrails(CubePickEmbodiment().info.action_space, 0.05)
+    out = approver.review(Action(data=np.array([0.08, 0.0])), {})
+    assert float(out.data[0]) == pytest.approx(0.05)
+    assert out.meta.get("delta_clamped") is True
+
+
+def test_build_guardrails_degrades_per_component() -> None:
+    import numpy as np
+
+    from inspect_robots.cli import _build_guardrails
+    from inspect_robots.spaces import ActionSemantics, Box
+
+    # Bounds-less absolute space (the isaacsim shape): nothing is applicable.
+    bare = Box(shape=(2,), semantics=ActionSemantics("joint_pos"))
+    _approver, active, warnings = _build_guardrails(bare, None)
+    assert active == []
+    assert any("no guardrails" in w for w in warnings)
+    # ...but an explicit max delta re-enables the delta limiter.
+    _, active, warnings = _build_guardrails(bare, 0.1)
+    assert active == ["delta-limit"]
+    assert not any("no guardrails" in w for w in warnings)
+
+    # Semantics-less bounded space: clamp works, delta limiter refuses.
+    blind = Box(shape=(2,), low=np.zeros(2), high=np.ones(2))
+    _, active, warnings = _build_guardrails(blind, None)
+    assert active == ["clamp"]
+    assert any("semantics" in w for w in warnings)
+
+    # Quat-repr pose space: the delta limiter names the rotation refusal.
+    quat = Box(
+        shape=(7,),
+        low=np.full(7, -1.0),
+        high=np.full(7, 1.0),
+        semantics=ActionSemantics("eef_abs_pose", rotation_repr="quat_wxyz"),
+    )
+    _, active, warnings = _build_guardrails(quat, None)
+    assert active == ["clamp"]
+    assert any("rotation_repr" in w for w in warnings)
+
+
+def test_cli_run_header_names_active_guardrails(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = main(
+        [
+            "run",
+            "--task",
+            "cubepick-reach",
+            "--policy",
+            "scripted",
+            "--embodiment",
+            "cubepick",
+            "--log-dir",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0
+    assert "guardrails: clamp + delta-limit" in capsys.readouterr().out
+
+
+def test_cli_disable_guardrails_warns_loudly(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = main(
+        [
+            "run",
+            "--task",
+            "cubepick-reach",
+            "--policy",
+            "scripted",
+            "--embodiment",
+            "cubepick",
+            "--log-dir",
+            str(tmp_path),
+            "--disable-guardrails",
+        ]
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "guardrails: disabled" in captured.out
+    assert "WARNING" in captured.err and "guardrails" in captured.err
+
+
+def test_cli_max_action_delta_conflicts_with_disable(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="disable-guardrails"):
+        main(
+            [
+                "run",
+                "--task",
+                "cubepick-reach",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(tmp_path),
+                "--disable-guardrails",
+                "--max-action-delta",
+                "0.1",
+            ]
+        )
+
+
+def test_cli_degraded_guardrails_warn_but_run(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A semantics-less, bounds-less action space: every guardrail component
+    # refuses, the CLI says so on stderr, and the run still proceeds.
+    from dataclasses import replace
+
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.registry import embodiment as embodiment_decorator
+    from inspect_robots.spaces import Box
+
+    class _BareSpaceEmbodiment(CubePickEmbodiment):
+        def __init__(self) -> None:
+            super().__init__()
+            self.info = replace(self.info, action_space=Box(shape=(2,)))
+
+    embodiment_decorator("bare-cubepick")(_BareSpaceEmbodiment)
+    rc = main(
+        [
+            "run",
+            "--task",
+            "cubepick-reach",
+            "--policy",
+            "scripted",
+            "--embodiment",
+            "bare-cubepick",
+            "--log-dir",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "guardrails: none active" in captured.out
+    assert "no guardrails" in captured.err
+
+
+def test_guided_error_mentions_config_set() -> None:
+    with pytest.raises(SystemExit, match="inspect-robots config set policy"):
+        main(["run", "--instruction", "reach the cube"])
+
+
+# --- config set / show (plan 0008 §3e) ----------------------------------------
+
+
+def test_cli_config_set_writes_and_show_reads(
+    _hermetic_defaults: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(["config", "set", "embodiment", "cubepick"]) == 0
+    assert main(["config", "set", "policy", "scripted"]) == 0
+    path = _hermetic_defaults / "inspect-robots" / "config.ini"
+    body = path.read_text(encoding="utf-8")
+    assert "embodiment = cubepick" in body and "policy = scripted" in body
+    capsys.readouterr()
+    assert main(["config", "show"]) == 0
+    out = capsys.readouterr().out
+    assert f"embodiment: cubepick  ({path})" in out
+    assert "sim_embodiment: (unset)" in out
+
+
+def test_cli_config_set_preserves_unknown_sections(_hermetic_defaults: Path) -> None:
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\nscorer = success_at_end\n[embodiment.args]\nleft_channel = can2\n",
+    )
+    assert main(["config", "set", "embodiment", "cubepick"]) == 0
+    body = (_hermetic_defaults / "inspect-robots" / "config.ini").read_text(encoding="utf-8")
+    assert "[embodiment.args]" in body and "left_channel = can2" in body
+    assert "scorer = success_at_end" in body
+    assert "embodiment = cubepick" in body
+
+
+def test_cli_config_set_validates_values(_hermetic_defaults: Path) -> None:
+    with pytest.raises(SystemExit, match="max_steps"):
+        main(["config", "set", "max_steps", "zero"])
+    with pytest.raises(SystemExit, match="store_frames"):
+        main(["config", "set", "store_frames", "maybe"])
+    # Unknown keys are rejected by argparse itself (exit code 2).
+    with pytest.raises(SystemExit) as excinfo:
+        main(["config", "set", "frobnicate", "1"])
+    assert excinfo.value.code == 2
+    # Valid values round-trip.
+    assert main(["config", "set", "max_steps", "50"]) == 0
+    assert main(["config", "set", "store_frames", "true"]) == 0

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -959,9 +959,12 @@ def test_cli_config_set_validates_values(_hermetic_defaults: Path) -> None:
     with pytest.raises(SystemExit) as excinfo:
         main(["config", "set", "frobnicate", "1"])
     assert excinfo.value.code == 2
+    with pytest.raises(SystemExit, match="rerun"):
+        main(["config", "set", "rerun", "sometimes"])
     # Valid values round-trip.
     assert main(["config", "set", "max_steps", "50"]) == 0
     assert main(["config", "set", "store_frames", "true"]) == 0
+    assert main(["config", "set", "rerun", "true"]) == 0
 
 
 def test_component_config_error_exits_cleanly(tmp_path: Path) -> None:

--- a/tests/test_rollout_hardening.py
+++ b/tests/test_rollout_hardening.py
@@ -147,6 +147,59 @@ def test_clamp_approver_high_only_bound() -> None:
     assert approver.review(unbounded_side, {}) is unbounded_side
 
 
+class _StopPolicy:
+    """Emits one hold-still action carrying the given meta every inference."""
+
+    def __init__(self, meta: dict[str, object]):
+        self.info = PolicyInfo(name="stopper", action_space=_BOX)
+        self.config = PolicyConfig()
+        self._meta = meta
+
+    def reset(self, scene: Scene) -> None:
+        return None
+
+    def act(self, observation: Observation) -> ActionChunk:
+        return ActionChunk(actions=[Action(data=np.zeros(2), meta=dict(self._meta))])
+
+
+def test_policy_request_stop_truncates_with_reason() -> None:
+    policy = _StopPolicy({"request_stop": True, "stop_reason": "done"})
+    record = _run(policy, CubePickEmbodiment())
+    assert record.truncated is True
+    assert record.terminated is False
+    assert record.termination_reason == "done"
+    assert len(record.steps) == 1  # the flagged action still executed, once
+
+
+def test_policy_request_stop_default_reason() -> None:
+    record = _run(_StopPolicy({"request_stop": True}), CubePickEmbodiment())
+    assert record.termination_reason == "policy_stop"
+
+
+def test_request_stop_survives_approver_rewrite() -> None:
+    class _MetaStrippingApprover:
+        def review(self, action: Action, store: dict[str, object]) -> Action:
+            return replace(action, data=np.asarray(action.data) * 0.5, meta={})
+
+    policy = _StopPolicy({"request_stop": True, "stop_reason": "done"})
+    record = _run(policy, CubePickEmbodiment(), approver=_MetaStrippingApprover())
+    assert record.truncated is True
+    assert record.termination_reason == "done"
+
+
+def test_embodiment_termination_wins_over_request_stop() -> None:
+    class _InstantSuccessEmbodiment(CubePickEmbodiment):
+        def step(self, action: Action):  # type: ignore[no-untyped-def]
+            result = super().step(action)
+            return replace(result, terminated=True, termination_reason="success")
+
+    policy = _StopPolicy({"request_stop": True, "stop_reason": "done"})
+    record = _run(policy, _InstantSuccessEmbodiment())
+    assert record.terminated is True
+    assert record.truncated is False
+    assert record.termination_reason == "success"
+
+
 def test_rollout_records_delta_clamped_approval_detail() -> None:
     from inspect_robots.approver import DeltaLimitApprover
 

--- a/tests/test_rollout_hardening.py
+++ b/tests/test_rollout_hardening.py
@@ -147,6 +147,19 @@ def test_clamp_approver_high_only_bound() -> None:
     assert approver.review(unbounded_side, {}) is unbounded_side
 
 
+def test_rollout_records_delta_clamped_approval_detail() -> None:
+    from inspect_robots.approver import DeltaLimitApprover
+
+    emb = CubePickEmbodiment()
+    # CubePick's scripted steps are 0.1-magnitude deltas; a tighter explicit
+    # limit forces a clamp so the approval event carries the new detail.
+    approver = DeltaLimitApprover(emb.info.action_space, max_delta=0.05)
+    record = _run(ScriptedPolicy(), emb, approver=approver)
+    approvals = [e for e in record.events if e.kind == "approval"]
+    assert approvals
+    assert approvals[0].data["detail"] == "delta_clamped"
+
+
 def test_frame_store_sanitizes_without_collisions(tmp_path: Path) -> None:
     store = FrameStore(str(tmp_path / "frames"))
     img = np.zeros((2, 2, 3), dtype=np.uint8)

--- a/tests/test_types_spaces.py
+++ b/tests/test_types_spaces.py
@@ -57,6 +57,22 @@ def test_action_semantics_defaults() -> None:
     assert sem.frame == "base"
 
 
+def test_action_semantics_joint_delta_and_dim_labels() -> None:
+    sem = ActionSemantics(control_mode="joint_delta", dim_labels=("left_j0", "left_gripper"))
+    assert sem.dim_labels == ("left_j0", "left_gripper")
+    # Default stays None so unlabeled spaces keep working.
+    assert ActionSemantics(control_mode="joint_pos").dim_labels is None
+
+
+def test_box_validates_dim_labels_length() -> None:
+    labeled = ActionSemantics(control_mode="joint_pos", dim_labels=("a", "b", "c"))
+    with pytest.raises(ValueError, match="dim_labels"):
+        Box(shape=(2,), semantics=labeled)
+    assert Box(shape=(3,), semantics=labeled).dim == 3
+    # No labels: any dim is fine.
+    Box(shape=(2,), semantics=ActionSemantics(control_mode="joint_pos"))
+
+
 def test_observation_space_derives_state_keys_from_spec() -> None:
     spec = StateSpec(
         fields=(

--- a/uv.lock
+++ b/uv.lock
@@ -10,8 +10,23 @@ resolution-markers = [
 [manifest]
 members = [
     "inspect-robots",
+    "inspect-robots-agent",
     "inspect-robots-isaacsim",
     "inspect-robots-xpolicylab",
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
 ]
 
 [[package]]
@@ -380,6 +395,43 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -458,6 +510,37 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
 ]
 provides-extras = ["all", "dev", "docs", "rerun", "viz"]
+
+[[package]]
+name = "inspect-robots-agent"
+version = "0.1.0"
+source = { editable = "plugins/inspect-robots-agent" }
+dependencies = [
+    { name = "httpx" },
+    { name = "inspect-robots" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "inspect-robots", editable = "." },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
+    { name = "numpy", specifier = ">=1.24" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
+]
+provides-extras = ["dev"]
 
 [[package]]
 name = "inspect-robots-isaacsim"


### PR DESCRIPTION
## Summary

Implements plan 0008 (\`plans/0008-llm-agent-mode.md\`, hardened by a 6-round adversarial design review): frontier LLMs (Claude, GPT, anything behind an OpenAI-compatible API) drive any registered embodiment through tool calls, as a first-class registered policy named \`agent\` — the same policy runs ad-hoc instructions and scores on registered tasks next to fine-tuned VLAs. Safety guardrails are wired into every CLI run by default, for every policy, with an explicit \`--disable-guardrails\` opt-out.

```bash
export ANTHROPIC_API_KEY=sk-ant-...
inspect-robots "pick up the cube" --policy agent \
    -P model=anthropic/claude-fable-5 --embodiment cubepick
```

## Changes

Core (all inside the 100% gate):
- \`spaces.py\`: \`ControlMode\` gains \`joint_delta\`; \`ActionSemantics.dim_labels\` names action dims (validated against the owning \`Box\`); \`EnsemblingController\` accepts \`joint_delta\`.
- \`approver.py\`: \`DeltaLimitApprover\` (semantics-aware no-wild-swings limiting: absolute modes clamp around the last approved action, displacement modes clamp magnitude against box ∩ ±max_delta; construction never guesses) and \`ChainApprover\`. Rollout approval events surface \`delta_clamped\`.
- \`policy.py\`/\`eval.py\`: optional duck-typed \`bind(embodiment_info)\` hook, called after resolution and before compat, for embodiment-adaptive policies.
- \`rollout.py\`: policy-requested stop via pre-review \`action.meta["request_stop"]\` (truncation; embodiment termination wins; documented ensembling limitation).
- \`cli.py\`/\`_defaults.py\`: guardrails on by default with per-component degradation warnings; \`--disable-guardrails\` / \`--max-action-delta\`; new \`config set/show\` subcommand (atomic INI writes, unknown sections preserved); guided errors point at \`config set\`; factory \`ConfigError\`s exit cleanly instead of printing tracebacks.

New plugin \`plugins/inspect-robots-agent\` (uv workspace member, own CI job in \`ci-ok.needs\`, \`publish-agent\` release job — needs a \`pypi-agent\` trusted-publisher environment before the next release):
- \`_llm.py\`: one httpx client speaking the chat-completions wire format; provider ladder (explicit \`base_url\` > \`anthropic/*\` > \`openai/*\` > OpenRouter) with guided errors; bounded retry on 429/5xx.
- \`_tools.py\`: bind-time validation + OpenAI tool schemas generated from the action space (labels, bounds, control mode); \`move_joints\` named partial targets / \`move_by\` displacement split; \`done\`/\`give_up\` hold-still stop actions; tool mistakes come back as correctable error strings.
- \`policy.py\`: \`LLMAgentPolicy\` (bind/reset/act conversation loop, stdlib PNG encoding for camera frames, LLM-call budget → forced give_up, bounded failure retries → \`PolicyError\`), \`AgentPolicyConfig\` recorded in the eval log.
- 31 plugin tests: scripted conversations via \`httpx.MockTransport\` through **real \`eval()\` on \`cubepick\`** — no network, no hardware.

Follow-ups (out of scope here, tracked in plan §6): yam-repo enablement PRs (dim_labels, \`joint_delta\` declaration + per-step delta bounds + MolmoAct2 lockstep, CLI-constructible cameras, \`[hardware]\` extra, hold-behavior verification, quickstart).

## Checklist

- [x] \`pre-commit install\` done; hooks pass (or ran \`pre-commit run --all-files\`)
- [x] Tests added/updated (and the \`CubePick\` mock exercises the change where applicable)
- [x] Coverage stays at **100%** (\`pytest --cov\`)
- [x] \`ruff check .\` and \`ruff format --check .\` pass
- [x] \`mypy\` passes (strict)
- [x] \`CHANGELOG.md\` updated under "Unreleased"
- [x] Public API changes are reflected in \`inspect_robots.__all__\` and the API-snapshot test (no \`__all__\` changes: new approvers live in \`inspect_robots.approver\` like \`ClampApprover\`)
- [x] Core stays NumPy-only (httpx is a plugin dependency only)

## Related

Implements \`plans/0008-llm-agent-mode.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)