### PR TITLE
fix: gate config [*.args] to the component they were configured for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). While the version is
 `0.x`, breaking changes may occur on any minor release.
 
+## [Unreleased]
+
+### Fixed
+
+- **Config `[*.args]` sections no longer follow a differently-selected
+  component** (#44). `[policy.args]` / `[embodiment.args]` /
+  `[sim_embodiment.args]` now apply only when the selected component matches
+  the `[defaults]` name they were configured alongside; selecting another
+  component (by flag or env var) ignores them with a stderr note instead of
+  crashing its constructor with foreign kwargs. Selecting the configured
+  default explicitly (e.g. `--embodiment` naming the config default) still
+  applies its args.
+
 ## [0.6.0] - 2026-07-10
 
 ### Added

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -55,7 +55,11 @@ headless = true
 
 Values parse like `-P/-E` args (bool/int/float/None/str), `~` expands in
 `[*.args]` values, and an explicit `-P/-E key=value` flag overrides the
-same-named config key. There is deliberately no project-local config file:
+same-named config key. An `[*.args]` section belongs to the component named
+in `[defaults]`: it applies whenever that same component is the one selected
+(by default, by flag, or by env var), and is ignored with a stderr note when
+a *different* component is selected. Your YAM rig's `rest_pose` never reaches
+`--embodiment kitchen`. There is deliberately no project-local config file:
 a checked-in file choosing which policy drives your hardware would be a trust
 footgun.
 

--- a/src/inspect_robots/_defaults.py
+++ b/src/inspect_robots/_defaults.py
@@ -65,6 +65,14 @@ class Defaults:
     policy_args: dict[str, Any] = field(default_factory=dict)
     embodiment_args: dict[str, Any] = field(default_factory=dict)
     sim_embodiment_args: dict[str, Any] = field(default_factory=dict)
+    # The [<kind>.args] sections are written alongside the config file's
+    # [defaults] component names; each args dict is only valid for that
+    # component (its "owner", issue #44). Env vars override the names above
+    # but never the owners: the file's args must not follow an env-selected
+    # component of a different name.
+    policy_args_owner: str | None = None
+    embodiment_args_owner: str | None = None
+    sim_embodiment_args_owner: str | None = None
 
 
 def _config_path(env: Mapping[str, str]) -> Path | None:
@@ -144,6 +152,9 @@ def _read_config(path: Path) -> Defaults:
         policy_args=_parse_args_section(parser, "policy.args"),
         embodiment_args=_parse_args_section(parser, "embodiment.args"),
         sim_embodiment_args=_parse_args_section(parser, "sim_embodiment.args"),
+        policy_args_owner=policy,
+        embodiment_args_owner=embodiment,
+        sim_embodiment_args_owner=sim_embodiment,
     )
 
 

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -238,6 +238,25 @@ def _pick_component(
     )
 
 
