### PR TITLE
Fix #53: adopt a definitive embodiment verdict instead of re-prompting the operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **Operator scoring no longer prompts twice for self-confirming embodiments**
+  (#53). On interactive ad-hoc runs, definitive `success` or `failure`
+  termination verdicts are adopted as the operator judgement, announced on the
+  terminal, and identified as embodiment-sourced in the in-memory transcript.
 - **Literal percent signs in config values now round-trip unchanged** (#54).
   Config reads no longer treat `%` as interpolation syntax, so values such as
   `policy = 50%off` work with `config set`, `config show`, and normal runs.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -87,17 +87,21 @@ robot.
 ### Operator scoring
 
 An arbitrary instruction has no success oracle, so ad-hoc runs default to the
-`operator` scorer: when run on an interactive terminal, the CLI asks after
-each trial,
+`operator` scorer. When run on an interactive terminal, the CLI asks after each
+trial unless the embodiment already terminated the episode with a definitive
+`success` or `failure` verdict. In that case, the CLI records the embodiment's
+verdict as the operator judgement instead of asking the operator a second time,
+and prints `operator verdict adopted from embodiment: success` (or `failure`) so
+the operator can catch a mistaken adoption live.
 
 ```text
 did the robot succeed? [y/n/partial/skip] (partial scores as failure)
 ```
 
-and records the verdict in the log (`skip` records nothing). Piped/CI
-stdin, `--no-prompt`, or a registered `--task` run never prompt: unattended
-runs stay non-blocking, and an unjudged trial honestly scores as failure with
-"no operator judgement recorded".
+Prompted verdicts are recorded in the log (`skip` records nothing). Piped/CI
+stdin, `--no-prompt`, or a registered `--task` run never prompt or adopt an
+embodiment verdict: unattended runs stay non-blocking, and an unjudged trial
+honestly scores as failure with "no operator judgement recorded".
 
 ## `inspect-robots setup`
 

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -360,13 +360,26 @@ def _build_guardrails(
 
 _PROMPT = "did the robot succeed? [y/n/partial/skip] (partial scores as failure) "
 _PROMPT_ANSWERS = frozenset({"y", "yes", "n", "no", "partial", "skip"})
+_DEFINITIVE_REASONS = frozenset({"success", "failure"})
 
 
 def _prompt_operator(record: TrialRecord, scene: Scene) -> None:
-    """Capture the terminal operator's verdict on the record (R6)."""
+    """Capture or adopt the terminal operator's verdict on the record (R6).
+
+    A terminated episode with a definitive embodiment verdict adopts and announces that
+    verdict instead of asking the operator to confirm the same outcome a second time.
+    """
     from inspect_robots.transcript import operator_event
 
     del scene
+    if record.terminated and record.termination_reason in _DEFINITIVE_REASONS:
+        verdict = "y" if record.termination_reason == "success" else "n"
+        record.operator_judgement = verdict
+        record.events.append(
+            operator_event(t=len(record.steps), verdict=verdict, source="embodiment")
+        )
+        print(f"operator verdict adopted from embodiment: {record.termination_reason}")
+        return
     while True:
         try:
             answer = input(_PROMPT).strip().lower()

--- a/src/inspect_robots/transcript.py
+++ b/src/inspect_robots/transcript.py
@@ -49,9 +49,9 @@ def approval_event(t: int, modified: bool, detail: str | None = None) -> Event:
     return Event(kind="approval", t=t, data={"modified": modified, "detail": detail})
 
 
-def operator_event(t: int, verdict: str) -> Event:
-    """Record the operator's verdict after the rollout ends."""
-    return Event(kind="operator", t=t, data={"verdict": verdict})
+def operator_event(t: int, verdict: str, source: str = "prompt") -> Event:
+    """Record the operator's verdict and its source after the rollout ends."""
+    return Event(kind="operator", t=t, data={"verdict": verdict, "source": source})
 
 
 def error_event(t: int, error_type: str, message: str) -> Event:

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -549,9 +549,34 @@ def test_operator_prompt_records_verdict_and_reprompts_on_typos(
     answers = iter(["yse", "y"])
     monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
     log_dir = tmp_path / "logs"
-    rc = main(["reach the cube", "--log-dir", str(log_dir)])  # default scorer: operator
+    rc = main(
+        ["reach the cube", "--max-steps", "3", "--log-dir", str(log_dir)]
+    )  # default scorer: operator
     assert rc == 0
     assert "unrecognized answer 'yse'" in capsys.readouterr().out
+    log = _read_only_log(log_dir)
+    assert log.samples[0].operator_judgements == ("y",)
+    assert log.results.metrics["operator"] == 1.0
+
+
+def test_operator_prompt_adopts_self_confirming_embodiment_verdict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv(ENV_POLICY, "scripted")
+    monkeypatch.setenv(ENV_EMBODIMENT, "cubepick")
+    _tty_stdin(monkeypatch)
+    prompts: list[str] = []
+
+    def _answer(prompt: str) -> str:
+        prompts.append(prompt)
+        return "y"
+
+    monkeypatch.setattr("builtins.input", _answer)
+    log_dir = tmp_path / "logs"
+    rc = main(["reach the cube", "--log-dir", str(log_dir)])
+    assert rc == 0
+    assert prompts == []
+    assert "operator verdict adopted from embodiment: success" in capsys.readouterr().out
     log = _read_only_log(log_dir)
     assert log.samples[0].operator_judgements == ("y",)
     assert log.results.metrics["operator"] == 1.0
@@ -624,6 +649,133 @@ def test_registered_task_never_prompts_even_with_operator_scorer_on_tty(
     assert rc == 0
     assert _read_only_log(log_dir).samples[0].operator_judgements == (None,)
     capsys.readouterr()
+
+
+@pytest.mark.parametrize(
+    ("termination_reason", "expected_verdict"),
+    [("success", "y"), ("failure", "n")],
+)
+def test_prompt_operator_adopts_definitive_embodiment_verdict(
+    termination_reason: str,
+    expected_verdict: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inspect_robots.cli import _prompt_operator
+    from inspect_robots.rollout import TrialRecord
+    from inspect_robots.scene import Scene
+
+    record = TrialRecord(
+        scene_id="s0",
+        epoch=0,
+        seed=0,
+        terminated=True,
+        termination_reason=termination_reason,
+    )
+    monkeypatch.setattr(
+        "builtins.input", lambda _prompt: pytest.fail("operator prompt must not fire")
+    )
+
+    _prompt_operator(record, Scene(id="s0", instruction="reach"))
+
+    assert record.operator_judgement == expected_verdict
+    (event,) = record.events
+    assert event.kind == "operator"
+    assert event.t == 0
+    assert event.data == {"verdict": expected_verdict, "source": "embodiment"}
+
+
+@pytest.mark.parametrize(
+    ("terminated", "termination_reason"),
+    [
+        (False, None),
+        (False, "max_steps"),
+        (False, "policy_stop"),
+        (True, None),
+    ],
+)
+def test_prompt_operator_still_prompts_without_definitive_verdict(
+    terminated: bool,
+    termination_reason: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inspect_robots.cli import _prompt_operator
+    from inspect_robots.rollout import TrialRecord
+    from inspect_robots.scene import Scene
+
+    record = TrialRecord(
+        scene_id="s0",
+        epoch=0,
+        seed=0,
+        terminated=terminated,
+        termination_reason=termination_reason,
+    )
+    prompts: list[str] = []
+
+    def _answer(prompt: str) -> str:
+        prompts.append(prompt)
+        return "y"
+
+    monkeypatch.setattr("builtins.input", _answer)
+    _prompt_operator(record, Scene(id="s0", instruction="reach"))
+
+    assert len(prompts) == 1
+    assert record.operator_judgement == "y"
+    (event,) = record.events
+    assert event.data == {"verdict": "y", "source": "prompt"}
+
+
+def test_prompt_operator_prompts_for_truncated_success_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inspect_robots.cli import _prompt_operator
+    from inspect_robots.rollout import TrialRecord
+    from inspect_robots.scene import Scene
+
+    record = TrialRecord(
+        scene_id="s0",
+        epoch=0,
+        seed=0,
+        terminated=False,
+        truncated=True,
+        termination_reason="success",
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+
+    _prompt_operator(record, Scene(id="s0", instruction="reach"))
+
+    assert record.operator_judgement == "n"
+    (event,) = record.events
+    assert event.data == {"verdict": "n", "source": "prompt"}
+
+
+@pytest.mark.parametrize(
+    ("termination_reason", "expected_score"),
+    [("success", True), ("failure", False)],
+)
+def test_operator_scorer_reads_adopted_embodiment_verdict(
+    termination_reason: str,
+    expected_score: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inspect_robots.cli import _prompt_operator
+    from inspect_robots.rollout import TrialRecord
+    from inspect_robots.scene import Scene
+    from inspect_robots.scorer import operator_scorer
+
+    record = TrialRecord(
+        scene_id="s0",
+        epoch=0,
+        seed=0,
+        terminated=True,
+        termination_reason=termination_reason,
+    )
+    monkeypatch.setattr(
+        "builtins.input", lambda _prompt: pytest.fail("operator prompt must not fire")
+    )
+
+    _prompt_operator(record, Scene(id="s0", instruction="reach"))
+
+    assert operator_scorer()(record, None).value is expected_score
 
 
 def test_prompt_operator_unit_semantics(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

On self-confirming rigs, every ad-hoc episode ended with two back-to-back verdict prompts: the embodiment's own confirm-success prompt, then the CLI's `_prompt_operator` (wired whenever the resolved scorer is `operator`, the ad-hoc default). Both encode the same fact, the operator answers twice per episode, and the two answers can disagree with nothing reconciling them.

## Fix (the issue's preferred skip-when-verdict-exists option)

`_prompt_operator` short-circuits when the record carries a definitive embodiment verdict — `terminated` with `termination_reason` in `{"success", "failure"}` (the documented yam contract emits both, so adopting only `"success"` would leave the double prompt on every "no") — synthesizing the operator judgement ("y"/"n"), announcing it with one status line (`operator verdict adopted from embodiment: <reason>`), and recording provenance (`source="embodiment"`) in the in-memory transcript event. Verdict-less endings (truncation, `max_steps`, policy stops, termination without a success/failure reason) still prompt — exactly the case the `operator` scorer exists for.

Deliberately preserved: `--no-prompt`, piped stdin, and registered `--task` runs never prompt **or adopt** — unattended runs stay non-blocking and an unjudged trial still honestly scores as failure. `docs/guide/cli.md` documents both behaviors.

## Interaction with #41 (merge-order note)

On current main, the isaacsim plugin's `_read_success` falls back to "terminated implies success", so an oracle-less Isaac failure-termination would be adopted as a success verdict (announced, not silent). Open PR #41 flips that fallback to an explicit `terminated_implies_success` opt-in (oracle-less terminations score not-successful → reason `None` → still prompts under this change). **#41 should land alongside this PR**; with it, every in-tree `"success"`/`"failure"` reason is a genuine verdict.

## Tests

- New unit tests: adoption on success/failure (prompt asserted unreachable), still-prompts parametrized over the real verdict-less rollout shapes, truncated-with-success-reason does not adopt, operator-scorer integration on adopted verdicts.
- New e2e wiring test driving adoption through `main()` on a fake TTY (zero `input()` calls, adoption line, judgements `("y",)`, operator metric 1.0) — mutation-verified to fail on both the unfixed code and a print-less variant.
- Reworked `test_operator_prompt_records_verdict_and_reprompts_on_typos` with `--max-steps 3` (cubepick needs ≥7 steps to reach, so the run truncates verdict-less and the typo-reprompt path stays reachable).
- `416 passed, 1 skipped`; 100% coverage gate, ruff, ruff format, strict mypy all green.

Process: plan → 2-round adversarial plan critique → implementation → 2-round fresh-eyes review with behavioral spot-checks and mutation testing, all verdicts OK.

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)