### PR TITLE
feat(setup): plugin-declared device slots drive the wizard's device interview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- Plugin-declared embodiment device slots for V4L2 cameras, SocketCAN
+  interfaces, and serial devices. `inspect-robots setup` probes and interviews
+  declared slots, enforces grouped all-or-none assignments, and suggests udev
+  serial pinning for order-dependent USB-CAN names (#61).
 - Runtime-requirement declarations for registered component factories, with
   missing-import preflight checklists in `inspect-robots setup` and
   `inspect-robots doctor` (#59).

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -31,6 +31,54 @@ registered, while `doctor` checks its selected embodiment before construction. B
 `importlib.util.find_spec` without importing the declared top-level modules and
 print each remediation command verbatim when a module is missing.
 
+## Declare device slots:
+
+Declare device-shaped constructor arguments on the registered embodiment
+factory. Import `DeviceSlot` from the `inspect_robots.conformance` submodule:
+
+```python
+from inspect_robots.conformance import DeviceSlot
+
+DEVICE_SLOTS = (
+    DeviceSlot(
+        arg="left_channel",
+        kind="can",
+        label="left arm CAN channel",
+        group="arms",
+    ),
+    DeviceSlot(
+        arg="right_channel",
+        kind="can",
+        label="right arm CAN channel",
+        group="arms",
+    ),
+    DeviceSlot(
+        arg="top_cam_device",
+        kind="v4l2",
+        label="top camera",
+        group="cameras",
+    ),
+    DeviceSlot(
+        arg="left_cam_device",
+        kind="v4l2",
+        label="left camera",
+        group="cameras",
+    ),
+    DeviceSlot(
+        arg="right_cam_device",
+        kind="v4l2",
+        label="right camera",
+        group="cameras",
+    ),
+)
+```
+
+The recognized kinds are `v4l2` for stable camera paths, `can` for SocketCAN
+interface names, and `serial` for absolute `/dev/serial/by-id` paths. The setup
+wizard probes and interviews slots in declaration order, then writes each
+selection to its `arg` key under `[embodiment.args]`. Slots with the same
+non-`None` `group` are all-or-none. Ungrouped slots remain independent.
+
 ## The conformance kit
 
 Add one test to your adapter repo:

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -31,7 +31,7 @@ registered, while `doctor` checks its selected embodiment before construction. B
 `importlib.util.find_spec` without importing the declared top-level modules and
 print each remediation command verbatim when a module is missing.
 
-## Declare device slots:
+## Declare device slots
 
 Declare device-shaped constructor arguments on the registered embodiment
 factory. Import `DeviceSlot` from the `inspect_robots.conformance` submodule:

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -111,6 +111,12 @@ disappeared. When identical cameras without serial numbers collide in the
 by-id listing, `p` switches to `/dev/v4l/by-path` names, which are stable
 per physical USB port.
 
+When the selected registered embodiment declares device slots, those slots
+drive one device interview for cameras, CAN interfaces, and serial devices.
+CAN slots list SocketCAN interfaces and support unplug-to-identify; rigs with
+multiple USB adapters named `can0`, `can1`, and so on also receive a udev
+pinning suggestion so replug order cannot swap physical devices.
+
 ```bash
 inspect-robots setup
 ```

--- a/plans/0011-device-slots.md
+++ b/plans/0011-device-slots.md
@@ -1,0 +1,204 @@
+# 0011 — Plugin-declared device slots: the wizard interviews buses like cameras
+
+Fixes #61 (check 5 of #50). The wizard's camera flow is good because it
+probes real devices; CAN buses get no probe, so a fresh config on a
+udev-pinned rig silently inherits the plugin default (`can0`/`can1`) and the
+first run dies with `Could not access SocketCAN device can0`. Components
+declare their device-shaped config args; the wizard runs the
+probe-and-interview appropriate to each kind. Cameras stop being a special
+case and become one declared kind. Builds on plan 0010's declaration
+mechanism (`RUNTIME_REQUIREMENTS`); a component may carry both.
+
+## 1. Protocol: `DeviceSlot` in `conformance.py`
+
+```python
+@dataclass(frozen=True)
+class DeviceSlot:
+    """One device-shaped constructor argument the setup wizard interviews.
+
+    ``arg`` is the ``[embodiment.args]`` key to write; ``kind`` selects the
+    probe (``"v4l2"``: /dev/v4l listings with unplug-identify; ``"can"``:
+    SocketCAN netdevs from sysfs with unplug-identify; ``"serial"``:
+    /dev/serial/by-id listing). ``label`` is the human prompt ("left arm CAN
+    channel"). Slots sharing a non-None ``group`` are all-or-none: the
+    wizard refuses to write a partial subset of the group.
+    """
+
+    arg: str
+    kind: str
+    label: str
+    group: str | None = None
+
+
+def device_slots(factory: object) -> tuple[DeviceSlot, ...]:
+    """The declared device slots, defensively read.
+
+    Reads ``DEVICE_SLOTS`` off ``factory``; anything that is not an iterable
+    of ``DeviceSlot`` instances (or contains a slot whose ``kind`` is not
+    recognized) has the offending entries ignored, never crashes the wizard.
+    Returns a tuple in declaration order.
+    """
+```
+
+Both live in `inspect_robots.conformance` next to
+`missing_runtime_requirements`; submodule import, no `__all__` change.
+Recognized kinds are a module constant `DEVICE_KINDS = ("v4l2", "can",
+"serial")`.
+
+Example declaration (the yam plugin's, tracked separately in
+robocurve/inspect-robots-yam#30):
+
+```python
+DEVICE_SLOTS = (
+    DeviceSlot(arg="left_channel",  kind="can",  label="left arm CAN channel"),
+    DeviceSlot(arg="right_channel", kind="can",  label="right arm CAN channel"),
+    DeviceSlot(arg="top_cam_device",   kind="v4l2", label="top camera", group="cameras"),
+    DeviceSlot(arg="left_cam_device",  kind="v4l2", label="left camera", group="cameras"),
+    DeviceSlot(arg="right_cam_device", kind="v4l2", label="right camera", group="cameras"),
+)
+```
+
+## 2. Probes (`_setup.py`, pure and injectable)
+
+- **v4l2**: existing `_scan_cameras` on `by_id_dir`/`by_path_dir`, unchanged.
+- **can**: `_scan_can(sysfs_net: Path) -> list[str]` — a CAN interface is a
+  netdev with ARPHRD type 280, so listing is a sysfs read: every child of
+  `/sys/class/net` whose `type` file reads `280`. Sorted interface names
+  (`can_left`, `can0`, ...). No privileges, no subprocess. Missing dir or
+  unreadable `type` files → skipped/`[]`. `run_setup` gains
+  `sysfs_net: Path = Path("/sys/class/net")`.
+- **serial**: `_scan_serial(serial_by_id_dir: Path) -> list[str]` — sorted
+  absolute paths under `/dev/serial/by-id`; missing dir → `[]`. `run_setup`
+  gains `serial_by_id_dir: Path = Path("/dev/serial/by-id")`.
+- **CAN serial numbers** (for §5): `_can_serial(sysfs_net: Path, ifname:
+  str) -> str | None` — reads
+  `(sysfs_net / ifname / "device").resolve().parent / "serial"`, stripped;
+  any failure → `None` (broad except: sysfs layouts vary).
+
+## 3. Slot-driven interview
+
+`run_setup` decides the device section's shape after the defaults prompts:
+
+- The configured embodiment name is registered AND `device_slots(factory)`
+  is non-empty → **slot mode**: interview exactly the declared slots, in
+  declaration order.
+- Otherwise → **fallback mode**: today's hardcoded camera section,
+  unchanged (quickstart-before-plugin-install keeps working).
+
+Slot mode reuses the existing role-prompt machinery, generalized:
+
+- One "Configure devices?" yes/no gate (default yes when any probe found
+  devices or the existing config assigns any slot arg; default no
+  otherwise), mirroring today's camera gate.
+- Per kind, on first use, print the listing (`Found N camera device(s)
+  under ...` stays; CAN: `Found N CAN interface(s) under /sys/class/net:`;
+  serial: `Found N serial device(s) under /dev/serial/by-id:`).
+- Each slot prompts with its `label` (not the arg):
+  `left arm CAN channel — number, 'u' to identify by unplugging, 's' to
+  skip[, 'p' to switch listing]: `. `u` is the same rescan-diff flow for
+  every kind ("Unplug the left arm CAN channel now..." wording comes from
+  the label; for CAN the operator unplugs the USB-CAN adapter). The `p`
+  by-id/by-path toggle exists only for v4l2. Manual entry: absolute path
+  for v4l2/serial (advisory existence warning, as today); for CAN a bare
+  interface name (no `/`), advisory warning when not in the listing.
+- "(current)" Enter-accept defaults from the existing config, per slot arg,
+  as today.
+- Duplicate-assignment confirm works across all slots of the same kind.
+- All-or-none applies per named `group` (the generalized message:
+  `"{embodiment} needs all {group} slots or none; writing none unless you
+  go back"`). Ungrouped slots are independent.
+
+Managed keys become dynamic: `_render_config` and the decline-preserve path
+currently hardcode `camera_keys`; both take the interviewed keys as a
+parameter (`managed_args: tuple[str, ...]`). Slot mode passes the declared
+slot args; fallback mode passes the camera keys (behavior unchanged).
+Declining the section preserves existing assignments for managed args, the
+all-or-none "write none" branch drops the group's args, and carried
+non-managed `[embodiment.args]` keys pass through raw, all exactly as today.
+
+## 4. What slot mode does NOT do (YAGNI)
+
+- No policy-side slots: only the embodiment is interviewed (policy args are
+  checkpoints/URLs, not devices).
+- No slot-declared defaults or validators; a slot is (arg, kind, label,
+  group) and nothing else until a second plugin needs more.
+- No attempt to probe whether a CAN interface is UP (`operstate`): existence
+  is the wizard's contract; `doctor`/#50 owns runnability.
+
+## 5. udev pinning suggestion (issue Layer 3, print-only)
+
+After slot-mode assignment, when TWO OR MORE assigned CAN interfaces have
+kernel-default order-dependent names (regex `^can\d+$`):
+
+- Read each one's adapter serial via `_can_serial`.
+- All readable and pairwise distinct → print (yellow) a warning that
+  order-dependent names can swap which physical arm receives commands on
+  replug, then the exact rules snippet, one line per assignment, with a
+  suggested stable name derived from the slot arg (`left_channel` →
+  `can_left`: strip a trailing `_channel`/`_bus`, prefix `can_` unless the
+  remainder already starts with `can`):
+
+```
+these CAN interfaces have order-dependent names; a replug can swap them.
+pin them by adapter serial (paste into /etc/udev/rules.d/70-can-names.rules,
+then replug or reboot), and re-run setup to record the pinned names:
+  SUBSYSTEM=="net", ACTION=="add", ATTRS{serial}=="3B004B", NAME="can_left"
+  SUBSYSTEM=="net", ACTION=="add", ATTRS{serial}=="3B004C", NAME="can_right"
+```
+
+- Serials unreadable or duplicated (identical adapters without unique
+  serials) → print only the swap warning, no snippet.
+- Pinned names (anything not matching `^can\d+$`) → nothing printed.
+
+The wizard never writes to `/etc` (sudo); this is guidance text only.
+
+## 6. Docs
+
+- `docs/guide/adapters.md`: extend the plan-0010 "Declare runtime
+  requirements" area with a "Declare device slots" section (dataclass
+  example above, kinds, group semantics, submodule import).
+- `docs/guide/cli.md` setup section: one short paragraph (slots drive the
+  interview when declared; CAN listing + unplug-identify; udev suggestion).
+- CHANGELOG "Added" entry referencing #61; module map row for
+  `conformance.py` extended; `_setup.py` row mentions device slots.
+
+## 7. Tests (100% branch, mypy strict)
+
+`tests/test_conformance.py`:
+- `device_slots`: absent → `()`; valid tuple round-trips in order; list
+  accepted; non-iterable / entries that are not DeviceSlot / unrecognized
+  kind → offending entries ignored (whole-value garbage → `()`); `None`
+  factory → `()`.
+
+`tests/test_setup.py` (fake sysfs tree in tmp_path: `net/<if>/type` files
+with `280`/`1`, `net/<if>/device` symlink into a `usb/...` dir whose parent
+holds `serial`):
+- `_scan_can`: filters type==280, sorted, missing dir → `[]`, unreadable
+  type file skipped. `_scan_serial`: listing, missing dir → `[]`.
+  `_can_serial`: reads through the device symlink; missing serial → None.
+- Slot mode activates: registered factory with DEVICE_SLOTS → prompts use
+  labels, CAN listing printed, number pick writes `left_channel = can_left`
+  into `[embodiment.args]`; fallback mode when unregistered or no
+  declaration (existing camera tests keep passing untouched).
+- CAN manual entry: bare name accepted with advisory warning when unlisted;
+  absolute-path entry rejected vocabulary (re-prompt) since CAN wants a
+  name; v4l2/serial keep path entry.
+- `u` flow for a CAN slot via injected rescan (shrink/restore lists).
+- Group all-or-none: partial `cameras` group → generalized message, both
+  branches; ungrouped CAN slots unaffected by the guard.
+- Decline preserves existing slot-arg assignments; carried non-managed keys
+  survive (managed_args parameterization).
+- udev suggestion: two `can\d+` assignments with distinct serials → warning
+  + two rule lines with the right serials and derived names; identical
+  serials → warning only; pinned names → silence.
+- `(current)` default for a slot arg.
+
+`tests/test_registry_cli.py`: none needed (doctor untouched).
+
+## 8. Execution
+
+Single PR on `feat/device-slots`, stacked on `feat/runtime-requirements`
+(rebase onto main once #62 merges). Commits: (1) protocol + probes,
+(2) slot-driven interview + managed-args generalization, (3) udev
+suggestion, (4) docs. Gates per commit; Fable review-edit loop before
+merge.

--- a/plans/0011-device-slots.md
+++ b/plans/0011-device-slots.md
@@ -64,7 +64,7 @@ DEVICE_SLOTS = (
 - **can**: `_scan_can(sysfs_net: Path) -> list[str]` — a CAN interface is a
   netdev with ARPHRD type 280, so listing is a sysfs read: every child of
   `/sys/class/net` whose `type` file reads `280`. Sorted interface names
-  (`can_left`, `can0`, ...). No privileges, no subprocess. Missing dir or
+  (`can0`, `can_left`, ...). No privileges, no subprocess. Missing dir or
   unreadable `type` files → skipped/`[]`. `run_setup` gains
   `sysfs_net: Path = Path("/sys/class/net")`.
 - **serial**: `_scan_serial(serial_by_id_dir: Path) -> list[str]` — sorted
@@ -101,6 +101,10 @@ Slot mode reuses the existing role-prompt machinery, generalized:
   by-id/by-path toggle exists only for v4l2. Manual entry: absolute path
   for v4l2/serial (advisory existence warning, as today); for CAN a bare
   interface name (no `/`), advisory warning when not in the listing.
+  `_identify_by_replug`'s messages parameterize their noun ("no camera
+  device disappeared" stays byte-identical for v4l2, since fallback tests
+  assert it verbatim; CAN says "no CAN interface disappeared", serial "no
+  serial device disappeared").
 - "(current)" Enter-accept defaults from the existing config, per slot arg,
   as today.
 - Duplicate-assignment confirm works across all slots of the same kind.
@@ -109,9 +113,10 @@ Slot mode reuses the existing role-prompt machinery, generalized:
   go back"`). Ungrouped slots are independent.
 
 Managed keys become dynamic: `_render_config` and the decline-preserve path
-currently hardcode `camera_keys`; both take the interviewed keys as a
-parameter (`managed_args: tuple[str, ...]`). Slot mode passes the declared
-slot args; fallback mode passes the camera keys (behavior unchanged).
+currently hardcode `camera_keys`; both gain a `managed_args: tuple[str, ...]`
+parameter that DEFAULTS to the camera keys, so the eight existing direct
+`_render_config(...)` test call sites keep compiling and passing unchanged.
+Slot mode passes the declared slot args; fallback mode uses the default.
 Declining the section preserves existing assignments for managed args, the
 all-or-none "write none" branch drops the group's args, and carried
 non-managed `[embodiment.args]` keys pass through raw, all exactly as today.
@@ -127,16 +132,26 @@ non-managed `[embodiment.args]` keys pass through raw, all exactly as today.
 
 ## 5. udev pinning suggestion (issue Layer 3, print-only)
 
-After slot-mode assignment, when TWO OR MORE assigned CAN interfaces have
-kernel-default order-dependent names (regex `^can\d+$`):
+After slot-mode assignment, when the SCAN found two or more CAN
+interfaces with kernel-default order-dependent names (regex `^can\d+$`)
+AND at least one of them was assigned to a slot (the issue's trigger is
+"two identical adapters with order-dependent names": with two adapters
+present, even a single `left_channel = can0` assignment silently rebinds
+to the other physical arm on replug; a true single-adapter rig, where
+`can0` is deterministic, stays quiet):
 
-- Read each one's adapter serial via `_can_serial`.
+- Read the adapter serial of every order-dependent SCANNED interface via
+  `_can_serial` (unassigned ones included: pinning half a pair is no fix).
 - All readable and pairwise distinct → print (yellow) a warning that
   order-dependent names can swap which physical arm receives commands on
-  replug, then the exact rules snippet, one line per assignment, with a
-  suggested stable name derived from the slot arg (`left_channel` →
-  `can_left`: strip a trailing `_channel`/`_bus`, prefix `can_` unless the
-  remainder already starts with `can`):
+  replug, then the exact rules snippet, one line per scanned interface.
+  Assigned interfaces get a stable name derived from their slot arg
+  (`left_channel` → `can_left`: strip a trailing `_channel`/`_bus`, prefix
+  `can_` unless the remainder already starts with `can`); unassigned ones
+  get `can_<ifname>` (e.g. `can_can1` is ugly but valid; the text says the
+  names are suggestions to edit). If derivation yields duplicate names or
+  a name over Linux's 15-char IFNAMSIZ, fall back to `can_a`, `can_b`, ...
+  in scan order (deterministic, always valid):
 
 ```
 these CAN interfaces have order-dependent names; a replug can swap them.
@@ -172,14 +187,24 @@ The wizard never writes to `/etc` (sudo); this is guidance text only.
 
 `tests/test_setup.py` (fake sysfs tree in tmp_path: `net/<if>/type` files
 with `280`/`1`, `net/<if>/device` symlink into a `usb/...` dir whose parent
-holds `serial`):
+holds `serial`; symlink-dependent tests carry a skip guard for platforms
+where os.symlink needs privileges, keeping the advisory Windows tier green):
 - `_scan_can`: filters type==280, sorted, missing dir → `[]`, unreadable
   type file skipped. `_scan_serial`: listing, missing dir → `[]`.
   `_can_serial`: reads through the device symlink; missing serial → None.
 - Slot mode activates: registered factory with DEVICE_SLOTS → prompts use
   labels, CAN listing printed, number pick writes `left_channel = can_left`
   into `[embodiment.args]`; fallback mode when unregistered or no
-  declaration (existing camera tests keep passing untouched).
+  declaration (existing camera tests keep passing; the only mechanical
+  change they may need is none, thanks to the managed_args default).
+- Slot-mode "Configure devices?" gate: default no when no probe found
+  devices and no existing slot arg; default yes from existing config;
+  declining → section skipped.
+- A `serial`-kind slot end to end: listing header, number pick, and
+  absolute-path manual entry.
+- Duplicate guard in slot mode: same-kind duplicate → confirm prompt;
+  cross-kind identical strings cannot occur (paths vs names) but the
+  same-kind scoping branch is exercised.
 - CAN manual entry: bare name accepted with advisory warning when unlisted;
   absolute-path entry rejected vocabulary (re-prompt) since CAN wants a
   name; v4l2/serial keep path entry.
@@ -197,8 +222,8 @@ holds `serial`):
 
 ## 8. Execution
 
-Single PR on `feat/device-slots`, stacked on `feat/runtime-requirements`
-(rebase onto main once #62 merges). Commits: (1) protocol + probes,
+Single PR on `feat/device-slots`, branched from main (#62 already
+merged). Commits: (1) protocol + probes,
 (2) slot-driven interview + managed-args generalization, (3) udev
 suggestion, (4) docs. Gates per commit; Fable review-edit loop before
 merge.

--- a/plans/0011-device-slots.md
+++ b/plans/0011-device-slots.md
@@ -50,8 +50,8 @@ robocurve/inspect-robots-yam#30):
 
 ```python
 DEVICE_SLOTS = (
-    DeviceSlot(arg="left_channel",  kind="can",  label="left arm CAN channel"),
-    DeviceSlot(arg="right_channel", kind="can",  label="right arm CAN channel"),
+    DeviceSlot(arg="left_channel",  kind="can",  label="left arm CAN channel", group="arms"),
+    DeviceSlot(arg="right_channel", kind="can",  label="right arm CAN channel", group="arms"),
     DeviceSlot(arg="top_cam_device",   kind="v4l2", label="top camera", group="cameras"),
     DeviceSlot(arg="left_cam_device",  kind="v4l2", label="left camera", group="cameras"),
     DeviceSlot(arg="right_cam_device", kind="v4l2", label="right camera", group="cameras"),
@@ -134,7 +134,9 @@ non-managed `[embodiment.args]` keys pass through raw, all exactly as today.
 
 After slot-mode assignment, when the SCAN found two or more CAN
 interfaces with kernel-default order-dependent names (regex `^can\d+$`)
-AND at least one of them was assigned to a slot (the issue's trigger is
+AND at least one of them was assigned to a slot (decline-preserved
+existing assignments count: the risk is about what the written config
+names, not how it got there; the issue's trigger is
 "two identical adapters with order-dependent names": with two adapters
 present, even a single `left_channel = can0` assignment silently rebinds
 to the other physical arm on replug; a true single-adapter rig, where
@@ -144,14 +146,17 @@ to the other physical arm on replug; a true single-adapter rig, where
   `_can_serial` (unassigned ones included: pinning half a pair is no fix).
 - All readable and pairwise distinct → print (yellow) a warning that
   order-dependent names can swap which physical arm receives commands on
-  replug, then the exact rules snippet, one line per scanned interface.
+  replug, then the exact rules snippet, one line per order-dependent
+  scanned interface (already-pinned names get no line).
   Assigned interfaces get a stable name derived from their slot arg
   (`left_channel` → `can_left`: strip a trailing `_channel`/`_bus`, prefix
   `can_` unless the remainder already starts with `can`); unassigned ones
   get `can_<ifname>` (e.g. `can_can1` is ugly but valid; the text says the
-  names are suggestions to edit). If derivation yields duplicate names or
-  a name over Linux's 15-char IFNAMSIZ, fall back to `can_a`, `can_b`, ...
-  in scan order (deterministic, always valid):
+  names are suggestions to edit). If ANY derived name collides with
+  another derived name or with any scanned interface name, or exceeds
+  Linux's 15-char IFNAMSIZ, the WHOLE SET falls back to `can_a`, `can_b`,
+  ... in scan order (per-name fallback could re-collide; deterministic,
+  always valid):
 
 ```
 these CAN interfaces have order-dependent names; a replug can swap them.
@@ -162,7 +167,11 @@ then replug or reboot), and re-run setup to record the pinned names:
 ```
 
 - Serials unreadable or duplicated (identical adapters without unique
-  serials) → print only the swap warning, no snippet.
+  serials) → print only the swap warning, no snippet. Platform CAN
+  (flexcan, SPI controllers) has no USB serial and its `can0`/`can1` are
+  deterministic, so the warning would be a false positive: skip the whole
+  suggestion (warning included) when NO order-dependent interface's
+  `device` symlink resolves under a `usb` path segment.
 - Pinned names (anything not matching `^can\d+$`) → nothing printed.
 
 The wizard never writes to `/etc` (sudo); this is guidance text only.
@@ -203,8 +212,9 @@ where os.symlink needs privileges, keeping the advisory Windows tier green):
 - A `serial`-kind slot end to end: listing header, number pick, and
   absolute-path manual entry.
 - Duplicate guard in slot mode: same-kind duplicate → confirm prompt;
-  cross-kind identical strings cannot occur (paths vs names) but the
-  same-kind scoping branch is exercised.
+  a cross-kind duplicate (v4l2 and serial both take absolute paths) is
+  deliberately unguarded (different arg semantics), and the same-kind
+  scoping branch is exercised.
 - CAN manual entry: bare name accepted with advisory warning when unlisted;
   absolute-path entry rejected vocabulary (re-prompt) since CAN wants a
   name; v4l2/serial keep path entry.
@@ -214,8 +224,12 @@ where os.symlink needs privileges, keeping the advisory Windows tier green):
 - Decline preserves existing slot-arg assignments; carried non-managed keys
   survive (managed_args parameterization).
 - udev suggestion: two `can\d+` assignments with distinct serials → warning
-  + two rule lines with the right serials and derived names; identical
-  serials → warning only; pinned names → silence.
+  + two rule lines with the right serials and derived names; two scanned
+  but only one assigned → the unassigned interface still gets a
+  `can_<ifname>` line; derivation collision or over-IFNAMSIZ name → the
+  whole set falls back to `can_a`/`can_b`; identical serials → warning
+  only; non-USB (no `usb` segment in the resolved device path) → complete
+  silence; pinned names → silence.
 - `(current)` default for a slot arg.
 
 `tests/test_registry_cli.py`: none needed (doctor untouched).

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -20,7 +20,7 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `frames.py` | `FrameStore`/`FrameRef` — stream camera frames to disk (R5) |
 | `transcript.py` | typed event stream (reset/inference/step/approval/operator/error) |
 | `compat.py` | `check_compatibility`/`assert_compatible` — fail-fast before rollout |
-| `conformance.py` | adapter conformance kit: `check_embodiment`/`assert_embodiment_conformant` for declarative guardrail/agent readiness; `missing_runtime_requirements` provides runtime-dependency preflight for setup and doctor |
+| `conformance.py` | adapter conformance kit: `check_embodiment`/`assert_embodiment_conformant` for declarative guardrail/agent readiness; `missing_runtime_requirements` provides runtime-dependency preflight; `DeviceSlot`/`device_slots` declare and defensively read embodiment device slots |
 | `errors.py` | error taxonomy (continue vs halt) |
 | `eval.py` | `eval()` / `eval_set()` orchestration |
 | `log.py` | immutable, schema-versioned `EvalLog` + `read_eval_log` |
@@ -28,7 +28,7 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `registry.py` | decorators + entry-point discovery; `_builtins.py` registers in-tree components |
 | `cli.py` | `inspect-robots list` / `run` / `inspect` / `config set|show` / `setup` (first-run wizard) / `doctor` (adapter conformance), plus the zero-config form `inspect-robots "<instruction>"` (ad-hoc single-scene task; operator prompt on TTY). Every run wires guardrails (Clamp + DeltaLimit) by default; `--disable-guardrails` is the loud opt-out and the chain degrades per component with stderr warnings |
 | `_defaults.py` | user default policy/embodiment (+ `--sim` counterpart) for the zero-config CLI: env vars > `~/.config/inspect-robots/config.ini` (INI — py3.10 has no tomllib; deliberately no project-local file); `set_default` backs `config set` |
-| `_setup.py` | the `inspect-robots setup` wizard (plan 0009): IO-injected prompts for `[defaults]`, V4L2 camera discovery (by-id, by-path fallback, unplug-to-identify), headless-rerun warning; renders config.ini itself (comments survive) and carries unmanaged sections/keys through raw |
+| `_setup.py` | the `inspect-robots setup` wizard (plans 0009 and 0011): IO-injected prompts for `[defaults]`, plugin-declared V4L2/CAN/serial device slots with unplug-to-identify and CAN udev guidance, fallback camera discovery, headless-rerun warning; renders config.ini itself (comments survive) and carries unmanaged sections/keys through raw |
 | `mock/` | dependency-free `CubePick` world + scripted/random/noop policies |
 
 ## Key invariants

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -719,9 +719,14 @@ def _suggest_can_pinning(
         assignments.get(slot.arg) in order_dependent for slot in slots if slot.kind == "can"
     ):
         return
-    if not any(
-        "usb" in (sysfs_net / ifname / "device").resolve().parts for ifname in order_dependent
-    ):
+
+    def _is_usb(ifname: str) -> bool:
+        # Real sysfs buses are numbered (usb1, usb2, ...); a bare "usb"
+        # segment never occurs on hardware.
+        parts = (sysfs_net / ifname / "device").resolve().parts
+        return any(re.fullmatch(r"usb\d*", part) for part in parts)
+
+    if not any(_is_usb(ifname) for ifname in order_dependent):
         return
 
     warning = "these CAN interfaces have order-dependent names; a replug can swap them."

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import IO
 
 from inspect_robots._defaults import _config_path, parse_value
+from inspect_robots.conformance import DeviceSlot, device_slots
 
 # Same minimal-ANSI convention as cli.py (#37): plain when piped or NO_COLOR.
 _BOLD = "1"
@@ -39,6 +40,7 @@ SUGGESTED: dict[str, str] = {
     "store_frames": "true",
 }
 CAM_ROLES: tuple[str, ...] = ("top", "left", "right")  # -> {role}_cam_device in [embodiment.args]
+CAMERA_KEYS: tuple[str, ...] = tuple(f"{role}_cam_device" for role in CAM_ROLES)
 V4L_BY_ID: Path = Path("/dev/v4l/by-id")
 V4L_BY_PATH: Path = Path("/dev/v4l/by-path")
 SYSFS_NET: Path = Path("/sys/class/net")
@@ -219,21 +221,26 @@ def _identify_by_replug(
     input_fn: Callable[[str], str],
     out: IO[str],
     rescan: Callable[[], list[str]],
+    noun: str = "camera device",
+    plural_noun: str = "camera devices",
+    retry_noun: str = "camera",
+    unplug_label: str | None = None,
 ) -> str | None:
     """Identify one device by diffing the listing while it is unplugged."""
-    input_fn(f"Unplug the {role} camera now, then press Enter...")
+    label = unplug_label if unplug_label is not None else f"{role} camera"
+    input_fn(f"Unplug the {label} now, then press Enter...")
     unplugged_devices = rescan()
     disappeared = [device for device in devices if device not in unplugged_devices]
     if not disappeared:
         print(
-            _paint("no camera device disappeared; unplug one camera and try again", _YELLOW, out),
+            _paint(f"no {noun} disappeared; unplug one {retry_noun} and try again", _YELLOW, out),
             file=out,
         )
         return None
     if len(disappeared) > 1:
         print(
             _paint(
-                f"{len(disappeared)} camera devices disappeared; unplug only one and try again",
+                f"{len(disappeared)} {plural_noun} disappeared; unplug only one and try again",
                 _YELLOW,
                 out,
             ),
@@ -257,67 +264,92 @@ def _identify_by_replug(
     return identified
 
 
-def _camera_role_prompt(
-    role: str,
+def _device_slot_prompt(
+    label: str,
+    kind: str,
     devices: list[str],
     current: str | None,
     advertise_path_toggle: bool,
     *,
     out: IO[str],
+    camera_fallback: bool = False,
 ) -> str:
-    """Prompt text for one camera role, with the Enter-accept current value."""
-    choices = f"{role} camera — number, 'u' to identify by unplugging"
-    if advertise_path_toggle:
+    """Build one kind-aware device prompt with an Enter-accept current value."""
+    choices = f"{label} — number, 'u' to identify by unplugging"
+    if camera_fallback and advertise_path_toggle:
         choices += ", 'p' to switch listing"
     choices += ", 's' to skip"
+    if not camera_fallback and kind == "v4l2" and advertise_path_toggle:
+        choices += ", 'p' to switch listing"
     if current is None:
         return choices + ": "
     status = "current" if current in devices else "current, not detected"
     return f"{choices} [{_paint(f'{current} ({status})', _CYAN, out)}]: "
 
 
-def _prompt_camera_role(
-    role: str,
+def _prompt_device_slot(
+    label: str,
+    kind: str,
     by_id_devices: list[str],
     by_path_devices: list[str],
     active_is_by_id: bool,
     by_id_dir: Path,
     by_path_dir: Path,
     current: str | None,
-    assigned: dict[str, str],
+    assigned: dict[str, tuple[str, str, str]],
     advertise_path_toggle: bool,
     *,
     input_fn: Callable[[str], str],
     out: IO[str],
+    rescan_by_id: Callable[[], list[str]],
+    rescan_by_path: Callable[[], list[str]],
+    camera_role: str | None = None,
 ) -> tuple[str | None, bool]:
-    """Prompt for one role and return its device plus active listing state."""
+    """Prompt for one slot and return its device plus active listing state."""
     while True:
         devices = by_id_devices if active_is_by_id else by_path_devices
         device_dir = by_id_dir if active_is_by_id else by_path_dir
-        prompt = _camera_role_prompt(role, devices, current, advertise_path_toggle, out=out)
+        prompt = _device_slot_prompt(
+            label,
+            kind,
+            devices,
+            current,
+            advertise_path_toggle,
+            out=out,
+            camera_fallback=camera_role is not None,
+        )
         entered = input_fn(prompt).strip()
         selected: str | None = None
         if entered.lower() == "s":
             return None, active_is_by_id
-        if entered.lower() == "p":
+        if entered.lower() == "p" and kind == "v4l2":
             active_is_by_id = not active_is_by_id
             devices = by_id_devices if active_is_by_id else by_path_devices
             device_dir = by_id_dir if active_is_by_id else by_path_dir
             _print_camera_listing(devices, device_dir, out)
             continue
         if entered.lower() == "u":
+            nouns = {
+                "v4l2": ("camera device", "camera devices", "camera"),
+                "can": ("CAN interface", "CAN interfaces", "CAN interface"),
+                "serial": ("serial device", "serial devices", "serial device"),
+            }
             selected = _identify_by_replug(
-                role,
+                camera_role or label,
                 devices,
                 input_fn=input_fn,
                 out=out,
-                rescan=partial(_scan_cameras, device_dir),
+                rescan=rescan_by_id if active_is_by_id else rescan_by_path,
+                noun=nouns[kind][0],
+                plural_noun=nouns[kind][1],
+                retry_noun=nouns[kind][2],
+                unplug_label=None if camera_role is not None else label,
             )
             if selected is None:
                 continue
         elif not entered and current is not None:
             selected = current
-        elif entered.startswith("/") or Path(entered).is_absolute():
+        elif kind != "can" and (entered.startswith("/") or Path(entered).is_absolute()):
             # startswith("/") keeps POSIX rig paths accepted on Windows
             # workstations, where "/dev/v4l/..." is not drive-absolute.
             if not Path(entered).exists():
@@ -335,36 +367,56 @@ def _prompt_camera_role(
             number = int(entered)
             if 1 <= number <= len(devices):
                 selected = devices[number - 1]
+        elif kind == "can" and entered and "/" not in entered:
+            if entered not in devices:
+                print(
+                    _paint(
+                        f"warning: {entered} is not in the scanned CAN interfaces "
+                        "(ok if this config is for another machine)",
+                        _YELLOW,
+                        out,
+                    ),
+                    file=out,
+                )
+            selected = entered
         if selected is None:
+            instruction = (
+                "enter an interface number, bare interface name, 'u' to identify, or 's' to skip"
+                if kind == "can"
+                else "enter a device number, absolute path, 'u' to identify, or 's' to skip"
+            )
             print(
-                _paint(
-                    "enter a device number, absolute path, 'u' to identify, or 's' to skip",
-                    _YELLOW,
-                    out,
-                ),
+                _paint(instruction, _YELLOW, out),
                 file=out,
             )
             continue
 
-        other_role = next(
+        other = next(
             (
-                assigned_key.removesuffix("_cam_device")
-                for assigned_key, device in assigned.items()
-                if device == selected
+                (assigned_label, device)
+                for assigned_kind, assigned_label, device in assigned.values()
+                if assigned_kind == kind and device == selected
             ),
             None,
         )
-        if other_role is not None:
+        if other is not None:
+            other_label, _device = other
+            if camera_role is not None:
+                warning_label = f"the {other_label} camera"
+                question = f"Use {selected} for both {other_label} and {camera_role} cameras?"
+            else:
+                warning_label = other_label
+                question = f"Use {selected} for both {other_label} and {label}?"
             print(
                 _paint(
-                    f"warning: {selected} is already assigned to the {other_role} camera",
+                    f"warning: {selected} is already assigned to {warning_label}",
                     _YELLOW,
                     out,
                 ),
                 file=out,
             )
             if not _ask_yes_no(
-                f"Use {selected} for both {other_role} and {role} cameras?",
+                question,
                 False,
                 input_fn=input_fn,
                 out=out,
@@ -389,11 +441,10 @@ def _camera_section(
     device_dir = by_id_dir if active_is_by_id else by_path_dir
     advertise_path_toggle = len(by_path_devices) > len(by_id_devices)
 
-    camera_keys = tuple(f"{role}_cam_device" for role in CAM_ROLES)
     existing_args = carried.get("embodiment.args", {})
-    default_enabled = bool(devices) or any(key in existing_args for key in camera_keys)
+    default_enabled = bool(devices) or any(key in existing_args for key in CAMERA_KEYS)
     if not _ask_yes_no("Configure cameras?", default_enabled, input_fn=input_fn, out=out):
-        return {key: existing_args[key] for key in camera_keys if key in existing_args}
+        return _preserve_managed_args(carried)
 
     if devices:
         _print_camera_listing(devices, device_dir, out)
@@ -416,23 +467,29 @@ def _camera_section(
 
     while True:
         assignments: dict[str, str] = {}
+        assigned_devices: dict[str, tuple[str, str, str]] = {}
         for role in CAM_ROLES:
             key = f"{role}_cam_device"
-            selected, active_is_by_id = _prompt_camera_role(
-                role,
+            selected, active_is_by_id = _prompt_device_slot(
+                f"{role} camera",
+                "v4l2",
                 by_id_devices,
                 by_path_devices,
                 active_is_by_id,
                 by_id_dir,
                 by_path_dir,
                 existing_args.get(key),
-                assignments,
+                assigned_devices,
                 advertise_path_toggle,
                 input_fn=input_fn,
                 out=out,
+                rescan_by_id=partial(_scan_cameras, by_id_dir),
+                rescan_by_path=partial(_scan_cameras, by_path_dir),
+                camera_role=role,
             )
             if selected is not None:
                 assignments[key] = selected
+                assigned_devices[key] = ("v4l2", role, selected)
         if len(assignments) in (0, len(CAM_ROLES)):
             return assignments
         print(
@@ -445,6 +502,161 @@ def _camera_section(
         )
         if not _ask_yes_no("Go back and choose cameras again?", True, input_fn=input_fn, out=out):
             return {}
+
+
+def _preserve_managed_args(
+    carried: dict[str, dict[str, str]],
+    managed_args: tuple[str, ...] = CAMERA_KEYS,
+) -> dict[str, str]:
+    """Return existing assignments for the keys managed by a device section."""
+    existing_args = carried.get("embodiment.args", {})
+    return {key: existing_args[key] for key in managed_args if key in existing_args}
+
+
+def _print_slot_listing(
+    kind: str,
+    devices: list[str],
+    directory: Path,
+    out: IO[str],
+) -> None:
+    """Print the first-use listing for one declared device kind."""
+    if kind == "v4l2":
+        _print_camera_listing(devices, directory, out)
+        return
+    noun = "CAN interface" if kind == "can" else "serial device"
+    display_dir = SYSFS_NET if kind == "can" else SERIAL_BY_ID
+    print(f"Found {len(devices)} {noun}(s) under {display_dir}:", file=out)
+    for number, device in enumerate(devices, start=1):
+        name = device if kind == "can" else Path(device).name
+        print(f"  {number}. {name}", file=out)
+
+
+def _device_section(
+    embodiment: str,
+    slots: tuple[DeviceSlot, ...],
+    carried: dict[str, dict[str, str]],
+    by_id_dir: Path,
+    by_path_dir: Path,
+    sysfs_net: Path,
+    serial_by_id_dir: Path,
+    *,
+    input_fn: Callable[[str], str],
+    out: IO[str],
+) -> dict[str, str]:
+    """Offer and collect assignments for plugin-declared device slots."""
+    kinds = {slot.kind for slot in slots}
+    by_id_devices = _scan_cameras(by_id_dir) if "v4l2" in kinds else []
+    by_path_devices = _scan_cameras(by_path_dir) if "v4l2" in kinds else []
+    can_devices = _scan_can(sysfs_net) if "can" in kinds else []
+    serial_devices = _scan_serial(serial_by_id_dir) if "serial" in kinds else []
+    active_is_by_id = bool(by_id_devices) or not by_path_devices
+    advertise_path_toggle = len(by_path_devices) > len(by_id_devices)
+    devices_by_kind = {
+        "v4l2": by_id_devices if active_is_by_id else by_path_devices,
+        "can": can_devices,
+        "serial": serial_devices,
+    }
+    managed_args = tuple(slot.arg for slot in slots)
+    existing_args = carried.get("embodiment.args", {})
+    default_enabled = any(devices_by_kind[kind] for kind in kinds) or any(
+        arg in existing_args for arg in managed_args
+    )
+    if not _ask_yes_no("Configure devices?", default_enabled, input_fn=input_fn, out=out):
+        return _preserve_managed_args(carried, managed_args)
+
+    listed_kinds: set[str] = set()
+    assignments: dict[str, str] = {}
+    assigned_devices: dict[str, tuple[str, str, str]] = {}
+
+    def prompt_slot(slot: DeviceSlot) -> None:
+        nonlocal active_is_by_id
+        if slot.kind == "v4l2":
+            primary_devices = by_id_devices
+            secondary_devices = by_path_devices
+            primary_dir = by_id_dir
+            secondary_dir = by_path_dir
+            current_devices = primary_devices if active_is_by_id else secondary_devices
+            current_dir = primary_dir if active_is_by_id else secondary_dir
+            rescan_primary = partial(_scan_cameras, primary_dir)
+            rescan_secondary = partial(_scan_cameras, secondary_dir)
+        elif slot.kind == "can":
+            primary_devices = secondary_devices = can_devices
+            primary_dir = secondary_dir = SYSFS_NET
+            current_devices = can_devices
+            current_dir = SYSFS_NET
+            rescan_primary = rescan_secondary = partial(_scan_can, sysfs_net)
+        else:
+            primary_devices = secondary_devices = serial_devices
+            primary_dir = secondary_dir = SERIAL_BY_ID
+            current_devices = serial_devices
+            current_dir = SERIAL_BY_ID
+            rescan_primary = rescan_secondary = partial(_scan_serial, serial_by_id_dir)
+
+        if slot.kind not in listed_kinds:
+            _print_slot_listing(slot.kind, current_devices, current_dir, out)
+            listed_kinds.add(slot.kind)
+            if slot.kind == "v4l2" and advertise_path_toggle:
+                print(
+                    _paint(
+                        f"only {len(by_id_devices)} by-id entries for "
+                        f"{len(by_path_devices)} detected cameras — identical cameras without "
+                        "serials collide there; by-path names are stable per physical USB port",
+                        _YELLOW,
+                        out,
+                    ),
+                    file=out,
+                )
+
+        selected, active_is_by_id = _prompt_device_slot(
+            slot.label,
+            slot.kind,
+            primary_devices,
+            secondary_devices,
+            active_is_by_id,
+            primary_dir,
+            secondary_dir,
+            existing_args.get(slot.arg),
+            assigned_devices,
+            advertise_path_toggle,
+            input_fn=input_fn,
+            out=out,
+            rescan_by_id=rescan_primary,
+            rescan_by_path=rescan_secondary,
+        )
+        assignments.pop(slot.arg, None)
+        assigned_devices.pop(slot.arg, None)
+        if selected is not None:
+            assignments[slot.arg] = selected
+            assigned_devices[slot.arg] = (slot.kind, slot.label, selected)
+
+    for slot in slots:
+        prompt_slot(slot)
+
+    groups = tuple(dict.fromkeys(slot.group for slot in slots if slot.group is not None))
+    for group in groups:
+        group_slots = tuple(slot for slot in slots if slot.group == group)
+        while 0 < sum(slot.arg in assignments for slot in group_slots) < len(group_slots):
+            print(
+                _paint(
+                    f"{embodiment} needs all {group} slots or none; "
+                    "writing none unless you go back",
+                    _YELLOW,
+                    out,
+                ),
+                file=out,
+            )
+            if not _ask_yes_no(
+                "Go back and choose devices again?", True, input_fn=input_fn, out=out
+            ):
+                for slot in group_slots:
+                    assignments.pop(slot.arg, None)
+                    assigned_devices.pop(slot.arg, None)
+                break
+            for slot in group_slots:
+                assignments.pop(slot.arg, None)
+                assigned_devices.pop(slot.arg, None)
+                prompt_slot(slot)
+    return assignments
 
 
 def _scan_cameras(v4l_dir: Path) -> list[str]:
@@ -510,6 +722,7 @@ def _render_config(
     defaults: dict[str, str],
     embodiment_args: dict[str, str],
     carried: dict[str, dict[str, str]],
+    managed_args: tuple[str, ...] = CAMERA_KEYS,
 ) -> str:
     """Render a full commented config while carrying unmanaged raw values."""
     sections: list[str] = []
@@ -532,16 +745,15 @@ def _render_config(
     if default_lines:
         sections.append("[defaults]\n" + "\n".join(default_lines))
 
-    camera_keys = tuple(f"{role}_cam_device" for role in CAM_ROLES)
     embodiment_lines: list[str] = []
-    for key in camera_keys:
+    for key in managed_args:
         if key in embodiment_args:
             # Enter-accepted "(current)" values come from the raw read and
             # can be multiline like any carried value.
             value = embodiment_args[key].replace("\n", "\n\t")
             embodiment_lines.append(f"{key} = {value}")
     for key, value in carried.get("embodiment.args", {}).items():
-        if key not in camera_keys:
+        if key not in managed_args:
             value = value.replace("\n", "\n\t")
             embodiment_lines.append(f"{key} = {value}")
     if embodiment_lines:
@@ -624,18 +836,42 @@ def run_setup(
             input_fn=input_fn,
             out=out,
         )
-        embodiment_args = _camera_section(
-            carried,
-            by_id_dir,
-            by_path_dir,
-            input_fn=input_fn,
-            out=out,
+        from inspect_robots.registry import registered
+
+        embodiment_factories = registered("embodiment")
+        configured_embodiment = defaults["embodiment"]
+        slots = (
+            device_slots(embodiment_factories[configured_embodiment])
+            if configured_embodiment in embodiment_factories
+            else ()
         )
+        if slots:
+            managed_args = tuple(slot.arg for slot in slots)
+            embodiment_args = _device_section(
+                configured_embodiment,
+                slots,
+                carried,
+                by_id_dir,
+                by_path_dir,
+                sysfs_net,
+                serial_by_id_dir,
+                input_fn=input_fn,
+                out=out,
+            )
+        else:
+            managed_args = CAMERA_KEYS
+            embodiment_args = _camera_section(
+                carried,
+                by_id_dir,
+                by_path_dir,
+                input_fn=input_fn,
+                out=out,
+            )
     except (EOFError, KeyboardInterrupt):
         print(_paint("setup aborted; nothing written", _YELLOW, out), file=out)
         return 1
 
-    text = _render_config(defaults, embodiment_args, carried)
+    text = _render_config(defaults, embodiment_args, carried, managed_args)
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(path.name + ".tmp")
     tmp.write_text(text, encoding="utf-8")

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import configparser
 import os
+import re
 from collections.abc import Callable, Mapping
 from functools import partial
 from pathlib import Path
@@ -704,6 +705,69 @@ def _can_serial(sysfs_net: Path, ifname: str) -> str | None:
         return None
 
 
+def _suggest_can_pinning(
+    sysfs_net: Path,
+    slots: tuple[DeviceSlot, ...],
+    assignments: Mapping[str, str],
+    *,
+    out: IO[str],
+) -> None:
+    """Suggest serial-pinned udev names for assigned order-dependent CAN devices."""
+    scanned = _scan_can(sysfs_net)
+    order_dependent = [ifname for ifname in scanned if re.fullmatch(r"can\d+", ifname)]
+    if len(order_dependent) < 2 or not any(
+        assignments.get(slot.arg) in order_dependent for slot in slots if slot.kind == "can"
+    ):
+        return
+    if not any(
+        "usb" in (sysfs_net / ifname / "device").resolve().parts for ifname in order_dependent
+    ):
+        return
+
+    warning = "these CAN interfaces have order-dependent names; a replug can swap them."
+    serials = [_can_serial(sysfs_net, ifname) for ifname in order_dependent]
+    if not all(serials) or len(set(serials)) != len(serials):
+        print(_paint(warning, _YELLOW, out), file=out)
+        return
+
+    derived_names: list[str] = []
+    for ifname in order_dependent:
+        assigned_arg = next(
+            (
+                slot.arg
+                for slot in slots
+                if slot.kind == "can" and assignments.get(slot.arg) == ifname
+            ),
+            None,
+        )
+        if assigned_arg is None:
+            derived_names.append(f"can_{ifname}")
+            continue
+        stem = re.sub(r"_(?:channel|bus)$", "", assigned_arg)
+        derived_names.append(stem if stem.startswith("can") else f"can_{stem}")
+
+    collision = len(set(derived_names)) != len(derived_names) or any(
+        name in scanned for name in derived_names
+    )
+    if collision or any(len(name) > 15 for name in derived_names):
+        derived_names = [f"can_{chr(ord('a') + index)}" for index in range(len(derived_names))]
+
+    serial_values = [serial for serial in serials if serial is not None]
+    rules = [
+        f'  SUBSYSTEM=="net", ACTION=="add", ATTRS{{serial}}=="{serial}", NAME="{name}"'
+        for serial, name in zip(serial_values, derived_names, strict=True)
+    ]
+    block = "\n".join(
+        [
+            warning,
+            "pin them by adapter serial (paste into /etc/udev/rules.d/70-can-names.rules,",
+            "then replug or reboot), and re-run setup to record the pinned names:",
+            *rules,
+        ]
+    )
+    print(_paint(block, _YELLOW, out), file=out)
+
+
 def _read_raw_config(path: Path) -> dict[str, dict[str, str]] | str:
     """Read raw section values, returning parse-error text instead of raising."""
     parser = configparser.ConfigParser(
@@ -858,6 +922,7 @@ def run_setup(
                 input_fn=input_fn,
                 out=out,
             )
+            _suggest_can_pinning(sysfs_net, slots, embodiment_args, out=out)
         else:
             managed_args = CAMERA_KEYS
             embodiment_args = _camera_section(

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -41,6 +41,8 @@ SUGGESTED: dict[str, str] = {
 CAM_ROLES: tuple[str, ...] = ("top", "left", "right")  # -> {role}_cam_device in [embodiment.args]
 V4L_BY_ID: Path = Path("/dev/v4l/by-id")
 V4L_BY_PATH: Path = Path("/dev/v4l/by-path")
+SYSFS_NET: Path = Path("/sys/class/net")
+SERIAL_BY_ID: Path = Path("/dev/serial/by-id")
 
 _DEFAULT_COMMENTS: dict[str, str] = {
     "policy": "from the inspect-robots-yam plugin",
@@ -455,6 +457,41 @@ def _scan_cameras(v4l_dir: Path) -> list[str]:
     return [str(entry) for entry in color_entries or entries]
 
 
+def _scan_can(sysfs_net: Path) -> list[str]:
+    """Return sorted SocketCAN interface names from a sysfs net directory."""
+    try:
+        entries = sorted(sysfs_net.iterdir())
+    except OSError:
+        return []
+    interfaces: list[str] = []
+    for entry in entries:
+        try:
+            interface_type = (entry / "type").read_text(encoding="utf-8").strip()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if interface_type == "280":
+            interfaces.append(entry.name)
+    return interfaces
+
+
+def _scan_serial(serial_by_id_dir: Path) -> list[str]:
+    """Return sorted absolute paths from a serial by-id directory."""
+    try:
+        entries = sorted(serial_by_id_dir.iterdir())
+    except OSError:
+        return []
+    return [str(entry.absolute()) for entry in entries]
+
+
+def _can_serial(sysfs_net: Path, ifname: str) -> str | None:
+    """Read a CAN adapter serial through its sysfs device link, if available."""
+    try:
+        serial_path = (sysfs_net / ifname / "device").resolve().parent / "serial"
+        return serial_path.read_text(encoding="utf-8").strip()
+    except Exception:
+        return None
+
+
 def _read_raw_config(path: Path) -> dict[str, dict[str, str]] | str:
     """Read raw section values, returning parse-error text instead of raising."""
     parser = configparser.ConfigParser(
@@ -531,6 +568,8 @@ def run_setup(
     interactive: bool,
     by_id_dir: Path = V4L_BY_ID,
     by_path_dir: Path = V4L_BY_PATH,
+    sysfs_net: Path = SYSFS_NET,
+    serial_by_id_dir: Path = SERIAL_BY_ID,
 ) -> int:
     """Drive the interactive setup wizard and return its process exit code."""
     if not interactive:

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -525,7 +525,9 @@ def _print_slot_listing(
         _print_camera_listing(devices, directory, out)
         return
     noun = "CAN interface" if kind == "can" else "serial device"
-    display_dir = SYSFS_NET if kind == "can" else SERIAL_BY_ID
+    # as_posix: these are canonical Linux locations; Windows str(Path) would
+    # render them with backslashes.
+    display_dir = (SYSFS_NET if kind == "can" else SERIAL_BY_ID).as_posix()
     print(f"Found {len(devices)} {noun}(s) under {display_dir}:", file=out)
     for number, device in enumerate(devices, start=1):
         name = device if kind == "can" else Path(device).name

--- a/src/inspect_robots/conformance.py
+++ b/src/inspect_robots/conformance.py
@@ -19,7 +19,7 @@ guide covers the human half.
 from __future__ import annotations
 
 import importlib.util
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -27,6 +27,47 @@ import numpy as np
 from inspect_robots.embodiment import EmbodimentInfo
 
 _ABSOLUTE_MODES = frozenset({"joint_pos", "eef_abs_pose"})
+DEVICE_KINDS = ("v4l2", "can", "serial")
+
+
+@dataclass(frozen=True)
+class DeviceSlot:
+    """One device-shaped constructor argument the setup wizard interviews.
+
+    ``arg`` is the ``[embodiment.args]`` key to write; ``kind`` selects the
+    probe (``"v4l2"``: /dev/v4l listings with unplug-identify; ``"can"``:
+    SocketCAN netdevs from sysfs with unplug-identify; ``"serial"``:
+    /dev/serial/by-id listing). ``label`` is the human prompt ("left arm CAN
+    channel"). Slots sharing a non-None ``group`` are all-or-none: the
+    wizard refuses to write a partial subset of the group.
+    """
+
+    arg: str
+    kind: str
+    label: str
+    group: str | None = None
+
+
+def device_slots(factory: object) -> tuple[DeviceSlot, ...]:
+    """The declared device slots, defensively read.
+
+    Reads ``DEVICE_SLOTS`` off ``factory``; anything that is not an iterable
+    of ``DeviceSlot`` instances (or contains a slot whose ``kind`` is not
+    recognized) has the offending entries ignored, never crashes the wizard.
+    Returns a tuple in declaration order.
+    """
+    try:
+        slots = getattr(factory, "DEVICE_SLOTS", None)
+    except Exception:
+        return ()
+    if not isinstance(slots, Iterable):
+        return ()
+    try:
+        return tuple(
+            slot for slot in slots if isinstance(slot, DeviceSlot) and slot.kind in DEVICE_KINDS
+        )
+    except Exception:
+        return ()
 
 
 def missing_runtime_requirements(factory: object) -> dict[str, str]:

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -8,8 +8,10 @@ import numpy as np
 import pytest
 
 from inspect_robots.conformance import (
+    DeviceSlot,
     assert_embodiment_conformant,
     check_embodiment,
+    device_slots,
     missing_runtime_requirements,
 )
 from inspect_robots.embodiment import EmbodimentInfo
@@ -51,6 +53,65 @@ def _good_absolute() -> EmbodimentInfo:
 
 def _codes(info: EmbodimentInfo) -> dict[str, str]:
     return {i.code: i.severity for i in check_embodiment(info).issues}
+
+
+def test_device_slots_absent_attribute_is_empty() -> None:
+    class _Factory:
+        pass
+
+    assert device_slots(_Factory) == ()
+    assert device_slots(None) == ()
+
+
+def test_device_slots_valid_tuple_round_trips_in_order() -> None:
+    slots = (
+        DeviceSlot("left_channel", "can", "left arm CAN channel", "arms"),
+        DeviceSlot("camera", "v4l2", "camera"),
+        DeviceSlot("tty", "serial", "controller serial port"),
+    )
+
+    class _Factory:
+        DEVICE_SLOTS: ClassVar[tuple[DeviceSlot, ...]] = slots
+
+    assert device_slots(_Factory) == slots
+
+
+def test_device_slots_accepts_lists_and_ignores_offending_entries() -> None:
+    valid = DeviceSlot("camera", "v4l2", "camera")
+
+    class _Factory:
+        DEVICE_SLOTS: ClassVar[list[object]] = [
+            "not a slot",
+            valid,
+            DeviceSlot("mystery", "unknown", "mystery"),
+        ]
+
+    assert device_slots(_Factory) == (valid,)
+
+
+@pytest.mark.parametrize("garbage", [7, None])
+def test_device_slots_whole_value_garbage_is_empty(garbage: object) -> None:
+    class _Factory:
+        DEVICE_SLOTS: ClassVar[object] = garbage
+
+    assert device_slots(_Factory) == ()
+
+
+def test_device_slots_attribute_or_iteration_failure_is_empty() -> None:
+    class _BrokenAttribute:
+        @property
+        def DEVICE_SLOTS(self) -> object:
+            raise RuntimeError("broken descriptor")
+
+    class _BrokenIteration:
+        def __iter__(self) -> object:
+            raise RuntimeError("broken iterator")
+
+    class _Factory:
+        DEVICE_SLOTS: ClassVar[object] = _BrokenIteration()
+
+    assert device_slots(_BrokenAttribute()) == ()
+    assert device_slots(_Factory) == ()
 
 
 def test_runtime_requirements_absent_attribute_is_empty() -> None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -21,6 +21,7 @@ from inspect_robots._setup import (
     _scan_serial,
     run_setup,
 )
+from inspect_robots.conformance import DeviceSlot
 
 
 def _scripted_input(
@@ -51,6 +52,31 @@ def _make_devices(directory: Path, count: int = 3) -> list[str]:
         path.touch()
         devices.append(str(path))
     return devices
+
+
+def _make_can_interfaces(sysfs_net: Path, *names: str) -> None:
+    for name in names:
+        interface = sysfs_net / name
+        interface.mkdir(parents=True)
+        (interface / "type").write_text("280\n", encoding="utf-8")
+
+
+def _register_device_slots(
+    monkeypatch: pytest.MonkeyPatch,
+    slots: tuple[DeviceSlot, ...],
+    name: str = "slot-body",
+) -> None:
+    class _Factory:
+        DEVICE_SLOTS: ClassVar[tuple[DeviceSlot, ...]] = slots
+
+    monkeypatch.setattr(
+        "inspect_robots.registry.registered",
+        lambda kind: {name: _Factory} if kind == "embodiment" else {},
+    )
+
+
+def _slot_defaults(name: str = "slot-body") -> list[str]:
+    return ["", name, "", "", "", ""]
 
 
 @pytest.fixture(autouse=True)
@@ -1032,6 +1058,38 @@ def test_identify_by_replug_finds_disappeared_then_restored_device() -> None:
     assert "That was: camera-left" in out.getvalue()
 
 
+@pytest.mark.parametrize(
+    ("noun", "retry_noun", "label", "expected"),
+    [
+        ("CAN interface", "CAN interface", "left CAN channel", "no CAN interface disappeared"),
+        ("serial device", "serial device", "arm serial port", "no serial device disappeared"),
+    ],
+)
+def test_identify_by_replug_parameterizes_non_camera_nouns(
+    noun: str,
+    retry_noun: str,
+    label: str,
+    expected: str,
+) -> None:
+    input_fn, prompts = _scripted_input([""])
+    out = io.StringIO()
+
+    identified = _identify_by_replug(
+        label,
+        ["device0"],
+        input_fn=input_fn,
+        out=out,
+        rescan=lambda: ["device0"],
+        noun=noun,
+        retry_noun=retry_noun,
+        unplug_label=label,
+    )
+
+    assert identified is None
+    assert prompts == [f"Unplug the {label} now, then press Enter..."]
+    assert expected in out.getvalue()
+
+
 @pytest.mark.parametrize("detected_on_retry", [True, False])
 def test_identify_by_replug_retries_replug_scan_once(
     detected_on_retry: bool,
@@ -1641,3 +1699,407 @@ def test_run_setup_reminder_names_only_the_missing_component(tmp_path: Path) -> 
     assert result == 0
     assert "reminder: embodiment 'yam_arms' not registered here" in text
     assert "policy 'molmoact2'" not in text.split("Wrote ")[1]
+
+
+def test_run_setup_registered_device_slots_use_labels_and_can_number_pick(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_device_slots(
+        monkeypatch,
+        (DeviceSlot("left_channel", "can", "left arm CAN channel"),),
+    )
+    sysfs_net = tmp_path / "net"
+    _make_can_interfaces(sysfs_net, "can_left")
+    input_fn, prompts = _scripted_input([*_slot_defaults(), "", "1"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        sysfs_net=sysfs_net,
+        serial_by_id_dir=tmp_path / "serial",
+    )
+
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert "Found 1 CAN interface(s) under /sys/class/net:" in out.getvalue()
+    assert "  1. can_left" in out.getvalue()
+    assert any(
+        prompt == "left arm CAN channel — number, 'u' to identify by unplugging, 's' to skip: "
+        for prompt in prompts
+    )
+    assert "left_channel = can_left" in text
+
+
+@pytest.mark.parametrize("registered_without_slots", [False, True])
+def test_run_setup_falls_back_to_cameras_without_registered_slots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    registered_without_slots: bool,
+) -> None:
+    if registered_without_slots:
+
+        class _Factory:
+            pass
+
+        monkeypatch.setattr(
+            "inspect_robots.registry.registered",
+            lambda kind: {"slot-body": _Factory} if kind == "embodiment" else {},
+        )
+    input_fn, prompts = _scripted_input([*_slot_defaults(), ""])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert any(prompt.startswith("Configure cameras?") for prompt in prompts)
+    assert not any(prompt.startswith("Configure devices?") for prompt in prompts)
+
+
+def test_run_setup_device_gate_defaults_no_without_probe_or_existing_arg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_device_slots(
+        monkeypatch,
+        (DeviceSlot("left_channel", "can", "left arm CAN channel"),),
+    )
+    input_fn, prompts = _scripted_input([*_slot_defaults(), ""])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        sysfs_net=tmp_path / "none-net",
+    )
+
+    assert result == 0
+    assert "Configure devices? [y/N] " in prompts
+    assert not any(prompt.startswith("left arm CAN channel") for prompt in prompts)
+
+
+def test_run_setup_serial_slots_support_number_and_manual_absolute_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_device_slots(
+        monkeypatch,
+        (
+            DeviceSlot("controller_port", "serial", "controller serial port"),
+            DeviceSlot("debug_port", "serial", "debug serial port"),
+        ),
+    )
+    serial_by_id = tmp_path / "serial-by-id"
+    serial_by_id.mkdir()
+    listed = serial_by_id / "usb-controller"
+    listed.touch()
+    manual = "/remote/serial-controller"
+    input_fn, _ = _scripted_input([*_slot_defaults(), "", "1", manual])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        serial_by_id_dir=serial_by_id,
+    )
+
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert out.getvalue().count("Found 1 serial device(s) under /dev/serial/by-id:") == 1
+    assert f"controller_port = {listed}" in text
+    assert f"debug_port = {manual}" in text
+    assert f"warning: {manual} does not exist here" in out.getvalue()
+
+
+def test_run_setup_slot_duplicate_guard_is_same_kind_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_device_slots(
+        monkeypatch,
+        (
+            DeviceSlot("top_cam", "v4l2", "top camera"),
+            DeviceSlot("side_cam", "v4l2", "side camera"),
+            DeviceSlot("controller_port", "serial", "controller serial port"),
+        ),
+    )
+    by_id = tmp_path / "by-id"
+    devices = _make_devices(by_id, count=2)
+    serial_by_id = tmp_path / "serial"
+    serial_by_id.mkdir()
+    (serial_by_id / "listed").touch()
+    input_fn, prompts = _scripted_input(
+        [*_slot_defaults(), "", devices[0], devices[0], "n", devices[1], devices[0]]
+    )
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=tmp_path / "none-path",
+        serial_by_id_dir=serial_by_id,
+    )
+
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert f"warning: {devices[0]} is already assigned to top camera" in out.getvalue()
+    assert (
+        sum(
+            "Use " in prompt and "for both top camera and side camera?" in prompt
+            for prompt in prompts
+        )
+        == 1
+    )
+    assert f"top_cam = {devices[0]}" in text
+    assert f"side_cam = {devices[1]}" in text
+    assert f"controller_port = {devices[0]}" in text
+
+
+def test_run_setup_can_manual_entry_rejects_paths_and_warns_when_unlisted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_device_slots(
+        monkeypatch,
+        (DeviceSlot("left_channel", "can", "left arm CAN channel"),),
+    )
+    input_fn, prompts = _scripted_input([*_slot_defaults(), "y", "/dev/can0", "can_remote"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        sysfs_net=tmp_path / "none-net",
+    )
+
+    assert result == 0
+    assert sum(prompt.startswith("left arm CAN channel") for prompt in prompts) == 2
+    assert "enter an interface number, bare interface name" in out.getvalue()
+    assert "warning: can_remote is not in the scanned CAN interfaces" in out.getvalue()
+    assert "left_channel = can_remote" in _config_path(tmp_path).read_text(encoding="utf-8")
+
+
+def test_run_setup_can_manual_entry_accepts_a_listed_name_without_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_device_slots(
+        monkeypatch,
+        (DeviceSlot("left_channel", "can", "left CAN channel"),),
+    )
+    sysfs_net = tmp_path / "net"
+    _make_can_interfaces(sysfs_net, "can0")
+    input_fn, _ = _scripted_input([*_slot_defaults(), "", "can0"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        sysfs_net=sysfs_net,
+    )
+
+    assert result == 0
+    assert "not in the scanned CAN interfaces" not in out.getvalue()
+    assert "left_channel = can0" in _config_path(tmp_path).read_text(encoding="utf-8")
+
+
+def test_run_setup_can_slot_identifies_by_unplug_rescan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_device_slots(
+        monkeypatch,
+        (DeviceSlot("left_channel", "can", "left arm CAN channel"),),
+    )
+    sysfs_net = tmp_path / "net"
+    _make_can_interfaces(sysfs_net, "can0")
+    pending = [*_slot_defaults(), "", "u", "", ""]
+    prompts: list[str] = []
+
+    def input_fn(prompt: str) -> str:
+        prompts.append(prompt)
+        if prompt.startswith("Unplug the left arm CAN channel"):
+            (sysfs_net / "can0" / "type").write_text("1\n", encoding="utf-8")
+        elif prompt.startswith("Plug it back in"):
+            (sysfs_net / "can0" / "type").write_text("280\n", encoding="utf-8")
+        return pending.pop(0)
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        sysfs_net=sysfs_net,
+    )
+
+    assert result == 0
+    assert "Unplug the left arm CAN channel now, then press Enter..." in prompts
+    assert "left_channel = can0" in _config_path(tmp_path).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("go_back", [False, True])
+def test_run_setup_device_group_all_or_none_keeps_ungrouped_slots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    go_back: bool,
+) -> None:
+    _register_device_slots(
+        monkeypatch,
+        (
+            DeviceSlot("left_channel", "can", "left CAN channel", "arms"),
+            DeviceSlot("right_channel", "can", "right CAN channel", "arms"),
+            DeviceSlot("controller_port", "serial", "controller serial port"),
+        ),
+    )
+    sysfs_net = tmp_path / "net"
+    _make_can_interfaces(sysfs_net, "can0", "can1")
+    serial_by_id = tmp_path / "serial"
+    serial_by_id.mkdir()
+    serial = serial_by_id / "controller"
+    serial.touch()
+    if not go_back:
+        path = _config_path(tmp_path)
+        path.parent.mkdir()
+        path.write_text(
+            "[defaults]\nembodiment = slot-body\n\n"
+            "[embodiment.args]\nleft_channel = old-left\nright_channel = old-right\n",
+            encoding="utf-8",
+        )
+    responses: list[str | BaseException] = [
+        *_slot_defaults(),
+        "",
+        "1",
+        "s",
+        "1",
+        "" if go_back else "n",
+    ]
+    if go_back:
+        responses += ["1", "2"]
+    input_fn, prompts = _scripted_input(responses)
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        sysfs_net=sysfs_net,
+        serial_by_id_dir=serial_by_id,
+    )
+
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert (
+        "slot-body needs all arms slots or none; writing none unless you go back" in out.getvalue()
+    )
+    assert f"controller_port = {serial}" in text
+    assert sum(prompt.startswith("controller serial port") for prompt in prompts) == 1
+    assert ("left_channel = can0" in text) is go_back
+    assert ("right_channel = can1" in text) is go_back
+    assert "old-left" not in text
+    assert "old-right" not in text
+
+
+def test_run_setup_declining_devices_preserves_slot_args_and_unmanaged_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_device_slots(
+        monkeypatch,
+        (DeviceSlot("left_channel", "can", "left CAN channel"),),
+    )
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[defaults]\nembodiment = slot-body\n\n"
+        "[embodiment.args]\nleft_channel = can9\ncalibration = preserved\n",
+        encoding="utf-8",
+    )
+    input_fn, prompts = _scripted_input(["", "", "", "", "", "", "n"])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        sysfs_net=tmp_path / "none-net",
+    )
+
+    text = path.read_text(encoding="utf-8")
+    assert result == 0
+    assert "Configure devices? [Y/n] " in prompts
+    assert "left_channel = can9" in text
+    assert "calibration = preserved" in text
+    assert not any(prompt.startswith("left CAN channel") for prompt in prompts)
+
+
+def test_run_setup_slot_enter_accepts_current_assignment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_device_slots(
+        monkeypatch,
+        (DeviceSlot("left_channel", "can", "left CAN channel"),),
+    )
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[defaults]\nembodiment = slot-body\n\n[embodiment.args]\nleft_channel = can0\n",
+        encoding="utf-8",
+    )
+    sysfs_net = tmp_path / "net"
+    _make_can_interfaces(sysfs_net, "can0")
+    input_fn, prompts = _scripted_input(["", "", "", "", "", "", "", ""])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        sysfs_net=sysfs_net,
+    )
+
+    assert result == 0
+    assert any("[can0 (current)]" in prompt for prompt in prompts)
+    assert "left_channel = can0" in path.read_text(encoding="utf-8")
+
+
+def test_run_setup_v4l2_slot_can_switch_to_by_path_listing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_device_slots(
+        monkeypatch,
+        (DeviceSlot("camera_device", "v4l2", "inspection camera"),),
+    )
+    by_id = tmp_path / "by-id"
+    by_path = tmp_path / "by-path"
+    _make_devices(by_id, count=1)
+    by_path_devices = _make_devices(by_path, count=2)
+    input_fn, prompts = _scripted_input([*_slot_defaults(), "", "p", "2"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=by_id,
+        by_path_dir=by_path,
+    )
+
+    assert result == 0
+    assert "only 1 by-id entries for 2 detected cameras" in out.getvalue()
+    assert any("'s' to skip, 'p' to switch listing" in prompt for prompt in prompts)
+    assert f"camera_device = {by_path_devices[1]}" in _config_path(tmp_path).read_text(
+        encoding="utf-8"
+    )

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -19,6 +19,7 @@ from inspect_robots._setup import (
     _scan_cameras,
     _scan_can,
     _scan_serial,
+    _suggest_can_pinning,
     run_setup,
 )
 from inspect_robots.conformance import DeviceSlot
@@ -59,6 +60,26 @@ def _make_can_interfaces(sysfs_net: Path, *names: str) -> None:
         interface = sysfs_net / name
         interface.mkdir(parents=True)
         (interface / "type").write_text("280\n", encoding="utf-8")
+
+
+def _attach_can_adapter(
+    tmp_path: Path,
+    sysfs_net: Path,
+    ifname: str,
+    serial: str | None,
+    *,
+    usb: bool = True,
+) -> None:
+    root = tmp_path / ("usb" if usb else "platform") / ifname / "adapter"
+    root.mkdir(parents=True)
+    if serial is not None:
+        (root / "serial").write_text(serial + "\n", encoding="utf-8")
+    device = root / "net-device"
+    device.mkdir()
+    try:
+        (sysfs_net / ifname / "device").symlink_to(device, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
 
 
 def _register_device_slots(
@@ -2103,3 +2124,140 @@ def test_run_setup_v4l2_slot_can_switch_to_by_path_listing(
     assert f"camera_device = {by_path_devices[1]}" in _config_path(tmp_path).read_text(
         encoding="utf-8"
     )
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
+def test_suggest_can_pinning_prints_exact_rules_for_distinct_usb_serials(
+    tmp_path: Path,
+) -> None:
+    sysfs_net = tmp_path / "net"
+    _make_can_interfaces(sysfs_net, "can0", "can1")
+    _attach_can_adapter(tmp_path, sysfs_net, "can0", "3B004B")
+    _attach_can_adapter(tmp_path, sysfs_net, "can1", "3B004C")
+    slots = (
+        DeviceSlot("can_left_channel", "can", "left CAN channel"),
+        DeviceSlot("right_bus", "can", "right CAN bus"),
+    )
+    out = io.StringIO()
+
+    _suggest_can_pinning(
+        sysfs_net,
+        slots,
+        {"can_left_channel": "can0", "right_bus": "can1"},
+        out=out,
+    )
+
+    assert out.getvalue() == (
+        "these CAN interfaces have order-dependent names; a replug can swap them.\n"
+        "pin them by adapter serial (paste into /etc/udev/rules.d/70-can-names.rules,\n"
+        "then replug or reboot), and re-run setup to record the pinned names:\n"
+        '  SUBSYSTEM=="net", ACTION=="add", ATTRS{serial}=="3B004B", NAME="can_left"\n'
+        '  SUBSYSTEM=="net", ACTION=="add", ATTRS{serial}=="3B004C", NAME="can_right"\n'
+    )
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
+def test_suggest_can_pinning_includes_unassigned_order_dependent_interface(
+    tmp_path: Path,
+) -> None:
+    sysfs_net = tmp_path / "net"
+    _make_can_interfaces(sysfs_net, "can0", "can1")
+    _attach_can_adapter(tmp_path, sysfs_net, "can0", "LEFT")
+    _attach_can_adapter(tmp_path, sysfs_net, "can1", "SPARE")
+    slots = (DeviceSlot("left_channel", "can", "left CAN channel"),)
+    out = io.StringIO()
+
+    _suggest_can_pinning(sysfs_net, slots, {"left_channel": "can0"}, out=out)
+
+    text = out.getvalue()
+    assert 'ATTRS{serial}=="LEFT", NAME="can_left"' in text
+    assert 'ATTRS{serial}=="SPARE", NAME="can_can1"' in text
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
+@pytest.mark.parametrize("fallback_reason", ["derived", "scanned", "long"])
+def test_suggest_can_pinning_name_conflict_or_length_falls_back_as_a_set(
+    tmp_path: Path,
+    fallback_reason: str,
+) -> None:
+    sysfs_net = tmp_path / "net"
+    names = ("can0", "can1", "can_left") if fallback_reason == "scanned" else ("can0", "can1")
+    _make_can_interfaces(sysfs_net, *names)
+    _attach_can_adapter(tmp_path, sysfs_net, "can0", "ONE")
+    _attach_can_adapter(tmp_path, sysfs_net, "can1", "TWO")
+    slots: tuple[DeviceSlot, ...]
+    assignments: dict[str, str]
+    if fallback_reason == "derived":
+        slots = (
+            DeviceSlot("left_channel", "can", "left CAN channel"),
+            DeviceSlot("left_bus", "can", "duplicate stable name"),
+        )
+        assignments = {"left_channel": "can0", "left_bus": "can1"}
+    elif fallback_reason == "scanned":
+        slots = (DeviceSlot("left_channel", "can", "left CAN channel"),)
+        assignments = {"left_channel": "can0"}
+    else:
+        slots = (DeviceSlot("extraordinarily_long_channel", "can", "long CAN channel"),)
+        assignments = {"extraordinarily_long_channel": "can0"}
+    out = io.StringIO()
+
+    _suggest_can_pinning(sysfs_net, slots, assignments, out=out)
+
+    text = out.getvalue()
+    assert 'ATTRS{serial}=="ONE", NAME="can_a"' in text
+    assert 'ATTRS{serial}=="TWO", NAME="can_b"' in text
+    assert 'NAME="can_can1"' not in text
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
+@pytest.mark.parametrize("serials", [("SAME", "SAME"), ("ONLY", None)])
+def test_suggest_can_pinning_bad_serials_print_warning_without_rules(
+    tmp_path: Path,
+    serials: tuple[str, str | None],
+) -> None:
+    sysfs_net = tmp_path / "net"
+    _make_can_interfaces(sysfs_net, "can0", "can1")
+    _attach_can_adapter(tmp_path, sysfs_net, "can0", serials[0])
+    _attach_can_adapter(tmp_path, sysfs_net, "can1", serials[1])
+    slots = (DeviceSlot("left_channel", "can", "left CAN channel"),)
+    out = io.StringIO()
+
+    _suggest_can_pinning(sysfs_net, slots, {"left_channel": "can0"}, out=out)
+
+    assert out.getvalue() == (
+        "these CAN interfaces have order-dependent names; a replug can swap them.\n"
+    )
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
+def test_suggest_can_pinning_non_usb_interfaces_are_completely_silent(
+    tmp_path: Path,
+) -> None:
+    sysfs_net = tmp_path / "net"
+    _make_can_interfaces(sysfs_net, "can0", "can1")
+    _attach_can_adapter(tmp_path, sysfs_net, "can0", "ONE", usb=False)
+    _attach_can_adapter(tmp_path, sysfs_net, "can1", "TWO", usb=False)
+    slots = (DeviceSlot("left_channel", "can", "left CAN channel"),)
+    out = io.StringIO()
+
+    _suggest_can_pinning(sysfs_net, slots, {"left_channel": "can0"}, out=out)
+
+    assert out.getvalue() == ""
+
+
+def test_suggest_can_pinning_pinned_names_or_no_assigned_kernel_name_are_silent(
+    tmp_path: Path,
+) -> None:
+    pinned_net = tmp_path / "pinned-net"
+    _make_can_interfaces(pinned_net, "can_left", "can_right")
+    slots = (DeviceSlot("left_channel", "can", "left CAN channel"),)
+    pinned_out = io.StringIO()
+
+    _suggest_can_pinning(pinned_net, slots, {"left_channel": "can_left"}, out=pinned_out)
+
+    order_net = tmp_path / "order-net"
+    _make_can_interfaces(order_net, "can0", "can1")
+    unassigned_out = io.StringIO()
+    _suggest_can_pinning(order_net, slots, {"left_channel": "can9"}, out=unassigned_out)
+    assert pinned_out.getvalue() == ""
+    assert unassigned_out.getvalue() == ""

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import os
 from collections.abc import Callable
 from pathlib import Path
 from typing import ClassVar
@@ -11,10 +12,13 @@ import pytest
 
 from inspect_robots._setup import (
     SUGGESTED,
+    _can_serial,
     _identify_by_replug,
     _read_raw_config,
     _render_config,
     _scan_cameras,
+    _scan_can,
+    _scan_serial,
     run_setup,
 )
 
@@ -88,6 +92,67 @@ def test_scan_cameras_falls_back_to_all_sorted_entries(tmp_path: Path) -> None:
 
 def test_scan_cameras_missing_directory_returns_empty(tmp_path: Path) -> None:
     assert _scan_cameras(tmp_path / "missing") == []
+
+
+def test_scan_can_filters_type_280_sorts_and_skips_unreadable(tmp_path: Path) -> None:
+    sysfs_net = tmp_path / "net"
+    for ifname, interface_type in (("can9", "280\n"), ("eth0", "1\n"), ("can1", "280")):
+        interface = sysfs_net / ifname
+        interface.mkdir(parents=True)
+        (interface / "type").write_text(interface_type, encoding="utf-8")
+    (sysfs_net / "broken").mkdir()
+
+    assert _scan_can(sysfs_net) == ["can1", "can9"]
+
+
+def test_scan_can_missing_directory_returns_empty(tmp_path: Path) -> None:
+    assert _scan_can(tmp_path / "missing") == []
+
+
+def test_scan_can_skips_undecodable_type_file(tmp_path: Path) -> None:
+    interface = tmp_path / "net" / "can0"
+    interface.mkdir(parents=True)
+    (interface / "type").write_bytes(b"\xff")
+
+    assert _scan_can(tmp_path / "net") == []
+
+
+def test_scan_serial_lists_sorted_absolute_paths(tmp_path: Path) -> None:
+    serial_by_id = tmp_path / "serial-by-id"
+    serial_by_id.mkdir()
+    for name in ("usb-controller-z", "usb-controller-a"):
+        (serial_by_id / name).touch()
+
+    assert _scan_serial(serial_by_id) == [
+        str(serial_by_id / "usb-controller-a"),
+        str(serial_by_id / "usb-controller-z"),
+    ]
+
+
+def test_scan_serial_missing_directory_returns_empty(tmp_path: Path) -> None:
+    assert _scan_serial(tmp_path / "missing") == []
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
+def test_can_serial_reads_through_device_symlink(tmp_path: Path) -> None:
+    sysfs_net = tmp_path / "net"
+    interface = sysfs_net / "can0"
+    interface.mkdir(parents=True)
+    adapter = tmp_path / "usb" / "adapter"
+    adapter.mkdir(parents=True)
+    (adapter / "serial").write_text(" 3B004B\n", encoding="utf-8")
+    device = adapter / "net-device"
+    device.mkdir()
+    try:
+        (interface / "device").symlink_to(device, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+
+    assert _can_serial(sysfs_net, "can0") == "3B004B"
+
+
+def test_can_serial_missing_serial_returns_none(tmp_path: Path) -> None:
+    assert _can_serial(tmp_path / "net", "can0") is None
 
 
 def test_read_raw_config_preserves_percent_and_literal_tilde(tmp_path: Path) -> None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -70,7 +70,8 @@ def _attach_can_adapter(
     *,
     usb: bool = True,
 ) -> None:
-    root = tmp_path / ("usb" if usb else "platform") / ifname / "adapter"
+    # "usb1" matches the numbered bus segments real sysfs uses (never bare "usb").
+    root = tmp_path / ("usb1" if usb else "platform") / ifname / "adapter"
     root.mkdir(parents=True)
     if serial is not None:
         (root / "serial").write_text(serial + "\n", encoding="utf-8")
@@ -185,7 +186,7 @@ def test_can_serial_reads_through_device_symlink(tmp_path: Path) -> None:
     sysfs_net = tmp_path / "net"
     interface = sysfs_net / "can0"
     interface.mkdir(parents=True)
-    adapter = tmp_path / "usb" / "adapter"
+    adapter = tmp_path / "usb3" / "adapter"
     adapter.mkdir(parents=True)
     (adapter / "serial").write_text(" 3B004B\n", encoding="utf-8")
     device = adapter / "net-device"


### PR DESCRIPTION
## Summary

The wizard's camera flow is good because it probes real devices; CAN buses got no probe, so a fresh config on a udev-pinned rig silently inherited the plugin default (`can0`/`can1`) and the first run died with `Could not access SocketCAN device can0` (#61, check 5 of #50). Components now declare their device-shaped constructor args and the wizard interviews each one with the probe appropriate to its kind. Cameras stop being a special case and become one declared kind; the hardcoded camera section remains as fallback for unregistered embodiments. Implements `plans/0011-device-slots.md` (two critique rounds before implementation).

## Changes

- `inspect_robots.conformance.DeviceSlot` (`arg`/`kind`/`label`/`group`) + defensive `device_slots(factory)` reader; kinds `v4l2`, `can`, `serial`. Same declaration mechanism as #59's `RUNTIME_REQUIREMENTS`; a component can carry both.
- Probes: CAN interfaces are netdevs with ARPHRD type 280, so listing is a sysfs read (no privileges, no subprocess); serial devices list from `/dev/serial/by-id`; v4l2 unchanged. All injectable for tests.
- Slot-driven interview: label-driven prompts in declaration order, per-kind listings and manual-entry vocabulary (bare interface names for CAN), the same unplug-to-identify flow for every kind, `(current)` Enter-accept defaults, kind-scoped duplicate guard, and per-`group` all-or-none. Managed `[embodiment.args]` keys are now parameterized (defaulting to the camera keys, so the fallback path and all existing tests are unchanged: the diff only adds tests).
- udev pinning suggestion (print-only): when the scan finds 2+ order-dependent `can\d+` interfaces on USB adapters and at least one is assigned, the wizard warns that a replug can swap which physical arm receives commands and prints the exact `ATTRS{serial}` rules snippet with stable names derived from the slot args (`left_channel` → `can_left`). Deterministic whole-set fallback on name collisions; silent for platform CAN (deterministic names) and already-pinned rigs.
- Docs: "Declare device slots" in the adapters guide, CLI guide paragraph, CHANGELOG, module map.

The yam plugin's declaration is tracked in robocurve/inspect-robots-yam#30.

## Review trail

Plan critiqued twice before implementation. The post-implementation review's empirical pass caught that the USB gate matched a bare `usb` path segment that real sysfs never produces (numbered buses only), which would have made the whole udev feature unreachable on hardware; fixed with realistic fixtures in 84ee5a4 and re-verified empirically.

## Checklist

- [x] Gates ran manually: `ruff check`, `ruff format --check`, `mypy`, `pytest --cov` (395 passed, 100.00% branch)
- [x] Tests added (protocol, probes, interview, udev; symlink fixtures skip on platforms without os.symlink)
- [x] Coverage stays at **100%**
- [x] No `__all__` change; core stays NumPy-only (stdlib `re`/`pathlib` only)
- [x] `CHANGELOG.md` updated under "Unreleased"

## Related

Closes #61. Check 5 of #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)