### PR TITLE
fix: auto-load .env from the working directory in the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ motion chunk per call:
 uv run inspect-robots "place the fork on the plate" --policy agent -P model=anthropic/claude-fable-5
 ```
 
+Keys can live in a `.env` file in the working directory: the CLI loads it
+automatically, and real environment variables take precedence over its values.
+
 ### Run in simulation
 
 The same instruction runs on your configured simulator instead of the

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -28,6 +28,7 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `registry.py` | decorators + entry-point discovery; `_builtins.py` registers in-tree components |
 | `cli.py` | `inspect-robots list` / `run` / `inspect` / `config set|show` / `setup` (first-run wizard) / `doctor` (adapter conformance), plus the zero-config form `inspect-robots "<instruction>"` (ad-hoc single-scene task; operator prompt on TTY). Every run wires guardrails (Clamp + DeltaLimit) by default; `--disable-guardrails` is the loud opt-out and the chain degrades per component with stderr warnings |
 | `_defaults.py` | user default policy/embodiment (+ `--sim` counterpart) for the zero-config CLI: env vars > `~/.config/inspect-robots/config.ini` (INI — py3.10 has no tomllib; deliberately no project-local file); `set_default` backs `config set` |
+| `_dotenv.py` | dependency-free `.env` parsing and working-directory auto-loading with real environment variables taking precedence |
 | `_setup.py` | the `inspect-robots setup` wizard (plans 0009 and 0011): IO-injected prompts for `[defaults]`, plugin-declared V4L2/CAN/serial device slots with unplug-to-identify and CAN udev guidance, fallback camera discovery, headless-rerun warning; renders config.ini itself (comments survive) and carries unmanaged sections/keys through raw |
 | `mock/` | dependency-free `CubePick` world + scripted/random/noop policies |
 

--- a/src/inspect_robots/_dotenv.py
+++ b/src/inspect_robots/_dotenv.py
@@ -28,11 +28,15 @@ def read_dotenv(path: Path) -> dict[str, str]:
         if not key:
             continue
         value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-            value = value[1:-1]
+        if value[:1] in {"'", '"'} and (closing := value.find(value[0], 1)) != -1:
+            # python-dotenv semantics: a quoted value ends at the matching
+            # quote and keeps "#" literally; anything after the closing quote
+            # (typically a comment) is ignored. An unmatched opening quote
+            # falls through and is kept literally.
+            value = value[1:closing]
         else:
             # python-dotenv semantics: an unquoted value ends at the first
-            # whitespace-preceded "#"; quoted values keep "#" literally.
+            # whitespace-preceded "#".
             value = re.split(r"\s#", value, maxsplit=1)[0].rstrip()
         parsed[key] = value
     return parsed

--- a/src/inspect_robots/_dotenv.py
+++ b/src/inspect_robots/_dotenv.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import MutableMapping
 from pathlib import Path
 
@@ -9,8 +10,8 @@ from pathlib import Path
 def read_dotenv(path: Path) -> dict[str, str]:
     """Return supported key-value pairs, or an empty mapping when the file is unreadable."""
     try:
-        contents = path.read_text(encoding="utf-8")
-    except OSError:
+        contents = path.read_text(encoding="utf-8-sig")
+    except (OSError, UnicodeDecodeError):
         return {}
 
     parsed: dict[str, str] = {}
@@ -29,6 +30,10 @@ def read_dotenv(path: Path) -> dict[str, str]:
         value = value.strip()
         if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
             value = value[1:-1]
+        else:
+            # python-dotenv semantics: an unquoted value ends at the first
+            # whitespace-preceded "#"; quoted values keep "#" literally.
+            value = re.split(r"\s#", value, maxsplit=1)[0].rstrip()
         parsed[key] = value
     return parsed
 

--- a/src/inspect_robots/_dotenv.py
+++ b/src/inspect_robots/_dotenv.py
@@ -1,0 +1,40 @@
+"""Mirror Inspect AI's ``.env`` auto-loading because the core must stay dependency-free."""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from pathlib import Path
+
+
+def read_dotenv(path: Path) -> dict[str, str]:
+    """Return supported key-value pairs, or an empty mapping when the file is unreadable."""
+    try:
+        contents = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+
+    parsed: dict[str, str] = {}
+    for raw_line in contents.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line.removeprefix("export ")
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not key:
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        parsed[key] = value
+    return parsed
+
+
+def init_dotenv(environ: MutableMapping[str, str], path: Path | None = None) -> None:
+    """Add file values only for keys absent from the supplied environment mapping."""
+    dotenv_path = Path(".env") if path is None else path
+    for key, value in read_dotenv(dotenv_path).items():
+        environ.setdefault(key, value)

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -41,6 +41,7 @@ from inspect_robots._defaults import (
     parse_value,
     set_default,
 )
+from inspect_robots._dotenv import init_dotenv
 
 if TYPE_CHECKING:
     from inspect_robots.approver import Approver
@@ -684,6 +685,7 @@ def _apply_instruction_sugar(argv: list[str]) -> list[str]:
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Parse arguments, dispatch one subcommand, and return its process exit code."""
+    init_dotenv(os.environ)
     argv_list = list(argv) if argv is not None else sys.argv[1:]
     parser = build_parser()
     args = parser.parse_args(_apply_instruction_sugar(argv_list))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,9 @@ def _isolate_dotenv(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     ``cli.main()`` loads ``./.env`` on every call; without this fixture a
     developer's real keys would leak into the test process and make
     default-resolution assertions depend on their machine. The dotenv wiring
-    test opts back in by restoring the real ``init_dotenv``.
+    test opts back in by restoring the real ``init_dotenv``. Patching only
+    the ``inspect_robots.cli`` name assumes ``main()`` stays the sole entry
+    point that loads ``.env`` — extend this fixture if another appears.
     """
     import inspect_robots.cli
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Suite-wide fixtures keeping tests hermetic against the developer's machine."""
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_dotenv(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Keep a repo-root ``.env`` out of ``os.environ`` during CLI tests.
+
+    ``cli.main()`` loads ``./.env`` on every call; without this fixture a
+    developer's real keys would leak into the test process and make
+    default-resolution assertions depend on their machine. The dotenv wiring
+    test opts back in by restoring the real ``init_dotenv``.
+    """
+    import inspect_robots.cli
+
+    def _noop(environ: Any, path: Any = None) -> None:
+        return None
+
+    monkeypatch.setattr(inspect_robots.cli, "init_dotenv", _noop)
+    yield

--- a/tests/test_dotenv.py
+++ b/tests/test_dotenv.py
@@ -1,0 +1,88 @@
+"""Tests for dependency-free working-directory dotenv loading."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from inspect_robots._dotenv import init_dotenv, read_dotenv
+
+
+def test_read_dotenv_parses_supported_syntax(tmp_path: Path) -> None:
+    path = tmp_path / ".env"
+    path.write_text(
+        """
+          # indented comment
+        PLAIN = value
+        export EXPORTED=available
+        WITH_EQUALS=first=second
+        SINGLE='single quoted'
+        DOUBLE="double quoted"
+        EMPTY=
+        SAME_ENDS=aba
+        LITERAL_ESCAPE="left\\nright"
+        UNMATCHED='left alone
+        MISSING_EQUALS
+        =empty key
+        DUPLICATE=first
+        DUPLICATE=second
+        """,
+        encoding="utf-8",
+    )
+
+    assert read_dotenv(path) == {
+        "PLAIN": "value",
+        "EXPORTED": "available",
+        "WITH_EQUALS": "first=second",
+        "SINGLE": "single quoted",
+        "DOUBLE": "double quoted",
+        "EMPTY": "",
+        "SAME_ENDS": "aba",
+        "LITERAL_ESCAPE": r"left\nright",
+        "UNMATCHED": "'left alone",
+        "DUPLICATE": "second",
+    }
+
+
+def test_read_dotenv_returns_empty_for_missing_file(tmp_path: Path) -> None:
+    assert read_dotenv(tmp_path / "missing.env") == {}
+
+
+def test_read_dotenv_returns_empty_for_os_error(tmp_path: Path) -> None:
+    assert read_dotenv(tmp_path) == {}
+
+
+def test_init_dotenv_sets_absent_keys_without_overriding_present(tmp_path: Path) -> None:
+    path = tmp_path / ".env"
+    path.write_text("NEW=from-file\nPRESENT=from-file\n", encoding="utf-8")
+    environ = {"PRESENT": "from-environment"}
+
+    init_dotenv(environ, path)
+
+    assert environ == {"NEW": "from-file", "PRESENT": "from-environment"}
+
+
+def test_init_dotenv_uses_working_directory_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / ".env").write_text("FROM_CWD=yes\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    environ: dict[str, str] = {}
+
+    init_dotenv(environ)
+
+    assert environ == {"FROM_CWD": "yes"}
+
+
+def test_cli_main_loads_working_directory_dotenv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sentinel = "INSPECT_ROBOTS_TEST_DOTENV_SENTINEL"
+    (tmp_path / ".env").write_text(f"{sentinel}=loaded\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv(sentinel, raising=False)
+
+    from inspect_robots.cli import main
+
+    assert main(["list"]) == 0
+    assert os.environ[sentinel] == "loaded"

--- a/tests/test_dotenv.py
+++ b/tests/test_dotenv.py
@@ -44,12 +44,41 @@ def test_read_dotenv_parses_supported_syntax(tmp_path: Path) -> None:
     }
 
 
+def test_read_dotenv_strips_unquoted_inline_comments(tmp_path: Path) -> None:
+    path = tmp_path / ".env"
+    path.write_text(
+        'KEY=sk-123 # prod key\nQUOTED="value # kept"\nHASH_VALUE=#not-a-comment\nANCHOR=a#b\n',
+        encoding="utf-8",
+    )
+
+    assert read_dotenv(path) == {
+        "KEY": "sk-123",
+        "QUOTED": "value # kept",
+        "HASH_VALUE": "#not-a-comment",
+        "ANCHOR": "a#b",
+    }
+
+
+def test_read_dotenv_strips_utf8_bom(tmp_path: Path) -> None:
+    path = tmp_path / ".env"
+    path.write_bytes(b"\xef\xbb\xbfANTHROPIC_API_KEY=abc\n")
+
+    assert read_dotenv(path) == {"ANTHROPIC_API_KEY": "abc"}
+
+
 def test_read_dotenv_returns_empty_for_missing_file(tmp_path: Path) -> None:
     assert read_dotenv(tmp_path / "missing.env") == {}
 
 
 def test_read_dotenv_returns_empty_for_os_error(tmp_path: Path) -> None:
     assert read_dotenv(tmp_path) == {}
+
+
+def test_read_dotenv_returns_empty_for_undecodable_file(tmp_path: Path) -> None:
+    path = tmp_path / ".env"
+    path.write_bytes(b"KEY=\xff\xfe\n")
+
+    assert read_dotenv(path) == {}
 
 
 def test_init_dotenv_sets_absent_keys_without_overriding_present(tmp_path: Path) -> None:
@@ -80,9 +109,15 @@ def test_cli_main_loads_working_directory_dotenv(
     sentinel = "INSPECT_ROBOTS_TEST_DOTENV_SENTINEL"
     (tmp_path / ".env").write_text(f"{sentinel}=loaded\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
-    monkeypatch.delenv(sentinel, raising=False)
+    # setenv-then-delenv records both operations, so teardown restores absence
+    # (delenv on a missing key records nothing and the value set by main()
+    # would leak into the rest of the session).
+    monkeypatch.setenv(sentinel, "preexisting")
+    monkeypatch.delenv(sentinel)
 
-    from inspect_robots.cli import main
+    import inspect_robots.cli
 
-    assert main(["list"]) == 0
+    monkeypatch.setattr(inspect_robots.cli, "init_dotenv", init_dotenv)
+
+    assert inspect_robots.cli.main(["list"]) == 0
     assert os.environ[sentinel] == "loaded"

--- a/tests/test_dotenv.py
+++ b/tests/test_dotenv.py
@@ -59,6 +59,20 @@ def test_read_dotenv_strips_unquoted_inline_comments(tmp_path: Path) -> None:
     }
 
 
+def test_read_dotenv_quoted_value_followed_by_comment(tmp_path: Path) -> None:
+    path = tmp_path / ".env"
+    path.write_text(
+        'DOUBLE="sk-123" # prod key\nSINGLE=\'sk-456\' # staging\nINNER="a # b" # c\n',
+        encoding="utf-8",
+    )
+
+    assert read_dotenv(path) == {
+        "DOUBLE": "sk-123",
+        "SINGLE": "sk-456",
+        "INNER": "a # b",
+    }
+
+
 def test_read_dotenv_strips_utf8_bom(tmp_path: Path) -> None:
     path = tmp_path / ".env"
     path.write_bytes(b"\xef\xbb\xbfANTHROPIC_API_KEY=abc\n")


### PR DESCRIPTION
## Problem

With `ANTHROPIC_API_KEY` present in `./.env`:

```
$ uv run inspect-robots "place the fork on the plate" --policy agent -P model=anthropic/claude-fable-5
no API key found for model 'anthropic/claude-fable-5'.
```

The agent policy resolves providers from `os.environ` only; nothing in the framework (or `uv run`) loads `.env`, so keys placed there were invisible. Inspect AI, which this framework mirrors, auto-loads `.env` at its entry points, so this is the workflow users expect.

## Fix

- New private `inspect_robots._dotenv`: a dependency-free `.env` parser (`KEY=VALUE`, `#` comments, optional `export` prefix, matching-quote stripping, malformed lines skipped) plus `init_dotenv()`, which applies values from `./.env` without overriding real environment variables. No python-dotenv dep: core stays NumPy-only.
- `cli.py:main()` calls `init_dotenv(os.environ)` before dispatch, so every subcommand (and `load_defaults`, which reads env) sees the values.
- README note and module-map row.

## Verification

- 422 tests pass at 100% coverage; ruff, ruff format, and strict mypy clean.
- End-to-end: with `ANTHROPIC_API_KEY=sk-test-123` in `./.env` and the variable unset in the shell, the same command now gets past provider resolution and reaches api.anthropic.com (the eval log records the expected HTTP 401 for the stub key). Without `.env` it still fails with the guided ConfigError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)