### PR TITLE
feat: record trial termination reasons in the eval log and surface max_steps timeouts in the CLI

### DIFF
--- a/plans/0012-surface-timeout.md
+++ b/plans/0012-surface-timeout.md
@@ -8,9 +8,10 @@ notice, is_adhoc plumbing, denominator and rate-approximation notes)
 ## Problem
 
 A real-robot run that hits the rollout step limit currently looks identical to a
-clean finish. Observed on a yam ad-hoc run (`logs/adhoc_7425493a.json`,
-`total_steps: 1200` at 10 Hz): the episode was cut off by `max_steps`, yet the
-CLI printed `status: success` and the eval log recorded nothing about the
+clean finish. Observed on a yam ad-hoc run (`adhoc_7425493a.json` in the
+operator's `inspect-robots-yam` checkout, `total_steps: 1200` at
+`control_hz: 10.0`): the episode was cut off by `max_steps`, yet the CLI
+printed `status: success` and the eval log recorded nothing about the
 truncation.
 
 The information exists and then gets dropped:
@@ -84,9 +85,12 @@ The information exists and then gets dropped:
     part unless both are present, numeric (`isinstance(x, (int, float))` —
     `None > 0` raises), and positive. The embodiment rate is an
     approximation: R1's precedence lets a chunk or registered task override
-    the effective rate, which the `~` hedge covers; ad-hoc tasks (the
-    motivating case) never set `control_hz`, so there it is exact. Do not add
-    more `EvalSpec` fields for this.
+    the effective rate, and the loop does no pacing yet (wall-clock seconds
+    are only real for `SELF_PACED` embodiments like yam) — the `~` hedge
+    covers both. Do not add more `EvalSpec` fields for this.
+  - When `log.eval.max_steps` is `None` (only reachable via a hand-edited or
+    foreign log read by `inspect`), print the note without the parenthetical
+    entirely — never `max_steps=None`.
   - `log.status` semantics are unchanged: a truncated run is still
     `success` (no errors); the note is advisory.
   - The `config set` hint applies to ad-hoc runs; registered tasks own their

--- a/plans/0012-surface-timeout.md
+++ b/plans/0012-surface-timeout.md
@@ -1,7 +1,9 @@
 # Surface rollout timeouts in the eval log and CLI
 
 Date: 2026-07-14
-Status: approved (log design and CLI surface options confirmed by Jay)
+Status: approved (log design and CLI surface options confirmed by Jay);
+revised after subagent critique round 1 (parallel-tuple fix, operator-prompt
+notice, is_adhoc plumbing, denominator and rate-approximation notes)
 
 ## Problem
 
@@ -40,10 +42,17 @@ The information exists and then gets dropped:
 ### `log.py`
 
 - `SceneResult.termination_reasons: tuple[str | None, ...] = ()` — strictly
-  parallel to `epochs`: one entry per scored trial, holding
+  parallel to `epochs`: one entry per recorded trial, holding
   `TrialRecord.termination_reason` (`"max_steps"`, an embodiment reason such
   as `"success"`/`"failure"`, a policy stop reason, or `None`). Errored trials
-  are not scored and get no entry, matching `epochs`/`operator_judgements`.
+  contribute a `None` entry, exactly like `operator_judgements` (and like the
+  `{}` entry `epochs` gets): `eval()` appends in both the errored and scored
+  branches, which is safe because `_record_failure` never sets
+  `termination_reason`, so error records always carry `None`.
+- The `"max_steps"` value is a stringly-typed sentinel, not a reserved word: a
+  policy stop or embodiment reason could collide with it. Accepted — a
+  collision would still mean "step budget exhausted" to an operator; do not
+  harden the CLI counting against it.
 - `EvalSpec.max_steps: int | None = None` — the task horizon, so a log is
   self-describing about the limit that produced a `"max_steps"` reason.
 - `EvalLog.from_dict` coerces `termination_reasons` back to a tuple with a
@@ -52,14 +61,18 @@ The information exists and then gets dropped:
 
 ### `eval.py`
 
