### PR TITLE
fix(rollout): formalize self-paced-only control-rate contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Removed
+
+- **`Task.control_hz`** (breaking). `rollout()` never actually paced the
+  control loop to it — `_effective_control_hz` was dead code and the loop
+  never slept — so the field only misled adapter authors and eval
+  reproducibility records. The rollout now documents plainly that it applies
+  no wall-clock pacing of its own; an embodiment that needs real-time cadence
+  paces itself in `step()` and declares the `"self_paced"` capability. Plan
+  0001 §9 R1 is updated to match (see the inline reversal note there for
+  rationale). `compat`'s policy/embodiment rate-mismatch warning is
+  unaffected.
+
 ### Added
 
 - Plugin-declared embodiment device slots for V4L2 cameras, SocketCAN

--- a/docs/guide/policies-and-embodiments.md
+++ b/docs/guide/policies-and-embodiments.md
@@ -80,8 +80,8 @@ class MyArm:
         ...
 
     def step(self, action: Action) -> StepResult:
-        # Returns as soon as the command is issued; the framework paces the loop
-        # unless this embodiment declares the "self_paced" capability.
+        # The rollout applies no wall-clock pacing of its own. If this embodiment
+        # needs real-time cadence, pace it here and declare "self_paced".
         ...
 
     def close(self) -> None:

--- a/plans/0001-foundation-design.md
+++ b/plans/0001-foundation-design.md
@@ -475,13 +475,23 @@ issues clustered in the rollout↔controller↔record triad. These resolutions a
 **binding** and supersede the prose above wherever they conflict:
 
 - **R1 — `step()` timing contract.** `Embodiment.step()` **returns as soon as the
-  command is issued** (it does *not* block until the control period elapses). The
-  **framework owns pacing** to the *effective rate* = `chunk.control_hz` →
-  `task.control_hz` → `embodiment.info.control_hz` (first non-None). A real-robot
-  adapter whose `step()` inherently blocks at the hardware rate declares
-  capability `"self_paced"`, and the rollout then skips its own pacing. `compat`
-  warns when the policy's emitted rate and the embodiment's native rate differ by
-  more than a tolerance.
+  command is issued** (it does *not* block until the control period elapses).
+  **Reversed 2026-07-14** (see issue tracker: rollout pacing was accepted-but-ignored
+  in practice — `_effective_control_hz`/`Task.control_hz` were dead code, and both
+  hardware adapters already self-paced as a workaround). The rollout applies **no
+  wall-clock pacing of its own**; an embodiment that needs real-time cadence paces
+  itself inside `step()` and declares capability `"self_paced"` to document that it
+  does. `Task.control_hz` is removed — the framework never had a rate of its own to
+  resolve. `compat` still warns when the policy's emitted rate and the embodiment's
+  native rate differ by more than a tolerance (unaffected by this reversal).
+
+  Original resolution (superseded above): The **framework owns pacing** to the
+  *effective rate* = `chunk.control_hz` → `task.control_hz` →
+  `embodiment.info.control_hz` (first non-None). A real-robot adapter whose
+  `step()` inherently blocks at the hardware rate declares capability
+  `"self_paced"`, and the rollout then skips its own pacing. `compat` warns when
+  the policy's emitted rate and the embodiment's native rate differ by more than a
+  tolerance.
 
 - **R2 — per-trial seeding.** The seed for scene `s`, epoch `e` is
   `derive_seed(eval_seed, s.init_seed, e)` (a stable hash mix), logged per trial.

--- a/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
+++ b/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
@@ -49,8 +49,9 @@ if TYPE_CHECKING:
     from inspect_robots import Action
 
 # Isaac Lab simulators expose a privileged success oracle, are resettable and
-# seedable, and can render — but they are NOT self-paced (they step as fast as the
-# GPU allows; Inspect Robots owns wall-clock pacing).
+# seedable, and can render — and they do NOT declare self_paced: they step as
+# fast as the GPU allows, and the rollout adds no wall-clock pacing of its own,
+# so evaluation runs at full sim speed rather than being throttled to real time.
 _DEFAULT_CAPABILITIES = frozenset({"seedable", "resettable", "privileged_success", "renderable"})
 
 # Isaac Sim allows exactly ONE SimulationApp per process. Track it module-side so a

