### PR TITLE
fix(cli): surface log.error in the run summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **`inspect-robots run` now surfaces evaluation failures in its summary**:
+  top-level errors, per-scene failure context, and a ready-to-run postmortem
+  `inspect` command are printed after unsuccessful runs (#57).
 - **Config `[*.args]` sections no longer follow a differently-selected
   component** (#44). `[policy.args]` / `[embodiment.args]` /
   `[sim_embodiment.args]` now apply only when the selected component matches

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -44,6 +44,7 @@ from inspect_robots._defaults import (
 
 if TYPE_CHECKING:
     from inspect_robots.approver import Approver
+    from inspect_robots.log import EvalLog
     from inspect_robots.logging.sink import LogSink
     from inspect_robots.rollout import TrialRecord
     from inspect_robots.scene import Scene
@@ -369,6 +370,29 @@ def _prompt_operator(record: TrialRecord, scene: Scene) -> None:
     record.events.append(operator_event(t=len(record.steps), verdict=answer))
 
 
+def _print_run_summary(log: EvalLog, log_path: str) -> None:
+    """Print the compact post-run summary and failure diagnostics."""
+    failed = log.status != "success"
+    status_color = _RED if failed else _GREEN
+    print(f"{_styled('status:', _CYAN)} {_styled(log.status, status_color)}")
+    if failed and log.error is not None:
+        print(f"{_styled('error:', _CYAN)} {_styled(log.error, _RED)}")
+    if failed:
+        for scene in log.samples:
+            if scene.status == "error":
+                detail = "" if scene.error in (None, log.error) else f": {scene.error}"
+                print(f"  [{_styled('error', _RED)}] {scene.scene_id}{detail}")
+    print(
+        f"{_styled('scenes:', _CYAN)} {log.results.total_scenes}  "
+        f"trials: {log.results.total_trials}"
+    )
+    for name, value in sorted(log.results.metrics.items()):
+        print(f"  {name}: {_styled(f'{value:.4g}', _BOLD)}")
+    print(f"{_styled('log:', _CYAN)} {_styled(log_path, _DIM)}")
+    if failed:
+        print(_styled(f"hint: inspect-robots inspect {log_path}", _DIM))
+
+
 def _cmd_run(args: argparse.Namespace) -> int:
     from dataclasses import replace
 
@@ -521,15 +545,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         # here and eval() can raise, and that must not leak the embodiment.
         embodiment.close()
     log = logs[0]
-    status_color = _GREEN if log.status == "success" else _RED
-    print(f"{_styled('status:', _CYAN)} {_styled(log.status, status_color)}")
-    print(
-        f"{_styled('scenes:', _CYAN)} {log.results.total_scenes}  "
-        f"trials: {log.results.total_trials}"
-    )
-    for name, value in sorted(log.results.metrics.items()):
-        print(f"  {name}: {_styled(f'{value:.4g}', _BOLD)}")
-    print(f"{_styled('log:', _CYAN)} {_styled(str(sink.path), _DIM)}")
+    _print_run_summary(log, str(sink.path))
     return 0 if log.status == "success" else 1
 
 

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -104,6 +104,98 @@ def test_cli_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     assert "success_at_end" in out
     (written,) = tmp_path.glob("*.json")
     assert f"log: {written}" in out  # the CLI tells the user where the log went
+    assert "error:" not in out
+    assert "hint:" not in out
+
+
+def test_cli_run_embodiment_fault_prints_error_scene_and_inspect_hint(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.registry import embodiment as embodiment_decorator
+    from inspect_robots.scene import Scene
+    from inspect_robots.types import Observation
+
+    class _FaultOnSecondScene(CubePickEmbodiment):
+        def __init__(self) -> None:
+            super().__init__()
+            self._resets = 0
+
+        def reset(self, scene: Scene, *, seed: int | None = None) -> Observation:
+            self._resets += 1
+            if self._resets == 2:
+                raise RuntimeError("reset exploded")
+            return super().reset(scene, seed=seed)
+
+    name = "fault-on-second-scene-for-cli-test"
+    embodiment_decorator(name)(_FaultOnSecondScene)
+    try:
+        rc = main(
+            [
+                "run",
+                "--task",
+                "cubepick-reach",
+                "-T",
+                "num_scenes=2",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                name,
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["embodiment"].pop(name)
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "status: error" in out
+    assert "error: EmbodimentFault: reset exploded" in out
+    assert "  [error] scene-1\n" in out
+    assert "scene-0" not in out  # successful scenes are not failure context
+    assert out.count("EmbodimentFault: reset exploded") == 1
+    (written,) = tmp_path.glob("*.json")
+    assert f"hint: inspect-robots inspect {written}" in out
+
+
+def test_cli_run_prints_distinct_scene_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from inspect_robots.registry import policy as policy_decorator
+    from inspect_robots.scene import Scene
+
+    class _ResetFailurePolicy(ScriptedPolicy):
+        def reset(self, scene: Scene) -> None:
+            raise RuntimeError("policy reset exploded")
+
+    name = "reset-failure-for-cli-test"
+    policy_decorator(name)(_ResetFailurePolicy)
+    try:
+        rc = main(
+            [
+                "run",
+                "--task",
+                "cubepick-reach",
+                "-T",
+                "num_scenes=1",
+                "--policy",
+                name,
+                "--embodiment",
+                "cubepick",
+                "--fail-on-error",
+                "1",
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["policy"].pop(name)
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "error: fail_on_error threshold exceeded (1 errors)" in out
+    assert "[error] scene-0: PolicyError: policy reset exploded" in out
 
 
 def test_cli_run_epochs_fail_on_error_store_frames(


### PR DESCRIPTION
## Summary

`inspect-robots run` printed `status: error` with exit code 1 but never the error itself; the cause was only visible inside the JSON log (via the separate `inspect` subcommand nothing pointed to). The run summary now prints the error, per-scene failure context, and a ready-to-run postmortem hint whenever the run is unsuccessful. Success output is byte-identical to before.

## Changes

- Extracted the inline summary block into `_print_run_summary`. On failure it prints `error: <log.error>` (red) right after the status line, one `[error] <scene_id>[: <scene.error>]` line per errored scene (the scene detail is suppressed when identical to the top-level error), and a dim `hint: inspect-robots inspect <path>` after the `log:` line.
- Two end-to-end CLI tests: a halting `EmbodimentFault` mid-run (asserts the error line, failing-scene context, dedup, and the hint with the real log path) and a `--fail-on-error` threshold run (covers the scene-error-differs branch). The success-path test now also asserts no `error:`/`hint:` lines appear.
- CHANGELOG entry under Unreleased.

Deliberate scope cut: the issue also proposed printing the step count at failure. `SceneResult` carries no per-trial step count and `EvalStats.total_steps` is run-wide, so honoring that verbatim needs an additive log-schema change, out of proportion here. The scene id plus the taxonomy error string identifies every failure in the #50 field report on its own; happy to file a follow-up if per-trial step counts are wanted in the schema.

## Checklist

- [x] `pre-commit install` done; hooks pass (or ran `pre-commit run --all-files`)
- [x] Tests added/updated (and the `CubePick` mock exercises the change where applicable)
- [x] Coverage stays at **100%** (`pytest --cov`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `mypy` passes (strict)
- [x] `CHANGELOG.md` updated under "Unreleased"
- [x] Public API changes are reflected in `inspect_robots.__all__` and the API-snapshot test (n/a: no public API change)
- [x] Core stays NumPy-only (new deps are optional extras, lazily imported)

## Related

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)