### PR TITLE
fix(config): interpolation-proof reader, stale-args warning, clean kwarg errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **Literal percent signs in config values now round-trip unchanged** (#54).
+  Config reads no longer treat `%` as interpolation syntax, so values such as
+  `policy = 50%off` work with `config set`, `config show`, and normal runs.
+- **Component argument mistakes now fail cleanly and stale args are flagged**
+  (#47). Changing a configured component warns when its non-empty args section
+  still belongs to the old name, and invalid constructor kwargs exit with
+  guidance to check the config section or CLI args flag instead of a traceback.
 - **`inspect-robots run` now surfaces evaluation failures in its summary**:
   top-level errors, per-scene failure context, and a ready-to-run postmortem
   `inspect` command are printed after unsuccessful runs (#57).

--- a/src/inspect_robots/_defaults.py
+++ b/src/inspect_robots/_defaults.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import configparser
 import os
+import sys
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -106,7 +107,7 @@ def _parse_args_section(parser: configparser.ConfigParser, section: str) -> dict
 
 
 def _read_config(path: Path) -> Defaults:
-    parser = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+    parser = configparser.ConfigParser(inline_comment_prefixes=(";", "#"), interpolation=None)
     try:
         with path.open(encoding="utf-8") as fh:
             parser.read_file(fh)
@@ -190,7 +191,7 @@ def set_default(env: Mapping[str, str], key: str, value: str) -> Path:
     path = _config_path(env)
     if path is None:
         raise SystemExit("cannot locate a config home: set $XDG_CONFIG_HOME or $HOME")
-    parser = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+    parser = configparser.ConfigParser(inline_comment_prefixes=(";", "#"), interpolation=None)
     if path.is_file():
         try:
             with path.open(encoding="utf-8") as fh:
@@ -199,6 +200,21 @@ def set_default(env: Mapping[str, str], key: str, value: str) -> Path:
             raise _die(path, f"malformed config: {exc}") from exc
     if not parser.has_section("defaults"):
         parser.add_section("defaults")
+    if key in ("policy", "embodiment", "sim_embodiment"):
+        old_value = parser.get("defaults", key, fallback=None)
+        args_section = f"{key}.args"
+        if (
+            old_value is not None
+            and old_value != value
+            and parser.has_section(args_section)
+            and parser.items(args_section)
+        ):
+            print(
+                f"warning: [{args_section}] was configured for {old_value!r}; "
+                f"it will be ignored for {value!r}: update or remove it "
+                f"in {path}",
+                file=sys.stderr,
+            )
     parser.set("defaults", key, value)
 
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -287,12 +287,16 @@ def _pick_sim_embodiment(defaults: Defaults) -> tuple[str, str]:
     )
 
 
-def _resolve_or_exit(kind: str, name: str, /, **kwargs: Any) -> Any:
+def _resolve_or_exit(
+    kind: str, name: str, args_section: str | None = None, /, **kwargs: Any
+) -> Any:
     """Registry resolution with a clean error instead of a traceback.
 
     Unknown names raise ``KeyError``; a factory that cannot construct itself
     (e.g. the agent policy with no model/key configured) raises a guided
-    ``ConfigError``. Both are user-facing messages, not bugs.
+    ``ConfigError``. Invalid constructor arguments raise ``TypeError``. All
+    three become user-facing messages rather than tracebacks. ``args_section``
+    can identify a config section whose name differs from the registry kind.
     """
     from inspect_robots.errors import ConfigError
     from inspect_robots.registry import resolve
@@ -303,6 +307,13 @@ def _resolve_or_exit(kind: str, name: str, /, **kwargs: Any) -> Any:
         raise SystemExit(str(exc.args[0])) from exc
     except ConfigError as exc:
         raise SystemExit(str(exc)) from exc
+    except TypeError as exc:
+        if args_section is None:
+            args_section = f"{kind}.args"
+        flag = {"task": "-T", "policy": "-P", "embodiment": "-E"}.get(kind, "the CLI args flag")
+        raise SystemExit(
+            f"invalid arguments for {kind} {name!r}: {exc}; check [{args_section}] and {flag} k=v"
+        ) from exc
 
 
 def _build_guardrails(
@@ -474,7 +485,12 @@ def _cmd_run(args: argparse.Namespace) -> int:
         task = _resolve_or_exit("task", args.task, **_parse_kvs(args.task_args))
 
     policy = _resolve_or_exit("policy", policy_name, **policy_kvs)
-    embodiment = _resolve_or_exit("embodiment", embodiment_name, **embodiment_kvs)
+    if args.sim:
+        embodiment = _resolve_or_exit(
+            "embodiment", embodiment_name, "sim_embodiment.args", **embodiment_kvs
+        )
+    else:
+        embodiment = _resolve_or_exit("embodiment", embodiment_name, **embodiment_kvs)
     try:
         if args.epochs is not None:
             task = replace(task, epochs=args.epochs)

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -14,6 +14,7 @@ from inspect_robots._defaults import (
     Defaults,
     load_defaults,
     parse_value,
+    set_default,
 )
 
 
@@ -58,6 +59,21 @@ def test_full_config_parses_with_inline_comments_and_expansion(tmp_path: Path) -
     assert d.policy_args["temperature"] == 0.5
     assert d.policy_args["verbose"] is True
     assert d.embodiment_args == {"cameras": "wrist,front", "port": None}
+
+
+def test_config_value_with_literal_percent_loads_unchanged(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, "[defaults]\npolicy = 50%off\n")
+    defaults = load_defaults({"XDG_CONFIG_HOME": str(tmp_path)})
+    assert defaults.policy == "50%off"
+    assert defaults.policy_source == str(path)
+
+
+def test_set_default_round_trips_literal_percent(tmp_path: Path) -> None:
+    env = {"XDG_CONFIG_HOME": str(tmp_path)}
+    path = set_default(env, "policy", "50%off")
+    assert set_default(env, "policy", "50%off") == path
+    assert load_defaults(env).policy == "50%off"
+    assert "policy = 50%off" in path.read_text(encoding="utf-8")
 
 
 def test_env_vars_override_config_names_but_not_args(tmp_path: Path) -> None:
@@ -221,17 +237,51 @@ def test_config_rerun_rejects_non_bool(tmp_path: Path) -> None:
 
 
 def test_set_default_requires_config_home() -> None:
-    from inspect_robots._defaults import set_default
-
     with pytest.raises(SystemExit, match="config home"):
         set_default({}, "policy", "scripted")
 
 
 def test_set_default_rejects_malformed_existing_config(tmp_path: Path) -> None:
-    from inspect_robots._defaults import set_default
-
     path = tmp_path / "inspect-robots" / "config.ini"
     path.parent.mkdir(parents=True)
     path.write_text("policy = dangling, no section header\n", encoding="utf-8")
     with pytest.raises(SystemExit, match="malformed config"):
         set_default({"XDG_CONFIG_HOME": str(tmp_path)}, "policy", "scripted")
+
+
+@pytest.mark.parametrize("key", ["policy", "embodiment", "sim_embodiment"])
+def test_set_default_warns_when_component_change_leaves_owned_args(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], key: str
+) -> None:
+    path = tmp_path / "inspect-robots" / "config.ini"
+    _write_config(
+        tmp_path,
+        f"[defaults]\n{key} = old-component\n[{key}.args]\nport = can0\n",
+    )
+    set_default({"XDG_CONFIG_HOME": str(tmp_path)}, key, "new-component")
+    assert capsys.readouterr().err == (
+        f"warning: [{key}.args] was configured for 'old-component'; "
+        f"it will be ignored for 'new-component': update or remove it in {path}\n"
+    )
+
+    set_default({"XDG_CONFIG_HOME": str(tmp_path)}, key, "new-component")
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.parametrize("args_section", ["", "[embodiment.args]\n"])
+def test_set_default_does_not_warn_without_nonempty_args_section(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    args_section: str,
+) -> None:
+    _write_config(tmp_path, f"[defaults]\nembodiment = old-arm\n{args_section}")
+    set_default({"XDG_CONFIG_HOME": str(tmp_path)}, "embodiment", "new-arm")
+    assert capsys.readouterr().err == ""
+
+
+def test_set_default_does_not_warn_when_args_have_no_prior_owner(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_config(tmp_path, "[embodiment.args]\nport = can0\n")
+    set_default({"XDG_CONFIG_HOME": str(tmp_path)}, "embodiment", "new-arm")
+    assert capsys.readouterr().err == ""

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -724,6 +724,31 @@ def test_sim_embodiment_args_reach_constructor_and_e_flag_overrides(
     capsys.readouterr()
 
 
+def test_env_selected_sim_drops_args_owned_by_configured_sim(
+    _hermetic_defaults: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\n"
+        "policy = scripted\n"
+        "sim_embodiment = other-sim\n"
+        "scorer = success_at_end\n"
+        "[sim_embodiment.args]\n"
+        "bogus_sim_knob = 1\n",
+    )
+    monkeypatch.setenv(ENV_SIM_EMBODIMENT, "cubepick")
+    log_dir = tmp_path / "logs"
+
+    assert main(["reach the cube", "--sim", "--log-dir", str(log_dir)]) == 0
+    assert (
+        "note: ignoring [sim_embodiment.args] for 'cubepick': they apply to 'other-sim'"
+    ) in capsys.readouterr().err
+    assert _read_only_log(log_dir).results.metrics["success_at_end"] == 1.0
+
+
 def test_sim_conflicts_with_explicit_embodiment() -> None:
     with pytest.raises(SystemExit, match="drop one"):
         main(["run", "--instruction", "reach it", "--sim", "--embodiment", "cubepick"])
@@ -1204,6 +1229,77 @@ def test_component_config_error_exits_cleanly(tmp_path: Path) -> None:
             ]
         )
     assert "Traceback" not in str(excinfo.value)
+
+
+def test_component_type_error_from_config_args_exits_cleanly(
+    _hermetic_defaults: Path, tmp_path: Path
+) -> None:
+    """Invalid persisted kwargs must identify their component and both sources."""
+    from inspect_robots.registry import policy as policy_decorator
+
+    name = "strict-args-policy-for-cli-test"
+
+    @policy_decorator(name)
+    def _factory() -> ScriptedPolicy:
+        return ScriptedPolicy()
+
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\n"
+        f"policy = {name}\n"
+        "embodiment = cubepick\n"
+        "scorer = success_at_end\n"
+        "[policy.args]\n"
+        "typoed_option = 1\n",
+    )
+    try:
+        with pytest.raises(SystemExit) as excinfo:
+            main(["reach it", "--log-dir", str(tmp_path)])
+    finally:
+        reg._FACTORIES["policy"].pop(name)
+
+    message = str(excinfo.value)
+    assert f"invalid arguments for policy {name!r}" in message
+    assert "unexpected keyword argument 'typoed_option'" in message
+    assert "[policy.args]" in message and "-P k=v" in message
+    assert "Traceback" not in message
+
+
+def test_sim_embodiment_type_error_names_sim_args_section(
+    _hermetic_defaults: Path, tmp_path: Path
+) -> None:
+    """Invalid sim kwargs must identify the sim-specific config section."""
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.registry import embodiment as embodiment_decorator
+
+    name = "strict-args-sim-embodiment-for-cli-test"
+
+    @embodiment_decorator(name)
+    def _factory() -> CubePickEmbodiment:
+        return CubePickEmbodiment()
+
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\n"
+        "policy = scripted\n"
+        "scorer = success_at_end\n"
+        f"sim_embodiment = {name}\n"
+        "[sim_embodiment.args]\n"
+        "typoed_option = 1\n",
+    )
+    try:
+        with pytest.raises(SystemExit) as excinfo:
+            main(["reach it", "--sim", "--log-dir", str(tmp_path)])
+    finally:
+        reg._FACTORIES["embodiment"].pop(name)
+
+    message = str(excinfo.value)
+    assert f"invalid arguments for embodiment {name!r}" in message
+    assert "unexpected keyword argument 'typoed_option'" in message
+    assert "check [sim_embodiment.args]" in message
+    assert "-E k=v" in message
+    assert "check [embodiment.args]" not in message
+    assert "Traceback" not in message
 
 
 # --- doctor (adapter conformance) ---------------------------------------------