--- a/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
+++ b/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
@@ -62,7 +62,7 @@ def test_info_describes_franka_joint_pos() -> None:
     assert sem.control_mode == "joint_pos"
     assert sem.gripper == "binary"
     assert "privileged_success" in emb.info.capabilities
-    assert "self_paced" not in emb.info.capabilities  # sim is framework-paced
+    assert "self_paced" not in emb.info.capabilities  # sim runs unthrottled, as fast as it steps
 
 
 def test_action_dim_tracks_arm_joints() -> None:

--- a/src/inspect_robots/compat.py
+++ b/src/inspect_robots/compat.py
@@ -152,7 +152,9 @@ def check_compatibility(
     _resolve_keys(pobs.camera_names, eobs.camera_names, remap, "camera", issues)
     _resolve_keys(pobs.state_keys, eobs.state_keys, remap, "state", issues)
 
-    # Control-rate reconciliation (R1): only warn, since the framework paces.
+    # Control-rate reconciliation (R1): only warn — the rollout enforces no
+    # wall-clock rate of its own (R1, revised), so a mismatch is the policy's
+    # or embodiment's to reconcile, not a hard error.
     p_hz = getattr(policy.info, "control_hz", None)
     e_hz = embodiment.info.control_hz
     if p_hz is not None and e_hz is not None and abs(p_hz - e_hz) > _RATE_TOL:
@@ -161,7 +163,8 @@ def check_compatibility(
                 "warning",
                 "control_rate",
                 f"policy desires {p_hz} Hz but embodiment runs at {e_hz} Hz; "
-                "framework will pace to the effective rate",
+                "neither rate is enforced by the rollout — reconcile in the "
+                "policy or embodiment",
             )
         )
 

--- a/src/inspect_robots/embodiment.py
+++ b/src/inspect_robots/embodiment.py
@@ -9,9 +9,11 @@ Designed around real-robot reality: ``reset`` may drive to a home pose and block
 on human confirmation; there is no guaranteed privileged success oracle.
 Simulators are a stricter special case that opt into extra ``capabilities``.
 
