### PR TITLE
CLI: --rerun flag + config default for a live Rerun viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,27 @@ With a default policy/embodiment configured once in
 `~/.config/inspect-robots/config.ini`, just tell the robot what to do:
 
 ```bash
-inspect-robots "place the spoon on the plate"                # zero-config ad-hoc eval
-inspect-robots "place the spoon on the plate" --sim          # same, on your configured sim
+inspect-robots "place the fork on the plate"                 # zero-config ad-hoc eval
+inspect-robots "place the fork on the plate" --sim           # same, on your configured sim
 ```
+
+A config file makes every knob a default (CLI flags override; `--no-rerun` and
+`--no-store-frames` turn the booleans off for a single run):
+
+```ini
+# ~/.config/inspect-robots/config.ini
+[defaults]
+policy = molmoact2        # e.g. from the inspect-robots-yam plugin
+embodiment = my_yam_arms  # your rig's embodiment factory (see the plugin's README)
+scorer = success_at_end
+max_steps = 1200          # 120 s at 10 Hz
+rerun = true              # live Rerun viewer per run: pip install "inspect-robots[rerun]"
+store_frames = true       # save each run's camera frames under <log-dir>/frames/
+```
+
+With `rerun = true` every run opens a live viewer streaming the cameras,
+proprioception, and actions straight from the eval pipeline, so you watch
+exactly what the policy sees while the robot moves.
 
 The full command line resolves any registered task/policy/embodiment
 (builtins + installed plugins):

--- a/src/inspect_robots/_defaults.py
+++ b/src/inspect_robots/_defaults.py
@@ -61,6 +61,7 @@ class Defaults:
     scorer: str | None = None
     max_steps: int | None = None
     store_frames: bool = False
+    rerun: bool = False
     policy_args: dict[str, Any] = field(default_factory=dict)
     embodiment_args: dict[str, Any] = field(default_factory=dict)
     sim_embodiment_args: dict[str, Any] = field(default_factory=dict)
@@ -119,6 +120,13 @@ def _read_config(path: Path) -> Defaults:
             raise _die(path, f"[defaults] store_frames must be true or false, got {raw_frames!r}")
         store_frames = parsed_frames
 
+    rerun = False
+    if raw_rerun := parser.get("defaults", "rerun", fallback=None):
+        parsed_rerun = parse_value(raw_rerun)
+        if not isinstance(parsed_rerun, bool):
+            raise _die(path, f"[defaults] rerun must be true or false, got {raw_rerun!r}")
+        rerun = parsed_rerun
+
     policy = parser.get("defaults", "policy", fallback=None)
     embodiment = parser.get("defaults", "embodiment", fallback=None)
     sim_embodiment = parser.get("defaults", "sim_embodiment", fallback=None)
@@ -132,6 +140,7 @@ def _read_config(path: Path) -> Defaults:
         scorer=parser.get("defaults", "scorer", fallback=None),
         max_steps=max_steps,
         store_frames=store_frames,
+        rerun=rerun,
         policy_args=_parse_args_section(parser, "policy.args"),
         embodiment_args=_parse_args_section(parser, "embodiment.args"),
         sim_embodiment_args=_parse_args_section(parser, "sim_embodiment.args"),

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -40,6 +40,7 @@ from inspect_robots._defaults import (
 )
 
 if TYPE_CHECKING:
+    from inspect_robots.logging.sink import LogSink
     from inspect_robots.rollout import TrialRecord
     from inspect_robots.scene import Scene
 
@@ -137,6 +138,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="stream camera frames to a per-run directory under <log-dir>/frames "
         "instead of keeping them in memory (--no-store-frames overrides a "
         "store_frames config default)",
+    )
+    p_run.add_argument(
+        "--rerun",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="stream the rollout (cameras, state, actions) to a live Rerun "
+        "viewer window; needs rerun-sdk (--no-rerun overrides a rerun config "
+        "default)",
     )
 
     p_inspect = sub.add_parser("inspect", help="print a saved eval log")
@@ -320,13 +329,21 @@ def _cmd_run(args: argparse.Namespace) -> int:
 
         # Construct the sink explicitly so we can tell the user where the log went.
         sink = JsonLogSink(args.log_dir)
