### PR TITLE
fix: surface errored samples in the CLI; all-errored runs report status error (#73)

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -192,7 +192,9 @@ the path of the written log is printed.
 the zero-config section above); `--instruction "..."` replaces `--task` to
 run a single ad-hoc scene.
 
-The exit code is `0` on a successful eval, `1` otherwise.
+The exit code is `0` on a successful eval, `1` otherwise. When trials errored,
+the summary shows the count (`trials: 4 (2 errored)`) and lists each errored
+scene; a run in which every trial errored reports `status: error` and exits `1`.
 
 ## `inspect-robots doctor`
 

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -77,6 +77,9 @@ Every error raised from inside a trial carries the partial
 [`TrialRecord`][inspect_robots.rollout.TrialRecord] on its `record` attribute, so the
 steps that did run are delivered to sinks. Errored trials are recorded but
 never scored: a failed trial cannot masquerade as data in the metrics.
+A finished run in which every trial errored ends with `status: "error"` even
+under the default `fail_on_error=False`: a run that scored nothing is not a
+success.
 
 ## The eval log
 

--- a/plans/0001-foundation-design.md
+++ b/plans/0001-foundation-design.md
@@ -591,7 +591,10 @@ RoboInspect mirrors these so Inspect users feel at home:
   of trials error, `x>1`=fail if that *count* error. RoboInspect adopts this verbatim
   for `PolicyError`-class failures. **Robotics addition:** `EmbodimentFault` /
   `SafetyAbort` always halt regardless of `fail_on_error` (hardware safety is not
-  negotiable) — this is the one place RoboInspect deliberately extends Inspect.
+  negotiable). **Second addition (issue #73):** a finished run in which *every*
+  trial errored degrades to `status: "error"` even under `fail_on_error=False` —
+  error tolerance protects surviving data, and a run that scored nothing has
+  none. These are the two places RoboInspect deliberately extends Inspect.
 - **`EvalLog` structure** mirrored: `version` (int), `status`
   (`"started"|"success"|"error"`), `eval` (an `EvalSpec`: task/policy/embodiment/
   created/git/versions), `plan` (resolved config incl. `PolicyConfig`,

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -182,9 +182,11 @@ def test_persistent_non_tool_output_becomes_policy_error(tmp_path: Path) -> None
     logs = ir_eval(
         _task(), _policy(script), CubePickEmbodiment(), log_dir=str(tmp_path), sinks=[sink]
     )
-    # A PolicyError marks the trial errored (never scored); the eval survives.
+    # A PolicyError marks the trial errored (never scored); the eval still
+    # returns a log, and with its only trial errored the log reports "error".
     (sample,) = logs[0].samples
     assert sample.status == "error"
+    assert logs[0].status == "error"
     (record,) = sink.records
     assert record.error is not None and "no tool call" in record.error
 

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -43,7 +43,9 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
   inside a trial carries the partial `TrialRecord` on `exc.record`.
 - `eval()` must always return/persist an `EvalLog` once rollouts have started —
   scorer/reducer failures degrade to an error log, never a crash. Errored
-  trials are recorded (and delivered to sinks) but **never scored**.
+  trials are recorded (and delivered to sinks) but **never scored**. A run in
+  which every trial errored ends with `status == "error"` even under the
+  default `fail_on_error=False`.
 - `eval()` closes embodiments it resolved from registry names ("close what we
   open"); caller-constructed objects are caller-owned.
 - `mock/` and core must never import `rerun`/`torch` at module top.

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -397,23 +397,26 @@ def _prompt_operator(record: TrialRecord, scene: Scene) -> None:
 def _print_run_summary(log: EvalLog, log_path: str) -> None:
     """Print the compact post-run summary and failure diagnostics."""
     failed = log.status != "success"
+    errored_count = log.results.errored_trials
     status_color = _RED if failed else _GREEN
     print(f"{_styled('status:', _CYAN)} {_styled(log.status, status_color)}")
     if failed and log.error is not None:
         print(f"{_styled('error:', _CYAN)} {_styled(log.error, _RED)}")
-    if failed:
+    if failed or errored_count:
+        # Errored scenes are failure context even when the run as a whole
+        # succeeded (issue #73): a partially-errored "success" must be legible.
         for scene in log.samples:
             if scene.status == "error":
                 detail = "" if scene.error in (None, log.error) else f": {scene.error}"
                 print(f"  [{_styled('error', _RED)}] {scene.scene_id}{detail}")
-    print(
-        f"{_styled('scenes:', _CYAN)} {log.results.total_scenes}  "
-        f"trials: {log.results.total_trials}"
-    )
+    trials = f"trials: {log.results.total_trials}"
+    if errored_count:
+        trials += f" ({errored_count} errored)"
+    print(f"{_styled('scenes:', _CYAN)} {log.results.total_scenes}  {trials}")
     for name, value in sorted(log.results.metrics.items()):
         print(f"  {name}: {_styled(f'{value:.4g}', _BOLD)}")
     print(f"{_styled('log:', _CYAN)} {_styled(log_path, _DIM)}")
-    if failed:
+    if failed or errored_count:
         print(_styled(f"hint: inspect-robots inspect {log_path}", _DIM))
 
 
@@ -588,7 +591,10 @@ def _cmd_inspect(path: str) -> int:
     print(f"status:      {log.status}")
     print(f"created:     {log.eval.created}")
     print(f"git:         {log.eval.git_commit}")
-    print(f"scenes:      {log.results.total_scenes}   trials: {log.results.total_trials}")
+    trials = f"trials: {log.results.total_trials}"
+    if log.results.errored_trials:
+        trials += f" ({log.results.errored_trials} errored)"
+    print(f"scenes:      {log.results.total_scenes}   {trials}")
     print("metrics:")
     for name, value in sorted(log.results.metrics.items()):
         print(f"  {name}: {value:.4g}")

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -138,6 +138,9 @@ def eval(
     as data in the metrics; it stays visible via ``SceneResult.status`` and an
     empty entry in ``SceneResult.epochs``.
 
+    A run in which **every** trial errored (nothing was scored) always ends
+    with ``status == "error"``, regardless of ``fail_on_error``.
+
     When ``store_frames`` is set, camera frames are streamed to
     ``<log_dir>/frames`` as binary side-cars (R5) rather than kept in memory.
 
@@ -268,6 +271,7 @@ def _run_eval(
     status = "success"
     error: str | None = None
     error_count = 0
+    errored_trials = 0
 
     halted = False
     stopped = False
@@ -326,6 +330,7 @@ def _run_eval(
                     # masquerade as data (e.g. an inf min-distance poisoning
                     # the metric mean). It stays visible via scene status.
                     epoch_dicts.append({})
+                    errored_trials += 1
                     judgements.append(None)
                 else:
                     if before_scoring is not None:
@@ -386,6 +391,13 @@ def _run_eval(
         if stopped:
             break
 
+    if status == "success" and total_trials > 0 and errored_trials == total_trials:
+        # Every trial errored: there is no surviving data for fail_on_error's
+        # flaky-trial tolerance to protect, and a "success" log would hide a
+        # total failure (issue #73).
+        status = "error"
+        error = f"all {total_trials} trial(s) errored; nothing was scored"
+
     metrics: dict[str, float] = {}
     for scorer in scorers:
         vals = [sr.reduced[scorer.name] for sr in scene_results if scorer.name in sr.reduced]
@@ -408,6 +420,7 @@ def _run_eval(
             total_scenes=len(scene_results),
             total_trials=total_trials,
             metrics=metrics,
+            errored_trials=errored_trials,
         ),
         stats=stats,
         samples=tuple(scene_results),

--- a/src/inspect_robots/log.py
+++ b/src/inspect_robots/log.py
@@ -74,8 +74,9 @@ class EvalResults:
     total_scenes: int
     total_trials: int
     metrics: dict[str, float] = field(default_factory=dict)
-    # Trials recorded but never scored (their epoch entries are empty). The
-    # default keeps logs written before this field existed readable.
+    # Trials recorded but never scored (visible per-scene as empty entries in
+    # ``SceneResult.epochs``). The default keeps logs written before this
+    # field existed readable.
     errored_trials: int = 0
 
 

--- a/src/inspect_robots/log.py
+++ b/src/inspect_robots/log.py
@@ -74,6 +74,9 @@ class EvalResults:
     total_scenes: int
     total_trials: int
     metrics: dict[str, float] = field(default_factory=dict)
+    # Trials recorded but never scored (their epoch entries are empty). The
+    # default keeps logs written before this field existed readable.
+    errored_trials: int = 0
 
 
 @dataclass(frozen=True)

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -63,6 +63,14 @@ def test_eval_log_round_trips_through_dict() -> None:
     assert restored.results.metrics["success_at_end"] == 1.0
 
 
+def test_results_without_errored_trials_reads_with_default() -> None:
+    """Logs written before EvalResults.errored_trials existed must still read."""
+    data = _golden_log().to_dict()
+    data["results"].pop("errored_trials", None)
+    log = EvalLog.from_dict(data)
+    assert log.results.errored_trials == 0
+
+
 def test_golden_log_reads_back(tmp_path: Path) -> None:
     # A log written today must remain readable: persist, then read.
     path = tmp_path / "golden.json"

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from inspect_robots import eval, eval_set
-from inspect_robots.errors import ConfigError, EmbodimentFault, PolicyError
+from inspect_robots.errors import ConfigError, EmbodimentFault, PolicyError, SafetyAbort
 from inspect_robots.eval import _git_commit
 from inspect_robots.log import EvalLog
 from inspect_robots.logging.sink import NullSink
@@ -136,6 +136,30 @@ def test_errored_trials_are_not_scored(tmp_path: Path) -> None:
     assert scene.epochs[1] == {}  # ...as an empty (unscored) epoch entry
     # ...but the metric comes from the good epoch only: finite, not inf.
     assert np.isfinite(log.results.metrics["min_distance_to_goal"])
+    assert log.status == "success"  # data survived: partials stay tolerated
+    assert log.results.errored_trials == 1
+    assert log.results.total_trials == 2
+
+
+def test_all_trials_errored_degrades_to_error_status(tmp_path: Path) -> None:
+    # Issue #73: a run that scored nothing must not report success.
+    (log,) = eval(_task(), _BoomPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path))
+    assert log.status == "error"
+    assert log.error == "all 1 trial(s) errored; nothing was scored"
+    assert log.results.errored_trials == log.results.total_trials == 1
+    assert log.results.metrics == {}
+
+
+def test_halt_error_message_is_not_overwritten_by_all_errored(tmp_path: Path) -> None:
+    # A SafetyAbort halt already sets status/error; the all-errored degrade
+    # must not clobber the more specific message.
+    class _AbortPolicy(ScriptedPolicy):
+        def reset(self, scene: Scene) -> None:
+            raise SafetyAbort("operator hit the e-stop")
+
+    (log,) = eval(_task(), _AbortPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path))
+    assert log.status == "error"
+    assert log.error == "SafetyAbort: operator hit the e-stop"  # not the all-errored message
 
 
 # --------------------------------------------------------------------------- #
@@ -155,7 +179,7 @@ def test_policy_error_partial_record_reaches_sinks() -> None:
 
     sink = _RecordingSink()
     (log,) = eval(_task(), _BoomLaterPolicy(), CubePickEmbodiment(), sinks=[sink])
-    assert log.status == "success"  # fail_on_error=False: the eval itself ran
+    assert log.status == "error"  # its only trial errored (issue #73)
     (record,) = sink.records
     assert record.status == "error"
     assert len(record.steps) == 4  # the steps walked before the failure survive
@@ -333,7 +357,7 @@ def test_policy_error_without_attached_record_synthesizes_one(tmp_path: Path) ->
         sinks=[sink],
         controller=_EagerErrorController(),
     )
-    assert log.status == "success"  # fail_on_error=False
+    assert log.status == "error"  # its only trial errored (issue #73)
     (record,) = sink.records
     assert record.status == "error"
 

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -198,6 +198,101 @@ def test_cli_run_prints_distinct_scene_error(
     assert "[error] scene-0: PolicyError: policy reset exploded" in out
 
 
+def test_cli_all_errored_run_exits_nonzero_with_diagnostics(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Issue #73: a run in which every trial errored must not look healthy.
+    from inspect_robots.registry import policy as policy_decorator
+    from inspect_robots.scene import Scene
+
+    class _AlwaysBoomPolicy(ScriptedPolicy):
+        def reset(self, scene: Scene) -> None:
+            raise RuntimeError("invalid API key")
+
+    name = "always-boom-for-cli-test"
+    policy_decorator(name)(_AlwaysBoomPolicy)
+    try:
+        rc = main(
+            [
+                "run",
+                "--task",
+                "cubepick-reach",
+                "-T",
+                "num_scenes=1",
+                "--policy",
+                name,
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["policy"].pop(name)
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "status: error" in out
+    assert "error: all 1 trial(s) errored; nothing was scored" in out
+    assert "[error] scene-0: PolicyError: invalid API key" in out
+    assert "trials: 1 (1 errored)" in out
+    (written,) = tmp_path.glob("*.json")
+    assert f"hint: inspect-robots inspect {written}" in out
+    # And `inspect` on the written log shows the same headline facts.
+    assert main(["inspect", str(written)]) == 1
+    out = capsys.readouterr().out
+    assert "status:      error" in out
+    assert "trials: 1 (1 errored)" in out
+
+
+def test_cli_partial_errors_stay_success_but_are_visible(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Issue #73: errored trials in an overall-success run must still be legible.
+    from inspect_robots.registry import policy as policy_decorator
+    from inspect_robots.scene import Scene
+
+    class _BoomOnSecondScenePolicy(ScriptedPolicy):
+        def __init__(self) -> None:
+            super().__init__()
+            self._resets = 0
+
+        def reset(self, scene: Scene) -> None:
+            self._resets += 1
+            if self._resets == 2:
+                raise RuntimeError("policy reset exploded")
+            super().reset(scene)
+
+    name = "boom-on-second-scene-for-cli-test"
+    policy_decorator(name)(_BoomOnSecondScenePolicy)
+    try:
+        rc = main(
+            [
+                "run",
+                "--task",
+                "cubepick-reach",
+                "-T",
+                "num_scenes=2",
+                "--policy",
+                name,
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["policy"].pop(name)
+
+    assert rc == 0  # data survived; library semantics unchanged for partials
+    out = capsys.readouterr().out
+    assert "status: success" in out
+    assert "trials: 2 (1 errored)" in out
+    assert "[error] scene-1: PolicyError: policy reset exploded" in out
+    (written,) = tmp_path.glob("*.json")
+    assert f"hint: inspect-robots inspect {written}" in out
+
+
 def test_cli_run_epochs_fail_on_error_store_frames(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
Closes #73.

A run in which every trial errored used to print `status: success` and exit 0; the failure was only visible by opening the log file. Found while verifying #72 (a stub API key produced a green-looking run).

## What changed

**Library (`eval.py`, `log.py`)**
- New `EvalResults.errored_trials` field counting trials recorded but never scored. Additive with a default, so no schema-version bump: logs written before the field read back with 0 (same precedent as `SceneResult.operator_judgements`).
- A finished run in which every trial errored now degrades to `status: "error"` with `all N trial(s) errored; nothing was scored`. Rationale: `fail_on_error=False` exists so long hardware runs survive flaky trials, but when nothing was scored there is no surviving data to protect. Halt errors (`EmbodimentFault`/`SafetyAbort`) and `fail_on_error` threshold messages take precedence and are never clobbered.
- This is a deliberate second extension of Inspect's `fail_on_error` semantics, so `plans/0001-foundation-design.md` §11 (binding) is amended alongside the code rather than silently contradicted.

**CLI (`cli.py`)**
- Run summary shows `trials: N (M errored)` whenever M > 0, and prints the per-scene `[error]` lines plus the `inspect` hint even when the overall status is success (partially-errored runs are now legible).
- `inspect-robots inspect` shows the errored count too.
- Exit code needed no change: `run` already keys off `log.status`, which now flips for the all-errored case. Direction 2 from the issue (`--fail-on-error`) already shipped earlier.

**Docs**: `docs/guide/concepts.md`, `docs/guide/cli.md`, package `CLAUDE.md` invariants.

## Verification

Beyond the test suite (430 passed, coverage 100%, ruff/mypy clean, agent-plugin suite green), the issue's exact repro was run end-to-end: `inspect-robots "place the fork on the plate" --policy agent -P model=... --embodiment cubepick` with an invalid `ANTHROPIC_API_KEY` now prints `status: error`, the 401 message per scene, `trials: 1 (1 errored)`, and exits 1. A healthy `cubepick-reach` run's output is byte-identical to before, and a real log written on main before this change reads back fine (`errored_trials` defaults to 0).


## Behavioral note for library callers

`eval_set`'s `success` flag (True iff every log has `status == "success"`) now returns False when a task's run errored on every trial, consistent with the status change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
