### PR TITLE
agent: reasoning effort knob, default low for latency

### DIFF
--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -44,4 +44,10 @@ its own.
 > on real hardware** unless you fully trust the policy and the rig.
 
 Configuration knobs (all `-P key=value`): `model`, `base_url`, `api_key_env`,
-`max_llm_calls`, `temperature`.
+`max_llm_calls`, `temperature`, `effort`.
+
+Reasoning effort defaults to `low`: robot control is latency-sensitive (the
+arm stands still while the model thinks), safety guardrails sit below the
+model either way, and frontier models at low effort remain strong at this
+task shape. Raise it for hard manipulation problems (`-P effort=high`) or
+pass `-P effort=none` to omit the parameter for endpoints that reject it.

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
@@ -144,12 +144,15 @@ class ChatClient:
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]],
         temperature: float | None = None,
+        reasoning_effort: str | None = None,
     ) -> AssistantMessage:
         body: dict[str, Any] = {"model": self._provider.model, "messages": messages}
         if tools:
             body["tools"] = tools
         if temperature is not None:
             body["temperature"] = temperature
+        if reasoning_effort is not None:
+            body["reasoning_effort"] = reasoning_effort
 
         last_error = "unknown error"
         for attempt in range(self._max_retries):

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -29,6 +29,10 @@ from inspect_robots_agent._tools import Toolset, build_toolset
 
 _MAX_CONSECUTIVE_FAILURES = 3
 
+# reasoning_effort values accepted across OpenAI-compatible endpoints
+# (Anthropic compat maps these to thinking effort; OpenRouter forwards them).
+_EFFORT_LEVELS = frozenset({"minimal", "low", "medium", "high", "xhigh", "max"})
+
 _SYSTEM_TEMPLATE = """You are controlling a real robot embodiment named {name!r} \
 through tool calls. Each observation message gives you the current \
 proprioceptive state and camera images. Work toward the user's goal in \
@@ -52,6 +56,7 @@ class AgentPolicyConfig(PolicyConfig):
     base_url: str | None = None
     api_key_env: str | None = None
     max_llm_calls: int = 50
+    effort: str | None = "low"
 
 
 class LLMAgentPolicy(PolicyBase):
@@ -69,6 +74,7 @@ class LLMAgentPolicy(PolicyBase):
         api_key_env: str | None = None,
         max_llm_calls: int = 50,
         temperature: float | None = None,
+        effort: str | None = "low",
         transport: httpx.BaseTransport | None = None,
         env: dict[str, str] | None = None,
     ):
@@ -81,15 +87,24 @@ class LLMAgentPolicy(PolicyBase):
         )
         if max_llm_calls < 1:
             raise ValueError("max_llm_calls must be >= 1")
+        if effort is not None and effort not in _EFFORT_LEVELS:
+            raise ValueError(
+                f"effort must be one of {sorted(_EFFORT_LEVELS)} or none, got {effort!r}"
+            )
         self._client = ChatClient(provider, transport=transport)
         self._max_llm_calls = max_llm_calls
         self._temperature = temperature
+        # Robot control is latency-sensitive: default to low reasoning effort
+        # (the arm stands still while the model thinks; safety guardrails sit
+        # below the model, so effort trades thinking time, not safety).
+        self._effort = effort
         self.config = AgentPolicyConfig(
             temperature=temperature,
             model=provider.model,
             base_url=provider.base_url,
             api_key_env=api_key_env,
             max_llm_calls=max_llm_calls,
+            effort=effort,
         )
         # Placeholder until bind(); eval() always binds before compat/rollout.
         self.info = PolicyInfo(name="agent", action_space=Box(shape=(1,)))
@@ -142,7 +157,10 @@ class LLMAgentPolicy(PolicyBase):
             if self._calls_used >= self._max_llm_calls:
                 return self._forced_give_up(toolset, observation, "LLM call budget exhausted")
             message = self._client.complete(
-                self._messages, toolset.schemas(), temperature=self._temperature
+                self._messages,
+                toolset.schemas(),
+                temperature=self._temperature,
+                reasoning_effort=self._effort,
             )
             self._calls_used += 1
             self._messages.append(message.raw())

--- a/plugins/inspect-robots-agent/tests/test_llm.py
+++ b/plugins/inspect-robots-agent/tests/test_llm.py
@@ -143,6 +143,20 @@ def test_complete_sends_wire_format_and_parses_tool_calls() -> None:
     assert json.loads(call.arguments)["duration_s"] == 1.0
 
 
+def test_reasoning_effort_is_sent_when_set_and_omitted_when_none() -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(200, json=_tool_call_response())
+
+    client = _client(handler)
+    client.complete(messages=[], tools=[], reasoning_effort="low")
+    client.complete(messages=[], tools=[])
+    assert bodies[0]["reasoning_effort"] == "low"
+    assert "reasoning_effort" not in bodies[1]
+
+
 def test_keyless_provider_sends_no_authorization_header() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert "authorization" not in request.headers

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -210,6 +210,26 @@ def test_recoverable_tool_error_is_fed_back_and_corrected(tmp_path: Path) -> Non
     assert any("unknown dimension 'dz'" in str(m["content"]) for m in tool_messages)
 
 
+def test_effort_defaults_low_and_is_tunable(tmp_path: Path) -> None:
+    script = _Script([_tool_response("done", {"summary": "ok"})])
+    logs = ir_eval(_task(), _policy(script), CubePickEmbodiment(), log_dir=str(tmp_path))
+    # Robot control is latency-sensitive: low effort by default (guardrails
+    # sit below the model, so this trades thinking time, not safety).
+    assert script.requests[0]["reasoning_effort"] == "low"
+    assert logs[0].eval.policy_config["effort"] == "low"
+
+    script = _Script([_tool_response("done", {"summary": "ok"})])
+    ir_eval(_task(), _policy(script, effort="high"), CubePickEmbodiment(), log_dir=str(tmp_path))
+    assert script.requests[0]["reasoning_effort"] == "high"
+
+    script = _Script([_tool_response("done", {"summary": "ok"})])
+    ir_eval(_task(), _policy(script, effort=None), CubePickEmbodiment(), log_dir=str(tmp_path))
+    assert "reasoning_effort" not in script.requests[0]
+
+    with pytest.raises(ValueError, match="effort"):
+        _policy(_Script([]), effort="turbo")
+
+
 def test_registry_resolves_agent_policy() -> None:
     from inspect_robots.registry import resolve
 


### PR DESCRIPTION
## Summary

The first live YAM run (today) used the endpoint default reasoning effort — on frontier models that is `high` with adaptive thinking, which produced 5-15 s of arm stillness per motion while the model thought. Robot control is latency-sensitive, and effort trades thinking time rather than safety (the guardrail chain sits below the model), so the agent policy now sends `reasoning_effort: "low"` by default on every chat completion.

## Changes

- `_llm.py`: `ChatClient.complete` gains `reasoning_effort` (omitted when `None`) — the OpenAI-compatible wire field; Anthropic's compat endpoint maps it to thinking effort, OpenRouter forwards it.
- `policy.py`: `effort` knob (default `"low"`, validated against `minimal/low/medium/high/xhigh/max`, `none` omits the field), threaded through every LLM call and recorded in `AgentPolicyConfig` so the eval log captures it.
- README: documents the default and the rationale.

Usage: `-P effort=high` for hard manipulation tasks; `-P effort=none` for endpoints that reject the field.

Gates: 33 plugin tests, mypy strict, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