+        sinks: list[LogSink] = [sink]
+        if args.rerun if args.rerun is not None else defaults.rerun:
+            from inspect_robots.logging.rerun_sink import RerunSink
+
+            # spawn=True opens the live viewer; the sink itself degrades to a
+            # warn-once no-op when rerun-sdk is not installed.
+            sinks.append(RerunSink(spawn=True))
+            print("rerun: live viewer")
         logs = eval(
             task,
             policy,
             embodiment,
             log_dir=args.log_dir,
             seed=args.seed,
-            sinks=[sink],
+            sinks=sinks,
             fail_on_error=args.fail_on_error if args.fail_on_error is not None else False,
             store_frames=(
                 args.store_frames if args.store_frames is not None else defaults.store_frames

--- a/src/inspect_robots/logging/rerun_sink.py
+++ b/src/inspect_robots/logging/rerun_sink.py
@@ -40,9 +40,12 @@ class RerunSink:
         self.spawn = spawn
         self._rr: Any | None = None
         self._warned = False
+        self._disabled = False
         self._prefix = "trial"
 
     def _ensure_rerun(self) -> Any | None:
+        if self._disabled:
+            return None
         if self._rr is not None:
             return self._rr
         try:
@@ -82,9 +85,21 @@ class RerunSink:
         rr = self._ensure_rerun()
         if rr is None:
             return
-        rr.init(self.application_id, spawn=self.spawn)
-        if self.recording_path is not None:
-            rr.save(self.recording_path)
+        try:
+            rr.init(self.application_id, spawn=self.spawn)
+            if self.recording_path is not None:
+                rr.save(self.recording_path)
+        except Exception as exc:
+            # A visualization sink must never take the eval down with it — a
+            # missing viewer binary (spawn) or unwritable recording path
+            # degrades to a warned no-op, exactly like a missing rerun-sdk.
+            warnings.warn(
+                f"RerunSink disabled: could not start the Rerun recording/viewer ({exc})",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            self._rr = None
+            self._disabled = True
 
     def on_trial_start(self, scene_id: str, epoch: int) -> None:
         # Namespace this trial's entities so trials never overwrite each other.

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -193,3 +193,22 @@ def test_config_store_frames_rejects_non_bool(tmp_path: Path) -> None:
     _write_config(config_home, "[defaults]\nstore_frames = 12\n")
     with pytest.raises(SystemExit, match="store_frames"):
         load_defaults({"XDG_CONFIG_HOME": str(config_home)})
+
+
+def test_config_rerun_parses_bool(tmp_path: Path) -> None:
+    config_home = tmp_path / "cfg"
+    _write_config(config_home, "[defaults]\nrerun = true\n")
+    assert load_defaults({"XDG_CONFIG_HOME": str(config_home)}).rerun is True
+
+
+def test_config_rerun_defaults_false(tmp_path: Path) -> None:
+    config_home = tmp_path / "cfg"
+    _write_config(config_home, "[defaults]\npolicy = x\n")
+    assert load_defaults({"XDG_CONFIG_HOME": str(config_home)}).rerun is False
+
+
+def test_config_rerun_rejects_non_bool(tmp_path: Path) -> None:
+    config_home = tmp_path / "cfg"
+    _write_config(config_home, "[defaults]\nrerun = viewer\n")
+    with pytest.raises(SystemExit, match="rerun"):
+        load_defaults({"XDG_CONFIG_HOME": str(config_home)})

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
@@ -650,3 +651,71 @@ def test_no_store_frames_flag_overrides_config_default(
     assert rc == 0
     assert not (log_dir / "frames").exists()
     assert _read_only_log(log_dir).stats.frames_dir is None
+
+
+class _FakeRerunSink:
+    """Stands in for RerunSink: records construction and step traffic."""
+
+    instances: ClassVar[list[_FakeRerunSink]] = []
+
+    def __init__(self, recording_path: str | None = None, *, spawn: bool = False) -> None:
+        self.spawn = spawn
+        self.steps = 0
+        _FakeRerunSink.instances.append(self)
+
+    def on_eval_start(self, spec: object) -> None: ...
+
+    def on_trial_start(self, scene_id: str, epoch: int) -> None: ...
+
+    def log_step(self, t: int, observation: object, action: object, result: object) -> None:
+        self.steps += 1
+
+    def on_trial_end(self, record: object) -> None: ...
+
+    def on_eval_end(self, log: object) -> None: ...
+
+
+@pytest.fixture()
+def _fake_rerun(monkeypatch: pytest.MonkeyPatch) -> type[_FakeRerunSink]:
+    import inspect_robots.logging.rerun_sink as rrs
+
+    _FakeRerunSink.instances = []
+    monkeypatch.setattr(rrs, "RerunSink", _FakeRerunSink)
+    return _FakeRerunSink
+
+
+def _run_adhoc(config_home: Path, tmp_path: Path, *extra: str) -> int:
+    _write_config(
+        config_home,
+        "[defaults]\npolicy = scripted\nembodiment = cubepick\n"
+        "scorer = success_at_end\nrerun = true\n",
+    )
+    return main(["reach the cube", "--log-dir", str(tmp_path / "logs"), *extra])
+
+
+def test_config_rerun_attaches_live_viewer_sink(
+    _hermetic_defaults: Path, tmp_path: Path, _fake_rerun: type[_FakeRerunSink]
+) -> None:
+    assert _run_adhoc(_hermetic_defaults, tmp_path) == 0
+    (sink,) = _fake_rerun.instances  # constructed exactly once
+    assert sink.spawn is True  # live viewer, not just a recording
+    assert sink.steps > 0  # actually received rollout traffic
+
+
+def test_no_rerun_flag_overrides_config(
+    _hermetic_defaults: Path, tmp_path: Path, _fake_rerun: type[_FakeRerunSink]
+) -> None:
+    assert _run_adhoc(_hermetic_defaults, tmp_path, "--no-rerun") == 0
+    assert _fake_rerun.instances == []
+
+
+def test_rerun_flag_enables_without_config(
+    _hermetic_defaults: Path, tmp_path: Path, _fake_rerun: type[_FakeRerunSink]
+) -> None:
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\npolicy = scripted\nembodiment = cubepick\nscorer = success_at_end\n",
+    )
+    rc = main(["reach the cube", "--log-dir", str(tmp_path / "logs"), "--rerun"])
+    assert rc == 0
+    assert len(_fake_rerun.instances) == 1

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -70,6 +70,10 @@ def test_viewer_failure_disables_sink_instead_of_crashing() -> None:
     sink = RerunSink(spawn=True)
     sink._rr = _FakeRR()
     with pytest.warns(RuntimeWarning, match="RerunSink disabled"):
-        sink.on_eval_start(EvalSpec(task="t", policy="p", embodiment="e"))
+        sink.on_eval_start(
+            EvalSpec(
+                task="t", policy="p", embodiment="e", created="now", inspect_robots_version="0"
+            )
+        )
     assert sink.available is False  # dormant from here on
     sink.log_step(0, None, None, None)  # type: ignore[arg-type]  # must not raise

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -57,3 +57,19 @@ def test_rerun_sink_writes_recording(tmp_path: Path) -> None:
     assert sink.available is True
     eval(_task(), ScriptedPolicy(), CubePickEmbodiment(), sinks=[sink])
     assert rrd.exists()
+
+
+def test_viewer_failure_disables_sink_instead_of_crashing() -> None:
+    """A missing viewer binary (rr.init raising) must not kill the eval."""
+    from inspect_robots.log import EvalSpec
+
+    class _FakeRR:
+        def init(self, *a: object, **k: object) -> None:
+            raise RuntimeError("Failed to find Rerun Viewer executable in PATH.")
+
+    sink = RerunSink(spawn=True)
+    sink._rr = _FakeRR()
+    with pytest.warns(RuntimeWarning, match="RerunSink disabled"):
+        sink.on_eval_start(EvalSpec(task="t", policy="p", embodiment="e"))
+    assert sink.available is False  # dormant from here on
+    sink.log_step(0, None, None, None)  # type: ignore[arg-type]  # must not raise


### PR DESCRIPTION
`inspect-robots run --rerun` (or `[defaults] rerun = true` in config.ini; `--no-rerun` overrides) attaches the existing `RerunSink` with `spawn=True` alongside the JSON sink: a live Rerun viewer window opens and streams the rollout's camera images, proprioception, and actions as the robot runs. Because the frames come from inside the pipeline (it's a log sink), the operator sees exactly what the policy sees with no camera contention.

Also hardens `RerunSink`: `rr.init(spawn=True)` raises when the viewer binary is missing from PATH, and that exception killed the whole eval from inside a visualization sink. It now degrades to a warned no-op — the same contract as a missing rerun-sdk.

Flag mirrors `--store-frames` (`BooleanOptionalAction`, flag > config > off). Verified live on the YAM rig host (viewer spawns, mock eval streams). All gates green: ruff, mypy --strict, 211 tests, coverage unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)