### PR TITLE
docs: restructure agent-mode quickstart into env, install, run steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,17 +96,28 @@ policy sees while the robot moves. CLI flags override any default
 ### Drive the robot with an LLM
 
 The policy slot is not limited to VLAs. With the
-[inspect-robots-agent](plugins/inspect-robots-agent/) plugin installed
-(`uv pip install inspect-robots-agent`) and `$ANTHROPIC_API_KEY` set, a
-frontier LLM drives the same rig through tool calls, one approver-checked
-motion chunk per call:
+[inspect-robots-agent](plugins/inspect-robots-agent/) plugin, a frontier LLM
+drives the same rig through tool calls, one approver-checked motion chunk
+per call.
+
+Create a `.env` file with your API key (the CLI loads it automatically; real
+environment variables take precedence over its values):
+
+```bash
+echo 'ANTHROPIC_API_KEY=sk-ant-...' > .env
+```
+
+Install the add-on:
+
+```bash
+uv pip install inspect-robots-agent
+```
+
+Run the LLM on the robot:
 
 ```bash
 uv run inspect-robots "place the fork on the plate" --policy agent -P model=anthropic/claude-fable-5
 ```
-
-Keys can live in a `.env` file in the working directory: the CLI loads it
-automatically, and real environment variables take precedence over its values.
 
 ### Run in simulation
 


### PR DESCRIPTION
Same treatment as inspect-robots-yam#37, adapted for this README's PyPI-install audience: the "Drive the robot with an LLM" section now reads as three labeled steps with separate code blocks (create a `.env` with your API key, install the add-on, run the LLM on the robot) instead of a parenthetical install and a single command.

Since this README's flow targets a fresh directory rather than a repo clone, step 1 writes the `.env` directly (`echo ... > .env`) instead of copying a template, and no `uv run` re-sync warning is needed (there is no uv project to re-sync in that flow). The `.env` auto-load it relies on shipped in v0.8.1. The plugins-showcase example further down keeps its compact `export` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)