### PR TITLE
isaacsim: cover _ensure_env's cfg-wiring contract without Isaac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). While the version is
 `0.x`, breaking changes may occur on any minor release.
 
+## [Unreleased]
+
+### Added
+
+- isaacsim plugin: `_ensure_env`'s cfg-wiring contract (`parse_env_cfg`'s
+  args, `gym.make(cfg=...)`, the `headless` → `_disable_debug_vis` gate, and
+  the named-obs-terms request) is now exercised in CI via stubbed
+  `gymnasium`/`isaaclab_tasks` modules. Previously only the fake-env-injected
+  `step()`/`reset()` translation was covered, so a regression in `_ensure_env`
+  itself (e.g. #15's missing `cfg=`) would only have failed live (#25).
+
 ## [0.6.0] - 2026-07-10
 
 ### Added

--- a/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
+++ b/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
@@ -308,3 +308,91 @@ def test_request_named_obs_terms_flips_concatenate_flag(
         _request_named_obs_terms(object(), "policy")
     assert len(caplog.records) == 2
     assert all("named observation terms" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# _ensure_env: the cfg-wiring contract, exercised without Isaac (#25).
+#
+# CI injects a fake env directly (_inject_fake) for step()/reset() translation
+# tests, so _ensure_env's own body — parse_env_cfg args, gym.make(cfg=...),
+# the headless->_disable_debug_vis gate, and the named-obs-terms request —
+# never actually ran in CI. A regression here (e.g. dropping cfg=, as #15
+# fixed) would only have failed live. Stub gymnasium/isaaclab_tasks via
+# sys.modules and assert the exact contract issue #25 specifies.
+# --------------------------------------------------------------------------- #
+class _FakeGroupCfg:
+    def __init__(self) -> None:
+        self.concatenate_terms = True
+
+
+class _FakeObservationsCfg:
+    def __init__(self) -> None:
+        self.policy = _FakeGroupCfg()
+
+
+class _FakeEnvCfg:
+    def __init__(self) -> None:
+        self.debug_vis = True
+        self.observations = _FakeObservationsCfg()
+
+
+def _install_fake_isaac_lab_modules(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[dict[str, Any], _FakeEnvCfg]:
+    """Register fake gymnasium/isaaclab_tasks(.utils) modules that record calls."""
+    import sys
+    import types
+
+    calls: dict[str, Any] = {}
+    fake_cfg = _FakeEnvCfg()
+
+    def fake_parse_env_cfg(task_id: str, *, device: str, num_envs: int) -> _FakeEnvCfg:
+        calls["parse_env_cfg"] = (task_id, device, num_envs)
+        return fake_cfg
+
+    def fake_make(task_id: str, *, cfg: Any, render_mode: str) -> str:
+        calls["gym_make"] = (task_id, cfg, render_mode)
+        return "fake-env"
+
+    fake_gym = types.ModuleType("gymnasium")
+    fake_gym.make = fake_make  # type: ignore[attr-defined]
+
+    fake_utils = types.ModuleType("isaaclab_tasks.utils")
+    fake_utils.parse_env_cfg = fake_parse_env_cfg  # type: ignore[attr-defined]
+    fake_tasks = types.ModuleType("isaaclab_tasks")
+    fake_tasks.utils = fake_utils  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "gymnasium", fake_gym)
+    monkeypatch.setitem(sys.modules, "isaaclab_tasks", fake_tasks)
+    monkeypatch.setitem(sys.modules, "isaaclab_tasks.utils", fake_utils)
+    return calls, fake_cfg
+
+
+def test_ensure_env_wires_cfg_correctly_when_headless(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls, fake_cfg = _install_fake_isaac_lab_modules(monkeypatch)
+    emb = IsaacSimEmbodiment(
+        task_id="Isaac-Lift-Cube-Franka-v0", device="cuda:0", headless=True, obs_group="policy"
+    )
+    monkeypatch.setattr(emb, "_ensure_app", lambda: None)
+
+    env = emb._ensure_env()
+
+    assert env == "fake-env"
+    assert calls["parse_env_cfg"] == ("Isaac-Lift-Cube-Franka-v0", "cuda:0", 1)
+    assert calls["gym_make"] == ("Isaac-Lift-Cube-Franka-v0", fake_cfg, "rgb_array")
+    assert fake_cfg.debug_vis is False  # headless=True -> _disable_debug_vis ran
+    assert fake_cfg.observations.policy.concatenate_terms is False  # named terms requested
+    assert emb._ensure_env() is env  # cached: second call doesn't re-wire
+
+
+def test_ensure_env_skips_debug_vis_disable_when_not_headless(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _calls, fake_cfg = _install_fake_isaac_lab_modules(monkeypatch)
+    emb = IsaacSimEmbodiment(headless=False)
+    monkeypatch.setattr(emb, "_ensure_app", lambda: None)
+
+    emb._ensure_env()
+
+    assert fake_cfg.debug_vis is True  # untouched: headless=False skips _disable_debug_vis
+    assert fake_cfg.observations.policy.concatenate_terms is False  # still requested either way

--- a/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
+++ b/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
@@ -349,9 +349,16 @@ def _install_fake_isaac_lab_modules(
         calls["parse_env_cfg"] = (task_id, device, num_envs)
         return fake_cfg
 
-    def fake_make(task_id: str, *, cfg: Any, render_mode: str) -> str:
+    def fake_make(task_id: str, *, cfg: Any, render_mode: str) -> object:
         calls["gym_make"] = (task_id, cfg, render_mode)
-        return "fake-env"
+        calls["gym_make_count"] = calls.get("gym_make_count", 0) + 1
+        # Snapshot cfg state at make-time: Isaac consumes the cfg during
+        # gym.make, so wiring applied after make would be a silent live no-op.
+        calls["debug_vis_at_make"] = cfg.debug_vis
+        calls["concatenate_terms_at_make"] = cfg.observations.policy.concatenate_terms
+        env = object()  # fresh per call: identity distinguishes a re-make from the cache
+        calls["env"] = env
+        return env
 
     fake_gym = types.ModuleType("gymnasium")
     fake_gym.make = fake_make  # type: ignore[attr-defined]
@@ -376,22 +383,23 @@ def test_ensure_env_wires_cfg_correctly_when_headless(monkeypatch: pytest.Monkey
 
     env = emb._ensure_env()
 
-    assert env == "fake-env"
+    assert env is calls["env"]
     assert calls["parse_env_cfg"] == ("Isaac-Lift-Cube-Franka-v0", "cuda:0", 1)
     assert calls["gym_make"] == ("Isaac-Lift-Cube-Franka-v0", fake_cfg, "rgb_array")
-    assert fake_cfg.debug_vis is False  # headless=True -> _disable_debug_vis ran
-    assert fake_cfg.observations.policy.concatenate_terms is False  # named terms requested
+    assert calls["debug_vis_at_make"] is False  # headless=True -> _disable_debug_vis ran
+    assert calls["concatenate_terms_at_make"] is False  # named terms requested before make
     assert emb._ensure_env() is env  # cached: second call doesn't re-wire
+    assert calls["gym_make_count"] == 1
 
 
 def test_ensure_env_skips_debug_vis_disable_when_not_headless(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _calls, fake_cfg = _install_fake_isaac_lab_modules(monkeypatch)
+    calls, _fake_cfg = _install_fake_isaac_lab_modules(monkeypatch)
     emb = IsaacSimEmbodiment(headless=False)
     monkeypatch.setattr(emb, "_ensure_app", lambda: None)
 
     emb._ensure_env()
 
-    assert fake_cfg.debug_vis is True  # untouched: headless=False skips _disable_debug_vis
-    assert fake_cfg.observations.policy.concatenate_terms is False  # still requested either way
+    assert calls["debug_vis_at_make"] is True  # untouched: headless=False skips the disable
+    assert calls["concatenate_terms_at_make"] is False  # still requested either way


### PR DESCRIPTION
## Summary

CI tests inject a fake env directly for step()/reset() translation, so `_ensure_env`'s own body never actually ran: `parse_env_cfg`'s args, `gym.make` receiving `cfg=`, the `headless` → `_disable_debug_vis` gate, and the named-obs-terms request. A regression here (e.g. #15's missing `cfg=`) would only have failed live.

## Changes

- Stub `gymnasium`/`isaaclab_tasks`(`.utils`) via `sys.modules` and assert the exact contract: `parse_env_cfg(task_id, device=..., num_envs=1)`, `gym.make(task_id, cfg=..., render_mode="rgb_array")`, `debug_vis` flipped only when `headless=True`, `concatenate_terms` always requested regardless of `headless`
- Confirmed `_ensure_env()` is memoized (a second call returns the cached env without re-wiring)
- `CHANGELOG.md` entry under "Unreleased" (there wasn't one yet — main had just cut 0.6.0)

## Checklist

- [x] `pre-commit install` done; hooks pass (or ran `pre-commit run --all-files`)
- [x] Tests added/updated (and the `CubePick` mock exercises the change where applicable) — N/A `CubePick`, this is the isaacsim plugin; added `sys.modules` stubs instead, same pattern as the existing `_disable_debug_vis`/`_request_named_obs_terms` tests
- [x] Coverage stays at **100%** (`pytest --cov`) — core untouched, still 100%; this PR only adds plugin tests (plugin has no 100% gate, per CLAUDE.md)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `mypy` passes (strict) — on `src/inspect_robots_isaacsim` (the only mypy scope CI/pre-commit enforce for this plugin)
- [x] `CHANGELOG.md` updated under "Unreleased"
- [x] Public API changes are reflected in `inspect_robots.__all__` and the API-snapshot test — N/A, no public API change, test-only
- [x] Core stays NumPy-only (new deps are optional extras, lazily imported) — unaffected, plugin-test-only change

## Related

Closes #25

