### PR TITLE
fix(setup): explain the prompt convention up front

### DIFF
--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -456,6 +456,12 @@ def run_setup(
     if path is None:
         raise SystemExit("cannot locate a config home: set $XDG_CONFIG_HOME or $HOME")
 
+    print(f"inspect-robots setup — writes {path}", file=out)
+    print(
+        "Each prompt shows a [suggested] value: press Enter to accept it, or type a replacement.",
+        file=out,
+    )
+
     try:
         carried: dict[str, dict[str, str]] = {}
         if path.is_file():
@@ -473,6 +479,11 @@ def run_setup(
                     return 1
             else:
                 carried = raw_config
+                print(
+                    "Found an existing config; its values are the suggestions "
+                    f"below (the old file will be saved as {path.name}.bak).",
+                    file=out,
+                )
 
         headless = "DISPLAY" not in env and "WAYLAND_DISPLAY" not in env
         defaults = _prompt_defaults(

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1303,3 +1303,45 @@ def test_run_setup_multiline_current_camera_still_parses(tmp_path: Path) -> None
     assert not isinstance(rewritten, str)
     lines = [line.lstrip() for line in rewritten["embodiment.args"]["top_cam_device"].splitlines()]
     assert lines == ["/dev/one", "/dev/one-continued"]
+
+
+def test_run_setup_prints_intro_header_and_enter_hint(tmp_path: Path) -> None:
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "n"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = out.getvalue()
+    assert result == 0
+    assert f"inspect-robots setup — writes {_config_path(tmp_path)}" in text
+    assert "press Enter to accept it, or type a replacement" in text
+    assert "Found an existing config" not in text
+
+
+def test_run_setup_intro_names_existing_config_and_backup(tmp_path: Path) -> None:
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text("[defaults]\npolicy = configured\n", encoding="utf-8")
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "n"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = out.getvalue()
+    assert result == 0
+    assert "Found an existing config; its values are the suggestions" in text
+    assert "config.ini.bak" in text


### PR DESCRIPTION
## Summary

A first-run operator on the YAM rig hit `policy [molmoact2]:` cold and asked whether it was a yes/no prompt. The wizard printed no introduction (the plan's transcript showed a header line, but no binding decision or test pinned it, so it was never implemented).

## Changes

- `run_setup` now opens with the target path and the prompt convention:
  ```
  inspect-robots setup — writes ~/.config/inspect-robots/config.ini
  Each prompt shows a [suggested] value: press Enter to accept it, or type a replacement.
  ```
- When an existing config parses, a line says its values are the suggestions and names the `config.ini.bak` backup.
- Two tests pin the header, the hint, and the existing-config note (and its absence on first run).

Smoke-tested through a pty; transcript now self-explains.

## Checklist

- [x] Gates ran manually: `ruff check`, `ruff format --check`, `mypy`, `pytest --cov` (337 passed, 100.00% branch)
- [x] Tests added/updated
- [x] Coverage stays at **100%**
- [x] No public API change, no CHANGELOG entry needed (unreleased wizard copy)
- [x] Core stays NumPy-only

## Related

Follow-up to #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)