### PR TITLE
feat(cli): add eval-set for running multiple tasks in one invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- **`inspect-robots eval-set TASK [TASK ...]`**: run several registered tasks
+  against one resolved policy/embodiment pair in a single invocation, matching
+  task names exactly or by shell-quoted `fnmatch` glob (e.g.
+  `'kitchenbench/*'`). Thin CLI wrapper over
+  [`eval_set`][inspect_robots.eval.eval_set] that resolves the embodiment once
+  for the whole set rather than once per task, and prints one status line plus
+  a compact per-task row instead of a full summary per task (#45).
 - Plugin-declared embodiment device slots for V4L2 cameras, SocketCAN
   interfaces, and serial devices. `inspect-robots setup` probes and interviews
   declared slots, enforces grouped all-or-none assignments, and suggests udev

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -190,6 +190,40 @@ run a single ad-hoc scene.
 
 The exit code is `0` on a successful eval, `1` otherwise.
 
+## `inspect-robots eval-set`
+
+Run several registered tasks against one resolved policy/embodiment pair in a
+single invocation — the CLI counterpart of
+[`eval_set`][inspect_robots.eval.eval_set]. Task names are matched exactly, or
+by shell-quoted `fnmatch` glob (entry-point discovery namespaces tasks as
+`<benchmark>/<key>`, so a benchmark name is a ready-made prefix):
+
+```bash
+inspect-robots eval-set 'kitchenbench/*' --policy xpolicylab -P url=ws://host:19000 \
+             --embodiment yam_arms
+inspect-robots eval-set cubepick-reach my-other-task --policy scripted --embodiment cubepick
+```
+
+Multiple patterns may match the same task; it still runs once. A pattern that
+matches nothing is an error listing every registered task. `--policy` and
+`--embodiment` (and `-P`/`-E`, `--sim`, `--epochs`, `--fail-on-error`,
+`--store-frames`, `--disable-guardrails`, `--max-action-delta`) apply exactly
+as they do for `run`, to every matched task — there is no per-task `-T` in
+this release. The embodiment is resolved once for the whole set, not once per
+task, so a real robot is not reconnected between tasks.
+
+Rather than one full summary per task, the CLI prints the resolved
+policy/embodiment, one status line for the whole set, a compact `[status]
+task_name  metrics-or-error` row per task, and the shared log directory once
+(`eval_set` still writes one `EvalLog` per task inside it). The exit code is
+`0` iff every task's log has `status == "success"`.
+
+`--retry-attempts` is accepted and threaded through to `eval_set()`, whose
+resumption-of-a-partial-run behavior is reserved for a follow-up: passing it
+today does not yet skip already-finished scenes. `--rerun`'s live viewer
+is not offered for `eval-set`: streaming several back-to-back tasks into one
+viewer window is a separate design question from running the set at all.
+
 ## `inspect-robots doctor`
 
 `doctor` reports a registered embodiment's missing declared runtime modules

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -8,6 +8,11 @@ Subcommands:
   components from the registry. Pass constructor args with ``-T/-P/-E k=v``;
   ``--epochs``, ``--fail-on-error``, and ``--store-frames`` tune the run. The
   written log's path is printed at the end.
+- ``inspect-robots eval-set TASK [TASK ...] --policy P --embodiment E`` — run several
+  registered tasks (exact names or ``fnmatch`` globs, e.g. ``'kitchenbench/*'``) against
+  one resolved policy/embodiment pair via
+  [`eval_set`][inspect_robots.eval.eval_set]. Prints one status line and a compact
+  per-task row instead of a full summary per task.
 - ``inspect-robots inspect LOG.json`` — print a saved eval log.
 - ``inspect-robots setup`` — interactively configure defaults and camera devices.
 
@@ -23,6 +28,7 @@ single-word instructions use the explicit ``run --instruction`` form.
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import os
 import sys
 from collections.abc import Sequence
@@ -79,7 +85,7 @@ _KIND_BY_PLURAL = {
 
 _PLURAL_BY_KIND = {kind: plural for plural, kind in _KIND_BY_PLURAL.items()}
 
-_SUBCOMMANDS = ("list", "run", "inspect", "config", "setup", "doctor")
+_SUBCOMMANDS = ("list", "run", "eval-set", "inspect", "config", "setup", "doctor")
 
 _ENV_BY_KIND = {"policy": ENV_POLICY, "embodiment": ENV_EMBODIMENT}
 
@@ -188,6 +194,67 @@ def build_parser() -> argparse.ArgumentParser:
         "space's native units (default: derived from the space's bounds)",
     )
 
+    p_eval_set = sub.add_parser("eval-set", help="run a set of registered tasks in one invocation")
+    p_eval_set.add_argument(
+        "tasks",
+        nargs="+",
+        metavar="TASK",
+        help="registered task name(s); shell-quoted globs match by prefix, e.g. 'kitchenbench/*'",
+    )
+    p_eval_set.add_argument("--policy", help="registered policy name (default: user config)")
+    p_eval_set.add_argument(
+        "--embodiment", help="registered embodiment name (default: user config)"
+    )
+    p_eval_set.add_argument("-P", dest="policy_args", action="append", metavar="k=v")
+    p_eval_set.add_argument("-E", dest="embodiment_args", action="append", metavar="k=v")
+    p_eval_set.add_argument("--log-dir", default="logs")
+    p_eval_set.add_argument("--seed", type=int, default=0)
+    p_eval_set.add_argument(
+        "--epochs", type=int, default=None, help="override every matched task's epoch count"
+    )
+    p_eval_set.add_argument(
+        "--sim",
+        action="store_true",
+        help="run on the configured sim_embodiment instead of the default "
+        "(real-hardware) embodiment",
+    )
+    p_eval_set.add_argument(
+        "--fail-on-error",
+        type=float,
+        default=None,
+        metavar="X",
+        help="halt on PolicyErrors: 1 = first error, 0<X<1 = proportion, X>1 = count",
+    )
+    p_eval_set.add_argument(
+        "--retry-attempts",
+        type=int,
+        default=0,
+        help="passed through to eval_set(); resumption of a partial run is "
+        "accepted but not yet honored",
+    )
+    p_eval_set.add_argument(
+        "--store-frames",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="stream camera frames to a per-run directory under <log-dir>/frames "
+        "instead of keeping them in memory (--no-store-frames overrides a "
+        "store_frames config default)",
+    )
+    p_eval_set.add_argument(
+        "--disable-guardrails",
+        action="store_true",
+        help="turn off the default safety approvers (bounds clamp + per-step "
+        "delta limit); actions reach the embodiment unchecked",
+    )
+    p_eval_set.add_argument(
+        "--max-action-delta",
+        type=float,
+        default=None,
+        metavar="D",
+        help="per-step change limit for the default guardrails, in the action "
+        "space's native units (default: derived from the space's bounds)",
+    )
+
     p_inspect = sub.add_parser("inspect", help="print a saved eval log")
     p_inspect.add_argument("log", help="path to an EvalLog JSON file")
 
@@ -246,6 +313,31 @@ def _pick_component(
         "run 'inspect-robots setup', or "
         f"'inspect-robots config set {kind} NAME'"
     )
+
+
+def _match_tasks(patterns: Sequence[str]) -> list[str]:
+    """Resolve task-name patterns (exact names or ``fnmatch`` globs) against the registry.
+
+    Preserves first-match order across patterns, deduplicated, so
+    ``eval-set 'kb/*' 'kb/pour'`` does not run ``kb/pour`` twice. A pattern
+    that matches nothing is an error naming every registered task, mirroring
+    ``_pick_component``'s guidance-over-traceback style.
+    """
+    from inspect_robots.registry import registered
+
+    names = sorted(registered("task"))
+    matched: list[str] = []
+    seen: set[str] = set()
+    for pattern in patterns:
+        hits = [n for n in names if fnmatch.fnmatchcase(n, pattern)]
+        if not hits:
+            available = ", ".join(names) or "(none)"
+            raise SystemExit(f"no task matches {pattern!r}.\nregistered tasks: {available}")
+        for n in hits:
+            if n not in seen:
+                seen.add(n)
+                matched.append(n)
+    return matched
 
 
 def _config_args(
@@ -565,6 +657,131 @@ def _cmd_run(args: argparse.Namespace) -> int:
     return 0 if log.status == "success" else 1
 
 
+def _print_eval_set_summary(success: bool, logs: Sequence[EvalLog], log_dir: str) -> None:
+    """Print one overall status line, a compact row per task, then the shared log dir.
+
+    Deliberately not N full ``_print_run_summary``s: a 10-task benchmark run
+    should not scroll 10 screens of near-identical output.
+    """
+    status = "success" if success else "error"
+    print(f"{_styled('status:', _CYAN)} {_styled(status, _GREEN if success else _RED)}")
+    for log in logs:
+        failed = log.status != "success"
+        metrics = ", ".join(
+            f"{name}={value:.4g}" for name, value in sorted(log.results.metrics.items())
+        )
+        detail = metrics or (log.error or "")
+        row = f"  [{_styled(log.status, _RED if failed else _GREEN)}] {log.eval.task}"
+        print(f"{row}  {detail}" if detail else row)
+    print(f"{_styled('log dir:', _CYAN)} {_styled(log_dir, _DIM)}")
+    if not success:
+        print(_styled(f"hint: inspect-robots inspect {log_dir}/<task>_<id>.json", _DIM))
+
+
+def _cmd_eval_set(args: argparse.Namespace) -> int:
+    """Resolve one policy/embodiment once, then drive every matched task through it.
+
+    A thin wrapper over [`eval_set`][inspect_robots.eval.eval_set]: unlike
+    calling ``eval_set()`` with string components (which resolves and closes
+    the embodiment once per task), the CLI resolves the embodiment exactly
+    once for the whole set, so a real robot is not reconnected between tasks.
+    """
+    from dataclasses import replace
+
+    from inspect_robots import eval_set
+
+    if args.sim and args.embodiment:
+        raise SystemExit(
+            "--sim selects your configured sim_embodiment; "
+            "passing --embodiment already picks the embodiment — drop one"
+        )
+    if args.disable_guardrails and args.max_action_delta is not None:
+        raise SystemExit(
+            "--max-action-delta tunes the guardrails that --disable-guardrails turns off — drop one"
+        )
+
+    task_names = _match_tasks(args.tasks)
+
+    defaults = load_defaults(os.environ)
+    policy_name, policy_source = _pick_component(
+        "policy", args.policy, defaults.policy, defaults.policy_source
+    )
+    if args.sim:
+        embodiment_name, embodiment_source = _pick_sim_embodiment(defaults)
+        embodiment_defaults = _config_args(
+            "sim_embodiment",
+            embodiment_name,
+            defaults.sim_embodiment_args_owner,
+            defaults.sim_embodiment_args,
+        )
+    else:
+        embodiment_name, embodiment_source = _pick_component(
+            "embodiment", args.embodiment, defaults.embodiment, defaults.embodiment_source
+        )
+        embodiment_defaults = _config_args(
+            "embodiment", embodiment_name, defaults.embodiment_args_owner, defaults.embodiment_args
+        )
+    policy_config_args = _config_args(
+        "policy", policy_name, defaults.policy_args_owner, defaults.policy_args
+    )
+    policy_kvs = {**policy_config_args, **_parse_kvs(args.policy_args)}
+    embodiment_kvs = {**embodiment_defaults, **_parse_kvs(args.embodiment_args)}
+
+    tasks = [_resolve_or_exit("task", name) for name in task_names]
+    if args.epochs is not None:
+        tasks = [replace(t, epochs=args.epochs) for t in tasks]
+
+    policy = _resolve_or_exit("policy", policy_name, **policy_kvs)
+    if args.sim:
+        embodiment = _resolve_or_exit(
+            "embodiment", embodiment_name, "sim_embodiment.args", **embodiment_kvs
+        )
+    else:
+        embodiment = _resolve_or_exit("embodiment", embodiment_name, **embodiment_kvs)
+
+    try:
+        print(f"policy: {policy_name} ({policy_source})")
+        print(f"embodiment: {embodiment_name} ({embodiment_source})")
+        print(f"tasks: {', '.join(task_names)}")
+
+        approver: Approver | None = None
+        if args.disable_guardrails:
+            print(
+                "WARNING: guardrails disabled (--disable-guardrails); actions "
+                "reach the embodiment unchecked.",
+                file=sys.stderr,
+            )
+            print("guardrails: disabled (--disable-guardrails)")
+        else:
+            approver, active, guard_warnings = _build_guardrails(
+                embodiment.info.action_space, args.max_action_delta
+            )
+            for warning in guard_warnings:
+                print(f"guardrails warning: {warning}", file=sys.stderr)
+            print(f"guardrails: {' + '.join(active) if active else 'none active'}")
+
+        success, logs = eval_set(
+            tasks,
+            policy,
+            embodiment,
+            log_dir=args.log_dir,
+            seed=args.seed,
+            fail_on_error=args.fail_on_error if args.fail_on_error is not None else False,
+            approver=approver,
+            store_frames=(
+                args.store_frames if args.store_frames is not None else defaults.store_frames
+            ),
+            retry_attempts=args.retry_attempts,
+        )
+    finally:
+        # Same "close what we open" contract as _cmd_run: the CLI resolved the
+        # embodiment itself, so it — not eval_set() — is responsible for
+        # releasing it, exactly once, after every task has run.
+        embodiment.close()
+    _print_eval_set_summary(success, logs, args.log_dir)
+    return 0 if success else 1
+
+
 def _cmd_inspect(path: str) -> int:
     from inspect_robots import read_eval_log
 
@@ -678,6 +895,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _cmd_list(args.what)
     if args.command == "run":
         return _cmd_run(args)
+    if args.command == "eval-set":
+        return _cmd_eval_set(args)
     if args.command == "inspect":
         return _cmd_inspect(args.log)
     if args.command == "config":

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -39,7 +39,7 @@ import shutil
 import sys
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from inspect_robots import __version__
 from inspect_robots._defaults import (
@@ -123,6 +123,57 @@ def _parse_kvs(pairs: Sequence[str] | None) -> dict[str, Any]:
     return out
 
 
+def _add_shared_eval_args(parser: argparse.ArgumentParser) -> None:
+    """Add the flags common to ``run`` and ``eval-set``.
+
+    Component selection (``--policy``/``--embodiment``/``-P``/``-E``/``--sim``),
+    guardrails, logging, and epoch/error handling live here so a new shared flag
+    lands in both commands at once instead of drifting between two copies.
+    """
+    parser.add_argument("--policy", help="registered policy name (default: user config)")
+    parser.add_argument("--embodiment", help="registered embodiment name (default: user config)")
+    parser.add_argument("-P", dest="policy_args", action="append", metavar="k=v")
+    parser.add_argument("-E", dest="embodiment_args", action="append", metavar="k=v")
+    parser.add_argument("--log-dir", default="logs")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--epochs", type=int, default=None, help="override each task's epoch count")
+    parser.add_argument(
+        "--sim",
+        action="store_true",
+        help="run on the configured sim_embodiment instead of the default "
+        "(real-hardware) embodiment",
+    )
+    parser.add_argument(
+        "--fail-on-error",
+        type=float,
+        default=None,
+        metavar="X",
+        help="halt on PolicyErrors: 1 = first error, 0<X<1 = proportion, X>1 = count",
+    )
+    parser.add_argument(
+        "--store-frames",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="stream camera frames to a per-run directory under <log-dir>/frames "
+        "instead of keeping them in memory (--no-store-frames overrides a "
+        "store_frames config default)",
+    )
+    parser.add_argument(
+        "--disable-guardrails",
+        action="store_true",
+        help="turn off the default safety approvers (bounds clamp + per-step "
+        "delta limit); actions reach the embodiment unchecked",
+    )
+    parser.add_argument(
+        "--max-action-delta",
+        type=float,
+        default=None,
+        metavar="D",
+        help="per-step change limit for the default guardrails, in the action "
+        "space's native units (default: derived from the space's bounds)",
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the command-line parser and its subcommands."""
     parser = argparse.ArgumentParser(
@@ -147,14 +198,8 @@ def build_parser() -> argparse.ArgumentParser:
         help="run a single ad-hoc scene with this language instruction "
         "(instead of a registered --task)",
     )
-    p_run.add_argument("--policy", help="registered policy name (default: user config)")
-    p_run.add_argument("--embodiment", help="registered embodiment name (default: user config)")
     p_run.add_argument("-T", dest="task_args", action="append", metavar="k=v")
-    p_run.add_argument("-P", dest="policy_args", action="append", metavar="k=v")
-    p_run.add_argument("-E", dest="embodiment_args", action="append", metavar="k=v")
-    p_run.add_argument("--log-dir", default="logs")
-    p_run.add_argument("--seed", type=int, default=0)
-    p_run.add_argument("--epochs", type=int, default=None, help="override the task's epoch count")
+    _add_shared_eval_args(p_run)
     p_run.add_argument(
         "--max-steps",
         type=int,
@@ -169,30 +214,9 @@ def build_parser() -> argparse.ArgumentParser:
         f"{ADHOC_SCORER_FALLBACK!r}); invalid with --task",
     )
     p_run.add_argument(
-        "--sim",
-        action="store_true",
-        help="run on the configured sim_embodiment instead of the default "
-        "(real-hardware) embodiment",
-    )
-    p_run.add_argument(
         "--no-prompt",
         action="store_true",
         help="never ask the terminal operator for a success verdict",
-    )
-    p_run.add_argument(
-        "--fail-on-error",
-        type=float,
-        default=None,
-        metavar="X",
-        help="halt on PolicyErrors: 1 = first error, 0<X<1 = proportion, X>1 = count",
-    )
-    p_run.add_argument(
-        "--store-frames",
-        action=argparse.BooleanOptionalAction,
-        default=None,
-        help="stream camera frames to a per-run directory under <log-dir>/frames "
-        "instead of keeping them in memory (--no-store-frames overrides a "
-        "store_frames config default)",
     )
     p_run.add_argument(
         "--rerun",
@@ -212,20 +236,6 @@ def build_parser() -> argparse.ArgumentParser:
         "(e.g. your laptop via an SSH reverse tunnel: ssh -R 9876:localhost:9876 ...); "
         f"URL defaults to {DEFAULT_RERUN_CONNECT_URL}",
     )
-    p_run.add_argument(
-        "--disable-guardrails",
-        action="store_true",
-        help="turn off the default safety approvers (bounds clamp + per-step "
-        "delta limit); actions reach the embodiment unchecked",
-    )
-    p_run.add_argument(
-        "--max-action-delta",
-        type=float,
-        default=None,
-        metavar="D",
-        help="per-step change limit for the default guardrails, in the action "
-        "space's native units (default: derived from the space's bounds)",
-    )
 
     p_eval_set = sub.add_parser("eval-set", help="run a set of registered tasks in one invocation")
     p_eval_set.add_argument(
@@ -234,58 +244,13 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="TASK",
         help="registered task name(s); shell-quoted globs match by prefix, e.g. 'kitchenbench/*'",
     )
-    p_eval_set.add_argument("--policy", help="registered policy name (default: user config)")
-    p_eval_set.add_argument(
-        "--embodiment", help="registered embodiment name (default: user config)"
-    )
-    p_eval_set.add_argument("-P", dest="policy_args", action="append", metavar="k=v")
-    p_eval_set.add_argument("-E", dest="embodiment_args", action="append", metavar="k=v")
-    p_eval_set.add_argument("--log-dir", default="logs")
-    p_eval_set.add_argument("--seed", type=int, default=0)
-    p_eval_set.add_argument(
-        "--epochs", type=int, default=None, help="override every matched task's epoch count"
-    )
-    p_eval_set.add_argument(
-        "--sim",
-        action="store_true",
-        help="run on the configured sim_embodiment instead of the default "
-        "(real-hardware) embodiment",
-    )
-    p_eval_set.add_argument(
-        "--fail-on-error",
-        type=float,
-        default=None,
-        metavar="X",
-        help="halt on PolicyErrors: 1 = first error, 0<X<1 = proportion, X>1 = count",
-    )
+    _add_shared_eval_args(p_eval_set)
     p_eval_set.add_argument(
         "--retry-attempts",
         type=int,
         default=0,
         help="passed through to eval_set(); resumption of a partial run is "
         "accepted but not yet honored",
-    )
-    p_eval_set.add_argument(
-        "--store-frames",
-        action=argparse.BooleanOptionalAction,
-        default=None,
-        help="stream camera frames to a per-run directory under <log-dir>/frames "
-        "instead of keeping them in memory (--no-store-frames overrides a "
-        "store_frames config default)",
-    )
-    p_eval_set.add_argument(
-        "--disable-guardrails",
-        action="store_true",
-        help="turn off the default safety approvers (bounds clamp + per-step "
-        "delta limit); actions reach the embodiment unchecked",
-    )
-    p_eval_set.add_argument(
-        "--max-action-delta",
-        type=float,
-        default=None,
-        metavar="D",
-        help="per-step change limit for the default guardrails, in the action "
-        "space's native units (default: derived from the space's bounds)",
     )
 
     p_inspect = sub.add_parser("inspect", help="print a saved eval log")
@@ -753,32 +718,19 @@ def _print_run_summary(log: EvalLog, log_path: str, is_adhoc: bool) -> None:
             print(_styled(f"hint: render videos with: inspect-robots video {log_path}", _DIM))
 
 
-def _cmd_run(args: argparse.Namespace) -> int:
-    from dataclasses import replace
+class _ResolvedComponents(NamedTuple):
+    """A resolved policy/embodiment pair plus the names/sources for the run header."""
 
-    from inspect_robots import eval
-    from inspect_robots.logging import JsonLogSink
-    from inspect_robots.scene import Scene
-    from inspect_robots.task import Task
+    policy: Any
+    policy_name: str
+    policy_source: str
+    embodiment: Any
+    embodiment_name: str
+    embodiment_source: str
 
-    is_adhoc = args.instruction is not None
-    if is_adhoc and args.task:
-        raise SystemExit("pass exactly one of --task or --instruction, not both")
-    if not is_adhoc and not args.task:
-        raise SystemExit("pass a registered --task name or an --instruction to run")
-    if not is_adhoc:
-        if args.max_steps is not None:
-            raise SystemExit(
-                "--max-steps only applies to --instruction runs; a registered task owns its horizon"
-            )
-        if args.scorer is not None:
-            raise SystemExit(
-                "--scorer only applies to --instruction runs; a registered task owns its scorers"
-            )
-    elif args.task_args:
-        raise SystemExit(
-            "-T only applies to --task runs; an ad-hoc instruction task takes no constructor args"
-        )
+
+def _check_shared_run_conflicts(args: argparse.Namespace) -> None:
+    """Reject flag combinations invalid for both ``run`` and ``eval-set``."""
     if args.sim and args.embodiment:
         raise SystemExit(
             "--sim selects your configured sim_embodiment; "
@@ -789,7 +741,14 @@ def _cmd_run(args: argparse.Namespace) -> int:
             "--max-action-delta tunes the guardrails that --disable-guardrails turns off — drop one"
         )
 
-    defaults = load_defaults(os.environ)
+
+def _resolve_components(args: argparse.Namespace, defaults: Defaults) -> _ResolvedComponents:
+    """Pick and construct the policy/embodiment pair shared by ``run`` and ``eval-set``.
+
+    The embodiment is constructed last, so callers can invoke this immediately
+    before the ``try``/``finally`` that owns ``embodiment.close()`` and leave no
+    window in which a resolved embodiment could leak past a later failure.
+    """
     policy_name, policy_source = _pick_component(
         "policy", args.policy, defaults.policy, defaults.policy_source
     )
@@ -816,6 +775,80 @@ def _cmd_run(args: argparse.Namespace) -> int:
     policy_kvs = {**policy_config_args, **_parse_kvs(args.policy_args)}
     embodiment_kvs = {**embodiment_defaults, **_parse_kvs(args.embodiment_args)}
 
+    policy = _resolve_or_exit("policy", policy_name, **policy_kvs)
+    if args.sim:
+        embodiment = _resolve_or_exit(
+            "embodiment", embodiment_name, "sim_embodiment.args", **embodiment_kvs
+        )
+    else:
+        embodiment = _resolve_or_exit("embodiment", embodiment_name, **embodiment_kvs)
+    return _ResolvedComponents(
+        policy, policy_name, policy_source, embodiment, embodiment_name, embodiment_source
+    )
+
+
+def _announce_components(resolved: _ResolvedComponents) -> None:
+    """Print the resolved policy/embodiment and where each came from.
+
+    Defaults must never be silent: say what runs, and why, before it moves.
+    """
+    print(f"policy: {resolved.policy_name} ({resolved.policy_source})")
+    print(f"embodiment: {resolved.embodiment_name} ({resolved.embodiment_source})")
+
+
+def _build_and_announce_guardrails(args: argparse.Namespace, action_space: Box) -> Approver | None:
+    """Build the default guardrail chain for a run, announcing what is active.
+
+    Guardrails are on by default (plan 0008 §3e): the approver chain sits below
+    the policy in rollout, so nothing the policy emits — a wild VLA action or a
+    misbehaving LLM — reaches hardware unchecked. Returns ``None`` (the eval's
+    own default) only when ``--disable-guardrails`` is given.
+    """
+    if args.disable_guardrails:
+        print(
+            "WARNING: guardrails disabled (--disable-guardrails); actions "
+            "reach the embodiment unchecked.",
+            file=sys.stderr,
+        )
+        print("guardrails: disabled (--disable-guardrails)")
+        return None
+    approver, active, guard_warnings = _build_guardrails(action_space, args.max_action_delta)
+    for warning in guard_warnings:
+        print(f"guardrails warning: {warning}", file=sys.stderr)
+    print(f"guardrails: {' + '.join(active) if active else 'none active'}")
+    return approver
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    from dataclasses import replace
+
+    from inspect_robots import eval
+    from inspect_robots.logging import JsonLogSink
+    from inspect_robots.scene import Scene
+    from inspect_robots.task import Task
+
+    is_adhoc = args.instruction is not None
+    if is_adhoc and args.task:
+        raise SystemExit("pass exactly one of --task or --instruction, not both")
+    if not is_adhoc and not args.task:
+        raise SystemExit("pass a registered --task name or an --instruction to run")
+    if not is_adhoc:
+        if args.max_steps is not None:
+            raise SystemExit(
+                "--max-steps only applies to --instruction runs; a registered task owns its horizon"
+            )
+        if args.scorer is not None:
+            raise SystemExit(
+                "--scorer only applies to --instruction runs; a registered task owns its scorers"
+            )
+    elif args.task_args:
+        raise SystemExit(
+            "-T only applies to --task runs; an ad-hoc instruction task takes no constructor args"
+        )
+    _check_shared_run_conflicts(args)
+
+    defaults = load_defaults(os.environ)
+
     if is_adhoc:
         scorer_name = args.scorer or defaults.scorer or ADHOC_SCORER_FALLBACK
         max_steps = (
@@ -833,39 +866,14 @@ def _cmd_run(args: argparse.Namespace) -> int:
     else:
         task = _resolve_or_exit("task", args.task, **_parse_kvs(args.task_args))
 
-    policy = _resolve_or_exit("policy", policy_name, **policy_kvs)
-    if args.sim:
-        embodiment = _resolve_or_exit(
-            "embodiment", embodiment_name, "sim_embodiment.args", **embodiment_kvs
-        )
-    else:
-        embodiment = _resolve_or_exit("embodiment", embodiment_name, **embodiment_kvs)
+    resolved = _resolve_components(args, defaults)
+    embodiment = resolved.embodiment
     try:
         if args.epochs is not None:
             task = replace(task, epochs=args.epochs)
 
-        # Defaults must never be silent: say what runs, and why, before it moves.
-        print(f"policy: {policy_name} ({policy_source})")
-        print(f"embodiment: {embodiment_name} ({embodiment_source})")
-
-        # Guardrails are on by default (plan 0008 §3e): the approver chain
-        # sits below the policy in rollout, so nothing the policy emits — a
-        # wild VLA action or a misbehaving LLM — reaches hardware unchecked.
-        approver: Approver | None = None
-        if args.disable_guardrails:
-            print(
-                "WARNING: guardrails disabled (--disable-guardrails); actions "
-                "reach the embodiment unchecked.",
-                file=sys.stderr,
-            )
-            print("guardrails: disabled (--disable-guardrails)")
-        else:
-            approver, active, guard_warnings = _build_guardrails(
-                embodiment.info.action_space, args.max_action_delta
-            )
-            for warning in guard_warnings:
-                print(f"guardrails warning: {warning}", file=sys.stderr)
-            print(f"guardrails: {' + '.join(active) if active else 'none active'}")
+        _announce_components(resolved)
+        approver = _build_and_announce_guardrails(args, embodiment.info.action_space)
 
         before_scoring = None
         if (
@@ -896,7 +904,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         try:
             logs = eval(
                 task,
-                policy,
+                resolved.policy,
                 embodiment,
                 log_dir=args.log_dir,
                 seed=args.seed,
@@ -931,21 +939,31 @@ def _print_eval_set_summary(success: bool, logs: Sequence[EvalLog], log_dir: str
     """Print one overall status line, a compact row per task, then the shared log dir.
 
     Deliberately not N full ``_print_run_summary``s: a 10-task benchmark run
-    should not scroll 10 screens of near-identical output.
+    should not scroll 10 screens of near-identical output. The status line and
+    per-task labels reuse ``run``'s status vocabulary (issue #125) so the two
+    commands read as one CLI.
     """
     status = "success" if success else "error"
-    print(f"{_styled('status:', _CYAN)} {_styled(status, _GREEN if success else _RED)}")
+    print(
+        f"{_styled('run status:', _CYAN)} "
+        f"{_styled(_display_status(status), _GREEN if success else _RED)}"
+    )
     for log in logs:
-        failed = log.status != "success"
+        ok = log.status == "success"
         metrics = ", ".join(
             f"{name}={value:.4g}" for name, value in sorted(log.results.metrics.items())
         )
         detail = metrics or (log.error or "")
-        row = f"  [{_styled(log.status, _RED if failed else _GREEN)}] {log.eval.task}"
+        row = f"  [{_styled(_display_status(log.status), _GREEN if ok else _RED)}] {log.eval.task}"
         print(f"{row}  {detail}" if detail else row)
     print(f"{_styled('log dir:', _CYAN)} {_styled(log_dir, _DIM)}")
     if not success:
-        print(_styled(f"hint: inspect-robots inspect {log_dir}/<task>_<id>.json", _DIM))
+        print(
+            _styled(
+                f"hint: inspect a log with: inspect-robots inspect {log_dir}/<task>_<id>.json",
+                _DIM,
+            )
+        )
 
 
 def _cmd_eval_set(args: argparse.Namespace) -> int:
@@ -960,89 +978,48 @@ def _cmd_eval_set(args: argparse.Namespace) -> int:
 
     from inspect_robots import eval_set
 
-    if args.sim and args.embodiment:
-        raise SystemExit(
-            "--sim selects your configured sim_embodiment; "
-            "passing --embodiment already picks the embodiment — drop one"
-        )
-    if args.disable_guardrails and args.max_action_delta is not None:
-        raise SystemExit(
-            "--max-action-delta tunes the guardrails that --disable-guardrails turns off — drop one"
-        )
-
+    _check_shared_run_conflicts(args)
     task_names = _match_tasks(args.tasks)
 
     defaults = load_defaults(os.environ)
-    policy_name, policy_source = _pick_component(
-        "policy", args.policy, defaults.policy, defaults.policy_source
-    )
-    if args.sim:
-        embodiment_name, embodiment_source = _pick_sim_embodiment(defaults)
-        embodiment_defaults = _config_args(
-            "sim_embodiment",
-            embodiment_name,
-            defaults.sim_embodiment_args_owner,
-            defaults.sim_embodiment_args,
-        )
-    else:
-        embodiment_name, embodiment_source = _pick_component(
-            "embodiment", args.embodiment, defaults.embodiment, defaults.embodiment_source
-        )
-        embodiment_defaults = _config_args(
-            "embodiment", embodiment_name, defaults.embodiment_args_owner, defaults.embodiment_args
-        )
-    policy_config_args = _config_args(
-        "policy", policy_name, defaults.policy_args_owner, defaults.policy_args
-    )
-    policy_kvs = {**policy_config_args, **_parse_kvs(args.policy_args)}
-    embodiment_kvs = {**embodiment_defaults, **_parse_kvs(args.embodiment_args)}
-
     tasks = [_resolve_or_exit("task", name) for name in task_names]
     if args.epochs is not None:
         tasks = [replace(t, epochs=args.epochs) for t in tasks]
 
-    policy = _resolve_or_exit("policy", policy_name, **policy_kvs)
-    if args.sim:
-        embodiment = _resolve_or_exit(
-            "embodiment", embodiment_name, "sim_embodiment.args", **embodiment_kvs
-        )
-    else:
-        embodiment = _resolve_or_exit("embodiment", embodiment_name, **embodiment_kvs)
-
+    resolved = _resolve_components(args, defaults)
+    embodiment = resolved.embodiment
     try:
-        print(f"policy: {policy_name} ({policy_source})")
-        print(f"embodiment: {embodiment_name} ({embodiment_source})")
+        _announce_components(resolved)
         print(f"tasks: {', '.join(task_names)}")
-
-        approver: Approver | None = None
-        if args.disable_guardrails:
+        approver = _build_and_announce_guardrails(args, embodiment.info.action_space)
+        try:
+            success, logs = eval_set(
+                tasks,
+                resolved.policy,
+                embodiment,
+                log_dir=args.log_dir,
+                seed=args.seed,
+                fail_on_error=args.fail_on_error if args.fail_on_error is not None else False,
+                approver=approver,
+                store_frames=(
+                    args.store_frames if args.store_frames is not None else defaults.store_frames
+                ),
+                retry_attempts=args.retry_attempts,
+            )
+        except KeyboardInterrupt:
+            # eval_set writes one log per task; eval() persists a cancelled log
+            # for the interrupted task before re-raising (#118). We don't hold
+            # the per-task sink paths, so point at the shared dir. The finally
+            # below still de-energizes the arm.
+            _print_degraded(f"cancelled: partial logs are under {args.log_dir}")
             print(
-                "WARNING: guardrails disabled (--disable-guardrails); actions "
-                "reach the embodiment unchecked.",
-                file=sys.stderr,
+                _styled(
+                    f"hint: inspect a log with: inspect-robots inspect "
+                    f"{args.log_dir}/<task>_<id>.json",
+                    _DIM,
+                )
             )
-            print("guardrails: disabled (--disable-guardrails)")
-        else:
-            approver, active, guard_warnings = _build_guardrails(
-                embodiment.info.action_space, args.max_action_delta
-            )
-            for warning in guard_warnings:
-                print(f"guardrails warning: {warning}", file=sys.stderr)
-            print(f"guardrails: {' + '.join(active) if active else 'none active'}")
-
-        success, logs = eval_set(
-            tasks,
-            policy,
-            embodiment,
-            log_dir=args.log_dir,
-            seed=args.seed,
-            fail_on_error=args.fail_on_error if args.fail_on_error is not None else False,
-            approver=approver,
-            store_frames=(
-                args.store_frames if args.store_frames is not None else defaults.store_frames
-            ),
-            retry_attempts=args.retry_attempts,
-        )
+            return 130
     finally:
         # Same "close what we open" contract as _cmd_run: the CLI resolved the
         # embodiment itself, so it — not eval_set() — is responsible for

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -682,9 +682,10 @@ def test_cli_eval_set_one_task_fails_aggregate_status_is_error(
 def test_cli_eval_set_policy_errors_every_reset_without_fail_on_error(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """No metrics, no top-level error: PolicyError-class failures without
-    --fail-on-error degrade every scene silently, so the eval-set summary
-    row has neither a metric nor an error to show (see _print_eval_set_summary).
+    """A task where every trial errors degrades to a top-level error log even
+    without --fail-on-error (issue #73): there is no surviving data for
+    fail_on_error's flaky-trial tolerance to protect, so eval-set surfaces it
+    as [error] with the "all N trial(s) errored" detail, not a silent success.
     """
     from inspect_robots.registry import policy as policy_decorator
     from inspect_robots.scene import Scene
@@ -712,7 +713,36 @@ def test_cli_eval_set_policy_errors_every_reset_without_fail_on_error(
     finally:
         reg._FACTORIES["policy"].pop(name, None)
         reg._FACTORIES["task"].pop("kb/a", None)
-    assert rc == 0  # PolicyErrors without --fail-on-error never flip the top-level status
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "status: error" in out
+    assert "[error] kb/a  all 1 trial(s) errored; nothing was scored" in out
+
+
+def test_cli_eval_set_zero_scene_task_has_no_metric_or_error_detail(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No metrics, no top-level error: a task with zero scenes succeeds
+    trivially (nothing ran, nothing to reduce), so its eval-set summary row
+    has neither a metric nor an error to show (see _print_eval_set_summary).
+    """
+    _register_task("kb/a", num_scenes=0)
+    try:
+        rc = main(
+            [
+                "eval-set",
+                "kb/a",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["task"].pop("kb/a", None)
+    assert rc == 0
     out = capsys.readouterr().out
     assert "status: success" in out
     assert "[success] kb/a\n" in out  # no trailing metric/error detail

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -419,9 +419,9 @@ def test_cli_eval_set_runs_multiple_exact_tasks(
     assert rc == 0
     out = capsys.readouterr().out
     assert "tasks: kb/a, kb/b" in out
-    assert "status: success" in out
-    assert "[success] kb/a" in out
-    assert "[success] kb/b" in out
+    assert "run status: completed" in out
+    assert "[completed] kb/a" in out
+    assert "[completed] kb/b" in out
     assert out.count("log dir:") == 1  # one shared line, not one per task
     assert len(list(tmp_path.glob("*.json"))) == 2
 
@@ -673,8 +673,8 @@ def test_cli_eval_set_one_task_fails_aggregate_status_is_error(
         reg._FACTORIES["task"].pop("kb/b", None)
     assert rc == 1
     out = capsys.readouterr().out
-    assert "status: error" in out
-    assert "[success] kb/a" in out
+    assert "run status: error" in out
+    assert "[completed] kb/a" in out
     assert "[error] kb/b" in out
     assert "reset exploded" in out
 
@@ -715,7 +715,7 @@ def test_cli_eval_set_policy_errors_every_reset_without_fail_on_error(
         reg._FACTORIES["task"].pop("kb/a", None)
     assert rc == 1
     out = capsys.readouterr().out
-    assert "status: error" in out
+    assert "run status: error" in out
     assert "[error] kb/a  all 1 trial(s) errored; nothing was scored" in out
 
 
@@ -744,8 +744,46 @@ def test_cli_eval_set_zero_scene_task_has_no_metric_or_error_detail(
         reg._FACTORIES["task"].pop("kb/a", None)
     assert rc == 0
     out = capsys.readouterr().out
-    assert "status: success" in out
-    assert "[success] kb/a\n" in out  # no trailing metric/error detail
+    assert "run status: completed" in out
+    assert "[completed] kb/a\n" in out  # no trailing metric/error detail
+
+
+def test_cli_eval_set_ctrl_c_reports_partial_logs_and_exits_130(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Ctrl-C mid-set points at the log dir and returns 130 instead of a traceback.
+
+    eval_set writes per-task logs and eval() persists a cancelled log for the
+    interrupted task (#118), but eval-set doesn't hold the sink paths, so the
+    hint points at the shared dir.
+    """
+    import inspect_robots
+
+    def interrupted_eval_set(*args: object, **kwargs: object) -> tuple[bool, list[EvalLog]]:
+        del args, kwargs
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(inspect_robots, "eval_set", interrupted_eval_set)
+    _register_task("kb/a")
+    try:
+        rc = main(
+            [
+                "eval-set",
+                "kb/a",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["task"].pop("kb/a", None)
+    assert rc == 130
+    out = capsys.readouterr().out
+    assert f"cancelled: partial logs are under {tmp_path}" in out
+    assert "inspect-robots inspect" in out
 
 
 def test_cli_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -227,6 +227,346 @@ def test_cli_run_epochs_fail_on_error_store_frames(
     assert list((tmp_path / "frames").rglob("*.npy"))  # --store-frames streamed (per-run subdir)
 
 
+def _register_task(name: str, *, num_scenes: int = 1, max_steps: int = 20) -> None:
+    from inspect_robots.registry import task as task_decorator
+    from inspect_robots.scene import Scene
+    from inspect_robots.scorer import success_at_end
+    from inspect_robots.task import Task
+
+    @task_decorator(name)
+    def _factory() -> Task:
+        return Task(
+            name=name,
+            scenes=[Scene(id=f"s{i}", instruction="reach", init_seed=i) for i in range(num_scenes)],
+            scorer=success_at_end(),
+            max_steps=max_steps,
+        )
+
+
+def test_cli_eval_set_runs_multiple_exact_tasks(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _register_task("kb/a")
+    _register_task("kb/b")
+    try:
+        rc = main(
+            [
+                "eval-set",
+                "kb/a",
+                "kb/b",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["task"].pop("kb/a", None)
+        reg._FACTORIES["task"].pop("kb/b", None)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "tasks: kb/a, kb/b" in out
+    assert "status: success" in out
+    assert "[success] kb/a" in out
+    assert "[success] kb/b" in out
+    assert out.count("log dir:") == 1  # one shared line, not one per task
+    assert len(list(tmp_path.glob("*.json"))) == 2
+
+
+def test_cli_eval_set_glob_matches_by_prefix(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _register_task("kb/a")
+    _register_task("kb/b")
+    _register_task("other/c")
+    try:
+        rc = main(
+            [
+                "eval-set",
+                "kb/*",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["task"].pop("kb/a", None)
+        reg._FACTORIES["task"].pop("kb/b", None)
+        reg._FACTORIES["task"].pop("other/c", None)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "tasks: kb/a, kb/b" in out
+    assert "other/c" not in out
+
+
+def test_cli_eval_set_dedups_overlapping_patterns(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _register_task("kb/a")
+    _register_task("kb/b")
+    try:
+        rc = main(
+            [
+                "eval-set",
+                "kb/*",
+                "kb/a",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["task"].pop("kb/a", None)
+        reg._FACTORIES["task"].pop("kb/b", None)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "tasks: kb/a, kb/b" in out  # kb/a not repeated despite matching twice
+    assert len(list(tmp_path.glob("*.json"))) == 2
+
+
+def test_cli_eval_set_unmatched_pattern_errors() -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(
+            [
+                "eval-set",
+                "does-not-exist/*",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                "cubepick",
+            ]
+        )
+    message = str(excinfo.value)
+    assert "no task matches 'does-not-exist/*'" in message
+    assert "registered tasks: " in message
+
+
+def test_cli_eval_set_epochs_override_applies_to_every_task(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _register_task("kb/a")
+    _register_task("kb/b")
+    try:
+        rc = main(
+            [
+                "eval-set",
+                "kb/a",
+                "kb/b",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                "cubepick",
+                "--epochs",
+                "2",
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["task"].pop("kb/a", None)
+        reg._FACTORIES["task"].pop("kb/b", None)
+    assert rc == 0
+    from inspect_robots import read_eval_log
+
+    logs = [read_eval_log(str(p)) for p in tmp_path.glob("*.json")]
+    assert len(logs) == 2
+    assert all(log.results.total_trials == 2 for log in logs)  # --epochs overrode both tasks
+
+
+def test_cli_eval_set_sim_and_embodiment_conflict() -> None:
+    with pytest.raises(SystemExit, match="drop one"):
+        main(["eval-set", "cubepick-reach", "--sim", "--embodiment", "cubepick"])
+
+
+def test_cli_eval_set_guardrail_flags_conflict() -> None:
+    with pytest.raises(SystemExit, match="drop one"):
+        main(
+            [
+                "eval-set",
+                "cubepick-reach",
+                "--disable-guardrails",
+                "--max-action-delta",
+                "0.1",
+            ]
+        )
+
+
+def test_cli_eval_set_disable_guardrails(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = main(
+        [
+            "eval-set",
+            "cubepick-reach",
+            "--policy",
+            "scripted",
+            "--embodiment",
+            "cubepick",
+            "--disable-guardrails",
+            "--log-dir",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0
+    out, err = capsys.readouterr()
+    assert "guardrails: disabled (--disable-guardrails)" in out
+    assert "WARNING: guardrails disabled" in err
+
+
+def test_cli_eval_set_degraded_guardrails_warn_but_run(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Same bare-space case as test_cli_degraded_guardrails_warn_but_run, via eval-set.
+    from dataclasses import replace
+
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.registry import embodiment as embodiment_decorator
+    from inspect_robots.spaces import Box
+
+    class _BareSpaceEmbodiment(CubePickEmbodiment):
+        def __init__(self) -> None:
+            super().__init__()
+            self.info = replace(self.info, action_space=Box(shape=(2,)))
+
+    name = "bare-cubepick-for-eval-set-test"
+    embodiment_decorator(name)(_BareSpaceEmbodiment)
+    try:
+        rc = main(
+            [
+                "eval-set",
+                "cubepick-reach",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                name,
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["embodiment"].pop(name, None)
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "guardrails: none active" in captured.out
+    assert "no guardrails" in captured.err
+
+
+def test_cli_eval_set_sim_flag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv(ENV_SIM_EMBODIMENT, "cubepick")
+    rc = main(
+        [
+            "eval-set",
+            "cubepick-reach",
+            "--policy",
+            "scripted",
+            "--sim",
+            "--log-dir",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"embodiment: cubepick (--sim, from ${ENV_SIM_EMBODIMENT})" in out
+
+
+def test_cli_eval_set_one_task_fails_aggregate_status_is_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.registry import embodiment as embodiment_decorator
+    from inspect_robots.scene import Scene
+    from inspect_robots.types import Observation
+
+    class _FaultOnSecondTask(CubePickEmbodiment):
+        def __init__(self) -> None:
+            super().__init__()
+            self._resets = 0
+
+        def reset(self, scene: Scene, *, seed: int | None = None) -> Observation:
+            self._resets += 1
+            if self._resets == 2:
+                raise RuntimeError("reset exploded")
+            return super().reset(scene, seed=seed)
+
+    name = "fault-on-second-task-for-eval-set-test"
+    embodiment_decorator(name)(_FaultOnSecondTask)
+    _register_task("kb/a")
+    _register_task("kb/b")
+    try:
+        rc = main(
+            [
+                "eval-set",
+                "kb/a",
+                "kb/b",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                name,
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["embodiment"].pop(name, None)
+        reg._FACTORIES["task"].pop("kb/a", None)
+        reg._FACTORIES["task"].pop("kb/b", None)
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "status: error" in out
+    assert "[success] kb/a" in out
+    assert "[error] kb/b" in out
+    assert "reset exploded" in out
+
+
+def test_cli_eval_set_policy_errors_every_reset_without_fail_on_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No metrics, no top-level error: PolicyError-class failures without
+    --fail-on-error degrade every scene silently, so the eval-set summary
+    row has neither a metric nor an error to show (see _print_eval_set_summary).
+    """
+    from inspect_robots.registry import policy as policy_decorator
+    from inspect_robots.scene import Scene
+
+    class _AlwaysFailsPolicy(ScriptedPolicy):
+        def reset(self, scene: Scene) -> None:
+            raise RuntimeError("policy reset exploded")
+
+    name = "always-fails-for-eval-set-test"
+    policy_decorator(name)(_AlwaysFailsPolicy)
+    _register_task("kb/a")
+    try:
+        rc = main(
+            [
+                "eval-set",
+                "kb/a",
+                "--policy",
+                name,
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["policy"].pop(name, None)
+        reg._FACTORIES["task"].pop("kb/a", None)
+    assert rc == 0  # PolicyErrors without --fail-on-error never flip the top-level status
+    out = capsys.readouterr().out
+    assert "status: success" in out
+    assert "[success] kb/a\n" in out  # no trailing metric/error detail
+
+
 def test_cli_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
     assert main([]) == 0
     assert "Inspect Robots" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

There was no way to run a whole benchmark from the CLI: `run` accepts exactly
one `--task`, so running e.g. all 10 KitchenBench tasks meant a shell loop or
dropping into Python to call `eval_set()` directly, even though the Python
API already has it.

## Changes

- Add `inspect-robots eval-set TASK [TASK ...]`: task names are matched
  exactly or by `fnmatch` glob (entry-point discovery already namespaces
  tasks as `<benchmark>/<key>`, so a benchmark name is a ready-made prefix,
  e.g. `'kitchenbench/*'`), deduplicated across overlapping patterns, and
  driven through `eval_set()` against one resolved policy/embodiment pair.
- Resolve the embodiment **once** for the whole set rather than once per task
  — `eval_set()` reconnects a string-embodiment on every call, which would
  mean reconnecting a real robot between every task in the set.
- Output: one status line, a compact `[status] task  metrics-or-error` row
  per task, and the shared log dir printed once — not N full run summaries.
- `-P`/`-E`/`--sim`/`--epochs`/`--fail-on-error`/`--store-frames`/
  `--disable-guardrails`/`--max-action-delta` behave exactly as they do for
  `run`, applied to every matched task.
- `docs/guide/cli.md` gets a new `eval-set` section; `CHANGELOG.md` gets an
  `Added` entry.

**Deliberately out of scope for this pass** (called out in the issue and in
code comments, not silently dropped):
- `--rerun`: `eval_set()` doesn't expose a `sinks` parameter to plug a live
  viewer into, and streaming several back-to-back tasks into one viewer
  window is a separate design question from running the set at all.
- `-T` (per-task constructor args): the issue frames this as a "thin CLI
  wrapper," and per-task args need their own disambiguation design.

## Checklist

- [x] `pre-commit install` done; hooks pass (or ran `pre-commit run --all-files`) — `pre-commit run --all-files` fails in this environment because its hooks shell out to `uv`, which isn't installed here; ran `ruff check .`, `ruff format --check .`, and `mypy` directly instead (all pass)
- [x] Tests added/updated (and the `CubePick` mock exercises the change where applicable) — 21 new tests in `test_registry_cli.py`: exact/glob/dedup matching, zero-match error, epochs override, `--sim`, guardrail conflict/disable/degrade branches, aggregate-error-on-one-task-failing, and the PolicyError-without-`--fail-on-error` case where a task row has neither a metric nor an error to show
- [x] Coverage stays at **100%** (`pytest --cov`) — `cli.py` is 100%; full local run shows 99.07% only because `test_setup.py`'s symlink tests skip without Windows dev-mode privilege (confirmed pre-existing on `main`, unrelated — CI's blocking gate runs Linux/macOS)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `mypy` passes (strict)
- [x] `CHANGELOG.md` updated under "Unreleased"
- [x] Public API changes are reflected in `inspect_robots.__all__` and the API-snapshot test — N/A, CLI-only, no change to the `inspect_robots` package's public symbols
- [x] Core stays NumPy-only (new deps are optional extras, lazily imported) — unaffected, no new deps; also ran a strict `mkdocs build --strict` locally to confirm the new docs section doesn't break the doc build

## Related

Closes #45
