### PR TITLE
feat(setup): end-of-run plugin reminder; quickstart installs the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ If you know [Inspect AI](https://inspect.aisi.org.uk/), this is that for robotic
 [![Docs coverage](https://img.shields.io/badge/public%20docstrings-100%25-brightgreen)](https://github.com/robocurve/inspect-robots/actions/workflows/ci.yml)
 
 [**Documentation**](https://inspectrobots.org/) ·
-[Quickstart](https://inspectrobots.org/guide/quickstart.html) ·
-[Concepts](https://inspectrobots.org/guide/concepts.html) ·
+[Quickstart](https://inspectrobots.org/guide/quickstart/) ·
+[Concepts](https://inspectrobots.org/guide/concepts/) ·
 [For LLMs](https://inspectrobots.org/llms.txt)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -68,42 +68,19 @@ below and no activation is needed.
 
 ## Quickstart
 
-Set your defaults once with the interactive wizard:
+Install the plugin for your rig (the wizard suggests this one's components)
+and set your defaults once:
 
 ```bash
+uv pip install inspect-robots-yam   # provides the molmoact2 policy + yam_arms rig
 uv run inspect-robots setup
 ```
 
-It walks you through the defaults (policy, embodiment, scorer, run length),
-lists the camera devices under `/dev/v4l/by-id`, and can tell you which
-physical camera is which: unplug one when asked and the wizard identifies it
-from the device that disappeared. Press Enter to accept the suggested values
-(the [inspect-robots-yam](https://github.com/robocurve/inspect-robots-yam)
-plugin shown below) or type your own; install the plugin whose components
-you configure (`uv pip install inspect-robots-yam`) or the wizard will warn
-that the names are not registered. The result lands in
-`~/.config/inspect-robots/config.ini`; note that later `inspect-robots
-config set` edits drop comments from that file.
-
-Prefer to write the file yourself? Replace the three camera paths with your
-rig's V4L2 color nodes:
-
-```bash
-mkdir -p ~/.config/inspect-robots && cat > ~/.config/inspect-robots/config.ini <<'EOF'
-[defaults]
-policy = molmoact2        # from the inspect-robots-yam plugin
-embodiment = yam_arms     # same plugin; cameras configured below
-scorer = success_at_end
-max_steps = 1200          # 120 s at 10 Hz
-rerun = true              # live viewer of cameras/state/actions each run
-store_frames = true       # save each run's camera frames under logs/frames/
-
-[embodiment.args]
-top_cam_device = /dev/v4l/by-id/YOUR-TOP-CAM
-left_cam_device = /dev/v4l/by-id/YOUR-LEFT-CAM
-right_cam_device = /dev/v4l/by-id/YOUR-RIGHT-CAM
-EOF
-```
+The wizard picks your defaults and finds your cameras (unplug one when asked
+and it identifies which is which), then writes
+`~/.config/inspect-robots/config.ini`. On a different rig, install its plugin
+instead and type its component names at the prompts; to write the config file
+by hand, see [the CLI guide](https://inspectrobots.org/guide/cli/).
 
 Then tell the robot what to do:
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -118,9 +118,31 @@ inspect-robots setup
 The result is written to `~/.config/inspect-robots/config.ini`
 (`$XDG_CONFIG_HOME` honored); an existing file is backed up to
 `config.ini.bak` first, and settings the wizard does not manage (such as
-`[policy.args]` or `sim_embodiment`) are carried through unchanged. The
-command requires an interactive terminal; for scripted configuration use
-`inspect-robots config set`.
+`[policy.args]` or `sim_embodiment`) are carried through unchanged. Note
+that later `inspect-robots config set` edits drop comments from the file.
+The command requires an interactive terminal; for scripted configuration
+use `inspect-robots config set`.
+
+Prefer to write the file yourself? This is the wizard's output for a YAM
+rig; replace the three camera paths with your rig's V4L2 color nodes
+(stable `/dev/v4l/by-id/...` or udev-symlink paths):
+
+```bash
+mkdir -p ~/.config/inspect-robots && cat > ~/.config/inspect-robots/config.ini <<'EOF'
+[defaults]
+policy = molmoact2        # from the inspect-robots-yam plugin
+embodiment = yam_arms     # same plugin; cameras configured below
+scorer = success_at_end
+max_steps = 1200          # 120 s at 10 Hz
+rerun = true              # live viewer of cameras/state/actions each run
+store_frames = true       # save each run's camera frames under logs/frames/
+
+[embodiment.args]
+top_cam_device = /dev/v4l/by-id/YOUR-TOP-CAM
+left_cam_device = /dev/v4l/by-id/YOUR-LEFT-CAM
+right_cam_device = /dev/v4l/by-id/YOUR-RIGHT-CAM
+EOF
+```
 
 ## `inspect-robots list`
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -120,8 +120,8 @@ The result is written to `~/.config/inspect-robots/config.ini`
 `config.ini.bak` first, and settings the wizard does not manage (such as
 `[policy.args]` or `sim_embodiment`) are carried through unchanged. Note
 that later `inspect-robots config set` edits drop comments from the file.
-The command requires an interactive terminal; for scripted configuration
-use `inspect-robots config set`.
+The setup command requires an interactive terminal; for scripted
+configuration use `inspect-robots config set`.
 
 Prefer to write the file yourself? This is the wizard's output for a YAM
 rig; replace the three camera paths with your rig's V4L2 color nodes

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -598,8 +598,9 @@ def run_setup(
     if missing:
         print(
             _paint(
-                f"reminder: {' and '.join(missing)} not registered here; run "
-                "`uv pip install inspect-robots-yam` before your first run",
+                f"reminder: {' and '.join(missing)} not registered here; install "
+                "the plugin (e.g. `uv pip install inspect-robots-yam`) before "
+                "your first run",
                 _YELLOW,
                 out,
             ),

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -100,7 +100,7 @@ def _ask_yes_no(
     out: IO[str],
 ) -> bool:
     """Ask a conventional yes/no question, re-prompting unclear answers."""
-    suffix = "[Y/n]" if default else "[y/N]"
+    suffix = _paint("[Y/n]" if default else "[y/N]", _CYAN, out)
     while True:
         entered = input_fn(f"{prompt} {suffix} ").strip().lower()
         if not entered:
@@ -112,11 +112,16 @@ def _ask_yes_no(
         print(_paint("please answer yes or no", _YELLOW, out), file=out)
 
 
-def _warn_unregistered(kind: str, name: str, out: IO[str]) -> None:
-    """Warn about unavailable plugins without importing the registry eagerly."""
+def _is_registered(kind: str, name: str) -> bool:
+    """Resolve ``name`` against the registry without importing it eagerly."""
     from inspect_robots.registry import registered
 
-    if name not in registered(kind):
+    return name in registered(kind)
+
+
+def _warn_unregistered(kind: str, name: str, out: IO[str]) -> None:
+    """Warn about unavailable plugins the moment a name is accepted."""
+    if not _is_registered(kind, name):
         print(
             _paint(
                 f"'{name}' is not registered here — install its plugin, e.g. "
@@ -239,8 +244,10 @@ def _camera_role_prompt(
     devices: list[str],
     current: str | None,
     advertise_path_toggle: bool,
+    *,
     out: IO[str],
 ) -> str:
+    """Prompt text for one camera role, with the Enter-accept current value."""
     choices = f"{role} camera — number, 'u' to identify by unplugging"
     if advertise_path_toggle:
         choices += ", 'p' to switch listing"
@@ -269,7 +276,7 @@ def _prompt_camera_role(
     while True:
         devices = by_id_devices if active_is_by_id else by_path_devices
         device_dir = by_id_dir if active_is_by_id else by_path_dir
-        prompt = _camera_role_prompt(role, devices, current, advertise_path_toggle, out)
+        prompt = _camera_role_prompt(role, devices, current, advertise_path_toggle, out=out)
         entered = input_fn(prompt).strip()
         selected: str | None = None
         if entered.lower() == "s":
@@ -581,6 +588,23 @@ def run_setup(
         path.replace(path.with_name(path.name + ".bak"))
     tmp.replace(path)
     print(_paint(f"Wrote {path}", _GREEN, out), file=out)
+    # Repeat the plugin reminder where it cannot scroll away: the per-prompt
+    # warning is easy to miss while Enter-accepting the suggestions.
+    missing = [
+        f"{kind} '{defaults[kind]}'"
+        for kind in ("policy", "embodiment")
+        if not _is_registered(kind, defaults[kind])
+    ]
+    if missing:
+        print(
+            _paint(
+                f"reminder: {' and '.join(missing)} not registered here; run "
+                "`uv pip install inspect-robots-yam` before your first run",
+                _YELLOW,
+                out,
+            ),
+            file=out,
+        )
     next_cmd = 'uv run inspect-robots "place the fork on the plate"'
     print(f"Next: {_paint(next_cmd, _CYAN, out)}", file=out)
     return 0

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1397,3 +1397,70 @@ def test_run_setup_honors_no_color_on_a_tty(
     assert result == 0
     assert "\x1b[" not in out.getvalue()
     assert all("\x1b[" not in prompt for prompt in prompts)
+
+
+def test_run_setup_repeats_plugin_reminder_after_writing(tmp_path: Path) -> None:
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "n"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = out.getvalue()
+    assert result == 0
+    reminder = (
+        "reminder: policy 'molmoact2' and embodiment 'yam_arms' not registered "
+        "here; run `uv pip install inspect-robots-yam` before your first run"
+    )
+    assert reminder in text
+    assert text.index("Wrote ") < text.index("reminder: ")
+
+
+def test_run_setup_no_reminder_when_components_registered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "inspect_robots.registry.registered",
+        lambda kind: {"molmoact2", "yam_arms"},
+    )
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "n"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert "reminder:" not in out.getvalue()
+
+
+def test_run_setup_reminder_names_only_the_missing_component(tmp_path: Path) -> None:
+    input_fn, _ = _scripted_input(["", "", "", "", "", "", "n"])
+    out = io.StringIO()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("inspect_robots.registry.registered", lambda kind: {"molmoact2"})
+        result = run_setup(
+            {"XDG_CONFIG_HOME": str(tmp_path)},
+            input_fn=input_fn,
+            out=out,
+            interactive=True,
+            by_id_dir=tmp_path / "none-id",
+            by_path_dir=tmp_path / "none-path",
+        )
+
+    text = out.getvalue()
+    assert result == 0
+    assert "reminder: embodiment 'yam_arms' not registered here" in text
+    assert "policy 'molmoact2'" not in text.split("Wrote ")[1]

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1416,7 +1416,8 @@ def test_run_setup_repeats_plugin_reminder_after_writing(tmp_path: Path) -> None
     assert result == 0
     reminder = (
         "reminder: policy 'molmoact2' and embodiment 'yam_arms' not registered "
-        "here; run `uv pip install inspect-robots-yam` before your first run"
+        "here; install the plugin (e.g. `uv pip install inspect-robots-yam`) "
+        "before your first run"
     )
     assert reminder in text
     assert text.index("Wrote ") < text.index("reminder: ")


### PR DESCRIPTION
## Summary

Clicking through the wizard with the suggested defaults (`molmoact2`, `yam_arms`) must produce a config that actually runs. Two changes make that true, plus a README diet.

## Changes

- **README quickstart:** now two commands (`uv pip install inspect-robots-yam` then `uv run inspect-robots setup`) and two sentences. The walkthrough paragraph is gone (the wizard explains itself at runtime since #55) and the manual heredoc moved to the `inspect-robots setup` section of the CLI guide with a pointer link. Unblocked by inspect-robots-yam 0.7.0 on PyPI (released today; 0.6.0 had the broken pose-field parsing from #50).
- **Wizard:** after `Wrote <path>`, if any accepted policy/embodiment name is unregistered, one yellow reminder line repeats the install command where it cannot scroll away (the per-prompt warning is easy to miss while Enter-accepting). New `_is_registered` helper backs both the per-prompt warning and the final check; three tests cover both-missing, none-missing, and one-missing.
- **Nits from the #56 review:** the `[Y/n]` suffix is now cyan like every other Enter-accept indicator, and `_camera_role_prompt` takes `out` keyword-only like its siblings.

## Checklist

- [x] Gates ran manually: `ruff check`, `ruff format --check`, `mypy`, `pytest --cov` (342 passed, 100.00% branch)
- [x] Tests added/updated
- [x] Coverage stays at **100%**
- [x] No public API change; core stays NumPy-only

## Related

Closes the quickstart half of #50's docs follow-up. Follow-up to #52/#55/#56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)