### PR TITLE
feat(cli): inspect-robots setup — first-run wizard for defaults and camera discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- **`inspect-robots setup`**: an interactive first-run wizard that prompts
+  for the `[defaults]` keys with suggested values, discovers camera devices
+  under `/dev/v4l/by-id` (with unplug-to-identify and a `/dev/v4l/by-path`
+  fallback for serial-less cameras that collide in by-id), and writes
+  `~/.config/inspect-robots/config.ini`. An existing file is backed up to
+  `config.ini.bak` and unmanaged sections/keys are carried through
+  unchanged. Warns before writing `rerun = true` in a headless session
+  (part of #50).
 - Public-docstring coverage gate via Ruff's D1 rules, with a full backfill of
   missing public docstrings.
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,25 @@ below and no activation is needed.
 
 ## Quickstart
 
-Set your defaults once. The policy and embodiment come from installed plugins
-([inspect-robots-yam](https://github.com/robocurve/inspect-robots-yam) shown
-here); replace the three camera paths with your rig's V4L2 color nodes:
+Set your defaults once with the interactive wizard:
+
+```bash
+uv run inspect-robots setup
+```
+
+It walks you through the defaults (policy, embodiment, scorer, run length),
+lists the camera devices under `/dev/v4l/by-id`, and can tell you which
+physical camera is which: unplug one when asked and the wizard identifies it
+from the device that disappeared. Press Enter to accept the suggested values
+(the [inspect-robots-yam](https://github.com/robocurve/inspect-robots-yam)
+plugin shown below) or type your own; install the plugin whose components
+you configure (`uv pip install inspect-robots-yam`) or the wizard will warn
+that the names are not registered. The result lands in
+`~/.config/inspect-robots/config.ini`; note that later `inspect-robots
+config set` edits drop comments from that file.
+
+Prefer to write the file yourself? Replace the three camera paths with your
+rig's V4L2 color nodes:
 
 ```bash
 mkdir -p ~/.config/inspect-robots && cat > ~/.config/inspect-robots/config.ini <<'EOF'

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -6,8 +6,9 @@ for the common typo; both run the same CLI.
 
 ## Zero-config: `inspect-robots "<instruction>"`
 
-Once you have configured a default policy and embodiment (below), giving the
-robot a command is a one-liner:
+Once you have configured a default policy and embodiment (run
+`inspect-robots setup`, or see below), giving the robot a command is a
+one-liner:
 
 ```bash
 inspect-robots "place the spoon on the plate"
@@ -97,6 +98,29 @@ and records the verdict in the log (`skip` records nothing). Piped/CI
 stdin, `--no-prompt`, or a registered `--task` run never prompt: unattended
 runs stay non-blocking, and an unjudged trial honestly scores as failure with
 "no operator judgement recorded".
+
+## `inspect-robots setup`
+
+The interactive first-run wizard: it prompts for each `[defaults]` key with
+a suggested value (Enter accepts, typing overrides), warns when a chosen
+policy or embodiment is not registered in the current environment, and then
+helps assign camera devices by listing `/dev/v4l/by-id`. If you do not know
+which physical camera a device path belongs to, answer `u` and unplug that
+camera when asked: the wizard rescans and identifies it from the entry that
+disappeared. When identical cameras without serial numbers collide in the
+by-id listing, `p` switches to `/dev/v4l/by-path` names, which are stable
+per physical USB port.
+
+```bash
+inspect-robots setup
+```
+
+The result is written to `~/.config/inspect-robots/config.ini`
+(`$XDG_CONFIG_HOME` honored); an existing file is backed up to
+`config.ini.bak` first, and settings the wizard does not manage (such as
+`[policy.args]` or `sim_embodiment`) are carried through unchanged. The
+command requires an interactive terminal; for scripted configuration use
+`inspect-robots config set`.
 
 ## `inspect-robots list`
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -54,6 +54,10 @@ from inspect_robots import eval
 
 ## From the command line
 
+On a real rig, configure defaults once with the interactive wizard
+(`inspect-robots setup`, covered in [the CLI guide](cli.md)). The explicit
+form below needs no configuration:
+
 ```bash
 inspect-robots list                                          # all registered components
 inspect-robots list policies                                 # just policies

--- a/plans/0009-setup-wizard.md
+++ b/plans/0009-setup-wizard.md
@@ -371,6 +371,25 @@ patterns).
   style) and that the heredoc block content is unchanged.
 - [ ] Commit `docs: point quickstart at inspect-robots setup`.
 
+### Task 5.5: headless rerun warning (issue #50 ingestion)
+
+Added mid-implementation after field report #50 (five first-run failures on
+a real rig). Only its item 4 (display probe) plus the docs follow-up fit
+this plan's scope; items 1-3 and 5-7 (import preflight, version skew, CAN
+and policy-server probes) are `doctor` follow-ups tracked on #50.
+
+**Files:** modify `src/inspect_robots/_setup.py`, `tests/test_setup.py`.
+
+- [ ] When the wizard reaches the `rerun` prompt and neither `DISPLAY` nor
+  `WAYLAND_DISPLAY` is present in `env`, the suggested default flips to
+  `false` and one line explains why ("no display detected (SSH?): the
+  rerun viewer cannot open here; frames still record with
+  store_frames"). The user can still type `true`. Tests: headless env →
+  default false + note printed; env with DISPLAY → default true, no note;
+  headless but existing config says `rerun = true` → existing value still
+  wins the default (§3.1.3) yet the note is printed.
+- [ ] Gates + commit `feat(setup): warn when rerun is enabled headless`.
+
 ### Task 6: end-to-end sanity + PR
 
 - [ ] `uv sync --all-packages --extra dev` in the worktree, then full gates:

--- a/plans/0009-setup-wizard.md
+++ b/plans/0009-setup-wizard.md
@@ -1,0 +1,383 @@
+# 0009 — `inspect-robots setup`: first-run wizard for defaults and camera discovery
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the README's error-prone heredoc quickstart with an
+interactive `inspect-robots setup` wizard that discovers V4L2 camera device
+paths, offers the documented defaults (`molmoact2`, `yam_arms`, ...), and
+writes `~/.config/inspect-robots/config.ini`.
+
+**Architecture:** A new stdlib-only module `src/inspect_robots/_setup.py`
+holds the wizard with all IO injected (env mapping, `input_fn`, output
+stream, V4L2 directory paths) so every branch is unit-testable to the 100%
+coverage gate. `cli.py` grows a thin `setup` subcommand that wires real IO.
+The README and docs point first-time users at the wizard; the manual heredoc
+stays as a fallback.
+
+**Tech stack:** Python stdlib only (`configparser`, `pathlib`); no new deps
+(core stays NumPy-only, and the wizard itself imports no NumPy).
+
+## 1. Motivation
+
+The README quickstart asks users to paste a heredoc and hand-edit three
+placeholder paths (`/dev/v4l/by-id/YOUR-TOP-CAM`, ...). First-time users have
+no idea which of the `/dev/v4l/by-id/` entries is which physical camera, or
+that the `-video-index0` node is the color stream while `-video-index1` is
+UVC metadata. That is the highest-friction step of onboarding and the wizard
+removes it:
+
+```text
+$ uv run inspect-robots setup
+inspect-robots setup — writes ~/.config/inspect-robots/config.ini
+
+policy [molmoact2]:                      # Enter accepts the suggestion
+embodiment [yam_arms]:
+scorer [success_at_end]:
+max steps [1200]:
+live rerun viewer [true]:
+store camera frames [true]:
+
+Found 3 camera device(s) under /dev/v4l/by-id:
+  1. usb-Global_Shutter_Camera_01-video-index0
+  2. usb-Global_Shutter_Camera_02-video-index0
+  3. usb-Global_Shutter_Camera_03-video-index0
+top camera — number, 'u' to identify by unplugging, 's' to skip: u
+  Unplug the top camera now, then press Enter...
+  That was: usb-Global_Shutter_Camera_02-video-index0
+  Plug it back in, then press Enter... ok
+left camera — number, 'u' to identify by unplugging, 's' to skip: 1
+right camera — number, 'u' to identify by unplugging, 's' to skip: 3
+
+Wrote /home/user/.config/inspect-robots/config.ini
+Next: uv run inspect-robots "place the fork on the plate"
+```
+
+## 2. What exists today (grounding)
+
+- `_defaults.py`: `_config_path(env)` resolves the config file location from
+  `$XDG_CONFIG_HOME`/`$HOME`; `_read_config(path) -> Defaults` parses and
+  validates it (raising `SystemExit` on malformed input); `set_default(env,
+  key, value)` atomically writes one `[defaults]` key and round-trips
+  unknown sections; `parse_value` / `CONFIG_KEYS` back validation. Note
+  `_parse_args_section` expands `~` on read, so `Defaults` is **not** a
+  faithful representation of the file text.
+- `cli.py`: argparse subcommands `list` / `run` / `inspect` / `config` /
+  `doctor`, dispatched from `main()` via `args.command`; the
+  `_SUBCOMMANDS` tuple (cli.py:80) backs the zero-config sugar guard.
+  Registry imports are deliberately lazy (function-local). `_pick_component`
+  prints "fix: ... or run 'inspect-robots config set ...'" when no default
+  exists; `tests/test_registry_cli.py:918` asserts on that message.
+- CLI tests live in `tests/test_registry_cli.py` (there is no
+  `tests/test_cli.py`).
+- README "Quickstart" (lines ~70-95): the heredoc this plan replaces.
+  `docs/guide/quickstart.md` ("From the command line", ~lines 55-63) and
+  `docs/guide/cli.md` (one `##` section per subcommand; config resolution
+  order at line ~34) are the docs-site counterparts.
+- The yam rig (`inspect-robots-yam` plugin, separate repo) reads
+  `[embodiment.args]` keys `top_cam_device` / `left_cam_device` /
+  `right_cam_device` as plain strings and **raises `ValueError` unless the
+  three are set all-or-none** (`YamConfig.__post_init__`). Users also keep
+  non-camera keys in `[embodiment.args]` (e.g. `cameras = wrist,front` in
+  docs/guide/cli.md, `left_channel` in the `config set` round-trip test).
+- Gates: `ruff check`, `ruff format --check`, `mypy --strict` (src **and**
+  tests), `pytest --cov` with branch coverage `fail_under = 100`. Core
+  stays NumPy-only.
+
+## 3. Design
+
+### 3.1 UX decisions (binding)
+
+1. **Interactive only.** `setup` on a non-TTY stdin exits with
+   `SystemExit("setup is interactive; see the README for manual config")`.
+   No `--yes` mode (YAGNI; `config set` already covers scripting).
+2. **Suggested defaults are prompt placeholders, not hard requirements.**
+   Constants mirror the README: `policy=molmoact2`, `embodiment=yam_arms`,
+   `scorer=success_at_end`, `max_steps=1200`, `rerun=true`,
+   `store_frames=true`. Pressing Enter accepts; typing overrides. If an
+   entered (or accepted) policy/embodiment name is not in the registry, the
+   wizard **warns** ("'molmoact2' is not registered here — install its
+   plugin, e.g. `uv pip install inspect-robots-yam`") but accepts it, since
+   users often configure before installing plugins. No `sim_embodiment`
+   prompt (YAGNI; `config set sim_embodiment` exists).
+3. **Existing config wins over built-in suggestions.** If the file exists
+   and parses, its current values become the prompt defaults, and the old
+   file is backed up to `config.ini.bak` before the new one replaces it
+   (atomic tmp+rename, same pattern as `set_default`). If the existing file
+   is **malformed**, the wizard must not die (it is the
+   obvious repair tool): it prints the parse error and asks "Back up the
+   broken file and start fresh? [Y/n]" — yes proceeds with built-in
+   suggestions, no aborts without writing. This repair prompt covers only
+   files `configparser` cannot parse; a parseable file with a
+   **type-invalid value** (e.g. `max_steps = abc`) is handled per prompt:
+   the raw value is used as the prompt default only when it passes that
+   prompt's validation, otherwise the built-in suggestion is shown with a
+   one-line note ("ignoring invalid max_steps 'abc' from config.ini") and
+   the rest of the file is untouched.
+4. **Validated re-prompt.** `max_steps` must parse as int >= 1; booleans
+   must parse as bool (via the existing `parse_value`). Invalid input prints
+   the constraint and re-asks (no crash, no silent acceptance).
+5. **Camera discovery scans `/dev/v4l/by-id` first, `/dev/v4l/by-path` as
+   fallback.** Prefer entries ending in `-video-index0` (the color node;
+   `-index1` is UVC metadata), falling back to all entries when none match
+   that suffix. Identical serial-less cameras **collide** in by-id (udev
+   derives the name from vendor/model/serial, last writer wins), so: when
+   the index0-filtered by-path listing has more entries than by-id, the
+   wizard prints one explanatory line ("only N by-id entries for M detected
+   cameras — identical cameras without serials collide there; by-path names
+   are stable per physical USB port") and role prompts accept `p` to switch
+   the listing to by-path. If neither directory yields devices, print why
+   ("no /dev/v4l devices found (not Linux, or no cameras attached)") and
+   offer manual path entry or skip. The camera section is offered with
+   default **yes** when devices were found or the existing config already
+   has `*_cam_device` keys, default **no** otherwise.
+6. **Role assignment.** For each role (top/left/right) the prompt accepts:
+   a device number; `u` (unplug-to-identify: rescan, the disappeared entry
+   is the answer; if zero or 2+ entries disappeared, explain and re-ask;
+   then ask to replug and rescan — if the device has not returned, offer
+   one "press Enter to rescan" retry before warning and keeping the
+   assignment); `p` (toggle by-id/by-path listing — always accepted, but
+   advertised in the prompt text only when §3.1.5's collision heuristic
+   fired, i.e. the index0-filtered by-path listing has more entries than
+   by-id, which is why the §1 transcript shows the shorter prompt); `s`
+   (skip); or a
+   literal absolute path (accepted with only an advisory warning when the
+   path does not exist locally, since configs are often written on a dev
+   box). A pre-existing assignment for the role is the Enter-accept
+   default, shown as "(current)" — or "(current, not detected)" when it is
+   absent from the scan. Assigning one device to two roles triggers a
+   warning plus confirm; declining re-asks.
+7. **All-three-or-none cameras.** The yam plugin rejects partial camera
+   sets, so if the user ends the section with 1 or 2 roles assigned the
+   wizard says so ("yam_arms needs all three cameras or none; writing
+   none") and asks: go back to the camera section, or write the config
+   without any `*_cam_device` keys. It never writes a partial set.
+8. **The wizard renders the file itself and carries unmanaged content
+   through raw.** The final INI is rendered from a template with the same
+   explanatory comments as the README block (comments survive because we
+   render text, not `configparser.write`). Managed content is the
+   `[defaults]` keys the wizard prompts for and the three `*_cam_device`
+   keys in `[embodiment.args]`; skipped managed keys are omitted.
+   Everything else — other sections (`[policy.args]`, ...), non-camera
+   keys inside `[embodiment.args]`, **and unmanaged keys inside
+   `[defaults]` itself** (e.g. a `sim_embodiment` set earlier via
+   `config set`) — is carried through verbatim from a **separate raw
+   read** of the existing file:
+   `ConfigParser(interpolation=None, inline_comment_prefixes=(";", "#"))`,
+   raw string values, no `~` expansion, no `parse_value` (reusing
+   `_read_config`/`_parse_args_section` here would bake in expanded home
+   paths and re-case booleans). `%` in values must not crash the wizard.
+   Comment loss in carried-through sections is the documented trade-off;
+   `.bak` is the recovery hatch.
+9. **Ctrl-C / Ctrl-D abort cleanly**: `EOFError`/`KeyboardInterrupt` from
+   `input_fn` exit with "setup aborted; nothing written" (exit code 1) and
+   never leave a partial file (the write happens once, at the end).
+
+### 3.2 Module: `src/inspect_robots/_setup.py`
+
+Everything the wizard touches is injected, mirroring how `_defaults.py`
+takes `env`:
+
+```python
+SUGGESTED = {
+    "policy": "molmoact2",
+    "embodiment": "yam_arms",
+    "scorer": "success_at_end",
+    "max_steps": "1200",
+    "rerun": "true",
+    "store_frames": "true",
+}
+CAM_ROLES = ("top", "left", "right")  # -> {role}_cam_device in [embodiment.args]
+V4L_BY_ID = Path("/dev/v4l/by-id")
+V4L_BY_PATH = Path("/dev/v4l/by-path")
+
+def run_setup(
+    env: Mapping[str, str],
+    *,
+    input_fn: Callable[[str], str],
+    out: IO[str],
+    interactive: bool,
+    by_id_dir: Path = V4L_BY_ID,
+    by_path_dir: Path = V4L_BY_PATH,
+) -> int:
+    """Drive the wizard; returns process exit code."""
+
+def _scan_cameras(v4l_dir: Path) -> list[str]:
+    """Sorted absolute device paths; -video-index0 entries preferred."""
+
+def _identify_by_replug(role, devices, *, input_fn, out, rescan) -> str | None:
+    """The unplug/replug diff; rescan is a zero-arg callable for testability."""
+
+def _read_raw_config(path: Path) -> dict[str, dict[str, str]] | str:
+    """Raw section->key->string map (interpolation off).
+
+    Unparseable file -> the parse-error text (so the repair prompt of
+    UX decision 3 can show it), never an exception.
+    """
+
+def _render_config(defaults: dict[str, str], embodiment_args: dict[str, str],
+                   carried: dict[str, dict[str, str]]) -> str:
+    """Full config.ini text, commented like the README block."""
+```
+
+Internal prompt helpers (`_ask(prompt, default, validate)`) loop until valid.
+`registered` from `inspect_robots.registry` is imported lazily inside the
+one function that warns about unregistered names, keeping import cost and
+the NumPy-only-core CI job unaffected.
+
+### 3.3 CLI integration (`cli.py`)
+
+- `sub.add_parser("setup", help="interactive first-run wizard: pick defaults "
+  "and discover camera devices, then write config.ini")` — no arguments.
+- `main()` dispatch: `if args.command == "setup": return _cmd_setup()` where
+  `_cmd_setup` calls `run_setup(os.environ, input_fn=input, out=sys.stdout,
+  interactive=sys.stdin.isatty())`.
+- Add `"setup"` to the `_SUBCOMMANDS` tuple (cli.py:80).
+- `_pick_component`'s guidance string gains the wizard:
+  `"fix: pass --{kind} NAME, set ${...}, run 'inspect-robots setup', or
+  'inspect-robots config set {kind} NAME'"` (keeps the exact substring
+  `inspect-robots config set` that `tests/test_registry_cli.py:918`
+  asserts on; extend that test to also expect `inspect-robots setup`).
+  `_pick_sim_embodiment`'s message stays unchanged (the wizard does not
+  configure `sim_embodiment`).
+- Module docstring subcommand list gains one line for `setup`.
+
+### 3.4 README and docs
+
+- README Quickstart: lead with
+  ```bash
+  uv run inspect-robots setup
+  ```
+  and one short paragraph: walks you through defaults, lists the cameras
+  under `/dev/v4l/by-id`, and can identify which is which when you unplug
+  one; writes `~/.config/inspect-robots/config.ini`. One sentence notes
+  that later `inspect-robots config set` edits drop comments from the file
+  (already the documented `set_default` trade-off). The existing heredoc
+  moves under a "Prefer to write the file yourself?" line, content
+  unchanged. Style rules apply (no em dashes in prose, no mid-sentence
+  bold, headers use colons).
+- `docs/guide/cli.md`: add a new `## inspect-robots setup` section (the
+  page is one `##` per subcommand; there is no single list to append to).
+- `docs/guide/quickstart.md`: mention `inspect-robots setup` in the "From
+  the command line" section.
+- `CHANGELOG.md`: one "Added" entry.
+- `src/inspect_robots/CLAUDE.md` module map: add `_setup.py` row; extend the
+  `cli.py` row's subcommand list.
+
+## 4. Non-goals (YAGNI)
+
+- No camera **preview** (needs OpenCV; core is NumPy-only). Unplug-diff
+  identification is dependency-free and unambiguous.
+- No plugin-provided setup hooks / entry points. The three yam camera roles
+  are constants here; a second embodiment plugin with different args is the
+  trigger to generalize.
+- No `--non-interactive` / `--yes` flags; `config set` is the scripting API.
+- No `sim_embodiment` prompt; `config set sim_embodiment` covers it.
+- No Windows camera support (`/dev/v4l` is Linux; on other OSes the wizard
+  still configures `[defaults]` and offers manual path entry).
+
+## 5. Tasks
+
+### Task 1: scan + raw-read + render (pure helpers)
+
+**Files:** create `src/inspect_robots/_setup.py`, `tests/test_setup.py`.
+
+- [ ] Failing tests — `_scan_cameras`: index0 filtering (mixed
+  index0/index1 dir → only index0, sorted); fallback (no index0 suffix →
+  all entries); missing dir → `[]`. `_read_raw_config`: raw `%` value
+  survives (no interpolation error); `~` paths stay literal; malformed file
+  → the parse-error string. `_render_config`: golden test (full defaults +
+  3 cams → exact INI text, comments included); omits skipped managed keys
+  and empty sections; carries through an unknown `[policy.args]` section,
+  a non-camera `[embodiment.args]` key (e.g. `left_channel = can2`)
+  alongside newly assigned cam keys, **and** an unmanaged `[defaults]`
+  key (`sim_embodiment = cubepick`).
+- [ ] Implement; `uv run pytest tests/test_setup.py -v` passes.
+- [ ] Gates: `uv run ruff check . && uv run mypy`.
+- [ ] Commit `feat(setup): camera scan + config rendering helpers`.
+
+### Task 2: prompt loop + `run_setup` happy path
+
+**Files:** modify `src/inspect_robots/_setup.py`, `tests/test_setup.py`.
+
+- [ ] Failing tests drive `run_setup` with a scripted `input_fn` (pop from a
+  list) and `io.StringIO` out, `by_id_dir`/`by_path_dir` pointed at
+  `tmp_path` dirs, `XDG_CONFIG_HOME` in `env` pointed at `tmp_path`:
+  all-Enter run writes the README-equivalent config; typed overrides land
+  in the file; invalid `max_steps` ("abc", "0") re-prompts;
+  non-interactive → `SystemExit`; EOF mid-wizard → exit 1, no file
+  written; existing valid config: values become prompt defaults and `.bak`
+  is created; existing **malformed** config: repair prompt shows the parse
+  error (yes → fresh suggestions + `.bak`, no → abort, nothing written);
+  parseable config with type-invalid `max_steps = abc` → built-in
+  suggestion offered with the "ignoring invalid" note, other keys still
+  used; unregistered-name warning text appears (registry check
+  monkeypatched); registered name → no warning; non-camera
+  `[embodiment.args]` keys **and** an unmanaged `sim_embodiment` in
+  `[defaults]` survive the rewrite; all-three-or-none guard: ending the
+  camera section with 1 or 2 roles assigned → the message plus both
+  branches ("go back" re-enters the section; "write none" writes a config
+  with zero `*_cam_device` keys).
+- [ ] Implement prompt helpers + `run_setup` minus camera interactivity
+  (camera section: number pick + manual path with advisory-only existence
+  warning + skip + the all-three-or-none guard of §3.1.7).
+- [ ] Gates + commit `feat(setup): interactive wizard core`.
+
+### Task 3: unplug-to-identify, by-path toggle, duplicate guard
+
+**Files:** modify `src/inspect_robots/_setup.py`, `tests/test_setup.py`.
+
+- [ ] Failing tests: `u` flow where rescan (injected callable returning
+  shrinking then restored lists) identifies the missing device; zero or 2+
+  devices missing → explanatory message, re-prompt; replug not detected →
+  one extra Enter-to-rescan retry, then warning but assignment kept; `p`
+  toggles the listing to by-path and back, and the prompt text mentions
+  `p` only when the index0-filtered by-path listing has more entries than
+  by-id (it is accepted regardless); by-id shorter than by-path → the
+  collision explainer line is printed; same device picked twice →
+  confirm prompt, 'n' re-asks; pre-existing assignment shown as
+  "(current)" Enter-accept default, and "(current, not detected)" when
+  absent from the scan.
+- [ ] Implement `_identify_by_replug`, the `p` toggle, and wire into the
+  role prompt.
+- [ ] Gates + commit `feat(setup): unplug-to-identify cameras`.
+
+### Task 4: CLI wiring
+
+**Files:** modify `src/inspect_robots/cli.py`,
+`tests/test_registry_cli.py` (the existing CLI test module; follow its
+patterns).
+
+- [ ] Failing tests: `inspect-robots setup` with patched stdin-isatty=False
+  → the interactive-only SystemExit; dispatch reaches `run_setup` (monkey-
+  patched) and returns its code; `--help` lists setup; the
+  `_pick_component` error-message test now also expects
+  `inspect-robots setup`; `_SUBCOMMANDS` contains `"setup"`.
+- [ ] Implement subparser, `_cmd_setup`, `_SUBCOMMANDS` entry, docstring
+  line, guidance string.
+- [ ] Gates incl. full `uv run pytest --cov` (100%) + commit
+  `feat(cli): setup subcommand`.
+
+### Task 5: README, docs, changelog, module map
+
+**Files:** modify `README.md`, `docs/guide/cli.md`,
+`docs/guide/quickstart.md`, `CHANGELOG.md`, `src/inspect_robots/CLAUDE.md`.
+
+- [ ] Rewrite Quickstart per §3.4 (setup first, heredoc as fallback,
+  comment-loss sentence), add the `## inspect-robots setup` docs section,
+  quickstart-guide mention, changelog entry, module-map row.
+- [ ] Check the README writing-style rules (no em dashes in prose, header
+  style) and that the heredoc block content is unchanged.
+- [ ] Commit `docs: point quickstart at inspect-robots setup`.
+
+### Task 6: end-to-end sanity + PR
+
+- [ ] `uv sync --all-packages --extra dev` in the worktree, then full gates:
+  `ruff check .`, `ruff format --check .`, `mypy`, `pytest --cov`
+  (must report 100% with branch coverage).
+- [ ] Manual smoke: `uv run inspect-robots setup` with `XDG_CONFIG_HOME`
+  pointed at a temp dir (macOS: camera section reports no devices and
+  offers manual entry — expected).
+- [ ] Push branch `feat/setup-wizard`, open PR; `ci-ok` is the required
+  check.

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -26,8 +26,9 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `log.py` | immutable, schema-versioned `EvalLog` + `read_eval_log` |
 | `logging/` | `LogSink` protocol, `JsonLogSink` (atomic), optional `RerunSink` |
 | `registry.py` | decorators + entry-point discovery; `_builtins.py` registers in-tree components |
-| `cli.py` | `inspect-robots list` / `run` / `inspect` / `config set|show` / `doctor` (adapter conformance), plus the zero-config form `inspect-robots "<instruction>"` (ad-hoc single-scene task; operator prompt on TTY). Every run wires guardrails (Clamp + DeltaLimit) by default; `--disable-guardrails` is the loud opt-out and the chain degrades per component with stderr warnings |
+| `cli.py` | `inspect-robots list` / `run` / `inspect` / `config set|show` / `setup` (first-run wizard) / `doctor` (adapter conformance), plus the zero-config form `inspect-robots "<instruction>"` (ad-hoc single-scene task; operator prompt on TTY). Every run wires guardrails (Clamp + DeltaLimit) by default; `--disable-guardrails` is the loud opt-out and the chain degrades per component with stderr warnings |
 | `_defaults.py` | user default policy/embodiment (+ `--sim` counterpart) for the zero-config CLI: env vars > `~/.config/inspect-robots/config.ini` (INI — py3.10 has no tomllib; deliberately no project-local file); `set_default` backs `config set` |
+| `_setup.py` | the `inspect-robots setup` wizard (plan 0009): IO-injected prompts for `[defaults]`, V4L2 camera discovery (by-id, by-path fallback, unplug-to-identify), headless-rerun warning; renders config.ini itself (comments survive) and carries unmanaged sections/keys through raw |
 | `mock/` | dependency-free `CubePick` world + scripted/random/noop policies |
 
 ## Key invariants

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -251,7 +251,9 @@ def _prompt_camera_role(
                 continue
         elif not entered and current is not None:
             selected = current
-        elif entered.startswith("/"):
+        elif entered.startswith("/") or Path(entered).is_absolute():
+            # startswith("/") keeps POSIX rig paths accepted on Windows
+            # workstations, where "/dev/v4l/..." is not drive-absolute.
             if not Path(entered).exists():
                 print(
                     f"warning: {entered} does not exist here "

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -1,13 +1,13 @@
-"""Pure support for the ``inspect-robots setup`` wizard from plan 0009.
-
-Task 1 ships only camera scanning, raw config reading, and commented config
-rendering. The IO-driven wizard that composes these helpers comes later.
-"""
+"""Pure, IO-injected support for the ``inspect-robots setup`` wizard."""
 
 from __future__ import annotations
 
 import configparser
+from collections.abc import Callable, Mapping
 from pathlib import Path
+from typing import IO
+
+from inspect_robots._defaults import _config_path, parse_value
 
 SUGGESTED: dict[str, str] = {
     "policy": "molmoact2",
@@ -28,6 +28,198 @@ _DEFAULT_COMMENTS: dict[str, str] = {
     "rerun": "live viewer of cameras/state/actions each run",
     "store_frames": "save each run's camera frames under logs/frames/",
 }
+_PROMPT_LABELS: dict[str, str] = {
+    "policy": "policy",
+    "embodiment": "embodiment",
+    "scorer": "scorer",
+    "max_steps": "max steps",
+    "rerun": "live rerun viewer",
+    "store_frames": "store camera frames",
+}
+
+_Validator = Callable[[str], bool]
+
+
+def _valid_text(_value: str) -> bool:
+    return True
+
+
+def _valid_max_steps(value: str) -> bool:
+    parsed = parse_value(value)
+    return isinstance(parsed, int) and not isinstance(parsed, bool) and parsed >= 1
+
+
+def _valid_bool(value: str) -> bool:
+    return isinstance(parse_value(value), bool)
+
+
+def _ask(
+    prompt: str,
+    default: str,
+    validate: _Validator,
+    constraint: str,
+    *,
+    input_fn: Callable[[str], str],
+    out: IO[str],
+) -> str:
+    """Ask for one value, accepting Enter as the displayed default."""
+    while True:
+        entered = input_fn(f"{prompt} [{default}]: ")
+        value = entered if entered else default
+        if validate(value):
+            return value
+        print(constraint, file=out)
+
+
+def _ask_yes_no(
+    prompt: str,
+    default: bool,
+    *,
+    input_fn: Callable[[str], str],
+    out: IO[str],
+) -> bool:
+    """Ask a conventional yes/no question, re-prompting unclear answers."""
+    suffix = "[Y/n]" if default else "[y/N]"
+    while True:
+        entered = input_fn(f"{prompt} {suffix} ").strip().lower()
+        if not entered:
+            return default
+        if entered in ("y", "yes"):
+            return True
+        if entered in ("n", "no"):
+            return False
+        print("please answer yes or no", file=out)
+
+
+def _warn_unregistered(kind: str, name: str, out: IO[str]) -> None:
+    """Warn about unavailable plugins without importing the registry eagerly."""
+    from inspect_robots.registry import registered
+
+    if name not in registered(kind):
+        print(
+            f"'{name}' is not registered here — install its plugin, e.g. "
+            "`uv pip install inspect-robots-yam`",
+            file=out,
+        )
+
+
+def _prompt_defaults(
+    carried: dict[str, dict[str, str]],
+    *,
+    input_fn: Callable[[str], str],
+    out: IO[str],
+) -> dict[str, str]:
+    """Prompt for managed defaults, using valid raw config values first."""
+    validators: dict[str, tuple[_Validator, str]] = {
+        "policy": (_valid_text, ""),
+        "embodiment": (_valid_text, ""),
+        "scorer": (_valid_text, ""),
+        "max_steps": (_valid_max_steps, "max_steps must be an integer >= 1"),
+        "rerun": (_valid_bool, "rerun must be true or false"),
+        "store_frames": (_valid_bool, "store_frames must be true or false"),
+    }
+    raw_defaults = carried.get("defaults", {})
+    defaults: dict[str, str] = {}
+    for key, suggestion in SUGGESTED.items():
+        validate, constraint = validators[key]
+        default = suggestion
+        if key in raw_defaults:
+            configured = raw_defaults[key]
+            if validate(configured):
+                default = configured
+            else:
+                print(f"ignoring invalid {key} {configured!r} from config.ini", file=out)
+        value = _ask(
+            _PROMPT_LABELS[key],
+            default,
+            validate,
+            constraint,
+            input_fn=input_fn,
+            out=out,
+        )
+        defaults[key] = value
+        if key in ("policy", "embodiment"):
+            _warn_unregistered(key, value, out)
+    return defaults
+
+
+def _print_camera_listing(devices: list[str], directory: Path, out: IO[str]) -> None:
+    print(f"Found {len(devices)} camera device(s) under {directory}:", file=out)
+    for number, device in enumerate(devices, start=1):
+        print(f"  {number}. {Path(device).name}", file=out)
+
+
+def _prompt_camera_role(
+    role: str,
+    devices: list[str],
+    *,
+    input_fn: Callable[[str], str],
+    out: IO[str],
+) -> str | None:
+    """Prompt for a numbered device, an absolute path, or a skipped role."""
+    prompt = f"{role} camera — number, absolute path, or 's' to skip: "
+    while True:
+        entered = input_fn(prompt).strip()
+        if entered.lower() == "s":
+            return None
+        if entered.startswith("/"):
+            if not Path(entered).exists():
+                print(
+                    f"warning: {entered} does not exist here "
+                    "(ok if this config is for another machine)",
+                    file=out,
+                )
+            return entered
+        if entered.isdigit():
+            number = int(entered)
+            if 1 <= number <= len(devices):
+                return devices[number - 1]
+        print("enter a device number, absolute path, or 's' to skip", file=out)
+
+
+def _camera_section(
+    carried: dict[str, dict[str, str]],
+    by_id_dir: Path,
+    by_path_dir: Path,
+    *,
+    input_fn: Callable[[str], str],
+    out: IO[str],
+) -> dict[str, str]:
+    """Offer and collect the Task 2 camera assignments."""
+    devices = _scan_cameras(by_id_dir)
+    device_dir = by_id_dir
+    if not devices:
+        devices = _scan_cameras(by_path_dir)
+        device_dir = by_path_dir
+
+    camera_keys = tuple(f"{role}_cam_device" for role in CAM_ROLES)
+    existing_args = carried.get("embodiment.args", {})
+    default_enabled = bool(devices) or any(key in existing_args for key in camera_keys)
+    if not _ask_yes_no("Configure cameras?", default_enabled, input_fn=input_fn, out=out):
+        return {}
+
+    if devices:
+        _print_camera_listing(devices, device_dir, out)
+    else:
+        print(
+            "no /dev/v4l devices found (not Linux, or no cameras attached)",
+            file=out,
+        )
+
+    while True:
+        assignments: dict[str, str] = {}
+        for role in CAM_ROLES:
+            selected = _prompt_camera_role(role, devices, input_fn=input_fn, out=out)
+            if selected is not None:
+                assignments[f"{role}_cam_device"] = selected
+        if len(assignments) in (0, len(CAM_ROLES)):
+            return assignments
+        print(
+            "yam_arms needs all three cameras or none; writing none unless you go back",
+            file=out,
+        )
+        if not _ask_yes_no("Go back and choose cameras again?", True, input_fn=input_fn, out=out):
+            return {}
 
 
 def _scan_cameras(v4l_dir: Path) -> list[str]:
@@ -95,3 +287,61 @@ def _render_config(
             sections.append(f"[{section}]\n" + "\n".join(lines))
 
     return "\n\n".join(sections) + "\n"
+
+
+def run_setup(
+    env: Mapping[str, str],
+    *,
+    input_fn: Callable[[str], str],
+    out: IO[str],
+    interactive: bool,
+    by_id_dir: Path = V4L_BY_ID,
+    by_path_dir: Path = V4L_BY_PATH,
+) -> int:
+    """Drive the interactive setup wizard and return its process exit code."""
+    if not interactive:
+        raise SystemExit("setup is interactive; see the README for manual config")
+
+    path = _config_path(env)
+    if path is None:
+        raise SystemExit("cannot locate a config home: set $XDG_CONFIG_HOME or $HOME")
+
+    try:
+        carried: dict[str, dict[str, str]] = {}
+        if path.is_file():
+            raw_config = _read_raw_config(path)
+            if isinstance(raw_config, str):
+                print(raw_config, file=out)
+                repair = _ask_yes_no(
+                    "Back up the broken file and start fresh?",
+                    True,
+                    input_fn=input_fn,
+                    out=out,
+                )
+                if not repair:
+                    return 1
+            else:
+                carried = raw_config
+
+        defaults = _prompt_defaults(carried, input_fn=input_fn, out=out)
+        embodiment_args = _camera_section(
+            carried,
+            by_id_dir,
+            by_path_dir,
+            input_fn=input_fn,
+            out=out,
+        )
+    except (EOFError, KeyboardInterrupt):
+        print("setup aborted; nothing written", file=out)
+        return 1
+
+    text = _render_config(defaults, embodiment_args, carried)
+    if path.is_file():
+        path.replace(path.with_name(path.name + ".bak"))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    tmp.replace(path)
+    print(f"Wrote {path}", file=out)
+    print('Next: uv run inspect-robots "place the fork on the plate"', file=out)
+    return 0

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -1,0 +1,97 @@
+"""Pure support for the ``inspect-robots setup`` wizard from plan 0009.
+
+Task 1 ships only camera scanning, raw config reading, and commented config
+rendering. The IO-driven wizard that composes these helpers comes later.
+"""
+
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+
+SUGGESTED: dict[str, str] = {
+    "policy": "molmoact2",
+    "embodiment": "yam_arms",
+    "scorer": "success_at_end",
+    "max_steps": "1200",
+    "rerun": "true",
+    "store_frames": "true",
+}
+CAM_ROLES: tuple[str, ...] = ("top", "left", "right")  # -> {role}_cam_device in [embodiment.args]
+V4L_BY_ID: Path = Path("/dev/v4l/by-id")
+V4L_BY_PATH: Path = Path("/dev/v4l/by-path")
+
+_DEFAULT_COMMENTS: dict[str, str] = {
+    "policy": "from the inspect-robots-yam plugin",
+    "embodiment": "same plugin; cameras configured below",
+    "max_steps": "120 s at 10 Hz",
+    "rerun": "live viewer of cameras/state/actions each run",
+    "store_frames": "save each run's camera frames under logs/frames/",
+}
+
+
+def _scan_cameras(v4l_dir: Path) -> list[str]:
+    """Return sorted device paths, preferring V4L2 color-stream entries."""
+    try:
+        entries = sorted(v4l_dir.iterdir())
+    except FileNotFoundError:
+        return []
+    color_entries = [entry for entry in entries if entry.name.endswith("-video-index0")]
+    return [str(entry) for entry in color_entries or entries]
+
+
+def _read_raw_config(path: Path) -> dict[str, dict[str, str]] | str:
+    """Read raw section values, returning parse-error text instead of raising."""
+    parser = configparser.ConfigParser(
+        interpolation=None,
+        inline_comment_prefixes=(";", "#"),
+    )
+    try:
+        with path.open(encoding="utf-8") as config_file:
+            parser.read_file(config_file)
+    except (configparser.Error, UnicodeDecodeError) as exc:
+        return str(exc)
+    return {section: dict(parser.items(section, raw=True)) for section in parser.sections()}
+
+
+def _render_config(
+    defaults: dict[str, str],
+    embodiment_args: dict[str, str],
+    carried: dict[str, dict[str, str]],
+) -> str:
+    """Render a full commented config while carrying unmanaged raw values."""
+    sections: list[str] = []
+
+    default_lines: list[str] = []
+    for key in SUGGESTED:
+        if key not in defaults:
+            continue
+        line = f"{key} = {defaults[key]}"
+        if comment := _DEFAULT_COMMENTS.get(key):
+            line = f"{line:<26}# {comment}"
+        default_lines.append(line)
+    for key, value in carried.get("defaults", {}).items():
+        if key not in SUGGESTED:
+            default_lines.append(f"{key} = {value}")
+    if default_lines:
+        sections.append("[defaults]\n" + "\n".join(default_lines))
+
+    camera_keys = tuple(f"{role}_cam_device" for role in CAM_ROLES)
+    embodiment_lines: list[str] = []
+    for key in camera_keys:
+        if key in embodiment_args:
+            embodiment_lines.append(f"{key} = {embodiment_args[key]}")
+    for key, value in carried.get("embodiment.args", {}).items():
+        if key not in camera_keys:
+            embodiment_lines.append(f"{key} = {value}")
+    if embodiment_lines:
+        sections.append("[embodiment.args]\n" + "\n".join(embodiment_lines))
+
+    for section, values in carried.items():
+        if section in ("defaults", "embodiment.args"):
+            continue
+        if values:
+            lines = [f"{key} = {value}" for key, value in values.items()]
+            sections.append(f"[{section}]\n" + "\n".join(lines))
+
+    return "\n\n".join(sections) + "\n"

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -65,7 +65,7 @@ def _ask(
 ) -> str:
     """Ask for one value, accepting Enter as the displayed default."""
     while True:
-        entered = input_fn(f"{prompt} [{default}]: ")
+        entered = input_fn(f"{prompt} [{default}]: ").strip()
         value = entered if entered else default
         if validate(value):
             return value
@@ -399,10 +399,11 @@ def _render_config(
             continue
         line = f"{key} = {defaults[key]}"
         if comment := _DEFAULT_COMMENTS.get(key):
-            line = f"{line:<26}# {comment}"
+            line = f"{line:<26}# {comment}" if len(line) < 26 else f"{line}  # {comment}"
         default_lines.append(line)
     for key, value in carried.get("defaults", {}).items():
         if key not in SUGGESTED:
+            value = value.replace("\n", "\n\t")
             default_lines.append(f"{key} = {value}")
     if default_lines:
         sections.append("[defaults]\n" + "\n".join(default_lines))
@@ -414,6 +415,7 @@ def _render_config(
             embodiment_lines.append(f"{key} = {embodiment_args[key]}")
     for key, value in carried.get("embodiment.args", {}).items():
         if key not in camera_keys:
+            value = value.replace("\n", "\n\t")
             embodiment_lines.append(f"{key} = {value}")
     if embodiment_lines:
         sections.append("[embodiment.args]\n" + "\n".join(embodiment_lines))
@@ -422,7 +424,10 @@ def _render_config(
         if section in ("defaults", "embodiment.args"):
             continue
         if values:
-            lines = [f"{key} = {value}" for key, value in values.items()]
+            lines = []
+            for key, value in values.items():
+                value = value.replace("\n", "\n\t")
+                lines.append(f"{key} = {value}")
             sections.append(f"[{section}]\n" + "\n".join(lines))
 
     return "\n\n".join(sections) + "\n"
@@ -458,6 +463,7 @@ def run_setup(
                     out=out,
                 )
                 if not repair:
+                    print("setup aborted; nothing written", file=out)
                     return 1
             else:
                 carried = raw_config

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -196,7 +196,7 @@ def _camera_section(
     existing_args = carried.get("embodiment.args", {})
     default_enabled = bool(devices) or any(key in existing_args for key in camera_keys)
     if not _ask_yes_no("Configure cameras?", default_enabled, input_fn=input_fn, out=out):
-        return {}
+        return {key: existing_args[key] for key in camera_keys if key in existing_args}
 
     if devices:
         _print_camera_listing(devices, device_dir, out)
@@ -336,11 +336,11 @@ def run_setup(
         return 1
 
     text = _render_config(defaults, embodiment_args, carried)
-    if path.is_file():
-        path.replace(path.with_name(path.name + ".bak"))
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(path.name + ".tmp")
     tmp.write_text(text, encoding="utf-8")
+    if path.is_file():
+        path.replace(path.with_name(path.name + ".bak"))
     tmp.replace(path)
     print(f"Wrote {path}", file=out)
     print('Next: uv run inspect-robots "place the fork on the plate"', file=out)

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -107,6 +107,7 @@ def _warn_unregistered(kind: str, name: str, out: IO[str]) -> None:
 def _prompt_defaults(
     carried: dict[str, dict[str, str]],
     *,
+    headless: bool,
     input_fn: Callable[[str], str],
     out: IO[str],
 ) -> dict[str, str]:
@@ -123,6 +124,13 @@ def _prompt_defaults(
     defaults: dict[str, str] = {}
     for key, suggestion in SUGGESTED.items():
         validate, constraint = validators[key]
+        if key == "rerun" and headless:
+            suggestion = "false"
+            print(
+                "no display detected (SSH?): the rerun viewer cannot open here; "
+                "frames still record with store_frames",
+                file=out,
+            )
         default = suggestion
         if key in raw_defaults:
             configured = raw_defaults[key]
@@ -452,7 +460,13 @@ def run_setup(
             else:
                 carried = raw_config
 
-        defaults = _prompt_defaults(carried, input_fn=input_fn, out=out)
+        headless = "DISPLAY" not in env and "WAYLAND_DISPLAY" not in env
+        defaults = _prompt_defaults(
+            carried,
+            headless=headless,
+            input_fn=input_fn,
+            out=out,
+        )
         embodiment_args = _camera_section(
             carried,
             by_id_dir,

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import configparser
 from collections.abc import Callable, Mapping
+from functools import partial
 from pathlib import Path
 from typing import IO
 
@@ -149,32 +150,139 @@ def _print_camera_listing(devices: list[str], directory: Path, out: IO[str]) -> 
         print(f"  {number}. {Path(device).name}", file=out)
 
 
-def _prompt_camera_role(
+def _identify_by_replug(
     role: str,
     devices: list[str],
     *,
     input_fn: Callable[[str], str],
     out: IO[str],
+    rescan: Callable[[], list[str]],
 ) -> str | None:
-    """Prompt for a numbered device, an absolute path, or a skipped role."""
-    prompt = f"{role} camera — number, absolute path, or 's' to skip: "
+    """Identify one device by diffing the listing while it is unplugged."""
+    input_fn(f"Unplug the {role} camera now, then press Enter...")
+    unplugged_devices = rescan()
+    disappeared = [device for device in devices if device not in unplugged_devices]
+    if not disappeared:
+        print("no camera device disappeared; unplug one camera and try again", file=out)
+        return None
+    if len(disappeared) > 1:
+        print(
+            f"{len(disappeared)} camera devices disappeared; unplug only one and try again",
+            file=out,
+        )
+        return None
+
+    identified = disappeared[0]
+    name = Path(identified).name
+    print(f"That was: {name}", file=out)
+    input_fn("Plug it back in, then press Enter...")
+    if identified not in rescan():
+        input_fn(f"{name} was not detected; press Enter to rescan...")
+        if identified not in rescan():
+            print(
+                f"warning: {name} was still not detected; keeping the assignment",
+                file=out,
+            )
+    return identified
+
+
+def _camera_role_prompt(
+    role: str,
+    devices: list[str],
+    current: str | None,
+    advertise_path_toggle: bool,
+) -> str:
+    choices = f"{role} camera — number, 'u' to identify by unplugging"
+    if advertise_path_toggle:
+        choices += ", 'p' to switch listing"
+    choices += ", 's' to skip"
+    if current is None:
+        return choices + ": "
+    status = "current" if current in devices else "current, not detected"
+    return f"{choices} [{current} ({status})]: "
+
+
+def _prompt_camera_role(
+    role: str,
+    by_id_devices: list[str],
+    by_path_devices: list[str],
+    active_is_by_id: bool,
+    by_id_dir: Path,
+    by_path_dir: Path,
+    current: str | None,
+    assigned: dict[str, str],
+    advertise_path_toggle: bool,
+    *,
+    input_fn: Callable[[str], str],
+    out: IO[str],
+) -> tuple[str | None, bool]:
+    """Prompt for one role and return its device plus active listing state."""
     while True:
+        devices = by_id_devices if active_is_by_id else by_path_devices
+        device_dir = by_id_dir if active_is_by_id else by_path_dir
+        prompt = _camera_role_prompt(role, devices, current, advertise_path_toggle)
         entered = input_fn(prompt).strip()
+        selected: str | None = None
         if entered.lower() == "s":
-            return None
-        if entered.startswith("/"):
+            return None, active_is_by_id
+        if entered.lower() == "p":
+            active_is_by_id = not active_is_by_id
+            devices = by_id_devices if active_is_by_id else by_path_devices
+            device_dir = by_id_dir if active_is_by_id else by_path_dir
+            _print_camera_listing(devices, device_dir, out)
+            continue
+        if entered.lower() == "u":
+            selected = _identify_by_replug(
+                role,
+                devices,
+                input_fn=input_fn,
+                out=out,
+                rescan=partial(_scan_cameras, device_dir),
+            )
+            if selected is None:
+                continue
+        elif not entered and current is not None:
+            selected = current
+        elif entered.startswith("/"):
             if not Path(entered).exists():
                 print(
                     f"warning: {entered} does not exist here "
                     "(ok if this config is for another machine)",
                     file=out,
                 )
-            return entered
-        if entered.isdigit():
+            selected = entered
+        elif entered.isdigit():
             number = int(entered)
             if 1 <= number <= len(devices):
-                return devices[number - 1]
-        print("enter a device number, absolute path, or 's' to skip", file=out)
+                selected = devices[number - 1]
+        if selected is None:
+            print(
+                "enter a device number, absolute path, 'u' to identify, or 's' to skip",
+                file=out,
+            )
+            continue
+
+        other_role = next(
+            (
+                assigned_key.removesuffix("_cam_device")
+                for assigned_key, device in assigned.items()
+                if device == selected
+            ),
+            None,
+        )
+        if other_role is not None:
+            print(
+                f"warning: {selected} is already assigned to the {other_role} camera",
+                file=out,
+            )
+            if not _ask_yes_no(
+                f"Use {selected} for both {other_role} and {role} cameras?",
+                False,
+                input_fn=input_fn,
+                out=out,
+            ):
+                continue
+        return selected, active_is_by_id
 
 
 def _camera_section(
@@ -185,12 +293,13 @@ def _camera_section(
     input_fn: Callable[[str], str],
     out: IO[str],
 ) -> dict[str, str]:
-    """Offer and collect the Task 2 camera assignments."""
-    devices = _scan_cameras(by_id_dir)
-    device_dir = by_id_dir
-    if not devices:
-        devices = _scan_cameras(by_path_dir)
-        device_dir = by_path_dir
+    """Offer and collect camera assignments from both stable V4L listings."""
+    by_id_devices = _scan_cameras(by_id_dir)
+    by_path_devices = _scan_cameras(by_path_dir)
+    active_is_by_id = bool(by_id_devices) or not by_path_devices
+    devices = by_id_devices if active_is_by_id else by_path_devices
+    device_dir = by_id_dir if active_is_by_id else by_path_dir
+    advertise_path_toggle = len(by_path_devices) > len(by_id_devices)
 
     camera_keys = tuple(f"{role}_cam_device" for role in CAM_ROLES)
     existing_args = carried.get("embodiment.args", {})
@@ -205,13 +314,33 @@ def _camera_section(
             "no /dev/v4l devices found (not Linux, or no cameras attached)",
             file=out,
         )
+    if advertise_path_toggle:
+        print(
+            f"only {len(by_id_devices)} by-id entries for "
+            f"{len(by_path_devices)} detected cameras — identical cameras without serials "
+            "collide there; by-path names are stable per physical USB port",
+            file=out,
+        )
 
     while True:
         assignments: dict[str, str] = {}
         for role in CAM_ROLES:
-            selected = _prompt_camera_role(role, devices, input_fn=input_fn, out=out)
+            key = f"{role}_cam_device"
+            selected, active_is_by_id = _prompt_camera_role(
+                role,
+                by_id_devices,
+                by_path_devices,
+                active_is_by_id,
+                by_id_dir,
+                by_path_dir,
+                existing_args.get(key),
+                assignments,
+                advertise_path_toggle,
+                input_fn=input_fn,
+                out=out,
+            )
             if selected is not None:
-                assignments[f"{role}_cam_device"] = selected
+                assignments[key] = selected
         if len(assignments) in (0, len(CAM_ROLES)):
             return assignments
         print(

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -397,7 +397,10 @@ def _render_config(
     for key in SUGGESTED:
         if key not in defaults:
             continue
-        line = f"{key} = {defaults[key]}"
+        # Prompted values can be multiline too: a continuation-line value in
+        # an existing config passes free-text validation and survives Enter.
+        value = defaults[key].replace("\n", "\n\t")
+        line = f"{key} = {value}"
         if comment := _DEFAULT_COMMENTS.get(key):
             line = f"{line:<26}# {comment}" if len(line) < 26 else f"{line}  # {comment}"
         default_lines.append(line)
@@ -412,7 +415,10 @@ def _render_config(
     embodiment_lines: list[str] = []
     for key in camera_keys:
         if key in embodiment_args:
-            embodiment_lines.append(f"{key} = {embodiment_args[key]}")
+            # Enter-accepted "(current)" values come from the raw read and
+            # can be multiline like any carried value.
+            value = embodiment_args[key].replace("\n", "\n\t")
+            embodiment_lines.append(f"{key} = {value}")
     for key, value in carried.get("embodiment.args", {}).items():
         if key not in camera_keys:
             value = value.replace("\n", "\n\t")

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -9,6 +9,7 @@ Subcommands:
   ``--epochs``, ``--fail-on-error``, and ``--store-frames`` tune the run. The
   written log's path is printed at the end.
 - ``inspect-robots inspect LOG.json`` — print a saved eval log.
+- ``inspect-robots setup`` — interactively configure defaults and camera devices.
 
 Zero-config form (plan 0005): ``inspect-robots "place the spoon on the plate"``
 is sugar for ``run --instruction "..."`` — a single ad-hoc scene on the user's
@@ -77,7 +78,7 @@ _KIND_BY_PLURAL = {
 
 _PLURAL_BY_KIND = {kind: plural for plural, kind in _KIND_BY_PLURAL.items()}
 
-_SUBCOMMANDS = ("list", "run", "inspect", "config", "doctor")
+_SUBCOMMANDS = ("list", "run", "inspect", "config", "setup", "doctor")
 
 _ENV_BY_KIND = {"policy": ENV_POLICY, "embodiment": ENV_EMBODIMENT}
 
@@ -196,6 +197,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_doctor.add_argument("--embodiment", help="registered embodiment name (default: user config)")
     p_doctor.add_argument("-E", dest="embodiment_args", action="append", metavar="k=v")
 
+    sub.add_parser(
+        "setup",
+        help="interactive first-run wizard: pick defaults and discover camera devices, "
+        "then write config.ini",
+    )
+
     p_config = sub.add_parser("config", help="view or set user defaults (config.ini)")
     config_sub = p_config.add_subparsers(dest="config_command", required=True)
     p_set = config_sub.add_parser("set", help="persist a [defaults] key to the config file")
@@ -234,7 +241,8 @@ def _pick_component(
     raise SystemExit(
         f"no {kind} given and no default configured.\n"
         f"registered {_PLURAL_BY_KIND[kind]}: {names}\n"
-        f"fix: pass --{kind} NAME, set ${_ENV_BY_KIND[kind]}, or run "
+        f"fix: pass --{kind} NAME, set ${_ENV_BY_KIND[kind]}, "
+        "run 'inspect-robots setup', or "
         f"'inspect-robots config set {kind} NAME'"
     )
 
@@ -576,6 +584,17 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
     return 0 if report.ok else 1
 
 
+def _cmd_setup() -> int:
+    from inspect_robots._setup import run_setup
+
+    return run_setup(
+        os.environ,
+        input_fn=input,
+        out=sys.stdout,
+        interactive=sys.stdin.isatty(),
+    )
+
+
 def _cmd_config(args: argparse.Namespace) -> int:
     if args.config_command == "set":
         path = set_default(os.environ, args.key, args.value)
@@ -627,6 +646,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _cmd_inspect(args.log)
     if args.command == "config":
         return _cmd_config(args)
+    if args.command == "setup":
+        return _cmd_setup()
     if args.command == "doctor":
         return _cmd_doctor(args)
     parser.print_help()

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 
 import pytest
 
+import inspect_robots.cli as cli
 import inspect_robots.registry as reg
 from inspect_robots._defaults import ENV_EMBODIMENT, ENV_POLICY, ENV_SIM_EMBODIMENT
 from inspect_robots.cli import main
@@ -137,6 +138,37 @@ def test_cli_run_epochs_fail_on_error_store_frames(
 def test_cli_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
     assert main([]) == 0
     assert "Inspect Robots" in capsys.readouterr().out
+
+
+def test_cli_help_lists_setup(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--help"])
+    assert excinfo.value.code == 0
+    assert "setup" in capsys.readouterr().out
+
+
+def test_setup_is_protected_by_instruction_sugar_guard() -> None:
+    assert "setup" in cli._SUBCOMMANDS
+
+
+def test_cli_setup_requires_an_interactive_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    with pytest.raises(SystemExit, match="setup is interactive"):
+        main(["setup"])
+
+
+def test_cli_setup_dispatches_to_wizard(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[bool] = []
+
+    def fake_run_setup(_env: object, *, input_fn: object, out: object, interactive: bool) -> int:
+        del input_fn, out
+        calls.append(interactive)
+        return 7
+
+    monkeypatch.setattr("inspect_robots._setup.run_setup", fake_run_setup)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    assert main(["setup"]) == 7
+    assert calls == [True]
 
 
 # --------------------------------------------------------------------------- #
@@ -1004,8 +1036,9 @@ def test_cli_degraded_guardrails_warn_but_run(
 
 
 def test_guided_error_mentions_config_set() -> None:
-    with pytest.raises(SystemExit, match="inspect-robots config set policy"):
+    with pytest.raises(SystemExit, match="inspect-robots config set policy") as excinfo:
         main(["run", "--instruction", "reach the cube"])
+    assert "inspect-robots setup" in str(excinfo.value)
 
 
 # --- config set / show (plan 0008 §3e) ----------------------------------------

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -520,7 +520,32 @@ def test_run_setup_carries_unmanaged_defaults_and_embodiment_args(tmp_path: Path
     assert result == 0
     assert "sim_embodiment = cubepick" in text
     assert "left_channel = can2" in text
-    assert "top_cam_device" not in text
+    assert "top_cam_device = /dev/old" in text
+
+
+def test_run_setup_declining_cameras_preserves_existing_assignments(tmp_path: Path) -> None:
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    camera_lines = [
+        "top_cam_device = /dev/old-top",
+        "left_cam_device = /dev/old-left",
+        "right_cam_device = /dev/old-right",
+    ]
+    path.write_text("[embodiment.args]\n" + "\n".join(camera_lines) + "\n", encoding="utf-8")
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "n"])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = path.read_text(encoding="utf-8")
+    assert result == 0
+    assert all(line in text.splitlines() for line in camera_lines)
 
 
 def test_run_setup_camera_choices_manual_paths_skip_and_invalid_entries(
@@ -687,6 +712,35 @@ def test_run_setup_partial_cameras_can_write_none(tmp_path: Path) -> None:
     assert result == 0
     assert "yam_arms needs all three cameras or none" in out.getvalue()
     assert "_cam_device" not in _config_path(tmp_path).read_text(encoding="utf-8")
+
+
+def test_run_setup_partial_cameras_write_none_drops_existing_assignments(
+    tmp_path: Path,
+) -> None:
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[embodiment.args]\n"
+        "top_cam_device = /dev/old-top\n"
+        "left_cam_device = /dev/old-left\n"
+        "right_cam_device = /dev/old-right\n",
+        encoding="utf-8",
+    )
+    by_id = tmp_path / "by-id"
+    _make_devices(by_id)
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "", "1", "s", "s", "n"])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert "_cam_device" not in path.read_text(encoding="utf-8")
 
 
 def test_run_setup_falls_back_to_by_path_devices(tmp_path: Path) -> None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -220,7 +220,7 @@ def test_run_setup_defaults_and_numbered_cameras_write_golden_config(tmp_path: P
     out = io.StringIO()
 
     result = run_setup(
-        {"XDG_CONFIG_HOME": str(tmp_path)},
+        {"XDG_CONFIG_HOME": str(tmp_path), "DISPLAY": ":0"},
         input_fn=input_fn,
         out=out,
         interactive=True,
@@ -244,6 +244,81 @@ def test_run_setup_defaults_and_numbered_cameras_write_golden_config(tmp_path: P
     assert f"  1. {Path(devices[0]).name}" in output
     assert f"Wrote {path}" in output
     assert 'Next: uv run inspect-robots "place the fork on the plate"' in output
+
+
+def test_run_setup_headless_defaults_rerun_false_and_explains(tmp_path: Path) -> None:
+    scripted_input, prompts = _scripted_input([""] * 7)
+    out = io.StringIO()
+    note = (
+        "no display detected (SSH?): the rerun viewer cannot open here; "
+        "frames still record with store_frames"
+    )
+
+    def input_fn(prompt: str) -> str:
+        if prompt.startswith("live rerun viewer"):
+            assert note in out.getvalue().splitlines()
+        return scripted_input(prompt)
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert "live rerun viewer [false]" in prompts[4]
+    assert out.getvalue().splitlines().count(note) == 1
+    assert "rerun = false" in _config_path(tmp_path).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("display_variable", ["DISPLAY", "WAYLAND_DISPLAY"])
+def test_run_setup_with_display_defaults_rerun_true_without_note(
+    tmp_path: Path,
+    display_variable: str,
+) -> None:
+    input_fn, prompts = _scripted_input([""] * 7)
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path), display_variable: ":0"},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert "live rerun viewer [true]" in prompts[4]
+    assert "no display detected (SSH?)" not in out.getvalue()
+    assert "rerun = true" in _config_path(tmp_path).read_text(encoding="utf-8")
+
+
+def test_run_setup_headless_existing_rerun_true_wins_and_note_is_printed(
+    tmp_path: Path,
+) -> None:
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text("[defaults]\nrerun = true\n", encoding="utf-8")
+    input_fn, prompts = _scripted_input([""] * 7)
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert "live rerun viewer [true]" in prompts[4]
+    assert "no display detected (SSH?)" in out.getvalue()
+    assert "rerun = true" in path.read_text(encoding="utf-8")
 
 
 def test_run_setup_typed_overrides_land_in_file(tmp_path: Path) -> None:
@@ -276,7 +351,7 @@ def test_run_setup_reprompts_invalid_typed_values(tmp_path: Path) -> None:
     out = io.StringIO()
 
     result = run_setup(
-        {"XDG_CONFIG_HOME": str(tmp_path)},
+        {"XDG_CONFIG_HOME": str(tmp_path), "DISPLAY": ":0"},
         input_fn=input_fn,
         out=out,
         interactive=True,
@@ -377,7 +452,7 @@ def test_run_setup_repairs_malformed_config_and_backs_it_up(tmp_path: Path, answ
     out = io.StringIO()
 
     result = run_setup(
-        {"XDG_CONFIG_HOME": str(tmp_path)},
+        {"XDG_CONFIG_HOME": str(tmp_path), "DISPLAY": ":0"},
         input_fn=input_fn,
         out=out,
         interactive=True,
@@ -441,7 +516,7 @@ def test_run_setup_ignores_only_invalid_existing_prompt_values(tmp_path: Path) -
     assert "ignoring invalid rerun 'perhaps' from config.ini" in out.getvalue()
     assert any("policy [kept-policy]" in prompt for prompt in prompts)
     assert any("max steps [1200]" in prompt for prompt in prompts)
-    assert any("live rerun viewer [true]" in prompt for prompt in prompts)
+    assert any("live rerun viewer [false]" in prompt for prompt in prompts)
     assert any("store camera frames [false]" in prompt for prompt in prompts)
 
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1236,3 +1236,70 @@ def test_run_setup_marks_undetected_current_camera_defaults(tmp_path: Path) -> N
     assert result == 0
     assert all("(current, not detected)" in prompt for prompt in role_prompts)
     assert all(device in text for device in current_devices)
+
+
+def test_render_config_comment_at_exact_boundary_never_glues(tmp_path: Path) -> None:
+    policy = "policy-with-17chr"  # "policy = " + 17 chars == 26, the pad width
+    assert len(f"policy = {policy}") == 26
+    path = tmp_path / "config.ini"
+    path.write_text(_render_config({"policy": policy}, {}, {}), encoding="utf-8")
+
+    carried = _read_raw_config(path)
+
+    assert not isinstance(carried, str)
+    assert carried["defaults"]["policy"] == policy
+    assert f"policy = {policy}  # " in path.read_text(encoding="utf-8")
+
+
+def test_run_setup_multiline_prompted_default_still_parses(tmp_path: Path) -> None:
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[defaults]\nscorer = line one\n    line two\n",
+        encoding="utf-8",
+    )
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "n"])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    rewritten = _read_raw_config(path)
+    assert result == 0
+    assert not isinstance(rewritten, str)
+    lines = [line.lstrip() for line in rewritten["defaults"]["scorer"].splitlines()]
+    assert lines == ["line one", "line two"]
+
+
+def test_run_setup_multiline_current_camera_still_parses(tmp_path: Path) -> None:
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[defaults]\npolicy = molmoact2\n\n"
+        "[embodiment.args]\n"
+        "top_cam_device = /dev/one\n    /dev/one-continued\n"
+        "left_cam_device = /dev/two\n"
+        "right_cam_device = /dev/three\n",
+        encoding="utf-8",
+    )
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "n"])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    rewritten = _read_raw_config(path)
+    assert result == 0
+    assert not isinstance(rewritten, str)
+    lines = [line.lstrip() for line in rewritten["embodiment.args"]["top_cam_device"].splitlines()]
+    assert lines == ["/dev/one", "/dev/one-continued"]

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -10,6 +10,7 @@ import pytest
 
 from inspect_robots._setup import (
     SUGGESTED,
+    _identify_by_replug,
     _read_raw_config,
     _render_config,
     _scan_cameras,
@@ -589,7 +590,9 @@ def test_run_setup_camera_choices_manual_paths_skip_and_invalid_entries(
     assert f"right_cam_device = {devices[2]}" in text
     assert f"warning: {missing} does not exist here " in out.getvalue()
     assert f"warning: {devices[1]} does not exist here" not in out.getvalue()
-    assert out.getvalue().count("enter a device number, absolute path, or 's'") == 3
+    assert (
+        out.getvalue().count("enter a device number, absolute path, 'u' to identify, or 's'") == 3
+    )
     assert sum(prompt.startswith("top camera") for prompt in prompts) == 4
 
 
@@ -802,3 +805,302 @@ def test_run_setup_yes_no_prompts_reprompt_invalid_answers(tmp_path: Path) -> No
     assert result == 0
     assert sum("Configure cameras?" in prompt for prompt in prompts) == 2
     assert "please answer yes or no" in out.getvalue()
+
+
+def test_identify_by_replug_finds_disappeared_then_restored_device() -> None:
+    devices = ["/dev/camera-top", "/dev/camera-left", "/dev/camera-right"]
+    scans = iter(
+        [
+            [devices[0], devices[2]],
+            devices,
+        ]
+    )
+    input_fn, prompts = _scripted_input(["", ""])
+    out = io.StringIO()
+
+    identified = _identify_by_replug(
+        "left",
+        devices,
+        input_fn=input_fn,
+        out=out,
+        rescan=lambda: next(scans),
+    )
+
+    assert identified == devices[1]
+    assert prompts == [
+        "Unplug the left camera now, then press Enter...",
+        "Plug it back in, then press Enter...",
+    ]
+    assert "That was: camera-left" in out.getvalue()
+
+
+@pytest.mark.parametrize("detected_on_retry", [True, False])
+def test_identify_by_replug_retries_replug_scan_once(
+    detected_on_retry: bool,
+) -> None:
+    devices = ["/dev/camera-top", "/dev/camera-left"]
+    without_top = [devices[1]]
+    scans = iter(
+        [
+            without_top,
+            without_top,
+            devices if detected_on_retry else without_top,
+        ]
+    )
+    input_fn, prompts = _scripted_input(["", "", ""])
+    out = io.StringIO()
+
+    identified = _identify_by_replug(
+        "top",
+        devices,
+        input_fn=input_fn,
+        out=out,
+        rescan=lambda: next(scans),
+    )
+
+    assert identified == devices[0]
+    assert prompts[-1] == "camera-top was not detected; press Enter to rescan..."
+    warning = "warning: camera-top was still not detected; keeping the assignment"
+    assert (warning in out.getvalue()) is not detected_on_retry
+
+
+def test_run_setup_identifies_camera_by_real_directory_replug(tmp_path: Path) -> None:
+    by_id = tmp_path / "by-id"
+    devices = _make_devices(by_id)
+    pending = ["", "", "", "", "", "", "", "u", "", "", "1", "3"]
+    prompts: list[str] = []
+
+    def input_fn(prompt: str) -> str:
+        prompts.append(prompt)
+        if prompt.startswith("Unplug the top camera"):
+            Path(devices[1]).unlink()
+        elif prompt.startswith("Plug it back in"):
+            Path(devices[1]).touch()
+        return pending.pop(0)
+
+    out = io.StringIO()
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert f"top_cam_device = {devices[1]}" in text
+    assert f"left_cam_device = {devices[0]}" in text
+    assert f"right_cam_device = {devices[2]}" in text
+    assert f"That was: {Path(devices[1]).name}" in out.getvalue()
+    assert Path(devices[1]).exists()
+    assert "Plug it back in, then press Enter..." in prompts
+
+
+@pytest.mark.parametrize("missing_count", [0, 2])
+def test_run_setup_ambiguous_unplug_diff_explains_and_reprompts_role(
+    tmp_path: Path,
+    missing_count: int,
+) -> None:
+    by_id = tmp_path / "by-id"
+    devices = _make_devices(by_id)
+    pending = ["", "", "", "", "", "", "", "u", "", "1", "2", "3"]
+    prompts: list[str] = []
+
+    def input_fn(prompt: str) -> str:
+        prompts.append(prompt)
+        if prompt.startswith("Unplug the top camera"):
+            for device in devices[:missing_count]:
+                Path(device).unlink()
+        return pending.pop(0)
+
+    out = io.StringIO()
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert sum(prompt.startswith("top camera") for prompt in prompts) == 2
+    explanation = (
+        "no camera device disappeared" if missing_count == 0 else "2 camera devices disappeared"
+    )
+    assert explanation in out.getvalue()
+
+
+def test_run_setup_path_toggle_is_accepted_when_not_advertised(tmp_path: Path) -> None:
+    by_id = tmp_path / "by-id"
+    by_path = tmp_path / "by-path"
+    by_id_devices = _make_devices(by_id)
+    _make_devices(by_path)
+    input_fn, prompts = _scripted_input(["", "", "", "", "", "", "", "p", "p", "1", "2", "3"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=by_path,
+    )
+
+    output = out.getvalue()
+    role_prompts = [prompt for prompt in prompts if " camera — " in prompt]
+    assert result == 0
+    assert output.count(f"Found 3 camera device(s) under {by_id}:") == 2
+    assert output.count(f"Found 3 camera device(s) under {by_path}:") == 1
+    assert all("'p'" not in prompt for prompt in role_prompts)
+    assert "only 3 by-id entries" not in output
+    assert f"top_cam_device = {by_id_devices[0]}" in _config_path(tmp_path).read_text(
+        encoding="utf-8"
+    )
+
+
+def test_run_setup_advertises_by_path_when_by_id_entries_collide(tmp_path: Path) -> None:
+    by_id = tmp_path / "by-id"
+    by_path = tmp_path / "by-path"
+    _make_devices(by_id, count=1)
+    by_path_devices = _make_devices(by_path)
+    input_fn, prompts = _scripted_input(["", "", "", "", "", "", "", "p", "1", "2", "3"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=by_path,
+    )
+
+    explanation = (
+        "only 1 by-id entries for 3 detected cameras — identical cameras without serials "
+        "collide there; by-path names are stable per physical USB port"
+    )
+    role_prompts = [prompt for prompt in prompts if " camera — " in prompt]
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert out.getvalue().count(explanation) == 1
+    assert all("'p' to switch listing" in prompt for prompt in role_prompts)
+    assert f"Found 3 camera device(s) under {by_path}:" in out.getvalue()
+    assert all(device in text for device in by_path_devices)
+
+
+def test_run_setup_declining_duplicate_device_reprompts_role(tmp_path: Path) -> None:
+    by_id = tmp_path / "by-id"
+    devices = _make_devices(by_id)
+    input_fn, prompts = _scripted_input(["", "", "", "", "", "", "", "1", "1", "n", "2", "3"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert f"warning: {devices[0]} is already assigned to the top camera" in out.getvalue()
+    assert any(
+        "Use " in prompt and "for both top and left cameras? [y/N]" in prompt for prompt in prompts
+    )
+    assert sum(prompt.startswith("left camera") for prompt in prompts) == 2
+    assert f"left_cam_device = {devices[1]}" in text
+
+
+def test_run_setup_accepting_duplicate_device_assigns_both_roles(tmp_path: Path) -> None:
+    by_id = tmp_path / "by-id"
+    devices = _make_devices(by_id)
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "", "1", "1", "y", "2"])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert f"top_cam_device = {devices[0]}" in text
+    assert f"left_cam_device = {devices[0]}" in text
+    assert f"right_cam_device = {devices[1]}" in text
+
+
+def test_run_setup_enter_accepts_detected_current_camera_defaults(tmp_path: Path) -> None:
+    by_id = tmp_path / "by-id"
+    devices = _make_devices(by_id)
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[embodiment.args]\n"
+        + "\n".join(
+            f"{role}_cam_device = {device}"
+            for role, device in zip(("top", "left", "right"), devices, strict=True)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    input_fn, prompts = _scripted_input([""] * 10)
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = path.read_text(encoding="utf-8")
+    role_prompts = [prompt for prompt in prompts if " camera — " in prompt]
+    assert result == 0
+    assert all(
+        f"[{device} (current)]" in prompt
+        for device, prompt in zip(devices, role_prompts, strict=True)
+    )
+    assert all(device in text for device in devices)
+
+
+def test_run_setup_marks_undetected_current_camera_defaults(tmp_path: Path) -> None:
+    by_id = tmp_path / "by-id"
+    _make_devices(by_id)
+    current_devices = ["/remote/top", "/remote/left", "/remote/right"]
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[embodiment.args]\n"
+        + "\n".join(
+            f"{role}_cam_device = {device}"
+            for role, device in zip(("top", "left", "right"), current_devices, strict=True)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    input_fn, prompts = _scripted_input([""] * 10)
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    role_prompts = [prompt for prompt in prompts if " camera — " in prompt]
+    text = path.read_text(encoding="utf-8")
+    assert result == 0
+    assert all("(current, not detected)" in prompt for prompt in role_prompts)
+    assert all(device in text for device in current_devices)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2,14 +2,54 @@
 
 from __future__ import annotations
 
+import io
+from collections.abc import Callable
 from pathlib import Path
+
+import pytest
 
 from inspect_robots._setup import (
     SUGGESTED,
     _read_raw_config,
     _render_config,
     _scan_cameras,
+    run_setup,
 )
+
+
+def _scripted_input(
+    responses: list[str | BaseException],
+) -> tuple[Callable[[str], str], list[str]]:
+    pending = responses.copy()
+    prompts: list[str] = []
+
+    def input_fn(prompt: str) -> str:
+        prompts.append(prompt)
+        response = pending.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+    return input_fn, prompts
+
+
+def _config_path(tmp_path: Path) -> Path:
+    return tmp_path / "inspect-robots" / "config.ini"
+
+
+def _make_devices(directory: Path, count: int = 3) -> list[str]:
+    directory.mkdir(parents=True)
+    devices: list[str] = []
+    for number in range(1, count + 1):
+        path = directory / f"camera-{number}-video-index0"
+        path.touch()
+        devices.append(str(path))
+    return devices
+
+
+@pytest.fixture(autouse=True)
+def _empty_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("inspect_robots.registry.registered", lambda _kind: {})
 
 
 def test_scan_cameras_prefers_sorted_absolute_index0_entries(tmp_path: Path) -> None:
@@ -170,3 +210,541 @@ def test_render_config_carries_unmanaged_content_without_managed_duplicates(
     assert "/dev/old-top" not in rendered
     assert rendered.index("[defaults]") < rendered.index("[embodiment.args]")
     assert rendered.index("[embodiment.args]") < rendered.index("[policy.args]")
+
+
+def test_run_setup_defaults_and_numbered_cameras_write_golden_config(tmp_path: Path) -> None:
+    by_id = tmp_path / "by-id"
+    devices = _make_devices(by_id)
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "", "1", "2", "3"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=tmp_path / "missing-by-path",
+    )
+
+    path = _config_path(tmp_path)
+    assert result == 0
+    assert path.read_text(encoding="utf-8") == _render_config(
+        dict(SUGGESTED),
+        {
+            "top_cam_device": devices[0],
+            "left_cam_device": devices[1],
+            "right_cam_device": devices[2],
+        },
+        {},
+    )
+    output = out.getvalue()
+    assert f"Found 3 camera device(s) under {by_id}:" in output
+    assert f"  1. {Path(devices[0]).name}" in output
+    assert f"Wrote {path}" in output
+    assert 'Next: uv run inspect-robots "place the fork on the plate"' in output
+
+
+def test_run_setup_typed_overrides_land_in_file(tmp_path: Path) -> None:
+    input_fn, _ = _scripted_input(["my-policy", "my-body", "my-scorer", "42", "false", "false", ""])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert "policy = my-policy" in text
+    assert "embodiment = my-body" in text
+    assert "scorer = my-scorer" in text
+    assert "max_steps = 42" in text
+    assert "rerun = false" in text
+    assert "store_frames = false" in text
+    assert "[embodiment.args]" not in text
+
+
+def test_run_setup_reprompts_invalid_typed_values(tmp_path: Path) -> None:
+    input_fn, prompts = _scripted_input(
+        ["", "", "", "abc", "0", "7", "maybe", "false", "1", "true", ""]
+    )
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert sum(prompt.startswith("max steps ") for prompt in prompts) == 3
+    assert sum(prompt.startswith("live rerun viewer ") for prompt in prompts) == 2
+    assert sum(prompt.startswith("store camera frames ") for prompt in prompts) == 2
+    assert out.getvalue().count("must be an integer >= 1") == 2
+    assert out.getvalue().count("must be true or false") == 2
+
+
+def test_run_setup_noninteractive_raises() -> None:
+    input_fn, _ = _scripted_input([])
+
+    with pytest.raises(
+        SystemExit,
+        match=r"^setup is interactive; see the README for manual config$",
+    ):
+        run_setup({}, input_fn=input_fn, out=io.StringIO(), interactive=False)
+
+
+def test_run_setup_without_config_home_raises() -> None:
+    input_fn, _ = _scripted_input([])
+
+    with pytest.raises(
+        SystemExit,
+        match=r"^cannot locate a config home: set \$XDG_CONFIG_HOME or \$HOME$",
+    ):
+        run_setup({}, input_fn=input_fn, out=io.StringIO(), interactive=True)
+
+
+@pytest.mark.parametrize("interruption", [EOFError(), KeyboardInterrupt()])
+def test_run_setup_interruption_aborts_without_writing(
+    tmp_path: Path, interruption: BaseException
+) -> None:
+    input_fn, _ = _scripted_input(["", interruption])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 1
+    assert "setup aborted; nothing written" in out.getvalue()
+    assert not _config_path(tmp_path).exists()
+    assert not _config_path(tmp_path).with_name("config.ini.bak").exists()
+
+
+def test_run_setup_existing_valid_config_supplies_prompt_defaults_and_backup(
+    tmp_path: Path,
+) -> None:
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    old = (
+        "[defaults]\n"
+        "policy = old-policy\n"
+        "embodiment = old-body\n"
+        "scorer = old-scorer\n"
+        "max_steps = 88\n"
+        "rerun = false\n"
+        "store_frames = false\n"
+    )
+    path.write_text(old, encoding="utf-8")
+    input_fn, prompts = _scripted_input(["", "", "", "", "", "", ""])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    for expected in ("old-policy", "old-body", "old-scorer", "88", "false"):
+        assert any(f"[{expected}]" in prompt for prompt in prompts)
+    assert "policy = old-policy" in path.read_text(encoding="utf-8")
+    assert path.with_name("config.ini.bak").read_text(encoding="utf-8") == old
+
+
+@pytest.mark.parametrize("answer", ["y", ""])
+def test_run_setup_repairs_malformed_config_and_backs_it_up(tmp_path: Path, answer: str) -> None:
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    broken = "key = value without a section\n"
+    path.write_text(broken, encoding="utf-8")
+    input_fn, prompts = _scripted_input([answer, "", "", "", "", "", "", ""])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert "File contains no section headers" in out.getvalue()
+    assert "Back up the broken file and start fresh? [Y/n]" in prompts[0]
+    assert path.read_text(encoding="utf-8") == _render_config(dict(SUGGESTED), {}, {})
+    assert path.with_name("config.ini.bak").read_text(encoding="utf-8") == broken
+
+
+def test_run_setup_declines_malformed_config_repair(tmp_path: Path) -> None:
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    broken = "not an ini file\n"
+    path.write_text(broken, encoding="utf-8")
+    input_fn, _ = _scripted_input(["n"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+    )
+
+    assert result == 1
+    assert "File contains no section headers" in out.getvalue()
+    assert path.read_text(encoding="utf-8") == broken
+    assert not path.with_name("config.ini.bak").exists()
+
+
+def test_run_setup_ignores_only_invalid_existing_prompt_values(tmp_path: Path) -> None:
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[defaults]\n"
+        "policy = kept-policy\n"
+        "max_steps = abc\n"
+        "rerun = perhaps\n"
+        "store_frames = false\n",
+        encoding="utf-8",
+    )
+    input_fn, prompts = _scripted_input(["", "", "", "", "", "", ""])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert "ignoring invalid max_steps 'abc' from config.ini" in out.getvalue()
+    assert "ignoring invalid rerun 'perhaps' from config.ini" in out.getvalue()
+    assert any("policy [kept-policy]" in prompt for prompt in prompts)
+    assert any("max steps [1200]" in prompt for prompt in prompts)
+    assert any("live rerun viewer [true]" in prompt for prompt in prompts)
+    assert any("store camera frames [false]" in prompt for prompt in prompts)
+
+
+def test_run_setup_warns_only_for_unregistered_policy_and_embodiment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "inspect_robots.registry.registered",
+        lambda kind: {"known-policy" if kind == "policy" else "known-body": object()},
+    )
+    input_fn, _ = _scripted_input(
+        ["missing-policy", "missing-body", "missing-scorer", "", "", "", ""]
+    )
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    warning = (
+        "is not registered here — install its plugin, e.g. `uv pip install inspect-robots-yam`"
+    )
+    assert f"'missing-policy' {warning}" in out.getvalue()
+    assert f"'missing-body' {warning}" in out.getvalue()
+    assert "missing-scorer' is not registered" not in out.getvalue()
+
+
+def test_run_setup_registered_names_do_not_warn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "inspect_robots.registry.registered",
+        lambda kind: {"known-policy": object()} if kind == "policy" else {"known-body": object()},
+    )
+    input_fn, _ = _scripted_input(["known-policy", "known-body", "", "", "", "", ""])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert "is not registered here" not in out.getvalue()
+
+
+def test_run_setup_carries_unmanaged_defaults_and_embodiment_args(tmp_path: Path) -> None:
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[defaults]\npolicy = old\nsim_embodiment = cubepick\n"
+        "\n[embodiment.args]\nleft_channel = can2\ntop_cam_device = /dev/old\n",
+        encoding="utf-8",
+    )
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "n"])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = path.read_text(encoding="utf-8")
+    assert result == 0
+    assert "sim_embodiment = cubepick" in text
+    assert "left_channel = can2" in text
+    assert "top_cam_device" not in text
+
+
+def test_run_setup_camera_choices_manual_paths_skip_and_invalid_entries(
+    tmp_path: Path,
+) -> None:
+    by_id = tmp_path / "by-id"
+    devices = _make_devices(by_id)
+    missing = "/another-machine/top-camera"
+    input_fn, prompts = _scripted_input(
+        [
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "garbage",
+            "9",
+            "relative/path",
+            missing,
+            devices[1],
+            "3",
+        ]
+    )
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert f"top_cam_device = {missing}" in text
+    assert f"left_cam_device = {devices[1]}" in text
+    assert f"right_cam_device = {devices[2]}" in text
+    assert f"warning: {missing} does not exist here " in out.getvalue()
+    assert f"warning: {devices[1]} does not exist here" not in out.getvalue()
+    assert out.getvalue().count("enter a device number, absolute path, or 's'") == 3
+    assert sum(prompt.startswith("top camera") for prompt in prompts) == 4
+
+
+def test_run_setup_skipping_every_camera_writes_no_camera_keys(tmp_path: Path) -> None:
+    by_id = tmp_path / "by-id"
+    _make_devices(by_id)
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "", "s", "s", "s"])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert "_cam_device" not in _config_path(tmp_path).read_text(encoding="utf-8")
+
+
+def test_run_setup_camera_offer_defaults_yes_when_devices_found(tmp_path: Path) -> None:
+    by_id = tmp_path / "by-id"
+    _make_devices(by_id)
+    input_fn, prompts = _scripted_input(["", "", "", "", "", "", "", "s", "s", "s"])
+
+    run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert "[Y/n]" in prompts[6]
+    assert any(prompt.startswith("top camera") for prompt in prompts)
+
+
+def test_run_setup_camera_offer_defaults_yes_for_existing_camera_keys(
+    tmp_path: Path,
+) -> None:
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text("[embodiment.args]\ntop_cam_device = /dev/old\n", encoding="utf-8")
+    input_fn, prompts = _scripted_input(["", "", "", "", "", "", "", "s", "s", "s"])
+
+    run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert "[Y/n]" in prompts[6]
+    assert "_cam_device" not in path.read_text(encoding="utf-8")
+
+
+def test_run_setup_camera_offer_defaults_no_without_devices_or_config(tmp_path: Path) -> None:
+    input_fn, prompts = _scripted_input(["", "", "", "", "", "", ""])
+    out = io.StringIO()
+
+    run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert "[y/N]" in prompts[6]
+    assert "no /dev/v4l devices found" not in out.getvalue()
+
+
+def test_run_setup_partial_cameras_can_go_back_and_assign_all(tmp_path: Path) -> None:
+    by_id = tmp_path / "by-id"
+    devices = _make_devices(by_id)
+    input_fn, prompts = _scripted_input(
+        ["", "", "", "", "", "", "", "1", "s", "s", "", "1", "2", "3"]
+    )
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert "yam_arms needs all three cameras or none" in out.getvalue()
+    assert sum(prompt.startswith("top camera") for prompt in prompts) == 2
+    assert all(
+        f"{role}_cam_device = {device}" in text
+        for role, device in zip(("top", "left", "right"), devices, strict=True)
+    )
+
+
+def test_run_setup_partial_cameras_can_write_none(tmp_path: Path) -> None:
+    by_id = tmp_path / "by-id"
+    _make_devices(by_id)
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "", "1", "s", "s", "n"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert "yam_arms needs all three cameras or none" in out.getvalue()
+    assert "_cam_device" not in _config_path(tmp_path).read_text(encoding="utf-8")
+
+
+def test_run_setup_falls_back_to_by_path_devices(tmp_path: Path) -> None:
+    by_path = tmp_path / "by-path"
+    devices = _make_devices(by_path)
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "", "1", "2", "3"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=by_path,
+    )
+
+    assert result == 0
+    assert f"Found 3 camera device(s) under {by_path}:" in out.getvalue()
+    assert f"top_cam_device = {devices[0]}" in _config_path(tmp_path).read_text(encoding="utf-8")
+
+
+def test_run_setup_without_detected_devices_accepts_manual_paths(tmp_path: Path) -> None:
+    manual = ["/remote/top", "/remote/left", "/remote/right"]
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "y", *manual])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert "no /dev/v4l devices found (not Linux, or no cameras attached)" in out.getvalue()
+    assert all(
+        f"{role}_cam_device = {path}" in text
+        for role, path in zip(("top", "left", "right"), manual, strict=True)
+    )
+
+
+def test_run_setup_yes_no_prompts_reprompt_invalid_answers(tmp_path: Path) -> None:
+    input_fn, prompts = _scripted_input(["", "", "", "", "", "", "perhaps", "yes", "s", "s", "s"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert sum("Configure cameras?" in prompt for prompt in prompts) == 2
+    assert "please answer yes or no" in out.getvalue()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,172 @@
+"""Pure helpers for setup-wizard camera discovery and config rendering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from inspect_robots._setup import (
+    SUGGESTED,
+    _read_raw_config,
+    _render_config,
+    _scan_cameras,
+)
+
+
+def test_scan_cameras_prefers_sorted_absolute_index0_entries(tmp_path: Path) -> None:
+    v4l_dir = tmp_path / "by-id"
+    v4l_dir.mkdir()
+    for name in (
+        "usb-camera-b-video-index1",
+        "usb-camera-b-video-index0",
+        "usb-camera-a-video-index0",
+    ):
+        (v4l_dir / name).touch()
+
+    devices = _scan_cameras(v4l_dir)
+
+    assert devices == [
+        str(v4l_dir / "usb-camera-a-video-index0"),
+        str(v4l_dir / "usb-camera-b-video-index0"),
+    ]
+    assert all(Path(device).is_absolute() for device in devices)
+
+
+def test_scan_cameras_falls_back_to_all_sorted_entries(tmp_path: Path) -> None:
+    v4l_dir = tmp_path / "by-path"
+    v4l_dir.mkdir()
+    for name in ("camera-z", "camera-a-video-index1", "camera-m"):
+        (v4l_dir / name).touch()
+
+    assert _scan_cameras(v4l_dir) == [
+        str(v4l_dir / "camera-a-video-index1"),
+        str(v4l_dir / "camera-m"),
+        str(v4l_dir / "camera-z"),
+    ]
+
+
+def test_scan_cameras_missing_directory_returns_empty(tmp_path: Path) -> None:
+    assert _scan_cameras(tmp_path / "missing") == []
+
+
+def test_read_raw_config_preserves_percent_and_literal_tilde(tmp_path: Path) -> None:
+    path = tmp_path / "config.ini"
+    path.write_text(
+        "[policy.args]\nlabel = 100% ready\ncheckpoint = ~/models/policy.pt\n",
+        encoding="utf-8",
+    )
+
+    result = _read_raw_config(path)
+
+    assert not isinstance(result, str)
+    assert result["policy.args"]["label"] == "100% ready"
+    assert result["policy.args"]["checkpoint"].startswith("~")
+
+
+def test_read_raw_config_returns_parse_error_text(tmp_path: Path) -> None:
+    path = tmp_path / "config.ini"
+    path.write_text("key = value without a section\n", encoding="utf-8")
+
+    result = _read_raw_config(path)
+
+    assert isinstance(result, str)
+    assert "File contains no section headers" in result
+
+
+def test_read_raw_config_returns_unicode_decode_error_text(tmp_path: Path) -> None:
+    path = tmp_path / "config.ini"
+    path.write_bytes(b"[defaults]\npolicy = \xff\n")
+
+    result = _read_raw_config(path)
+
+    assert isinstance(result, str)
+    assert "utf-8" in result
+
+
+def test_render_config_matches_readme_quickstart_block() -> None:
+    rendered = _render_config(
+        dict(SUGGESTED),
+        {
+            "top_cam_device": "/dev/v4l/by-id/YOUR-TOP-CAM",
+            "left_cam_device": "/dev/v4l/by-id/YOUR-LEFT-CAM",
+            "right_cam_device": "/dev/v4l/by-id/YOUR-RIGHT-CAM",
+        },
+        {},
+    )
+
+    assert rendered == (
+        "[defaults]\n"
+        "policy = molmoact2        # from the inspect-robots-yam plugin\n"
+        "embodiment = yam_arms     # same plugin; cameras configured below\n"
+        "scorer = success_at_end\n"
+        "max_steps = 1200          # 120 s at 10 Hz\n"
+        "rerun = true              # live viewer of cameras/state/actions each run\n"
+        "store_frames = true       # save each run's camera frames under logs/frames/\n"
+        "\n"
+        "[embodiment.args]\n"
+        "top_cam_device = /dev/v4l/by-id/YOUR-TOP-CAM\n"
+        "left_cam_device = /dev/v4l/by-id/YOUR-LEFT-CAM\n"
+        "right_cam_device = /dev/v4l/by-id/YOUR-RIGHT-CAM\n"
+    )
+
+
+def test_render_config_omits_skipped_keys_and_empty_sections() -> None:
+    rendered = _render_config(
+        {"policy": "custom-policy"},
+        {},
+        {"embodiment.args": {}, "policy.args": {}},
+    )
+
+    assert "policy = custom-policy" in rendered
+    for key in SUGGESTED.keys() - {"policy"}:
+        assert f"{key} =" not in rendered
+    assert "[embodiment.args]" not in rendered
+    assert "[policy.args]" not in rendered
+    assert rendered.endswith("\n")
+
+
+def test_render_config_omits_empty_defaults_section() -> None:
+    rendered = _render_config({}, {"top_cam_device": "/dev/top"}, {})
+
+    assert "[defaults]" not in rendered
+    assert rendered == "[embodiment.args]\ntop_cam_device = /dev/top\n"
+
+
+def test_render_config_carries_unmanaged_content_without_managed_duplicates(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "config.ini"
+    path.write_text(
+        "[defaults]\n"
+        "policy = old-policy\n"
+        "sim_embodiment = cubepick\n"
+        "\n"
+        "[embodiment.args]\n"
+        "top_cam_device = /dev/old-top\n"
+        "left_channel = can2\n"
+        "\n"
+        "[policy.args]\n"
+        "checkpoint = ~/models/policy.pt\n",
+        encoding="utf-8",
+    )
+    carried = _read_raw_config(path)
+    assert not isinstance(carried, str)
+
+    rendered = _render_config(
+        {"policy": "new-policy", "embodiment": "yam_arms"},
+        {
+            "top_cam_device": "/dev/new-top",
+            "left_cam_device": "/dev/new-left",
+            "right_cam_device": "/dev/new-right",
+        },
+        carried,
+    )
+
+    assert "sim_embodiment = cubepick" in rendered
+    assert "left_channel = can2" in rendered
+    assert "[policy.args]\ncheckpoint = ~/models/policy.pt" in rendered
+    assert rendered.count("policy = new-policy") == 1
+    assert "old-policy" not in rendered
+    assert rendered.count("top_cam_device = /dev/new-top") == 1
+    assert "/dev/old-top" not in rendered
+    assert rendered.index("[defaults]") < rendered.index("[embodiment.args]")
+    assert rendered.index("[embodiment.args]") < rendered.index("[policy.args]")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -150,6 +150,17 @@ def test_render_config_matches_readme_quickstart_block() -> None:
     )
 
 
+def test_render_config_long_commented_value_round_trips(tmp_path: Path) -> None:
+    policy = "my_custom_policy_v2"
+    path = tmp_path / "config.ini"
+    path.write_text(_render_config({"policy": policy}, {}, {}), encoding="utf-8")
+
+    carried = _read_raw_config(path)
+
+    assert not isinstance(carried, str)
+    assert carried["defaults"]["policy"] == policy
+
+
 def test_render_config_omits_skipped_keys_and_empty_sections() -> None:
     rendered = _render_config(
         {"policy": "custom-policy"},
@@ -321,8 +332,10 @@ def test_run_setup_headless_existing_rerun_true_wins_and_note_is_printed(
     assert "rerun = true" in path.read_text(encoding="utf-8")
 
 
-def test_run_setup_typed_overrides_land_in_file(tmp_path: Path) -> None:
-    input_fn, _ = _scripted_input(["my-policy", "my-body", "my-scorer", "42", "false", "false", ""])
+def test_run_setup_strips_typed_overrides_and_whitespace_uses_default(tmp_path: Path) -> None:
+    input_fn, _ = _scripted_input(
+        ["  my-policy  ", "  my-body  ", "   ", " 42 ", " false ", " false ", ""]
+    )
 
     result = run_setup(
         {"XDG_CONFIG_HOME": str(tmp_path)},
@@ -337,7 +350,7 @@ def test_run_setup_typed_overrides_land_in_file(tmp_path: Path) -> None:
     assert result == 0
     assert "policy = my-policy" in text
     assert "embodiment = my-body" in text
-    assert "scorer = my-scorer" in text
+    assert "scorer = success_at_end" in text
     assert "max_steps = 42" in text
     assert "rerun = false" in text
     assert "store_frames = false" in text
@@ -484,6 +497,7 @@ def test_run_setup_declines_malformed_config_repair(tmp_path: Path) -> None:
 
     assert result == 1
     assert "File contains no section headers" in out.getvalue()
+    assert "setup aborted; nothing written" in out.getvalue()
     assert path.read_text(encoding="utf-8") == broken
     assert not path.with_name("config.ini.bak").exists()
 
@@ -597,6 +611,49 @@ def test_run_setup_carries_unmanaged_defaults_and_embodiment_args(tmp_path: Path
     assert "sim_embodiment = cubepick" in text
     assert "left_channel = can2" in text
     assert "top_cam_device = /dev/old" in text
+
+
+def test_run_setup_carries_multiline_values_in_all_sections(tmp_path: Path) -> None:
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[defaults]\n"
+        "notes = defaults line 1\n"
+        "    defaults line 2\n"
+        "\n"
+        "[embodiment.args]\n"
+        "calibration = args line 1\n"
+        "    args line 2\n"
+        "\n"
+        "[policy.args]\n"
+        "notes = policy line 1\n"
+        "    policy line 2\n",
+        encoding="utf-8",
+    )
+    original = _read_raw_config(path)
+    assert not isinstance(original, str)
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "n"])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    rewritten = _read_raw_config(path)
+    assert result == 0
+    assert not isinstance(rewritten, str)
+    for section, key in (
+        ("defaults", "notes"),
+        ("embodiment.args", "calibration"),
+        ("policy.args", "notes"),
+    ):
+        original_lines = [line.lstrip() for line in original[section][key].splitlines()]
+        rewritten_lines = [line.lstrip() for line in rewritten[section][key].splitlines()]
+        assert rewritten_lines == original_lines
 
 
 def test_run_setup_declining_cameras_preserves_existing_assignments(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Replaces the README's error-prone heredoc quickstart with an interactive `inspect-robots setup` wizard (plan `plans/0009-setup-wizard.md`). First-time users no longer hand-edit `/dev/v4l/by-id/YOUR-TOP-CAM` placeholders: the wizard prompts for each `[defaults]` key with the documented suggestions (Enter accepts), discovers V4L2 camera devices, and can identify which physical camera is which via unplug-to-identify (rescan and diff). Writes `~/.config/inspect-robots/config.ini` atomically with the README's explanatory comments.

## Changes

- `src/inspect_robots/_setup.py` (new, stdlib-only): IO-injected wizard. Existing config values win over suggestions; malformed files get a back-up-and-start-fresh repair prompt; unmanaged sections/keys (`[policy.args]`, non-camera `[embodiment.args]` keys, `sim_embodiment`) are carried through raw (interpolation off, no `~` expansion); existing file backed up to `config.ini.bak`; Ctrl-C/EOF aborts write nothing.
- Camera discovery: `/dev/v4l/by-id` first, `-video-index0` color nodes preferred; when serial-less identical cameras collide in by-id, a `p` toggle offers `/dev/v4l/by-path` (stable per USB port) with an explainer. Duplicate-assignment confirm, `(current)` Enter-accept defaults, and an all-three-or-none guard matching `YamConfig`'s validation.
- `cli.py`: `setup` subparser, dispatch, `_SUBCOMMANDS` entry, and `_pick_component` guidance now mentions the wizard.
- Headless probe (#50 item 4): no `DISPLAY`/`WAYLAND_DISPLAY` flips the suggested `rerun` default to `false` with a one-line note.
- README/docs: Quickstart leads with the wizard (heredoc kept as manual fallback, plus the plugin install command per #50's docs follow-up); new `## inspect-robots setup` section in `docs/guide/cli.md`; quickstart guide mention; CHANGELOG entry; module map row.

Smoke-tested end-to-end through a pty on macOS (no V4L devices: camera section defaults to skip) and the written file round-trips through `inspect-robots config show`.

## Checklist

- [x] hooks equivalent ran manually (`ruff check`, `ruff format --check`, `mypy`, `pytest --cov`; the local pre-commit shim is broken in this shell)
- [x] Tests added/updated (57 new tests across `tests/test_setup.py` + CLI tests)
- [x] Coverage stays at **100%** (`pytest --cov`: 330 passed, 100.00% branch)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `mypy` passes (strict)
- [x] `CHANGELOG.md` updated under "Unreleased"
- [x] Public API unchanged (`_setup` stays private; API snapshot untouched)
- [x] Core stays NumPy-only (`_setup.py` is stdlib-only; registry import lazy)

## Related

Part of #50: covers item 4 (display probe) and the docs follow-up. Items 1-3 and 5-7 (import preflight, version skew, CAN/policy-server probes, check-everything-report-everything) are `doctor`-shaped follow-ups and stay tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)