### PR TITLE
fix: probe V4L2 nodes for color capture instead of assuming index0

### DIFF
--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -56,9 +56,25 @@ _VIDIOC_ENUM_FMT = 0xC0405602
 _V4L2_CAP_VIDEO_CAPTURE = 0x00000001
 _V4L2_CAP_DEVICE_CAPS = 0x80000000
 # UYVY/GREY are deliberately absent: RealSense stereo-IR nodes advertise them,
-# and listing those would offer IR streams as cameras.
+# and listing those would offer IR streams as cameras. RGGB/GRBG/GBRG/BA81 are
+# the 8-bit raw Bayer layouts OpenCV debayers to color.
 _V4L2_COLOR_FOURCCS = frozenset(
-    {"YUYV", "MJPG", "JPEG", "H264", "NV12", "NV21", "YU12", "YV12", "RGB3", "BGR3"}
+    {
+        "YUYV",
+        "MJPG",
+        "JPEG",
+        "H264",
+        "NV12",
+        "NV21",
+        "YU12",
+        "YV12",
+        "RGB3",
+        "BGR3",
+        "RGGB",
+        "GRBG",
+        "GBRG",
+        "BA81",
+    }
 )
 
 _DEFAULT_COMMENTS: dict[str, str] = {
@@ -695,15 +711,16 @@ def _v4l2_color_capture(path: Path) -> bool | None:
         except OSError:
             return None
 
-        capabilities, device_caps = struct.unpack_from("<II", capability, 84)
+        capabilities, device_caps = struct.unpack_from("=II", capability, 84)
         effective_caps = device_caps if capabilities & _V4L2_CAP_DEVICE_CAPS else capabilities
         if not effective_caps & _V4L2_CAP_VIDEO_CAPTURE:
             return False
 
-        index = 0
-        while True:
+        # Bounded far above any real device's format count, so a driver that
+        # never ends the enumeration cannot hang the wizard.
+        for index in range(64):
             description = bytearray(64)
-            struct.pack_into("<II", description, 0, index, 1)
+            struct.pack_into("=II", description, 0, index, 1)
             try:
                 fcntl.ioctl(fd, _VIDIOC_ENUM_FMT, description)
             except OSError:
@@ -711,7 +728,7 @@ def _v4l2_color_capture(path: Path) -> bool | None:
             fourcc = description[44:48].decode("ascii", errors="replace")
             if fourcc in _V4L2_COLOR_FOURCCS:
                 return True
-            index += 1
+        return False
     finally:
         os.close(fd)
 

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import configparser
 import os
 import re
+import struct
 from collections.abc import Callable, Mapping
 from functools import partial
 from pathlib import Path
@@ -46,6 +47,19 @@ V4L_BY_ID: Path = Path("/dev/v4l/by-id")
 V4L_BY_PATH: Path = Path("/dev/v4l/by-path")
 SYSFS_NET: Path = Path("/sys/class/net")
 SERIAL_BY_ID: Path = Path("/dev/serial/by-id")
+
+# Kernel V4L2 ABI: ioctl request numbers and the byte offsets used below
+# (capabilities at 84 in struct v4l2_capability, pixelformat at 44 in
+# struct v4l2_fmtdesc) are fixed by <linux/videodev2.h>.
+_VIDIOC_QUERYCAP = 0x80685600
+_VIDIOC_ENUM_FMT = 0xC0405602
+_V4L2_CAP_VIDEO_CAPTURE = 0x00000001
+_V4L2_CAP_DEVICE_CAPS = 0x80000000
+# UYVY/GREY are deliberately absent: RealSense stereo-IR nodes advertise them,
+# and listing those would offer IR streams as cameras.
+_V4L2_COLOR_FOURCCS = frozenset(
+    {"YUYV", "MJPG", "JPEG", "H264", "NV12", "NV21", "YU12", "YV12", "RGB3", "BGR3"}
+)
 
 _DEFAULT_COMMENTS: dict[str, str] = {
     "policy": "from the inspect-robots-yam plugin",
@@ -662,13 +676,53 @@ def _device_section(
     return assignments
 
 
+def _v4l2_color_capture(path: Path) -> bool | None:
+    """Return whether a node captures color, or ``None`` when probing is inconclusive."""
+    try:
+        import fcntl
+    except ImportError:
+        return None
+
+    try:
+        fd = os.open(str(path), os.O_RDWR | os.O_NONBLOCK)
+    except OSError:
+        return None
+
+    try:
+        capability = bytearray(104)
+        try:
+            fcntl.ioctl(fd, _VIDIOC_QUERYCAP, capability)
+        except OSError:
+            return None
+
+        capabilities, device_caps = struct.unpack_from("<II", capability, 84)
+        effective_caps = device_caps if capabilities & _V4L2_CAP_DEVICE_CAPS else capabilities
+        if not effective_caps & _V4L2_CAP_VIDEO_CAPTURE:
+            return False
+
+        index = 0
+        while True:
+            description = bytearray(64)
+            struct.pack_into("<II", description, 0, index, 1)
+            try:
+                fcntl.ioctl(fd, _VIDIOC_ENUM_FMT, description)
+            except OSError:
+                return False
+            fourcc = description[44:48].decode("ascii", errors="replace")
+            if fourcc in _V4L2_COLOR_FOURCCS:
+                return True
+            index += 1
+    finally:
+        os.close(fd)
+
+
 def _scan_cameras(v4l_dir: Path) -> list[str]:
-    """Return sorted device paths, preferring V4L2 color-stream entries."""
+    """Return V4L2-probed color paths, or all sorted entries when none are confirmed."""
     try:
         entries = sorted(v4l_dir.iterdir())
     except FileNotFoundError:
         return []
-    color_entries = [entry for entry in entries if entry.name.endswith("-video-index0")]
+    color_entries = [entry for entry in entries if _v4l2_color_capture(entry) is True]
     return [str(entry) for entry in color_entries or entries]
 
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import errno
 import io
 import os
+import struct
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import ClassVar
@@ -11,6 +14,8 @@ from typing import ClassVar
 import pytest
 
 from inspect_robots._setup import (
+    _VIDIOC_ENUM_FMT,
+    _VIDIOC_QUERYCAP,
     SUGGESTED,
     _can_serial,
     _identify_by_replug,
@@ -20,6 +25,7 @@ from inspect_robots._setup import (
     _scan_can,
     _scan_serial,
     _suggest_can_pinning,
+    _v4l2_color_capture,
     run_setup,
 )
 from inspect_robots.conformance import DeviceSlot
@@ -106,7 +112,37 @@ def _empty_registry(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("inspect_robots.registry.registered", lambda _kind: {})
 
 
-def test_scan_cameras_prefers_sorted_absolute_index0_entries(tmp_path: Path) -> None:
+def test_scan_cameras_prefers_color_capture_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    v4l_dir = tmp_path / "by-id"
+    v4l_dir.mkdir()
+    # RealSense-style layout: index0 is the depth node, index2 the IR pair,
+    # index4 the color stream — the name says nothing about capturability.
+    verdicts = {
+        "usb-realsense-video-index0": False,
+        "usb-realsense-video-index2": False,
+        "usb-realsense-video-index4": True,
+        "usb-webcam-video-index0": True,
+        "usb-webcam-video-index1": None,
+    }
+    for name in verdicts:
+        (v4l_dir / name).touch()
+    monkeypatch.setattr(
+        "inspect_robots._setup._v4l2_color_capture",
+        lambda path: verdicts[Path(path).name],
+    )
+
+    devices = _scan_cameras(v4l_dir)
+
+    assert devices == [
+        str(v4l_dir / "usb-realsense-video-index4"),
+        str(v4l_dir / "usb-webcam-video-index0"),
+    ]
+    assert all(Path(device).is_absolute() for device in devices)
+
+
+def test_scan_cameras_lists_all_entries_when_probe_is_inconclusive(tmp_path: Path) -> None:
     v4l_dir = tmp_path / "by-id"
     v4l_dir.mkdir()
     for name in (
@@ -121,8 +157,8 @@ def test_scan_cameras_prefers_sorted_absolute_index0_entries(tmp_path: Path) -> 
     assert devices == [
         str(v4l_dir / "usb-camera-a-video-index0"),
         str(v4l_dir / "usb-camera-b-video-index0"),
+        str(v4l_dir / "usb-camera-b-video-index1"),
     ]
-    assert all(Path(device).is_absolute() for device in devices)
 
 
 def test_scan_cameras_falls_back_to_all_sorted_entries(tmp_path: Path) -> None:
@@ -140,6 +176,104 @@ def test_scan_cameras_falls_back_to_all_sorted_entries(tmp_path: Path) -> None:
 
 def test_scan_cameras_missing_directory_returns_empty(tmp_path: Path) -> None:
     assert _scan_cameras(tmp_path / "missing") == []
+
+
+_V4L2_CAP_VIDEO_CAPTURE = 0x00000001
+_V4L2_CAP_META_CAPTURE = 0x00800000
+_V4L2_CAP_DEVICE_CAPS = 0x80000000
+
+
+def _fake_v4l2_ioctl(
+    capabilities: int, device_caps: int, fourccs: list[bytes]
+) -> Callable[[int, int, bytearray], int]:
+    """Simulate the kernel's VIDIOC_QUERYCAP / VIDIOC_ENUM_FMT ioctl ABI.
+
+    Buffer offsets follow ``struct v4l2_capability`` (capabilities at byte 84,
+    device_caps at 88) and ``struct v4l2_fmtdesc`` (index/type at 0/4,
+    pixelformat at 44) — fixed kernel layouts, not implementation choices.
+    """
+
+    def ioctl(fd: int, request: int, buf: bytearray) -> int:
+        if request == _VIDIOC_QUERYCAP:
+            struct.pack_into("<II", buf, 84, capabilities, device_caps)
+        elif request == _VIDIOC_ENUM_FMT:
+            index, buf_type = struct.unpack_from("<II", buf, 0)
+            assert buf_type == 1  # V4L2_BUF_TYPE_VIDEO_CAPTURE
+            if index >= len(fourccs):
+                raise OSError(errno.EINVAL, "format enumeration exhausted")
+            buf[44:48] = fourccs[index]
+        else:
+            raise AssertionError(f"unexpected ioctl request {request:#x}")
+        return 0
+
+    return ioctl
+
+
+def _probe_target(tmp_path: Path) -> Path:
+    node = tmp_path / "cam"
+    node.touch()
+    return node
+
+
+def test_v4l2_color_capture_true_for_color_capable_device(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "fcntl.ioctl",
+        _fake_v4l2_ioctl(
+            _V4L2_CAP_DEVICE_CAPS,
+            _V4L2_CAP_VIDEO_CAPTURE,
+            [b"GREY", b"YUYV"],
+        ),
+    )
+
+    assert _v4l2_color_capture(_probe_target(tmp_path)) is True
+
+
+def test_v4l2_color_capture_false_for_depth_only_device(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No DEVICE_CAPS flag: the probe must fall back to `capabilities`.
+    monkeypatch.setattr(
+        "fcntl.ioctl",
+        _fake_v4l2_ioctl(_V4L2_CAP_VIDEO_CAPTURE, 0, [b"Z16 "]),
+    )
+
+    assert _v4l2_color_capture(_probe_target(tmp_path)) is False
+
+
+def test_v4l2_color_capture_false_for_metadata_node_without_enumerating(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Color fourccs are on offer, but a node without VIDEO_CAPTURE must be
+    # rejected on capabilities alone — enumerating it would report True.
+    monkeypatch.setattr(
+        "fcntl.ioctl",
+        _fake_v4l2_ioctl(
+            _V4L2_CAP_DEVICE_CAPS | _V4L2_CAP_META_CAPTURE,
+            _V4L2_CAP_META_CAPTURE,
+            [b"YUYV"],
+        ),
+    )
+
+    assert _v4l2_color_capture(_probe_target(tmp_path)) is False
+
+
+def test_v4l2_color_capture_none_for_unopenable_path(tmp_path: Path) -> None:
+    assert _v4l2_color_capture(tmp_path / "missing") is None
+
+
+def test_v4l2_color_capture_none_for_non_v4l2_file(tmp_path: Path) -> None:
+    # A regular file opens fine but rejects V4L2 ioctls (ENOTTY).
+    assert _v4l2_color_capture(_probe_target(tmp_path)) is None
+
+
+def test_v4l2_color_capture_none_without_fcntl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setitem(sys.modules, "fcntl", None)
+
+    assert _v4l2_color_capture(_probe_target(tmp_path)) is None
 
 
 def test_scan_can_filters_type_280_sorts_and_skips_unreadable(tmp_path: Path) -> None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -195,9 +195,9 @@ def _fake_v4l2_ioctl(
 
     def ioctl(fd: int, request: int, buf: bytearray) -> int:
         if request == _VIDIOC_QUERYCAP:
-            struct.pack_into("<II", buf, 84, capabilities, device_caps)
+            struct.pack_into("=II", buf, 84, capabilities, device_caps)
         elif request == _VIDIOC_ENUM_FMT:
-            index, buf_type = struct.unpack_from("<II", buf, 0)
+            index, buf_type = struct.unpack_from("=II", buf, 0)
             assert buf_type == 1  # V4L2_BUF_TYPE_VIDEO_CAPTURE
             if index >= len(fourccs):
                 raise OSError(errno.EINVAL, "format enumeration exhausted")
@@ -209,12 +209,29 @@ def _fake_v4l2_ioctl(
     return ioctl
 
 
+def _endless_v4l2_ioctl() -> Callable[[int, int, bytearray], int]:
+    """Simulate a misbehaving driver whose format enumeration never ends."""
+
+    def ioctl(fd: int, request: int, buf: bytearray) -> int:
+        if request == _VIDIOC_QUERYCAP:
+            struct.pack_into("=II", buf, 84, _V4L2_CAP_DEVICE_CAPS, _V4L2_CAP_VIDEO_CAPTURE)
+        else:
+            buf[44:48] = b"Z16 "
+        return 0
+
+    return ioctl
+
+
 def _probe_target(tmp_path: Path) -> Path:
     node = tmp_path / "cam"
     node.touch()
     return node
 
 
+_needs_fcntl = pytest.mark.skipif(sys.platform == "win32", reason="fcntl is POSIX-only")
+
+
+@_needs_fcntl
 def test_v4l2_color_capture_true_for_color_capable_device(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -230,6 +247,25 @@ def test_v4l2_color_capture_true_for_color_capable_device(
     assert _v4l2_color_capture(_probe_target(tmp_path)) is True
 
 
+@_needs_fcntl
+def test_v4l2_color_capture_true_for_bayer_only_device(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Raw Bayer nodes are color cameras OpenCV can debayer; hiding them in a
+    # mixed rig would silently drop a working camera from the listing.
+    monkeypatch.setattr(
+        "fcntl.ioctl",
+        _fake_v4l2_ioctl(
+            _V4L2_CAP_DEVICE_CAPS,
+            _V4L2_CAP_VIDEO_CAPTURE,
+            [b"RGGB"],
+        ),
+    )
+
+    assert _v4l2_color_capture(_probe_target(tmp_path)) is True
+
+
+@_needs_fcntl
 def test_v4l2_color_capture_false_for_depth_only_device(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -242,6 +278,18 @@ def test_v4l2_color_capture_false_for_depth_only_device(
     assert _v4l2_color_capture(_probe_target(tmp_path)) is False
 
 
+@_needs_fcntl
+def test_v4l2_color_capture_false_for_endless_format_enumeration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A driver that never terminates VIDIOC_ENUM_FMT must yield False, not a
+    # hung wizard.
+    monkeypatch.setattr("fcntl.ioctl", _endless_v4l2_ioctl())
+
+    assert _v4l2_color_capture(_probe_target(tmp_path)) is False
+
+
+@_needs_fcntl
 def test_v4l2_color_capture_false_for_metadata_node_without_enumerating(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Problem

`inspect-robots setup` filters `/dev/v4l/by-id` camera candidates to names ending in `-video-index0`, assuming udev's first node per device is the color stream. On an Intel RealSense D405 that node is the depth stream (Z16 only), which OpenCV's V4L2 backend cannot open. The wizard therefore suggested (and re-suggested) a device that can never work, and every run on a D405 rig died with:

```
error: EmbodimentFault: cannot open left_cam at /dev/v4l/by-id/usb-Intel_R__RealSense_TM__Depth_Camera_405_..._-video-index0
```

Probing the actual nodes on a real rig (two D405s, one D435, two Innomaker UVC cams) shows why the name heuristic cannot work:

| node | formats | usable as camera |
|---|---|---|
| D435 `index0` | YUYV | yes (why only this one worked) |
| D405 `index0` | Z16 depth | no: the crash |
| D405 `index2` | GREY/UYVY/Y8I/Y12I | stereo-IR pair, decodes as false color |
| D405 `index4` | YUYV | yes: the real color stream |
| Innomaker `index0` | MJPG/YUYV | yes |

## Fix

Replace the name filter with a stdlib-only V4L2 capability probe (`fcntl` ioctls, no new dependencies, lazily imported so the module still imports on Windows):

- `_v4l2_color_capture(path)` returns `True` when `VIDIOC_QUERYCAP` reports a video-capture device and `VIDIOC_ENUM_FMT` advertises a color-image fourcc, `False` for depth/IR/metadata nodes, and `None` when probing is inconclusive (open or ioctl fails, non-Linux). UYVY and GREY are deliberately excluded from the color set because RealSense stereo-IR nodes advertise them.
- `_scan_cameras()` lists the nodes probed as color; when none are confidently color it falls back to listing every entry, so nothing is hidden on platforms or rigs the probe cannot judge.

## Testing

- TDD: new tests were written first and confirmed failing, then the implementation brought them green.
- Unit tests cover the probe's True/False/None contract against a fake kernel ioctl implementing the `v4l2_capability`/`v4l2_fmtdesc` ABI (offsets validated against real devices), including the regression case: a metadata node advertising YUYV must still be rejected on capabilities alone.
- `ruff check`, `ruff format --check`, strict `mypy` (src and tests), and `pytest --cov` at 100% all pass in a lockfile-faithful environment.
- Hardware check: on the rig above, the wizard listing went from five entries with two broken depth nodes to exactly one working color node per physical camera, each verified to open and stream through the yam plugin's OpenCV path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)