### PR DESCRIPTION
## Summary

Two config-robustness fixes in one pass.

**#54**: `_read_config` and `set_default`'s reader used configparser's default `BasicInterpolation`, so a bare `%` in any value (e.g. `config set policy "50%off"`) wrote fine but crashed every later read with an `InterpolationSyntaxError` traceback. Both parsers now use `interpolation=None`, matching the setup wizard's raw reader; values are re-parsed by `parse_value` anyway and nothing relied on interpolation, so the whole failure class is gone and literal `%` round-trips.

**#47**: two residual gaps from the #44/#46 review:
- `config set <kind> <new>` while a non-empty `[<kind>.args]` section belongs to the old name now warns on stderr that the args will be ignored, naming the config file to edit (covers policy/embodiment/sim_embodiment).
- `_resolve_or_exit` now catches `TypeError` alongside `KeyError`/`ConfigError`, so a bad kwarg from a matching args section exits with a clean message naming the args section and the matching CLI flag instead of a raw traceback. The section label is threaded separately from the registry kind (positional-only `args_section` param) so the `--sim` path correctly names `[sim_embodiment.args]`.
- Added the missing sim drop-path test (`$INSPECT_ROBOTS_SIM_EMBODIMENT` differing from the config's `sim_embodiment` drops `[sim_embodiment.args]` with the stderr note).

## Changes

- `src/inspect_robots/_defaults.py`: `interpolation=None` on both parsers; stale-args warning in `set_default`.
- `src/inspect_robots/cli.py`: `TypeError` handling in `_resolve_or_exit` with an `args_section` label; `--sim` call site passes `sim_embodiment.args`.
- Tests: percent round-trip (read + set paths), warning fire/silence branches parametrized over all three keys, clean-exit on bad kwargs (default and `--sim` section naming), sim drop path.
- CHANGELOG entries under Unreleased.

## Checklist

- [x] `pre-commit install` done; hooks pass (or ran `pre-commit run --all-files`)
- [x] Tests added/updated (and the `CubePick` mock exercises the change where applicable)
- [x] Coverage stays at **100%** (`pytest --cov`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `mypy` passes (strict)
- [x] `CHANGELOG.md` updated under "Unreleased"
- [x] Public API changes are reflected in `inspect_robots.__all__` and the API-snapshot test (n/a: no public API change)
- [x] Core stays NumPy-only (new deps are optional extras, lazily imported)

## Related

Closes #54
Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)