### PR TITLE
feat(conformance): runtime-requirement preflight in setup and doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- Runtime-requirement declarations for registered component factories, with
+  missing-import preflight checklists in `inspect-robots setup` and
+  `inspect-robots doctor` (#59).
 - isaacsim plugin: `_ensure_env`'s cfg-wiring contract (`parse_env_cfg`'s
   args, `gym.make(cfg=...)`, the `headless` → `_disable_debug_vis` gate, and
   the named-obs-terms request) is now exercised in CI via stubbed

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -14,6 +14,23 @@ those declarations load-bearing:
 An adapter with missing or dishonest declarations silently degrades both.
 This page is the contract; the conformance kit makes most of it mechanical.
 
+## Declare runtime requirements
+
+Declare imports that cannot be expressed by package metadata on the registered
+component factory:
+
+```python
+RUNTIME_REQUIREMENTS = {
+    "i2rt": 'uv pip install "i2rt @ git+https://github.com/i2rt-robotics/i2rt"',
+    "cv2": 'uv pip install "inspect-robots-yam[cameras]"',
+}
+```
+
+The setup wizard checks registered policies and embodiments, while `doctor`
+checks its selected embodiment before construction. Both use
+`importlib.util.find_spec` without importing the declared top-level modules and
+print each remediation command verbatim when a module is missing.
+
 ## The conformance kit
 
 Add one test to your adapter repo:

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -26,8 +26,8 @@ RUNTIME_REQUIREMENTS = {
 }
 ```
 
-The setup wizard checks registered policies and embodiments, while `doctor`
-checks its selected embodiment before construction. Both use
+The setup wizard checks the configured policy and embodiment when they are
+registered, while `doctor` checks its selected embodiment before construction. Both use
 `importlib.util.find_spec` without importing the declared top-level modules and
 print each remediation command verbatim when a module is missing.
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -122,6 +122,9 @@ The result is written to `~/.config/inspect-robots/config.ini`
 that later `inspect-robots config set` edits drop comments from the file.
 The setup command requires an interactive terminal; for scripted
 configuration use `inspect-robots config set`.
+After writing the config, setup lists missing runtime requirements declared by
+the selected registered policy and embodiment, together with their remediation
+commands.
 
 Prefer to write the file yourself? This is the wizard's output for a YAM
 rig; replace the three camera paths with your rig's V4L2 color nodes
@@ -180,6 +183,15 @@ the zero-config section above); `--instruction "..."` replaces `--task` to
 run a single ad-hoc scene.
 
 The exit code is `0` on a successful eval, `1` otherwise.
+
+## `inspect-robots doctor`
+
+`doctor` reports a registered embodiment's missing declared runtime modules
+before constructing it, then checks its spaces for adapter conformance.
+
+```bash
+inspect-robots doctor --embodiment my_arms
+```
 
 ## `inspect-robots inspect`
 

--- a/plans/0010-runtime-requirements.md
+++ b/plans/0010-runtime-requirements.md
@@ -1,0 +1,141 @@
+# 0010 — Runtime-requirement preflight (`RUNTIME_REQUIREMENTS`)
+
+Fixes #59. Adapters have runtime deps that install metadata cannot express
+(the `i2rt` motor driver is git-only, so PyPI forbids depending on it); today
+they surface as `EmbodimentFault: No module named 'i2rt'` at reset, with the
+arms already in the loop. Components declare their runtime imports as data;
+`setup` and `doctor` preflight them with `importlib.util.find_spec`, which
+never executes the module.
+
+## 1. Protocol (data only)
+
+A component factory (class or function, whatever is registered) may carry:
+
+```python
+RUNTIME_REQUIREMENTS = {
+    "i2rt": 'uv pip install "i2rt @ git+https://github.com/i2rt-robotics/i2rt"',
+    "cv2": 'uv pip install "inspect-robots-yam[cameras]"',
+}
+```
+
+Keys are importable module names, values are remediation commands shown
+verbatim. Absent attribute means no requirements. The declaration lives on
+the factory so checking never constructs the component (constructors are
+hardware-free by convention, but the whole point is to run before anything
+plugin-shaped executes).
+
+## 2. Core checker: `conformance.py`
+
+```python
+def missing_runtime_requirements(factory: object) -> dict[str, str]:
+    """The declared runtime modules that are not importable here.
+
+    Reads ``RUNTIME_REQUIREMENTS`` (module name -> remediation command) off
+    ``factory`` and probes each with ``importlib.util.find_spec``. Top-level
+    names (the intended use) are probed without executing anything; a dotted
+    name imports its parent package when present, so declare top-level names.
+    ANY probe failure counts as missing (broad ``except Exception``: a
+    present-but-broken parent package propagates arbitrary errors from its
+    ``__init__``, and this checker must never crash setup or doctor).
+    Entries whose key or value is not ``str``, or a ``RUNTIME_REQUIREMENTS``
+    that is not a ``Mapping``, are ignored (a plugin typo must not crash the
+    preflight). Returns the missing subset, insertion-ordered.
+    """
+```
+
+Lives in `inspect_robots.conformance` and is imported from there, matching
+its siblings (`check_embodiment` is deliberately NOT in `__all__`; the
+adapters guide teaches `from inspect_robots.conformance import ...`). No
+`__all__` or API-snapshot change. `importlib.util` import stays
+module-level (stdlib, numpy-only rule holds).
+
+## 3. Consumers
+
+### 3.1 `setup` wizard (final step, after `Wrote`)
+
+For each of the two configured kinds (policy, embodiment) whose accepted
+name IS registered: fetch the factory via `registered(kind)` (already loaded
+by the per-prompt warning, so this is a dict lookup) and sweep. If anything
+is missing, print a yellow checklist after the existing unregistered-name
+reminder position:
+
+```
+setup complete, but 2 runtime dependencies are missing:
+  ✗ i2rt (yam_arms) → uv pip install "i2rt @ git+https://github.com/i2rt-robotics/i2rt"
+  ✗ cv2 (yam_arms) → uv pip install "inspect-robots-yam[cameras]"
+```
+
+Singular "1 runtime dependency is" handled; the header counts lines. Exit
+code stays 0: the config file is correct; the checklist is the actionable
+part. No dedup: one line per (kind, name, module) — two components may need
+the same module with different remedies, and collapsing across kinds could
+silently drop a remedy. The `✗` is output only (functional mark, allowed);
+`→` likewise.
+
+### 3.2 `doctor`
+
+`_cmd_doctor` is reordered so the sweep runs and PRINTS before construction
+(construction can itself die on the missing module; `_resolve_or_exit`
+catches only `KeyError`/`ConfigError`, so a constructor-time
+`ModuleNotFoundError` would otherwise traceback with no guidance):
+
+1. Print the `embodiment: {name} ({source})` header first (moved up from
+   after construction).
+2. Sweep `registered("embodiment").get(name)` (`.get`: an unknown name must
+   fall through to `_resolve_or_exit`'s guided SystemExit, not KeyError;
+   `missing_runtime_requirements(None)` returns `{}`). Print one line per
+   missing module, before constructing:
+
+```
+  [error] runtime-requirement: i2rt missing → uv pip install "i2rt @ git+..."
+```
+
+3. Construct and run the conformance checks as today; the summary prints
+   after (its first line repeats the embodiment name, which is acceptable).
+4. Exit 1 when the report failed OR requirements were missing.
+
+Doctor stays embodiment-only (its existing scope). A constructor that still
+crashes on the missing module now crashes after the guided lines printed.
+
+## 4. Docs and plugin side
+
+- `docs/guide/adapters.md`: short section "Declare runtime requirements"
+  with the dict example and the two consumers.
+- `docs/guide/cli.md`: one sentence each under setup and doctor.
+- CHANGELOG "Added" entry referencing #59.
+- Module map: extend the `conformance.py` row.
+- Plugin declaration for `yam_arms` is tracked separately
+  (robocurve/inspect-robots-yam#30); this PR ships the protocol + consumers.
+  The CubePick mock declares nothing (numpy-only, nothing to declare).
+
+## 5. Tests (100% branch, mypy strict incl. tests)
+
+`tests/test_conformance.py` (or wherever check_embodiment's tests live):
+- no attribute → `{}`; all present (e.g. `{"os": "..."}`).
+- missing top-level module → returned with its remedy, order preserved.
+- submodule key with missing parent (`"definitely_missing_xyz.sub"`) →
+  treated missing, no exception.
+- probe raising an arbitrary exception (monkeypatched `find_spec` raising
+  `OSError`, the broken-parent-package case) → treated missing, no crash.
+- non-mapping attribute, and mapping entries with non-str key or value →
+  ignored without crashing; `missing_runtime_requirements(None)` → `{}`.
+
+`tests/test_setup.py`:
+- registered fake factory (monkeypatched `registered`) carrying a missing
+  requirement → checklist printed after `Wrote`, singular/plural forms,
+  `(component)` attribution, remedy verbatim.
+- requirements all present → no checklist.
+- unregistered names → no sweep (existing reminder only).
+
+`tests/test_registry_cli.py` (doctor):
+- conformant embodiment whose factory declares a missing module → the
+  `[error] runtime-requirement:` line and exit 1; the line appears BEFORE
+  the conformance summary in captured output.
+- declares only present modules → unchanged pass (exit 0).
+- unknown embodiment name → the existing guided SystemExit, unchanged.
+
+## 6. Execution
+
+Single PR on `feat/runtime-requirements`: (1) checker + tests, (2) setup
+consumer + tests, (3) doctor consumer + tests, (4) docs/changelog. Gates
+per commit; Fable review-edit loop before merge.

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -20,7 +20,7 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `frames.py` | `FrameStore`/`FrameRef` — stream camera frames to disk (R5) |
 | `transcript.py` | typed event stream (reset/inference/step/approval/operator/error) |
 | `compat.py` | `check_compatibility`/`assert_compatible` — fail-fast before rollout |
-| `conformance.py` | adapter conformance kit: `check_embodiment`/`assert_embodiment_conformant` — declarative guardrail/agent readiness; backs `inspect-robots doctor` and adapter-repo CI tests |
+| `conformance.py` | adapter conformance kit: `check_embodiment`/`assert_embodiment_conformant` for declarative guardrail/agent readiness; `missing_runtime_requirements` provides runtime-dependency preflight for setup and doctor |
 | `errors.py` | error taxonomy (continue vs halt) |
 | `eval.py` | `eval()` / `eval_set()` orchestration |
 | `log.py` | immutable, schema-versioned `EvalLog` + `read_eval_log` |

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -133,6 +133,22 @@ def _warn_unregistered(kind: str, name: str, out: IO[str]) -> None:
         )
 
 
+def _runtime_requirement_lines(defaults: Mapping[str, str]) -> list[str]:
+    """Build setup checklist lines for registered configured components."""
+    from inspect_robots.conformance import missing_runtime_requirements
+    from inspect_robots.registry import registered
+
+    lines: list[str] = []
+    for kind in ("policy", "embodiment"):
+        name = defaults[kind]
+        factories = registered(kind)
+        if name not in factories:
+            continue
+        for module, remedy in missing_runtime_requirements(factories[name]).items():
+            lines.append(f"  ✗ {module} ({name}) → {remedy}")
+    return lines
+
+
 def _prompt_defaults(
     carried: dict[str, dict[str, str]],
     *,
@@ -606,6 +622,14 @@ def run_setup(
             ),
             file=out,
         )
+    runtime_lines = _runtime_requirement_lines(defaults)
+    if runtime_lines:
+        count = len(runtime_lines)
+        dependency = "dependency is" if count == 1 else "dependencies are"
+        block = "\n".join(
+            [f"setup complete, but {count} runtime {dependency} missing:", *runtime_lines]
+        )
+        print(_paint(block, _YELLOW, out), file=out)
     next_cmd = 'uv run inspect-robots "place the fork on the plate"'
     print(f"Next: {_paint(next_cmd, _CYAN, out)}", file=out)
     return 0

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -573,12 +573,13 @@ def _cmd_inspect(path: str) -> int:
 
 
 def _cmd_doctor(args: argparse.Namespace) -> int:
-    """Run the declarative conformance checks against an installed adapter.
+    """Preflight runtime requirements and conformance for an installed adapter.
 
     Purely declarative — the embodiment is constructed (adapters keep
     constructors hardware-free by convention) but never reset or stepped.
     """
-    from inspect_robots.conformance import check_embodiment
+    from inspect_robots.conformance import check_embodiment, missing_runtime_requirements
+    from inspect_robots.registry import registered
 
     defaults = load_defaults(os.environ)
     name, source = _pick_component(
@@ -588,16 +589,19 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
         "embodiment", name, defaults.embodiment_args_owner, defaults.embodiment_args
     )
     kvs = {**config_kvs, **_parse_kvs(args.embodiment_args)}
+    print(f"embodiment: {name} ({source})")
+    missing = missing_runtime_requirements(registered("embodiment").get(name))
+    for module, remedy in missing.items():
+        print(f"  [error] runtime-requirement: {module} missing → {remedy}")
     embodiment = _resolve_or_exit("embodiment", name, **kvs)
     try:
         report = check_embodiment(embodiment.info)
     finally:
         embodiment.close()
-    print(f"embodiment: {name} ({source})")
     print(report.summary())
     if not report.ok:
         print("see the adapter authoring guide: docs/guide/adapters.md")
-    return 0 if report.ok else 1
+    return 1 if not report.ok or missing else 0
 
 
 def _cmd_setup() -> int:

--- a/src/inspect_robots/conformance.py
+++ b/src/inspect_robots/conformance.py
@@ -18,6 +18,8 @@ guide covers the human half.
 
 from __future__ import annotations
 
+import importlib.util
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -25,6 +27,37 @@ import numpy as np
 from inspect_robots.embodiment import EmbodimentInfo
 
 _ABSOLUTE_MODES = frozenset({"joint_pos", "eef_abs_pose"})
+
+
+def missing_runtime_requirements(factory: object) -> dict[str, str]:
+    """The declared runtime modules that are not importable here.
+
+    Reads ``RUNTIME_REQUIREMENTS`` (module name -> remediation command) off
+    ``factory`` and probes each with ``importlib.util.find_spec``. Top-level
+    names (the intended use) are probed without executing anything; a dotted
+    name imports its parent package when present, so declare top-level names.
+    ANY probe failure counts as missing (broad ``except Exception``: a
+    present-but-broken parent package propagates arbitrary errors from its
+    ``__init__``, and this checker must never crash setup or doctor).
+    Entries whose key or value is not ``str``, or a ``RUNTIME_REQUIREMENTS``
+    that is not a ``Mapping``, are ignored (a plugin typo must not crash the
+    preflight). Returns the missing subset, insertion-ordered.
+    """
+    requirements = getattr(factory, "RUNTIME_REQUIREMENTS", None)
+    if not isinstance(requirements, Mapping):
+        return {}
+
+    missing: dict[str, str] = {}
+    for name, remedy in requirements.items():
+        if not isinstance(name, str) or not isinstance(remedy, str):
+            continue
+        try:
+            spec = importlib.util.find_spec(name)
+        except Exception:
+            spec = None
+        if spec is None:
+            missing[name] = remedy
+    return missing
 
 
 @dataclass(frozen=True)

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
-import numpy as np
+from typing import ClassVar
 
-from inspect_robots.conformance import assert_embodiment_conformant, check_embodiment
+import numpy as np
+import pytest
+
+from inspect_robots.conformance import (
+    assert_embodiment_conformant,
+    check_embodiment,
+    missing_runtime_requirements,
+)
 from inspect_robots.embodiment import EmbodimentInfo
 from inspect_robots.mock import CubePickEmbodiment
 from inspect_robots.spaces import (
@@ -44,6 +51,76 @@ def _good_absolute() -> EmbodimentInfo:
 
 def _codes(info: EmbodimentInfo) -> dict[str, str]:
     return {i.code: i.severity for i in check_embodiment(info).issues}
+
+
+def test_runtime_requirements_absent_attribute_is_empty() -> None:
+    class _Factory:
+        pass
+
+    assert missing_runtime_requirements(_Factory) == {}
+    assert missing_runtime_requirements(None) == {}
+
+
+def test_runtime_requirements_all_present_is_empty() -> None:
+    class _Factory:
+        RUNTIME_REQUIREMENTS: ClassVar[dict[str, str]] = {"os": "install operating system"}
+
+    assert missing_runtime_requirements(_Factory) == {}
+
+
+def test_runtime_requirements_return_missing_entries_in_declaration_order() -> None:
+    class _Factory:
+        RUNTIME_REQUIREMENTS: ClassVar[dict[str, str]] = {
+            "definitely_missing_xyz_one": "install one",
+            "os": "already present",
+            "definitely_missing_xyz_two": "install two",
+        }
+
+    assert list(missing_runtime_requirements(_Factory).items()) == [
+        ("definitely_missing_xyz_one", "install one"),
+        ("definitely_missing_xyz_two", "install two"),
+    ]
+
+
+def test_runtime_requirement_with_missing_parent_is_missing() -> None:
+    class _Factory:
+        RUNTIME_REQUIREMENTS: ClassVar[dict[str, str]] = {
+            "definitely_missing_xyz.sub": "install parent"
+        }
+
+    assert missing_runtime_requirements(_Factory) == {
+        "definitely_missing_xyz.sub": "install parent"
+    }
+
+
+def test_runtime_requirement_probe_exception_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_oserror(_name: str, _package: str | None = None) -> None:
+        raise OSError("broken parent package")
+
+    monkeypatch.setattr("inspect_robots.conformance.importlib.util.find_spec", raise_oserror)
+
+    class _Factory:
+        RUNTIME_REQUIREMENTS: ClassVar[dict[str, str]] = {"broken": "repair it"}
+
+    assert missing_runtime_requirements(_Factory) == {"broken": "repair it"}
+
+
+def test_non_mapping_runtime_requirements_are_ignored() -> None:
+    class _Factory:
+        RUNTIME_REQUIREMENTS: ClassVar[list[str]] = ["definitely_missing_xyz"]
+
+    assert missing_runtime_requirements(_Factory) == {}
+
+
+def test_non_string_runtime_requirement_entries_are_ignored() -> None:
+    class _Factory:
+        RUNTIME_REQUIREMENTS: ClassVar[dict[object, object]] = {
+            7: "ignored key",
+            "os": 9,
+            "definitely_missing_xyz": "install valid",
+        }
+
+    assert missing_runtime_requirements(_Factory) == {"definitely_missing_xyz": "install valid"}
 
 
 def test_good_absolute_and_displacement_pass() -> None:
@@ -183,8 +260,6 @@ def test_zero_width_dims_are_a_warning() -> None:
 
 
 def test_assert_helper_raises_with_summary() -> None:
-    import pytest
-
     bad = _info(space=Box(shape=(2,)))
     with pytest.raises(AssertionError, match="semantics"):
         assert_embodiment_conformant(bad)

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -1214,6 +1214,58 @@ def test_doctor_passes_on_conformant_embodiment(capsys: pytest.CaptureFixture[st
     assert "conformant" in capsys.readouterr().out
 
 
+def test_doctor_reports_missing_runtime_requirement_before_conformance(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.registry import embodiment as embodiment_decorator
+
+    name = "missing-runtime-doctor-cubepick"
+
+    class _MissingRuntimeCubePick(CubePickEmbodiment):
+        RUNTIME_REQUIREMENTS: ClassVar[dict[str, str]] = {
+            "definitely_missing_xyz": "uv pip install thing"
+        }
+
+    embodiment_decorator(name)(_MissingRuntimeCubePick)
+    assert main(["doctor", "--embodiment", name]) == 1
+    out = capsys.readouterr().out
+    error = "[error] runtime-requirement: definitely_missing_xyz missing → uv pip install thing"
+    assert error in out
+    assert out.index(error) < out.index("conformant")
+
+
+def test_doctor_accepts_present_runtime_requirements(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.registry import embodiment as embodiment_decorator
+
+    name = "present-runtime-doctor-cubepick"
+
+    class _PresentRuntimeCubePick(CubePickEmbodiment):
+        RUNTIME_REQUIREMENTS: ClassVar[dict[str, str]] = {"os": "install os"}
+
+    embodiment_decorator(name)(_PresentRuntimeCubePick)
+    assert main(["doctor", "--embodiment", name]) == 0
+    assert "runtime-requirement" not in capsys.readouterr().out
+
+
+def test_doctor_unknown_embodiment_keeps_guided_exit(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    name = "definitely-missing-doctor-embodiment"
+
+    with pytest.raises(SystemExit, match=f"no embodiment named '{name}'") as excinfo:
+        main(["doctor", "--embodiment", name])
+
+    message = str(excinfo.value)
+    assert "available:" in message
+    assert "cubepick" in message
+    assert "Traceback" not in message
+    assert f"embodiment: {name} (--embodiment)" in capsys.readouterr().out
+
+
 def test_doctor_fails_on_nonconformant_embodiment(capsys: pytest.CaptureFixture[str]) -> None:
     from dataclasses import replace
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 from collections.abc import Callable
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
@@ -1421,6 +1422,113 @@ def test_run_setup_repeats_plugin_reminder_after_writing(tmp_path: Path) -> None
     )
     assert reminder in text
     assert text.index("Wrote ") < text.index("reminder: ")
+    assert "runtime dependenc" not in text
+
+
+def test_run_setup_reports_one_missing_runtime_dependency(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _PolicyFactory:
+        pass
+
+    class _EmbodimentFactory:
+        RUNTIME_REQUIREMENTS: ClassVar[dict[str, str]] = {
+            "definitely_missing_xyz": "pip install thing"
+        }
+
+    def fake_registered(kind: str) -> dict[str, object]:
+        if kind == "policy":
+            return {"runtime-policy": _PolicyFactory}
+        return {"runtime-body": _EmbodimentFactory}
+
+    monkeypatch.setattr("inspect_robots.registry.registered", fake_registered)
+    input_fn, _ = _scripted_input(["runtime-policy", "runtime-body", "", "", "", "", "n"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = out.getvalue()
+    assert result == 0
+    assert "setup complete, but 1 runtime dependency is missing:" in text
+    assert "  ✗ definitely_missing_xyz (runtime-body) → pip install thing" in text
+    assert text.index("Wrote ") < text.index("1 runtime dependency is missing:")
+    assert text.index("1 runtime dependency is missing:") < text.index("Next: ")
+
+
+def test_run_setup_reports_multiple_missing_runtime_dependencies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _PolicyFactory:
+        RUNTIME_REQUIREMENTS: ClassVar[dict[str, str]] = {
+            "definitely_missing_xyz_policy": "install policy dependency"
+        }
+
+    class _EmbodimentFactory:
+        RUNTIME_REQUIREMENTS: ClassVar[dict[str, str]] = {
+            "definitely_missing_xyz_body": "install embodiment dependency"
+        }
+
+    def fake_registered(kind: str) -> dict[str, object]:
+        if kind == "policy":
+            return {"runtime-policy": _PolicyFactory}
+        return {"runtime-body": _EmbodimentFactory}
+
+    monkeypatch.setattr("inspect_robots.registry.registered", fake_registered)
+    input_fn, _ = _scripted_input(["runtime-policy", "runtime-body", "", "", "", "", "n"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = out.getvalue()
+    assert result == 0
+    assert "setup complete, but 2 runtime dependencies are missing:" in text
+    assert "definitely_missing_xyz_policy (runtime-policy)" in text
+    assert "definitely_missing_xyz_body (runtime-body)" in text
+
+
+def test_run_setup_omits_runtime_checklist_when_requirements_are_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _PolicyFactory:
+        RUNTIME_REQUIREMENTS: ClassVar[dict[str, str]] = {"os": "install os"}
+
+    class _EmbodimentFactory:
+        RUNTIME_REQUIREMENTS: ClassVar[dict[str, str]] = {"os": "install os"}
+
+    def fake_registered(kind: str) -> dict[str, object]:
+        if kind == "policy":
+            return {"runtime-policy": _PolicyFactory}
+        return {"runtime-body": _EmbodimentFactory}
+
+    monkeypatch.setattr("inspect_robots.registry.registered", fake_registered)
+    input_fn, _ = _scripted_input(["runtime-policy", "runtime-body", "", "", "", "", "n"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert "runtime dependenc" not in out.getvalue()
 
 
 def test_run_setup_no_reminder_when_components_registered(
@@ -1428,7 +1536,7 @@ def test_run_setup_no_reminder_when_components_registered(
 ) -> None:
     monkeypatch.setattr(
         "inspect_robots.registry.registered",
-        lambda kind: {"molmoact2", "yam_arms"},
+        lambda kind: {"molmoact2": object(), "yam_arms": object()},
     )
     input_fn, _ = _scripted_input(["", "", "", "", "", "", "n"])
     out = io.StringIO()
@@ -1451,7 +1559,10 @@ def test_run_setup_reminder_names_only_the_missing_component(tmp_path: Path) -> 
     out = io.StringIO()
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr("inspect_robots.registry.registered", lambda kind: {"molmoact2"})
+        mp.setattr(
+            "inspect_robots.registry.registered",
+            lambda kind: {"molmoact2": object()},
+        )
         result = run_setup(
             {"XDG_CONFIG_HOME": str(tmp_path)},
             input_fn=input_fn,


### PR DESCRIPTION
## Summary

Adapters have runtime deps that install metadata cannot express (the `i2rt` motor driver is git-only, so the yam plugin literally cannot depend on it); today they first surface as `EmbodimentFault: No module named 'i2rt'` at reset, with the arms already in the loop. Components can now declare them as data and both `setup` and `doctor` preflight them. Implements #59 per `plans/0010-runtime-requirements.md` (plan reviewed through a critique loop before implementation).

## Changes

- `inspect_robots.conformance.missing_runtime_requirements(factory)`: reads a `RUNTIME_REQUIREMENTS = {module: remediation_command}` mapping off any registered factory and probes each module with `importlib.util.find_spec` (top-level names probe without executing anything). Any probe failure counts as missing; malformed declarations are ignored, never crash the preflight.
- `setup` wizard: after `Wrote`, sweeps the configured policy and embodiment (when registered) and ends with a yellow checklist, one line per (kind, name, module):
  ```
  setup complete, but 1 runtime dependency is missing:
    ✗ i2rt (yam_arms) → uv pip install "i2rt @ git+https://github.com/i2rt-robotics/i2rt"
  ```
- `doctor`: prints guided `[error] runtime-requirement:` lines BEFORE constructing the embodiment (a constructor that dies on the missing module now dies after the guidance printed) and exits 1 when requirements are missing.
- Docs: "Declare runtime requirements" section in the adapters guide, setup/doctor sentences in the CLI guide, CHANGELOG, module map.

Plugin-side declaration for `yam_arms` is tracked in robocurve/inspect-robots-yam#30.

## Checklist

- [x] Gates ran manually: `ruff check`, `ruff format --check`, `mypy`, `pytest --cov` (355 passed, 100.00% branch)
- [x] Tests added (7 checker, 4 setup, 3 doctor)
- [x] Coverage stays at **100%**
- [x] No `__all__` change (conformance kit stays submodule-imported, like its siblings)
- [x] Core stays NumPy-only (`importlib.util` is stdlib)
- [x] `CHANGELOG.md` updated under "Unreleased"

## Related

Closes #59. Check 2 of #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)