+def _config_args(
+    kind: str, name: str, owner: str | None, config_args: dict[str, Any]
+) -> dict[str, Any]:
+    """Config-file ``[<kind>.args]``, gated to the component they were written for.
+
+    An args section is only valid for the ``[defaults]`` component it was
+    configured alongside (its owner); handing it to a differently-selected
+    component injects kwargs that constructor never asked for (issue #44).
+    Dropping is loud on stderr: persisted rig calibration vanishing silently
+    would be a worse failure than the crash this replaces.
+    """
+    if name == owner:
+        return config_args
+    if config_args:
+        reason = f"they apply to {owner!r}" if owner else f"no default {kind} is configured"
+        print(f"note: ignoring [{kind}.args] for {name!r}: {reason}", file=sys.stderr)
+    return {}
+
+
 def _pick_sim_embodiment(defaults: Defaults) -> tuple[str, str]:
     """The --sim chain: env var > config ``sim_embodiment``, or exit with guidance.
 
@@ -383,15 +402,25 @@ def _cmd_run(args: argparse.Namespace) -> int:
     )
     if args.sim:
         embodiment_name, embodiment_source = _pick_sim_embodiment(defaults)
-        embodiment_defaults = defaults.sim_embodiment_args
+        embodiment_defaults = _config_args(
+            "sim_embodiment",
+            embodiment_name,
+            defaults.sim_embodiment_args_owner,
+            defaults.sim_embodiment_args,
+        )
     else:
         embodiment_name, embodiment_source = _pick_component(
             "embodiment", args.embodiment, defaults.embodiment, defaults.embodiment_source
         )
-        embodiment_defaults = defaults.embodiment_args
-    # Config-file args apply to whichever component is selected; explicit
-    # -P/-E flags override same-named keys.
-    policy_kvs = {**defaults.policy_args, **_parse_kvs(args.policy_args)}
+        embodiment_defaults = _config_args(
+            "embodiment", embodiment_name, defaults.embodiment_args_owner, defaults.embodiment_args
+        )
+    # Config-file args apply only to the component they were configured
+    # alongside (issue #44); explicit -P/-E flags override same-named keys.
+    policy_config_args = _config_args(
+        "policy", policy_name, defaults.policy_args_owner, defaults.policy_args
+    )
+    policy_kvs = {**policy_config_args, **_parse_kvs(args.policy_args)}
     embodiment_kvs = {**embodiment_defaults, **_parse_kvs(args.embodiment_args)}
 
     if is_adhoc:
@@ -530,7 +559,10 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
     name, source = _pick_component(
         "embodiment", args.embodiment, defaults.embodiment, defaults.embodiment_source
     )
-    kvs = {**defaults.embodiment_args, **_parse_kvs(args.embodiment_args)}
+    config_kvs = _config_args(
+        "embodiment", name, defaults.embodiment_args_owner, defaults.embodiment_args
+    )
+    kvs = {**config_kvs, **_parse_kvs(args.embodiment_args)}
     embodiment = _resolve_or_exit("embodiment", name, **kvs)
     try:
         report = check_embodiment(embodiment.info)

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -73,8 +73,12 @@ def test_env_vars_override_config_names_but_not_args(tmp_path: Path) -> None:
     assert d.policy_source == f"${ENV_POLICY}"
     assert d.embodiment == "other-arm"
     assert d.embodiment_source == f"${ENV_EMBODIMENT}"
-    # Config-file args still apply to whatever component ends up selected.
+    # Config-file args stay loaded, but their owner stays the *file's* name:
+    # the CLI applies them only when the selected component matches it, so an
+    # env-selected "other-policy" never inherits molmoact2-yam's args (#44).
     assert d.policy_args["temperature"] == 0.5
+    assert d.policy_args_owner == "molmoact2-yam"
+    assert d.embodiment_args_owner == "yam-bimanual"
 
 
 def test_env_vars_work_without_any_config_file(tmp_path: Path) -> None:
@@ -106,7 +110,7 @@ def test_unknown_sections_and_keys_are_ignored(tmp_path: Path) -> None:
     )
     d = load_defaults({"XDG_CONFIG_HOME": str(tmp_path)})
     # Full equality: the unknown key and section contributed nothing at all.
-    assert d == Defaults(policy="p", policy_source=str(path))
+    assert d == Defaults(policy="p", policy_source=str(path), policy_args_owner="p")
 
 
 def test_malformed_ini_raises_system_exit_naming_file(tmp_path: Path) -> None:
@@ -159,6 +163,8 @@ def test_sim_embodiment_config_is_independent_of_real(tmp_path: Path) -> None:
         sim_embodiment_source=str(path),
         embodiment_args={"port": "/dev/ttyUSB0"},
         sim_embodiment_args={"headless": True, "scene_file": scene_file},
+        embodiment_args_owner="yam-bimanual",
+        sim_embodiment_args_owner="yam-bimanual-isaac",
     )
 
 

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -245,6 +245,94 @@ def test_cli_flags_beat_config_defaults_and_args(
     assert _read_only_log(log_dir).eval.policy_config["action_horizon"] == 4
 
 
+def test_config_args_do_not_leak_to_explicitly_selected_components(
+    _hermetic_defaults: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Issue #44: the [*.args] sections belong to the configured defaults; before
+    # the fix they followed *whatever* was selected, so a persisted rig arg
+    # (rest_pose here) TypeErrored an unrelated --embodiment. Now the run is
+    # green and each dropped section is noted on stderr.
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\n"
+        "policy = noop\n"
+        "embodiment = yam-arms\n"
+        "scorer = success_at_end\n"
+        "[policy.args]\n"
+        "bogus_policy_knob = 1\n"
+        "[embodiment.args]\n"
+        "rest_pose = 0.5\n",
+    )
+    log_dir = tmp_path / "logs"
+    rc = main(
+        [
+            "run",
+            "--instruction",
+            "reach the cube",
+            "--policy",
+            "scripted",
+            "--embodiment",
+            "cubepick",
+            "--log-dir",
+            str(log_dir),
+        ]
+    )
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "note: ignoring [policy.args] for 'scripted': they apply to 'noop'" in err
+    assert "note: ignoring [embodiment.args] for 'cubepick': they apply to 'yam-arms'" in err
+    assert _read_only_log(log_dir).results.metrics["success_at_end"] == 1.0
+
+
+def test_config_args_apply_when_flag_names_the_configured_default(
+    _hermetic_defaults: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Selecting the configured default *explicitly* must keep its args: a lab
+    # operator typing --policy for the component the file already names cannot
+    # silently lose the configured calibration (gate on name, not provenance).
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\n"
+        "policy = scripted\n"
+        "embodiment = cubepick\n"
+        "scorer = success_at_end\n"
+        "[policy.args]\n"
+        "chunk_size = 6\n",
+    )
+    log_dir = tmp_path / "logs"
+    args = ["run", "--instruction", "reach the cube", "--policy", "scripted"]
+    rc = main([*args, "--log-dir", str(log_dir)])
+    assert rc == 0
+    assert "note: ignoring" not in capsys.readouterr().err
+    assert _read_only_log(log_dir).eval.policy_config["action_horizon"] == 6
+
+
+def test_env_selected_component_does_not_inherit_config_args(
+    _hermetic_defaults: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # An env var swaps the component name but the file's args stay owned by the
+    # file's name — they must not follow the env-selected component.
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\n"
+        "policy = noop\n"
+        "embodiment = cubepick\n"
+        "scorer = success_at_end\n"
+        "[policy.args]\n"
+        "bogus_policy_knob = 1\n",
+    )
+    monkeypatch.setenv(ENV_POLICY, "scripted")
+    log_dir = tmp_path / "logs"
+    rc = main(["run", "--instruction", "reach the cube", "--log-dir", str(log_dir)])
+    assert rc == 0
+    assert "note: ignoring [policy.args] for 'scripted': they apply to 'noop'" in (
+        capsys.readouterr().err
+    )
+
+
 def test_mistyped_subcommand_never_starts_a_rollout(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -1027,6 +1115,34 @@ def test_doctor_uses_default_embodiment_and_guides_when_unset(
     monkeypatch.setenv(ENV_EMBODIMENT, "cubepick")
     assert main(["doctor"]) == 0
     assert "cubepick" in capsys.readouterr().out
+
+
+def test_doctor_ignores_config_args_for_a_different_embodiment(
+    _hermetic_defaults: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The issue-#44 repro: a lab machine's persisted rig args must not crash a
+    # conformance check of an unrelated, explicitly-selected embodiment.
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\nembodiment = yam-arms\n[embodiment.args]\nrest_pose = 0.5\n",
+    )
+    assert main(["doctor", "--embodiment", "cubepick"]) == 0
+    captured = capsys.readouterr()
+    assert "conformant" in captured.out
+    assert "note: ignoring [embodiment.args] for 'cubepick': they apply to 'yam-arms'" in (
+        captured.err
+    )
+
+
+def test_doctor_config_args_without_a_default_owner_never_apply(
+    _hermetic_defaults: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # An [embodiment.args] section with no [defaults] embodiment has no owner,
+    # so it applies to nothing (and says so).
+    _write_config(_hermetic_defaults, "[embodiment.args]\nrest_pose = 0.5\n")
+    assert main(["doctor", "--embodiment", "cubepick"]) == 0
+    err = capsys.readouterr().err
+    assert "no default embodiment is configured" in err
 
 
 def test_doctor_closes_the_embodiment_it_constructs() -> None:


### PR DESCRIPTION
## What

Fixes #44. The `[policy.args]` / `[embodiment.args]` / `[sim_embodiment.args]` config sections were applied to whatever component ended up selected, so a lab machine's persisted YAM calibration crashed `doctor --embodiment kitchen` with a foreign-kwarg TypeError.

Each args section now has an **owner**: the `[defaults]` component name in the same config file (`Defaults.*_args_owner`, set at parse time and untouched by env-var overrides). The CLI applies a section only when the selected component matches its owner, and otherwise drops it with a stderr note:

```
note: ignoring [embodiment.args] for 'kitchen': they apply to 'yam_arms'
```

## Why name-match instead of provenance-match

The issue suggested gating on selection source (flag vs config). That has a footgun: `--embodiment yam_arms` typed explicitly when yam_arms is also the config default would drop the rig calibration silently, and a real arm moving without its configured `rest_pose` is worse than the crash this fixes. Gating on the *name* keeps args whenever the selected component is the one they were written for, however it was selected.

## Behavior matrix

| Selection | Args applied? |
|---|---|
| config default (no flag) | yes (unchanged) |
| flag/env naming the same component as the config default | yes |
| flag/env naming a different component | no, stderr note |
| args section with no `[defaults]` name | never, stderr note |

## Verification

All gates green locally: 273 passed at 100% branch coverage, ruff check + format, strict mypy. New tests cover the leak (run + doctor), the name-match keep, the env-override case, and the ownerless section. Reproduced the exact issue scenario end-to-end before/after: TypeError on main, conformant + note on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)