-- Collect `record.termination_reason` alongside `record.operator_judgement`
-  in the scored-trial branch; pass the tuple into `SceneResult`.
+- Collect `record.termination_reason` for every recorded trial — errored and
+  scored branches both — keeping the tuple positionally aligned with
+  `epochs`; pass it into `SceneResult`.
 - Pass `task.max_steps` into `EvalSpec`.
 
 ### `cli.py`
 
-- `_print_run_summary()`: count scored trials whose reason is `"max_steps"`
-  across all samples. When nonzero, print (yellow, before the metrics):
+- `_print_run_summary()`: count trials whose reason is `"max_steps"` across
+  all samples (N), over `log.results.total_trials` (M — includes errored
+  trials, so "1/2 trials" with one errored and one timed-out trial reads
+  honestly). When N > 0, print (yellow, before the metrics; add a
+  `_YELLOW = "33"` constant next to the existing `_styled` colors):
 
   ```
   note: 1/1 trials hit the step limit before terminating (max_steps=1200, ~120s at 10 Hz)
@@ -68,15 +81,27 @@ The information exists and then gets dropped:
 
   - The seconds figure uses `log.eval.max_steps` and
     `log.eval.embodiment_info["control_hz"]`; omit the parenthetical seconds
-    part when either is missing or the rate is not a positive number.
+    part unless both are present, numeric (`isinstance(x, (int, float))` —
+    `None > 0` raises), and positive. The embodiment rate is an
+    approximation: R1's precedence lets a chunk or registered task override
+    the effective rate, which the `~` hedge covers; ad-hoc tasks (the
+    motivating case) never set `control_hz`, so there it is exact. Do not add
+    more `EvalSpec` fields for this.
   - `log.status` semantics are unchanged: a truncated run is still
     `success` (no errors); the note is advisory.
   - The `config set` hint applies to ad-hoc runs; registered tasks own their
-    horizon, so when `log.eval.task != "adhoc"` the hint line instead says the
-    task defines its own `max_steps`.
+    horizon, so the hint line instead says the task defines its own
+    `max_steps`. `_cmd_run` passes its `is_adhoc` flag into
+    `_print_run_summary` (the log's task name is not a reliable signal).
+- `_prompt_operator()`: when the trial ended truncated with reason
+  `"max_steps"`, print a one-line notice before asking for the verdict — the
+  operator otherwise judges success without knowing the episode was cut off
+  (the prompt runs via `before_scoring`, well before the run summary).
 - `_cmd_inspect()`: per scene, when any termination reason is `"max_steps"`,
   append a short `(N/M trials hit max_steps)` marker to the scene line, and
-  reuse the same note line at the top when the count is nonzero.
+  reuse the same note line at the top when the count is nonzero. Here the
+  ad-hoc signal falls back to `log.eval.task == "adhoc"` — a name heuristic;
+  accepted limitation since `Task.metadata` is not persisted in the log.
 
 ### Out of scope
 
@@ -94,10 +119,12 @@ TDD; the core gate is 100% coverage, mypy strict, ruff. New/updated tests:
   of a v1 dict missing both fields defaults them (golden/back-compat test).
 - `eval.py`: an eval whose trial truncates at `max_steps` produces a
   `SceneResult` carrying `("max_steps",)` and an `EvalSpec.max_steps` equal to
-  the task horizon; errored trials contribute no entry.
+  the task horizon; errored trials contribute a `None` entry, keeping
+  `termination_reasons` the same length as `epochs`.
 - `cli.py`: run summary prints the note + hint when a reason is
-  `"max_steps"` (with and without a usable `control_hz`; adhoc vs registered
-  task hint); prints nothing extra otherwise; `inspect` output shows the
-  marker.
+  `"max_steps"` (with and without a usable `control_hz`, including
+  `control_hz=None`; adhoc vs registered task hint); prints nothing extra
+  otherwise; operator prompt shows the truncation notice; `inspect` output
+  shows the marker.
 - `tests/test_api_snapshot.py`: only if the public surface changes (fields on
   existing dataclasses should not alter `__all__`).

--- a/plans/0012-surface-timeout.md
+++ b/plans/0012-surface-timeout.md
@@ -1,0 +1,103 @@
+# Surface rollout timeouts in the eval log and CLI
+
+Date: 2026-07-14
+Status: approved (log design and CLI surface options confirmed by Jay)
+
+## Problem
+
+A real-robot run that hits the rollout step limit currently looks identical to a
+clean finish. Observed on a yam ad-hoc run (`logs/adhoc_7425493a.json`,
+`total_steps: 1200` at 10 Hz): the episode was cut off by `max_steps`, yet the
+CLI printed `status: success` and the eval log recorded nothing about the
+truncation.
+
+The information exists and then gets dropped:
+
+1. `rollout()` sets `TrialRecord.truncated = True` and
+   `termination_reason = "max_steps"` when the loop exhausts the horizon
+   (`rollout.py`, the `while` loop's `else` arm).
+2. `eval()` builds `SceneResult` from the trial records but discards
+   `truncated` / `termination_reason` (`eval.py`, `SceneResult(...)`).
+3. `_print_run_summary()` in `cli.py` only reads `log.status`, which means
+   "no errors", so the run reports success.
+
+## Requirements
+
+1. The eval log records, per trial, why the trial ended (so a timeout is
+   visible in the persisted artifact).
+2. The post-run CLI summary tells the operator when trials hit the step limit,
+   including the limit in steps and (when the control rate is known) seconds.
+3. The summary reminds the operator how to raise the limit: `--max-steps N` on
+   ad-hoc runs, or `inspect-robots config set max_steps N`.
+4. `inspect-robots inspect <log>` surfaces the same information for logs read
+   back later.
+5. Old logs (schema v1, written before these fields) keep reading back
+   without error; schema version stays 1 (additive change, same pattern as
+   `SceneResult.operator_judgements`).
+
+## Design
+
+### `log.py`
+
+- `SceneResult.termination_reasons: tuple[str | None, ...] = ()` — strictly
+  parallel to `epochs`: one entry per scored trial, holding
+  `TrialRecord.termination_reason` (`"max_steps"`, an embodiment reason such
+  as `"success"`/`"failure"`, a policy stop reason, or `None`). Errored trials
+  are not scored and get no entry, matching `epochs`/`operator_judgements`.
+- `EvalSpec.max_steps: int | None = None` — the task horizon, so a log is
+  self-describing about the limit that produced a `"max_steps"` reason.
+- `EvalLog.from_dict` coerces `termination_reasons` back to a tuple with a
+  `()` default, and `EvalSpec` gains its field with a `None` default, so
+  logs written before this change still read (newer reads older).
+
+### `eval.py`
+
+- Collect `record.termination_reason` alongside `record.operator_judgement`
+  in the scored-trial branch; pass the tuple into `SceneResult`.
+- Pass `task.max_steps` into `EvalSpec`.
+
+### `cli.py`
+
+- `_print_run_summary()`: count scored trials whose reason is `"max_steps"`
+  across all samples. When nonzero, print (yellow, before the metrics):
+
+  ```
+  note: 1/1 trials hit the step limit before terminating (max_steps=1200, ~120s at 10 Hz)
+  hint: raise it with --max-steps N or: inspect-robots config set max_steps N
+  ```
+
+  - The seconds figure uses `log.eval.max_steps` and
+    `log.eval.embodiment_info["control_hz"]`; omit the parenthetical seconds
+    part when either is missing or the rate is not a positive number.
+  - `log.status` semantics are unchanged: a truncated run is still
+    `success` (no errors); the note is advisory.
+  - The `config set` hint applies to ad-hoc runs; registered tasks own their
+    horizon, so when `log.eval.task != "adhoc"` the hint line instead says the
+    task defines its own `max_steps`.
+- `_cmd_inspect()`: per scene, when any termination reason is `"max_steps"`,
+  append a short `(N/M trials hit max_steps)` marker to the scene line, and
+  reuse the same note line at the top when the count is nonzero.
+
+### Out of scope
+
+- The yam plugin's live countdown showing the horizon (`t = 42s / 120s`)
+  requires setting the `max_steps_hint` embodiment arg in the operator's
+  config; that is a config/docs follow-up in the `inspect-robots-yam` repo,
+  not a core change.
+- Changing `EvalLog.status` or scoring semantics for truncated trials.
+
+## Testing
+
+TDD; the core gate is 100% coverage, mypy strict, ruff. New/updated tests:
+
+- `log.py`: round-trip with `termination_reasons` and `max_steps`; read-back
+  of a v1 dict missing both fields defaults them (golden/back-compat test).
+- `eval.py`: an eval whose trial truncates at `max_steps` produces a
+  `SceneResult` carrying `("max_steps",)` and an `EvalSpec.max_steps` equal to
+  the task horizon; errored trials contribute no entry.
+- `cli.py`: run summary prints the note + hint when a reason is
+  `"max_steps"` (with and without a usable `control_hz`; adhoc vs registered
+  task hint); prints nothing extra otherwise; `inspect` output shows the
+  marker.
+- `tests/test_api_snapshot.py`: only if the public surface changes (fields on
+  existing dataclasses should not alter `__all__`).

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -413,10 +413,12 @@ def _print_step_limit_notice(log: EvalLog, is_adhoc: bool) -> None:
 
     note = f"note: {count}/{log.results.total_trials} trials hit the step limit before terminating"
     max_steps = log.eval.max_steps
-    if max_steps is not None:
+    # Guards below reject bool/str values a hand-edited log can smuggle past
+    # from_dict (bool is an int subclass, so isinstance alone lets True in).
+    if isinstance(max_steps, int) and not isinstance(max_steps, bool):
         parenthetical = f"max_steps={max_steps}"
         rate = log.eval.embodiment_info.get("control_hz")
-        if isinstance(rate, (int, float)) and rate > 0:
+        if isinstance(rate, (int, float)) and not isinstance(rate, bool) and rate > 0:
             parenthetical += f", ~{max_steps / rate:g}s at {rate:g} Hz"
         note += f" ({parenthetical})"
     print(_styled(note, _YELLOW))

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -68,6 +68,7 @@ _DIM = "2"
 _CYAN = "36"
 _GREEN = "32"
 _RED = "31"
+_YELLOW = "33"
 
 
 _KIND_BY_PLURAL = {
@@ -381,6 +382,8 @@ def _prompt_operator(record: TrialRecord, scene: Scene) -> None:
         )
         print(f"operator verdict adopted from embodiment: {record.termination_reason}")
         return
+    if record.truncated and record.termination_reason == "max_steps":
+        print("note: this trial hit the step limit before terminating")
     while True:
         try:
             answer = input(_PROMPT).strip().lower()
@@ -395,7 +398,36 @@ def _prompt_operator(record: TrialRecord, scene: Scene) -> None:
     record.events.append(operator_event(t=len(record.steps), verdict=answer))
 
 
-def _print_run_summary(log: EvalLog, log_path: str) -> None:
+def _step_limit_count(log: EvalLog) -> int:
+    """Count recorded trials whose termination reason is the step horizon."""
+    return sum(
+        reason == "max_steps" for scene in log.samples for reason in scene.termination_reasons
+    )
+
+
+def _print_step_limit_notice(log: EvalLog, is_adhoc: bool) -> None:
+    """Print the shared timeout note and the horizon-ownership hint when needed."""
+    count = _step_limit_count(log)
+    if count == 0:
+        return
+
+    note = f"note: {count}/{log.results.total_trials} trials hit the step limit before terminating"
+    max_steps = log.eval.max_steps
+    if max_steps is not None:
+        parenthetical = f"max_steps={max_steps}"
+        rate = log.eval.embodiment_info.get("control_hz")
+        if isinstance(rate, (int, float)) and rate > 0:
+            parenthetical += f", ~{max_steps / rate:g}s at {rate:g} Hz"
+        note += f" ({parenthetical})"
+    print(_styled(note, _YELLOW))
+    if is_adhoc:
+        hint = "hint: raise it with --max-steps N or: inspect-robots config set max_steps N"
+    else:
+        hint = f"hint: task {log.eval.task!r} defines its own max_steps"
+    print(_styled(hint, _DIM))
+
+
+def _print_run_summary(log: EvalLog, log_path: str, is_adhoc: bool) -> None:
     """Print the compact post-run summary and failure diagnostics."""
     failed = log.status != "success"
     errored_count = log.results.errored_trials
@@ -410,6 +442,7 @@ def _print_run_summary(log: EvalLog, log_path: str) -> None:
             if scene.status == "error":
                 detail = "" if scene.error in (None, log.error) else f": {scene.error}"
                 print(f"  [{_styled('error', _RED)}] {scene.scene_id}{detail}")
+    _print_step_limit_notice(log, is_adhoc)
     trials = f"trials: {log.results.total_trials}"
     if errored_count:
         trials += f" ({errored_count} errored)"
@@ -578,7 +611,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         # here and eval() can raise, and that must not leak the embodiment.
         embodiment.close()
     log = logs[0]
-    _print_run_summary(log, str(sink.path))
+    _print_run_summary(log, str(sink.path), is_adhoc)
     return 0 if log.status == "success" else 1
 
 
@@ -586,6 +619,7 @@ def _cmd_inspect(path: str) -> int:
     from inspect_robots import read_eval_log
 
     log = read_eval_log(path)
+    _print_step_limit_notice(log, log.eval.task == "adhoc")
     print(f"task:        {log.eval.task}")
     print(f"policy:      {log.eval.policy}")
     print(f"embodiment:  {log.eval.embodiment}")
@@ -602,7 +636,11 @@ def _cmd_inspect(path: str) -> int:
     print("scenes:")
     for scene in log.samples:
         reduced = "  ".join(f"{k}={v:.4g}" for k, v in sorted(scene.reduced.items()))
-        print(f"  [{scene.status}] {scene.scene_id}: {reduced}")
+        step_limit_count = sum(reason == "max_steps" for reason in scene.termination_reasons)
+        details = [reduced] if reduced else []
+        if step_limit_count:
+            details.append(f"({step_limit_count}/{len(scene.epochs)} trials hit max_steps)")
+        print(f"  [{scene.status}] {scene.scene_id}: {'  '.join(details)}")
     if log.error:
         print(f"error: {log.error}")
     return 0 if log.status == "success" else 1

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -258,6 +258,7 @@ def _run_eval(
             "capabilities": sorted(embodiment.info.capabilities),
         },
         seed=seed,
+        max_steps=task.max_steps,
     )
     bus.on_eval_start(spec)
 
@@ -279,6 +280,7 @@ def _run_eval(
         per_scorer_scores: dict[str, list[Score]] = {s.name: [] for s in scorers}
         epoch_dicts: list[dict[str, float]] = []
         judgements: list[str | None] = []
+        termination_reasons: list[str | None] = []
         scene_status = "success"
         scene_error: str | None = None
 
@@ -332,6 +334,7 @@ def _run_eval(
                     epoch_dicts.append({})
                     errored_trials += 1
                     judgements.append(None)
+                    termination_reasons.append(record.termination_reason)
                 else:
                     if before_scoring is not None:
                         # The only trials the hook sees are the ones scorers
@@ -345,6 +348,7 @@ def _run_eval(
                         epoch_values[scorer.name] = value_to_float(score.value)
                     epoch_dicts.append(epoch_values)
                     judgements.append(record.operator_judgement)
+                    termination_reasons.append(record.termination_reason)
                 bus.on_trial_end(record)
 
             if halted:
@@ -386,6 +390,7 @@ def _run_eval(
                 error=scene_error,
                 instruction=scene.instruction,
                 operator_judgements=tuple(judgements),
+                termination_reasons=tuple(termination_reasons),
             )
         )
         if stopped:

--- a/src/inspect_robots/log.py
+++ b/src/inspect_robots/log.py
@@ -24,7 +24,7 @@ SCHEMA_VERSION = 1
 
 @dataclass(frozen=True)
 class EvalSpec:
-    """Top-level identity of an eval: what was run, with what, when."""
+    """Top-level identity and configured horizon of a reproducible eval."""
 
     task: str
     policy: str
@@ -35,6 +35,7 @@ class EvalSpec:
     policy_config: dict[str, Any] = field(default_factory=dict)
     embodiment_info: dict[str, Any] = field(default_factory=dict)
     seed: int | None = None
+    max_steps: int | None = None
 
 
 @dataclass(frozen=True)
@@ -65,6 +66,9 @@ class SceneResult:
     # trial, ``None`` when the trial errored or no judgement was captured.
     # Defaults keep logs written before these fields existed readable.
     operator_judgements: tuple[str | None, ...] = ()
+    # Strictly parallel to ``epochs``: why each recorded trial ended, or
+    # ``None`` for errored trials. The default keeps older schema-v1 logs readable.
+    termination_reasons: tuple[str | None, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -115,6 +119,7 @@ class EvalLog:
             # written before ``operator_judgements`` existed (newer reads older).
             sample["epochs"] = tuple(sample.get("epochs", ()))
             sample["operator_judgements"] = tuple(sample.get("operator_judgements", ()))
+            sample["termination_reasons"] = tuple(sample.get("termination_reasons", ()))
             samples.append(SceneResult(**sample))
         return cls(
             version=data["version"],

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -35,6 +35,7 @@ def _golden_log() -> EvalLog:
             inspect_robots_version="0.0.0",
             git_commit="deadbeef",
             seed=0,
+            max_steps=1200,
         ),
         results=EvalResults(total_scenes=1, total_trials=1, metrics={"success_at_end": 1.0}),
         stats=EvalStats(
@@ -51,6 +52,7 @@ def _golden_log() -> EvalLog:
                 epochs=({"success_at_end": 1.0},),
                 instruction="reach the cube",
                 operator_judgements=("yes",),
+                termination_reasons=("success",),
             ),
         ),
     )
@@ -81,21 +83,26 @@ def test_golden_log_reads_back(tmp_path: Path) -> None:
     assert restored.samples[0].scene_id == "s0"
     assert restored.samples[0].instruction == "reach the cube"
     assert restored.samples[0].operator_judgements == ("yes",)
+    assert restored.samples[0].termination_reasons == ("success",)
+    assert restored.eval.max_steps == 1200
 
 
-def test_pre_instruction_log_without_new_scene_fields_reads_back(tmp_path: Path) -> None:
-    # Logs written before SceneResult grew instruction/operator_judgements
-    # must stay readable at the same schema version (newer reads older).
+def test_v1_log_without_additive_fields_reads_back(tmp_path: Path) -> None:
+    # Older schema-v1 logs missing additive fields must remain readable.
     data = _golden_log().to_dict()
+    del data["eval"]["max_steps"]
     for sample in data["samples"]:
         del sample["instruction"]
         del sample["operator_judgements"]
+        del sample["termination_reasons"]
     path = tmp_path / "old.json"
     path.write_text(json.dumps(data), encoding="utf-8")
     restored = read_eval_log(str(path))
     assert restored.samples[0].reduced == {"success_at_end": 1.0}
     assert restored.samples[0].instruction is None
     assert restored.samples[0].operator_judgements == ()
+    assert restored.samples[0].termination_reasons == ()
+    assert restored.eval.max_steps is None
 
 
 def test_eval_log_and_friends_are_frozen() -> None:
@@ -117,6 +124,8 @@ def test_eval_log_and_friends_are_frozen() -> None:
         log.samples.clear()  # type: ignore[attr-defined]
     with pytest.raises(AttributeError):
         log.samples[0].operator_judgements.append("no")  # type: ignore[attr-defined]
+    with pytest.raises(AttributeError):
+        log.samples[0].termination_reasons.append("failure")  # type: ignore[attr-defined]
 
 
 def test_unsupported_schema_version_rejected() -> None:

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -139,6 +139,14 @@ def test_errored_trials_are_not_scored(tmp_path: Path) -> None:
     assert log.status == "success"  # data survived: partials stay tolerated
     assert log.results.errored_trials == 1
     assert log.results.total_trials == 2
+    assert scene.termination_reasons == ("success", None)
+    assert len(scene.termination_reasons) == len(scene.epochs)
+
+
+def test_step_limit_reason_and_horizon_are_recorded(tmp_path: Path) -> None:
+    (log,) = eval(_task(max_steps=1), ScriptedPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path))
+    assert log.samples[0].termination_reasons == ("max_steps",)
+    assert log.eval.max_steps == 1
 
 
 def test_all_trials_errored_degrades_to_error_status(tmp_path: Path) -> None:

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -106,6 +106,10 @@ def test_halted_eval_with_pass_at_k_reducer_still_writes_log(tmp_path: Path) -> 
     assert log.status == "error"
     assert log.error is not None and "motor stalled" in log.error
     assert log.samples[0].error is not None and "reducer" in log.samples[0].error
+    # The halt path keeps the parallel tuples aligned: the faulted trial gets
+    # a None reason next to its empty epoch entry.
+    assert log.samples[0].termination_reasons == ("success", "success", None)
+    assert len(log.samples[0].termination_reasons) == len(log.samples[0].epochs)
     assert list(tmp_path.glob("*.json"))  # the log reached disk
 
 

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 from typing import ClassVar
@@ -12,7 +13,7 @@ import inspect_robots.cli as cli
 import inspect_robots.registry as reg
 from inspect_robots._defaults import ENV_EMBODIMENT, ENV_POLICY, ENV_SIM_EMBODIMENT
 from inspect_robots.cli import main
-from inspect_robots.log import EvalLog
+from inspect_robots.log import EvalLog, EvalResults, EvalSpec, EvalStats, SceneResult
 from inspect_robots.mock import ScriptedPolicy
 from inspect_robots.registry import registered, resolve
 
@@ -366,6 +367,105 @@ def _read_only_log(log_dir: Path) -> EvalLog:
 
     (path,) = log_dir.glob("*.json")
     return read_eval_log(str(path))
+
+
+def _step_limit_log(
+    *,
+    task: str = "adhoc",
+    reasons: tuple[str | None, ...] = ("max_steps",),
+    max_steps: int | None = 1200,
+    control_hz: object = 10.0,
+) -> EvalLog:
+    return EvalLog(
+        version=1,
+        status="success",
+        eval=EvalSpec(
+            task=task,
+            policy="p",
+            embodiment="e",
+            created="x",
+            inspect_robots_version="0",
+            embodiment_info={"control_hz": control_hz},
+            max_steps=max_steps,
+        ),
+        results=EvalResults(
+            total_scenes=1,
+            total_trials=len(reasons),
+            metrics={"success_at_end": 0.0},
+        ),
+        stats=EvalStats(started_at="a", completed_at="b", duration_s=0.0, total_steps=1),
+        samples=(
+            SceneResult(
+                scene_id="s0",
+                status="success",
+                epochs=tuple({} for _ in reasons),
+                termination_reasons=reasons,
+            ),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("control_hz", "parenthetical"),
+    [
+        (10.0, " (max_steps=1200, ~120s at 10 Hz)"),
+        (None, " (max_steps=1200)"),
+        (0, " (max_steps=1200)"),
+    ],
+)
+def test_run_summary_surfaces_step_limit_for_adhoc_runs(
+    control_hz: object,
+    parenthetical: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    cli._print_run_summary(_step_limit_log(control_hz=control_hz), "run.json", is_adhoc=True)
+    out = capsys.readouterr().out
+    note = f"note: 1/1 trials hit the step limit before terminating{parenthetical}"
+    assert note in out
+    assert out.index(note) < out.index("success_at_end")
+    assert ("hint: raise it with --max-steps N or: inspect-robots config set max_steps N") in out
+
+
+def test_run_summary_uses_registered_task_hint(capsys: pytest.CaptureFixture[str]) -> None:
+    cli._print_run_summary(_step_limit_log(task="registered-task"), "run.json", is_adhoc=False)
+    out = capsys.readouterr().out
+    assert "hint: task 'registered-task' defines its own max_steps" in out
+    assert "--max-steps N" not in out
+
+
+def test_run_summary_omits_step_limit_note_without_truncation(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    cli._print_run_summary(_step_limit_log(reasons=("success",)), "run.json", is_adhoc=True)
+    out = capsys.readouterr().out
+    assert "step limit" not in out
+    assert "raise it" not in out
+
+
+def test_run_summary_omits_parenthetical_without_horizon(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    cli._print_run_summary(_step_limit_log(max_steps=None), "run.json", is_adhoc=True)
+    out = capsys.readouterr().out
+    assert "note: 1/1 trials hit the step limit before terminating\n" in out
+    assert "max_steps=None" not in out
+
+
+def test_inspect_surfaces_step_limit_note_hint_and_scene_marker(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    log = _step_limit_log(reasons=("max_steps", "success"), control_hz=None)
+    path = tmp_path / "timeout.json"
+    path.write_text(json.dumps(log.to_dict()), encoding="utf-8")
+
+    assert main(["inspect", str(path)]) == 0
+
+    out = capsys.readouterr().out
+    assert out.startswith(
+        "note: 1/2 trials hit the step limit before terminating (max_steps=1200)\n"
+    )
+    assert "hint: raise it with --max-steps N" in out
+    assert "[success] s0: (1/2 trials hit max_steps)" in out
 
 
 def test_bare_instruction_runs_adhoc_task_from_env_defaults(
@@ -841,6 +941,28 @@ def test_prompt_operator_prompts_for_truncated_success_reason(
     assert record.operator_judgement == "n"
     (event,) = record.events
     assert event.data == {"verdict": "n", "source": "prompt"}
+
+
+def test_prompt_operator_warns_before_judging_step_limited_trial(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from inspect_robots.cli import _prompt_operator
+    from inspect_robots.rollout import TrialRecord
+    from inspect_robots.scene import Scene
+
+    record = TrialRecord(
+        scene_id="s0",
+        epoch=0,
+        seed=0,
+        truncated=True,
+        termination_reason="max_steps",
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+
+    _prompt_operator(record, Scene(id="s0", instruction="reach"))
+
+    assert "trial hit the step limit before terminating" in capsys.readouterr().out
+    assert record.operator_judgement == "n"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -411,6 +411,8 @@ def _step_limit_log(
         (10.0, " (max_steps=1200, ~120s at 10 Hz)"),
         (None, " (max_steps=1200)"),
         (0, " (max_steps=1200)"),
+        # bool is an int subclass; a hand-edited log must not print "at 1 Hz".
+        (True, " (max_steps=1200)"),
     ],
 )
 def test_run_summary_surfaces_step_limit_for_adhoc_runs(
@@ -466,6 +468,23 @@ def test_inspect_surfaces_step_limit_note_hint_and_scene_marker(
     )
     assert "hint: raise it with --max-steps N" in out
     assert "[success] s0: (1/2 trials hit max_steps)" in out
+
+
+def test_inspect_tolerates_non_numeric_max_steps_in_hand_edited_log(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # from_dict does no field validation, so a hand-edited log can carry a
+    # string horizon; the note must degrade to no parenthetical, not crash.
+    data = _step_limit_log().to_dict()
+    data["eval"]["max_steps"] = "1200"
+    path = tmp_path / "edited.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    assert main(["inspect", str(path)]) == 0
+
+    out = capsys.readouterr().out
+    assert "note: 1/1 trials hit the step limit before terminating\n" in out
+    assert "max_steps=1200" not in out
 
 
 def test_bare_instruction_runs_adhoc_task_from_env_defaults(


### PR DESCRIPTION
Closes #75.

A run that hits the rollout step limit currently prints `status: success` and writes an eval log with no trace of the truncation. `rollout()` already records `termination_reason="max_steps"` on the `TrialRecord`; this PR stops `eval()` from dropping it and teaches the CLI to tell the operator.

Design doc: [plans/0012-surface-timeout.md](https://github.com/robocurve/inspect-robots/blob/feat/surface-timeout/plans/0012-surface-timeout.md).

## Changes (planned)

- `log.py`: `SceneResult.termination_reasons` (per scored trial, parallel to `epochs`, same additive pattern as `operator_judgements`) and `EvalSpec.max_steps`. Schema stays v1; old logs read back with defaults.
- `eval.py`: thread `record.termination_reason` and `task.max_steps` into the log.
- `cli.py`: post-run summary prints a note when trials hit the step limit, with the limit in steps and seconds (via `embodiment_info.control_hz`) and a reminder: `--max-steps N` or `inspect-robots config set max_steps N` (registered tasks own their horizon instead). `inspect-robots inspect <log>` shows the same for existing logs.
- `log.status` semantics unchanged: a truncated run is still `success`; the note is advisory.

## Status

Draft while the plan goes through the critique loop; implementation follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)