### PR TITLE
docs: LLM-agent policy example in the quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ policy sees while the robot moves. CLI flags override any default
 (`--no-rerun`, `--no-store-frames`, `--max-steps 300`, ...).
 
 The policy slot is not limited to VLAs. With the
-[inspect-robots-agent](plugins/inspect-robots-agent) plugin installed
+[inspect-robots-agent](plugins/inspect-robots-agent/) plugin installed
 (`uv pip install inspect-robots-agent`) and `$ANTHROPIC_API_KEY` set, a
 frontier LLM drives the same rig through tool calls, one approver-checked
 motion chunk per call:

--- a/README.md
+++ b/README.md
@@ -97,8 +97,20 @@ uv run inspect-robots "place the fork on the plate"
 Every run opens a live Rerun viewer streaming the cameras, proprioception,
 and actions straight from the eval pipeline, so you watch exactly what the
 policy sees while the robot moves. CLI flags override any default
-(`--no-rerun`, `--no-store-frames`, `--max-steps 300`, ...), and the same
-instruction runs on your configured simulator instead of the real robot:
+(`--no-rerun`, `--no-store-frames`, `--max-steps 300`, ...).
+
+The policy slot is not limited to VLAs. With the
+[inspect-robots-agent](plugins/inspect-robots-agent) plugin installed
+(`uv pip install inspect-robots-agent`) and `$ANTHROPIC_API_KEY` set, a
+frontier LLM drives the same rig through tool calls, one approver-checked
+motion chunk per call:
+
+```bash
+uv run inspect-robots "place the fork on the plate" --policy agent -P model=anthropic/claude-fable-5
+```
+
+And the same instruction runs on your configured simulator instead of the
+real robot:
 
 ```bash
 uv run inspect-robots "place the fork on the plate" --sim


### PR DESCRIPTION
Adds a Fable-via-`agent`-policy example to the quickstart, between the real-robot ad-hoc run and its `--sim` variant:

```bash
uv run inspect-robots "place the fork on the plate" --policy agent -P model=anthropic/claude-fable-5
```

with the two prerequisites inline (`uv pip install inspect-robots-agent`, `$ANTHROPIC_API_KEY`). The surrounding paragraph was split so the Rerun/flag-override sentence keeps introducing the first block and a new sentence introduces the `--sim` block.

## Verification

- The exact command was run on a keyless machine: the instruction sugar composes with `--policy agent -P model=...`, resolves the plugin policy, and stops only at the guided missing-key error, confirming the syntax end to end.
- `ruff check`, `ruff format --check`, and the test suite pass locally (273 passed; the one skip is the rerun-sdk-gated test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)