-Per R1 (see the design doc): ``step()`` returns as soon as the command is issued
-and does NOT block for the control period — the framework owns pacing — unless
-the embodiment declares the ``"self_paced"`` capability.
+Per R1 (see the design doc): ``rollout()`` applies no wall-clock pacing of its
+own — ``step()`` is called as fast as the policy/controller/approver can
+produce actions. An embodiment that needs real-time cadence (e.g. matching a
+real robot's control period) paces itself inside ``step()``, and declares the
+``"self_paced"`` capability to document that it does.
 """
 
 from __future__ import annotations
@@ -61,7 +63,9 @@ class Embodiment(Protocol):
         ...
 
     def step(self, action: Action) -> StepResult:
-        """Issue one action without waiting for the control period unless ``self_paced``."""
+        """Issue one action. The rollout does not wait for the control period between
+        calls; declare ``"self_paced"`` if this embodiment paces itself to real time.
+        """
         ...
 
     def close(self) -> None:
@@ -81,7 +85,9 @@ class EmbodimentBase(ABC):
 
     @abstractmethod
     def step(self, action: Action) -> StepResult:
-        """Issue one action without waiting for the control period unless ``self_paced``."""
+        """Issue one action. The rollout does not wait for the control period between
+        calls; declare ``"self_paced"`` if this embodiment paces itself to real time.
+        """
         ...
 
     def close(self) -> None:  # noqa: B027 - intentional no-op default

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -293,7 +293,6 @@ def _run_eval(
                     controller=controller,
                     approver=approver,
                     sink=bus,
-                    control_hz=task.control_hz,
                     frame_store=frame_store,
                 )
             except (EmbodimentFault, SafetyAbort) as exc:

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -85,22 +85,6 @@ class TrialRecord:
     events: list[Event] = field(default_factory=list)
 
 
-def _effective_control_hz(
-    chunk_hz: float | None, task_hz: float | None, embodiment_hz: float | None
-) -> float | None:
-    """First non-None of chunk → task → embodiment rate (R1).
-
-    Real-time pacing (sleeping the control loop to this rate, honoring the
-    ``SELF_PACED`` capability) is wired up together with the first real-robot
-    adapter; until then the test suite stays fast and this helper is unused by
-    the loop below.
-    """
-    for hz in (chunk_hz, task_hz, embodiment_hz):
-        if hz is not None:
-            return hz
-    return None
-
-
 def _record_failure(record: TrialRecord, exc: InspectRobotsError, t: int) -> InspectRobotsError:
     """Mark ``record`` failed and attach it to ``exc`` (see ``InspectRobotsError.record``).
 
@@ -136,7 +120,6 @@ def rollout(
     controller: Controller,
     approver: Approver,
     sink: LogSink,
-    control_hz: float | None = None,
     frame_store: FrameStore | None = None,
 ) -> TrialRecord:
     """Run a single trial and return its record.
@@ -151,8 +134,11 @@ def rollout(
     raised from inside the trial carries the partial ``TrialRecord`` on
     ``exc.record`` for the orchestrator to preserve.
 
-    ``control_hz`` is accepted for R1's rate-precedence chain; real-time pacing
-    lands with the first real-robot adapter (see ``_effective_control_hz``).
+    The loop applies no wall-clock pacing of its own: ``embodiment.step()`` is
+    called as fast as the policy/controller/approver can produce actions. An
+    embodiment that needs real-time cadence paces itself inside ``step()`` and
+    declares the ``"self_paced"`` capability to document that it does (see
+    [`Embodiment`][inspect_robots.embodiment.Embodiment]).
     """
     trial_id = f"{scene.id}-e{epoch}"
     record = TrialRecord(scene_id=scene.id, epoch=epoch, seed=seed)

--- a/src/inspect_robots/task.py
+++ b/src/inspect_robots/task.py
@@ -40,8 +40,9 @@ class TaskEnvelope:
     ``bind_task(envelope)`` hook: enough for the adapter to display or
     pre-allocate for the run (e.g. an operator countdown against
     ``max_steps``), and nothing that would let it second-guess scoring or the
-    dataset. Deliberately carries no control rate — the effective rate is
-    R1's chunk → task → embodiment precedence, unknowable before inference.
+    dataset. Deliberately carries no control rate — the rollout enforces no
+    wall-clock rate of its own (R1, revised); a self-paced embodiment owns its
+    own cadence.
     """
 
     name: str

--- a/src/inspect_robots/task.py
+++ b/src/inspect_robots/task.py
@@ -2,7 +2,7 @@
 
 Mirrors Inspect AI's ``Task = dataset + scorer + epochs/reducer``, adapted for
 robotics: the dataset is a sequence of [`Scene`][inspect_robots.scene.Scene] initial
-conditions and the rollout horizon (``max_steps``) and control rate live here.
+conditions and the rollout horizon (``max_steps``) lives here.
 """
 
 from __future__ import annotations
@@ -45,7 +45,6 @@ class Task:
     scorer: Scorer | str | Sequence[Scorer | str]
     max_steps: int
     epochs: int | Epochs = 1
-    control_hz: float | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:

--- a/src/inspect_robots/types.py
+++ b/src/inspect_robots/types.py
@@ -62,8 +62,9 @@ class ActionChunk:
     Modern VLAs (π0, ACT, diffusion policies) predict ``H`` future actions that
     are executed open-loop because inference is slower than the control rate.
     ``H == 1`` is the degenerate "reactive policy" case. ``control_hz`` is the
-    rate the chunk was intended to be played at (``None`` defers to the
-    embodiment's native rate); ``inference_latency_s``, when measured, is logged.
+    rate the chunk was intended to be played at — advisory metadata a consumer
+    may honor (the rollout enforces no rate; ``None`` leaves it unspecified).
+    ``inference_latency_s``, when measured, is logged.
     """
 
     actions: Sequence[Action]

--- a/tests/test_coverage_completion.py
+++ b/tests/test_coverage_completion.py
@@ -30,7 +30,7 @@ from inspect_robots.logging.sink import NullSink
 from inspect_robots.mock import CubePickEmbodiment, NoopPolicy, ScriptedPolicy
 from inspect_robots.policy import PolicyConfig, PolicyInfo
 from inspect_robots.registry import register, registered, resolve
-from inspect_robots.rollout import StepRecord, TrialRecord, _effective_control_hz, rollout
+from inspect_robots.rollout import StepRecord, TrialRecord, rollout
 from inspect_robots.scene import ListSceneDataset, Scene
 from inspect_robots.scorer import min_distance_to_goal, success_at_end, value_to_float
 from inspect_robots.spaces import ActionSemantics, Box, ObservationSpace
@@ -224,14 +224,6 @@ def test_min_distance_without_signal() -> None:
 # --------------------------------------------------------------------------- #
 # rollout
 # --------------------------------------------------------------------------- #
-def test_effective_control_hz_precedence() -> None:
-    # First non-None of chunk -> task -> embodiment (R1).
-    assert _effective_control_hz(None, None, None) is None
-    assert _effective_control_hz(30.0, 20.0, 10.0) == 30.0
-    assert _effective_control_hz(None, 20.0, 10.0) == 20.0
-    assert _effective_control_hz(None, None, 10.0) == 10.0
-
-
 class _PolicyErrorPolicy:
     def __init__(self) -> None:
         self.info = PolicyInfo(name="perr", action_space=Box(shape=(2,), semantics=_CUBE_SEM))


### PR DESCRIPTION
## Summary

`rollout()` accepted `control_hz` (from `task.control_hz`) but never paced the
loop: `_effective_control_hz()` computed R1's chunk → task → embodiment rate
precedence, but nothing called it and the loop never slept. Docs and
docstrings claimed "the framework owns pacing," which was false on real
hardware — both hardware adapters (so101, yam) already self-pace internally
as a workaround. Formalize that as the actual contract instead of
implementing real pacing, which would need its own design pass to keep the
CubePick-driven test suite fast (CubePick declares `control_hz=10.0`; real
pacing would add ~0.1s/step to every test).

## Changes

- Remove the dead `_effective_control_hz` helper and `rollout()`'s unused
  `control_hz` param.
- Remove `Task.control_hz` (its only reader was the now-removed rollout
  param) — public API break.
- Rewrite the "framework owns pacing" docstrings (`embodiment.py`,
  `docs/guide/policies-and-embodiments.md`) from the adapter author's point
  of view: rollout paces nothing; an embodiment needing real-time cadence
  paces itself in `step()` and declares `"self_paced"` to document that.
- Update plan 0001 §9 R1 in place, keeping the original resolution visible
  under a dated inline reversal note with rationale.
- `compat`'s policy/embodiment rate-mismatch warning is untouched.

## Checklist

- [x] `pre-commit install` done; hooks pass (or ran `pre-commit run --all-files`) — `pre-commit run --all-files` fails in this environment because its hooks shell out to `uv`, which isn't installed here; ran `ruff check .`, `ruff format --check .`, and `mypy` directly instead (all pass)
- [x] Tests added/updated (and the `CubePick` mock exercises the change where applicable) — removed the now-meaningless `test_effective_control_hz_precedence`; no new behavior to cover since this only removes dead code/params and rewrites docs
- [x] Coverage stays at **100%** (`pytest --cov`) — 100% on every touched module (`rollout.py`, `task.py`, `eval.py`, `embodiment.py`); full local run shows 99.03% only because `test_setup.py`'s symlink tests skip without Windows dev-mode privilege (confirmed pre-existing on `main`, unrelated — CI's blocking gate runs Linux/macOS)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `mypy` passes (strict)
- [x] `CHANGELOG.md` updated under "Unreleased" — added a `Removed` section (none existed yet)
- [x] Public API changes are reflected in `inspect_robots.__all__` and the API-snapshot test — N/A to `__all__` (`Task` stays exported; only a field was removed, which the snapshot test doesn't check at field level); flagged as breaking in the changelog instead, per @jeqcho's request the next release should be cut as **minor**
- [x] Core stays NumPy-only (new deps are optional extras, lazily imported) — unaffected, no new deps

## Related

Direction confirmed with @jeqcho in the issue thread before implementation.

Closes #3
