### PR TITLE
feat: embodiment bind_task(envelope) hook so the body can learn the rollout horizon

### DIFF
--- a/plans/0013-embodiment-bind-task-info.md
+++ b/plans/0013-embodiment-bind-task-info.md
@@ -95,11 +95,13 @@ if callable(bind_task):
     bind_task(task.envelope)
 ```
 
-Error semantics match the policy hook (verified): the call sits before sink
-construction and `bus.on_eval_start`, so a raising `bind_task` propagates
-and aborts with no log written — the same observable behavior as a
-`CompatibilityError`, and no conflict with the "always persist a log once
-rollouts have started" invariant (none has).
+Error semantics match the policy hook (verified): the call sits before
+`bus.on_eval_start`, and `JsonLogSink` writes nothing until `on_eval_end`,
+so a raising `bind_task` propagates and aborts with no log written on every
+entry path (the CLI constructs its sinks before `eval()`, so "before sink
+construction" would not hold there — the no-`on_eval_start` argument does).
+Same observable behavior as a `CompatibilityError`; no conflict with the
+"always persist a log once rollouts have started" invariant (none has).
 
 ### The adapter contract (goes in the hook docstrings)
 
@@ -162,7 +164,9 @@ TDD; gates: 100% coverage, mypy strict, ruff (D1 docstrings).
 - `eval()` runs unchanged for embodiments without the hook (the existing
   suite covers this for free) and for a non-callable `bind_task` attribute.
 - A raising `bind_task` aborts the eval before any rollout, with no log
-  written (matching a compat failure).
+  written (matching a compat failure), and a registry-owned embodiment is
+  still closed (the `finally` guarantees it; pin it like the existing
+  compat-failure ownership test).
 - `EmbodimentBase.bind_task` default is a no-op (coverage).
 - API snapshot updated alongside `__all__`.
 

--- a/plans/0013-embodiment-bind-task-info.md
+++ b/plans/0013-embodiment-bind-task-info.md
@@ -1,0 +1,125 @@
+# Embodiment `bind(task_info)`: let the body learn the rollout horizon
+
+Date: 2026-07-14
+Status: draft (headed for subagent critique loop; Jay approved the direction:
+kill the yam `max_steps_hint` duplication with a real core channel)
+
+## Problem
+
+An embodiment that renders an operator status line cannot show the episode
+horizon, because nothing in the core interface tells it the task's
+`max_steps`. The `Embodiment` protocol is `reset(scene, seed)` /
+`step(action)` / `close()`; the horizon lives on the `Task` and is enforced
+by the rollout loop.
+
+The yam plugin worked around this with a `max_steps_hint` embodiment arg
+whose own docstring concedes the defect: "Display-only hint of the
+framework's episode horizon (the Task/CLI owns the real max_steps) ...
+Bounds nothing." Operators must duplicate a value the framework already has;
+unset, the countdown silently drops the horizon (`t = 42s` instead of
+`t = 42s / 120s`); set, it drifts the moment `--max-steps` changes.
+
+## Design
+
+Mirror the existing policy-side precedent (plan 0008 §3c) exactly.
+
+### `task.py` — `TaskInfo` and `Task.info`
+
+A small frozen dataclass carrying what a component may legitimately learn
+about the task it is running:
+
+```python
+@dataclass(frozen=True)
+class TaskInfo:
+    """Identity and rollout envelope of a task, safe to hand to adapters."""
+
+    name: str
+    max_steps: int
+    control_hz: float | None = None
+```
+
+`Task.info` is a property returning it, mirroring `policy.info` /
+`embodiment.info`. `control_hz` is the task's own rate (may be `None`); the
+embodiment already knows its own rate, and the chunk-level rate of R1's
+precedence chain cannot be known before inference, so `TaskInfo` does not
+pretend to resolve R1 — it reports the task layer only.
+
+No `epochs`, scenes, or scorers in `TaskInfo` (YAGNI; scoring and dataset
+contents are none of the embodiment's business).
+
+### `embodiment.py` — optional duck-typed hook
+
+Exactly like `Policy`: the `Embodiment` Protocol is unchanged; its docstring
+documents an optional `bind(task_info)` hook that is not part of the
+Protocol, so every existing embodiment stays conformant. `EmbodimentBase`
+ships a no-op default:
+
+```python
+def bind(self, task_info: TaskInfo) -> None:  # noqa: B027 - no-op default
+    """Default: embodiments that don't display or pre-allocate per-task ignore it."""
+```
+
+### `eval.py` — call site
+
+Immediately next to the policy bind, before `assert_compatible` (fail fast
+before touching hardware), once per eval:
+
+```python
+bind_embodiment = getattr(embodiment, "bind", None)
+if callable(bind_embodiment):
+    bind_embodiment(task.info)
+```
+
+Error semantics match the policy hook: an exception from `bind` propagates
+and aborts the eval before any rollout starts (no trial exists yet, so
+nothing is recorded — same as a failing `assert_compatible`).
+
+### Public API
+
+`TaskInfo` is exported: add to `inspect_robots.__all__` and update
+`tests/test_api_snapshot.py` together (the repo rule). `Task` is already
+public.
+
+### Out of scope (follow-up in `inspect-robots-yam`)
+
+The yam embodiment implements `bind(task_info)` to drive the countdown from
+the real horizon (`max_steps / control_hz`, preferring its own configured
+rate as today) and drops the `max_steps_hint` config knob entirely — it
+bounds nothing and is now auto-populated. That is a separate PR in the yam
+repo, gated the same way.
+
+## Compatibility notes
+
+- Not a Protocol change: `runtime_checkable` `isinstance` checks and all
+  existing embodiments (in-tree mock, isaacsim plugin, out-of-tree) are
+  untouched.
+- Name-collision risk (an existing embodiment with an unrelated `bind`
+  attribute) is the same risk the policy side accepted; symmetry wins.
+- `conformance.py` needs no change: the hook is optional, and
+  `check_embodiment` checks declarative readiness, not optional hooks.
+- Binding resolutions: R1 untouched (see above); the hook adds no rate
+  authority. Nothing in plans/0001 §9–§11 reserves the embodiment surface.
+
+## Testing
+
+TDD; gates: 100% coverage, mypy strict, ruff (D1 docstrings).
+
+- `Task.info` returns the name/max_steps/control_hz of the task, frozen.
+- `eval()` calls `bind` on an embodiment that defines it, with the task's
+  `TaskInfo`, before `reset` is ever called (ordering assert), and exactly
+  once for multi-scene/multi-epoch tasks.
+- `eval()` runs unchanged for embodiments without `bind` (the mock world
+  keeps passing untouched — regression suite covers this for free) and for a
+  non-callable `bind` attribute.
+- A raising `bind` aborts the eval before any rollout (no log written —
+  matching a compat failure).
+- `EmbodimentBase.bind` default is a no-op (coverage).
+- API snapshot updated alongside `__all__`.
+
+## Documentation
+
+- `embodiment.py` Protocol docstring documents the hook (mirroring
+  `Policy`'s wording).
+- `src/inspect_robots/CLAUDE.md` module-map rows for `task.py`,
+  `embodiment.py` (and `policy.py`'s row already mentions its hook — keep
+  the two rows parallel).

--- a/plans/0013-embodiment-bind-task-info.md
+++ b/plans/0013-embodiment-bind-task-info.md
@@ -1,8 +1,10 @@
-# Embodiment `bind(task_info)`: let the body learn the rollout horizon
+# Embodiment `bind_task(envelope)`: let the body learn the rollout horizon
 
 Date: 2026-07-14
-Status: draft (headed for subagent critique loop; Jay approved the direction:
-kill the yam `max_steps_hint` duplication with a real core channel)
+Status: revised after subagent critique round 1 (renamed `TaskInfo` →
+`TaskEnvelope` to keep the Inspect-faithful name free, hook renamed
+`bind` → `bind_task`, dropped `control_hz`, added the optional-input adapter
+contract and yam migration notes)
 
 ## Problem
 
@@ -21,105 +23,153 @@ unset, the countdown silently drops the horizon (`t = 42s` instead of
 
 ## Design
 
-Mirror the existing policy-side precedent (plan 0008 §3c) exactly.
+Mirror the mechanics of the policy-side precedent (plan 0008 §3c): an
+optional duck-typed hook, not part of the Protocol, no-op default on the
+base class, called by `eval()` before the compatibility check.
 
-### `task.py` — `TaskInfo` and `Task.info`
+### `task.py` — `TaskEnvelope` and `Task.envelope`
 
-A small frozen dataclass carrying what a component may legitimately learn
+A small frozen dataclass carrying what an adapter may legitimately learn
 about the task it is running:
 
 ```python
 @dataclass(frozen=True)
-class TaskInfo:
-    """Identity and rollout envelope of a task, safe to hand to adapters."""
+class TaskEnvelope:
+    """Identity and rollout limits of a task, safe to hand to adapters."""
 
     name: str
     max_steps: int
-    control_hz: float | None = None
 ```
 
-`Task.info` is a property returning it, mirroring `policy.info` /
-`embodiment.info`. `control_hz` is the task's own rate (may be `None`); the
-embodiment already knows its own rate, and the chunk-level rate of R1's
-precedence chain cannot be known before inference, so `TaskInfo` does not
-pretend to resolve R1 — it reports the task layer only.
+`Task.envelope` is a property returning it (matching `Task`'s existing
+derived-view properties `scorers` / `epoch_spec`).
 
-No `epochs`, scenes, or scorers in `TaskInfo` (YAGNI; scoring and dataset
-contents are none of the embodiment's business).
+Naming: NOT `TaskInfo` — Inspect AI exports a `TaskInfo` (`file`/`name`/
+`attribs`, the `list_tasks()` listing entry), and plan 0001 §11 makes
+Inspect API fidelity binding, so that name stays reserved for a future
+faithful mirror. "Envelope" says what it is: the identity plus the limits of
+the run.
+
+No `control_hz`: the rollout loop does no pacing today (R1's chain is
+explicitly unwired, `rollout._effective_control_hz`), a `SELF_PACED`
+embodiment like yam paces at its own configured rate, and the chunk-level
+rate that tops R1's precedence cannot be known before inference — so a
+task-layer rate would only mislead adapters into wrong seconds math. Fields
+can be added compatibly later; removing an exported one cannot. No `epochs`,
+scenes, or scorers either (scoring and dataset contents are none of the
+embodiment's business).
 
 ### `embodiment.py` — optional duck-typed hook
 
-Exactly like `Policy`: the `Embodiment` Protocol is unchanged; its docstring
-documents an optional `bind(task_info)` hook that is not part of the
-Protocol, so every existing embodiment stays conformant. `EmbodimentBase`
-ships a no-op default:
+The `Embodiment` Protocol is unchanged; its docstring documents an optional
+`bind_task(envelope)` hook that is not part of the Protocol, so every
+existing embodiment stays conformant. `EmbodimentBase` ships a no-op
+default:
 
 ```python
-def bind(self, task_info: TaskInfo) -> None:  # noqa: B027 - no-op default
-    """Default: embodiments that don't display or pre-allocate per-task ignore it."""
+def bind_task(self, envelope: TaskEnvelope) -> None:  # noqa: B027 - no-op default
+    """Default: embodiments with nothing to display or pre-allocate ignore it."""
 ```
+
+`TaskEnvelope` is imported under `TYPE_CHECKING` (the same mechanics
+`policy.py` uses for `EmbodimentInfo`) — no runtime import edge from
+`embodiment.py` to `task.py`.
+
+Naming: NOT bare `bind` — `policy.bind(embodiment_info)` means "receive your
+counterpart's info"; an embodiment hook receiving the *task* is a different
+relation, and reusing the name would leave it unavailable when policies
+later want the envelope too (the agent plugin's `_max_llm_calls` knob is the
+same duplication smell on the policy side). `bind_task` is unambiguous, can
+be adopted by policies with the identical signature later, and avoids
+duck-typing on `bind`, a common method name on transport-ish objects an
+embodiment might proxy.
 
 ### `eval.py` — call site
 
 Immediately next to the policy bind, before `assert_compatible` (fail fast
-before touching hardware), once per eval:
+before touching hardware), once per `eval()`:
 
 ```python
-bind_embodiment = getattr(embodiment, "bind", None)
-if callable(bind_embodiment):
-    bind_embodiment(task.info)
+bind_task = getattr(embodiment, "bind_task", None)
+if callable(bind_task):
+    bind_task(task.envelope)
 ```
 
-Error semantics match the policy hook: an exception from `bind` propagates
-and aborts the eval before any rollout starts (no trial exists yet, so
-nothing is recorded — same as a failing `assert_compatible`).
+Error semantics match the policy hook (verified): the call sits before sink
+construction and `bus.on_eval_start`, so a raising `bind_task` propagates
+and aborts with no log written — the same observable behavior as a
+`CompatibilityError`, and no conflict with the "always persist a log once
+rollouts have started" invariant (none has).
+
+### The adapter contract (goes in the hook docstrings)
+
+- **Optional input, not a guarantee:** the hook never fires on direct
+  `rollout()` calls or on older cores that predate it. Adapters must keep a
+  graceful fallback (yam: no horizon shown, exactly today's hint-unset
+  behavior).
+- **Re-bind, latest wins:** the hook fires once per `eval()`, which can be
+  several times over an embodiment's lifetime (`eval_set`, or a caller
+  reusing one instance across `eval()` calls). Each call replaces the
+  previous envelope.
 
 ### Public API
 
-`TaskInfo` is exported: add to `inspect_robots.__all__` and update
-`tests/test_api_snapshot.py` together (the repo rule). `Task` is already
-public.
+`TaskEnvelope` is exported: `__init__.py` import + `__all__` +
+`tests/test_api_snapshot.py` `EXPECTED` move together (any one missing fails
+the suite). Docs self-render via mkdocstrings (`docs/api/index.md` already
+includes `::: inspect_robots.task`).
 
 ### Out of scope (follow-up in `inspect-robots-yam`)
 
-The yam embodiment implements `bind(task_info)` to drive the countdown from
-the real horizon (`max_steps / control_hz`, preferring its own configured
-rate as today) and drops the `max_steps_hint` config knob entirely — it
-bounds nothing and is now auto-populated. That is a separate PR in the yam
-repo, gated the same way.
+The yam embodiment implements `bind_task` and computes the countdown as
+`envelope.max_steps / cfg.control_hz` — its own configured rate, which is
+correct because yam is `SELF_PACED` and that rate is the one it actually
+sleeps to. Migration constraints for that PR, recorded here because the core
+design creates them:
+
+- `max_steps_hint` cannot be deleted outright: `YamConfig.from_kwargs`
+  raises `TypeError` on unknown keys, so operators with the key in
+  `config.ini` would crash on upgrade. Deprecate first: accept the key,
+  warn, use it only as the fallback when `bind_task` never fires; delete in
+  a later release.
+- Version coupling: yam pins `inspect-robots>=0.8`. Either bump the floor to
+  the core release that ships `TaskEnvelope`, or keep the import under
+  `TYPE_CHECKING` (yam already uses `from __future__ import annotations`) so
+  the module still imports on older cores.
 
 ## Compatibility notes
 
 - Not a Protocol change: `runtime_checkable` `isinstance` checks and all
   existing embodiments (in-tree mock, isaacsim plugin, out-of-tree) are
-  untouched.
-- Name-collision risk (an existing embodiment with an unrelated `bind`
-  attribute) is the same risk the policy side accepted; symmetry wins.
-- `conformance.py` needs no change: the hook is optional, and
-  `check_embodiment` checks declarative readiness, not optional hooks.
-- Binding resolutions: R1 untouched (see above); the hook adds no rate
-  authority. Nothing in plans/0001 §9–§11 reserves the embodiment surface.
+  untouched; none defines `bind_task`.
+- `conformance.py` needs no change: `check_embodiment` checks declarative
+  readiness from `EmbodimentInfo`, and the attribute-scanning helpers read
+  only `DEVICE_SLOTS`/`RUNTIME_REQUIREMENTS`.
+- Binding resolutions: R1 untouched (the envelope carries no rate
+  authority); §11's Inspect-name fidelity is respected by avoiding
+  `TaskInfo`.
 
 ## Testing
 
 TDD; gates: 100% coverage, mypy strict, ruff (D1 docstrings).
 
-- `Task.info` returns the name/max_steps/control_hz of the task, frozen.
-- `eval()` calls `bind` on an embodiment that defines it, with the task's
-  `TaskInfo`, before `reset` is ever called (ordering assert), and exactly
-  once for multi-scene/multi-epoch tasks.
-- `eval()` runs unchanged for embodiments without `bind` (the mock world
-  keeps passing untouched — regression suite covers this for free) and for a
-  non-callable `bind` attribute.
-- A raising `bind` aborts the eval before any rollout (no log written —
-  matching a compat failure).
-- `EmbodimentBase.bind` default is a no-op (coverage).
+- `Task.envelope` returns the task's name and `max_steps`, frozen.
+- `eval()` calls `bind_task` on an embodiment that defines it, with the
+  task's envelope, before `reset` is ever called (ordering assert), and
+  exactly once per eval for multi-scene/multi-epoch tasks.
+- Two sequential `eval()` calls against one embodiment instance re-bind with
+  each task's envelope (latest wins).
+- `eval()` runs unchanged for embodiments without the hook (the existing
+  suite covers this for free) and for a non-callable `bind_task` attribute.
+- A raising `bind_task` aborts the eval before any rollout, with no log
+  written (matching a compat failure).
+- `EmbodimentBase.bind_task` default is a no-op (coverage).
 - API snapshot updated alongside `__all__`.
 
 ## Documentation
 
-- `embodiment.py` Protocol docstring documents the hook (mirroring
-  `Policy`'s wording).
-- `src/inspect_robots/CLAUDE.md` module-map rows for `task.py`,
-  `embodiment.py` (and `policy.py`'s row already mentions its hook — keep
-  the two rows parallel).
+- `embodiment.py` Protocol docstring documents the hook and the adapter
+  contract above (mirroring the wording style of `Policy`'s).
+- `src/inspect_robots/CLAUDE.md` module-map rows for `task.py` and
+  `embodiment.py` mention the envelope/hook, keeping parity with
+  `policy.py`'s row.

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -10,9 +10,9 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `types.py` | `Observation`, `Action`, `ActionChunk`, `StepResult` (frozen, NumPy-native) |
 | `spaces.py` | `Box`, `ObservationSpace`, `ActionSemantics`, `StateSpec` + canonical state vocab |
 | `policy.py` | `Policy` Protocol + `PolicyBase` ABC, `PolicyInfo`, `PolicyConfig`; optional duck-typed `bind(embodiment_info)` hook for embodiment-adaptive policies (called by `eval()` before compat) |
-| `embodiment.py` | `Embodiment` Protocol + `EmbodimentBase` ABC, `EmbodimentInfo`, capability flags |
+| `embodiment.py` | `Embodiment` Protocol + `EmbodimentBase` ABC, `EmbodimentInfo`, capability flags; optional duck-typed `bind_task(envelope)` hook for horizon-aware adapters (called by `eval()` before compat; optional input — never fires on direct `rollout()`, keep a fallback) |
 | `scene.py` | `Scene` (the Inspect `Sample` analog), `Target`, `ListSceneDataset` |
-| `task.py` | `Task` (scenes + scorer + horizon), `Epochs` |
+| `task.py` | `Task` (scenes + scorer + horizon), `Epochs`, `TaskEnvelope` (`Task.envelope` — the adapter-safe identity+limits view passed to `bind_task` hooks) |
 | `scorer.py` | `Score`/`Scorer`, epoch reducers, builtin scorers (incl. operator/VLM) |
 | `controller.py` | `Controller` middleware: `DefaultController` (open-loop chunking), `SmoothingController` |
 | `approver.py` | `Approver` safety gate: `AutoApprover`, `ClampApprover`, `DeltaLimitApprover` (semantics-aware no-wild-swings limit), `ChainApprover` |

--- a/src/inspect_robots/__init__.py
+++ b/src/inspect_robots/__init__.py
@@ -53,7 +53,7 @@ from inspect_robots.spaces import (
     StateField,
     StateSpec,
 )
-from inspect_robots.task import Epochs, Task
+from inspect_robots.task import Epochs, Task, TaskEnvelope
 from inspect_robots.types import Action, ActionChunk, Observation, StepResult
 
 # The public, stability-guaranteed API. Anything not listed here (or prefixed
@@ -88,6 +88,7 @@ __all__ = [
     "StepResult",
     "Target",
     "Task",
+    "TaskEnvelope",
     "TrialRecord",
     "__version__",
     "embodiment",

--- a/src/inspect_robots/embodiment.py
+++ b/src/inspect_robots/embodiment.py
@@ -18,11 +18,14 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from inspect_robots.scene import Scene
 from inspect_robots.spaces import Box, ObservationSpace
 from inspect_robots.types import Action, Observation, StepResult
+
+if TYPE_CHECKING:
+    from inspect_robots.task import TaskEnvelope
 
 # Opt-in capability flags an embodiment may advertise.
 Capability = str
@@ -52,7 +55,20 @@ class EmbodimentInfo:
 
 @runtime_checkable
 class Embodiment(Protocol):
-    """The robot/simulator contract."""
+    """The robot/simulator contract.
+
+    Embodiments may additionally define an **optional** ``bind_task(envelope)``
+    hook (not part of this Protocol, so existing embodiments stay conformant):
+    ``eval()`` calls it with the task's
+    [`TaskEnvelope`][inspect_robots.task.TaskEnvelope] before the
+    compatibility check, letting adapters learn the rollout horizon — e.g. an
+    operator countdown showing elapsed/total. The hook is optional *input*,
+    not a guarantee: it never fires on direct ``rollout()`` calls or on older
+    cores, so adapters must keep a graceful fallback. It fires once per
+    ``eval()``, which can be several times over an embodiment's lifetime;
+    each call replaces the previous envelope. ``EmbodimentBase`` ships a
+    no-op default.
+    """
 
     info: EmbodimentInfo
 
@@ -83,6 +99,9 @@ class EmbodimentBase(ABC):
     def step(self, action: Action) -> StepResult:
         """Issue one action without waiting for the control period unless ``self_paced``."""
         ...
+
+    def bind_task(self, envelope: TaskEnvelope) -> None:  # noqa: B027 - no-op default
+        """Default: embodiments with nothing to display or pre-allocate ignore it."""
 
     def close(self) -> None:  # noqa: B027 - intentional no-op default
         """Default: nothing to release."""

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -213,6 +213,14 @@ def _run_eval(
     if callable(bind):
         bind(embodiment.info)
 
+    # Horizon-aware embodiments (plan 0013): an optional bind_task() hook runs
+    # here too, so the adapter can learn the rollout envelope (e.g. for an
+    # operator countdown) before any hardware is touched. Duck-typed —
+    # bind_task is not part of the Embodiment Protocol.
+    bind_task = getattr(embodiment, "bind_task", None)
+    if callable(bind_task):
+        bind_task(task.envelope)
+
     # Fail fast on incompatible pairings before touching any hardware/sim.
     assert_compatible(policy, embodiment, task, remap=remap)
 

--- a/src/inspect_robots/task.py
+++ b/src/inspect_robots/task.py
@@ -32,6 +32,22 @@ class Epochs:
             raise ConfigError(f"Epochs count must be >= 1, got {self.count}")
 
 
+@dataclass(frozen=True)
+class TaskEnvelope:
+    """Identity and rollout limits of a task, safe to hand to adapters.
+
+    This is what ``eval()`` passes to an embodiment's optional
+    ``bind_task(envelope)`` hook: enough for the adapter to display or
+    pre-allocate for the run (e.g. an operator countdown against
+    ``max_steps``), and nothing that would let it second-guess scoring or the
+    dataset. Deliberately carries no control rate — the effective rate is
+    R1's chunk → task → embodiment precedence, unknowable before inference.
+    """
+
+    name: str
+    max_steps: int
+
+
 @dataclass
 class Task:
     """A benchmark: scenes + scorer(s) + horizon, independent of any embodiment.
@@ -76,3 +92,8 @@ class Task:
     def epoch_spec(self) -> Epochs:
         """Normalize an integer epoch count to an ``Epochs`` specification."""
         return self.epochs if isinstance(self.epochs, Epochs) else Epochs(count=self.epochs)
+
+    @property
+    def envelope(self) -> TaskEnvelope:
+        """The adapter-safe view of this task handed to ``bind_task`` hooks."""
+        return TaskEnvelope(name=self.name, max_steps=self.max_steps)

--- a/tests/test_api_snapshot.py
+++ b/tests/test_api_snapshot.py
@@ -22,6 +22,7 @@ EXPECTED = {
     "TrialRecord",
     # tasks, scenes, scoring
     "Task",
+    "TaskEnvelope",
     "Epochs",
     "Scene",
     "Target",

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -301,12 +301,22 @@ def test_eval_binds_task_envelope_before_reset(tmp_path: Path) -> None:
             self.calls.append("reset")
             return super().reset(scene, seed=seed)
 
+    two_scenes = Task(
+        name="t",
+        scenes=[
+            Scene(id="s0", instruction="reach", init_seed=0),
+            Scene(id="s1", instruction="reach", init_seed=1),
+        ],
+        scorer=success_at_end(),
+        max_steps=7,
+        epochs=2,
+    )
     aware = _HorizonAware()
-    (log,) = eval(_task(epochs=2, max_steps=7), ScriptedPolicy(), aware, log_dir=str(tmp_path))
+    (log,) = eval(two_scenes, ScriptedPolicy(), aware, log_dir=str(tmp_path))
     assert log.status == "success"
     assert aware.calls[0] == TaskEnvelope(name="t", max_steps=7)
-    # Exactly one bind per eval, even across multiple epochs; resets follow it.
-    assert aware.calls.count("reset") == 2
+    # Exactly one bind per eval — not per scene or per epoch; resets follow it.
+    assert aware.calls.count("reset") == 4
     assert [c for c in aware.calls if c != "reset"] == [TaskEnvelope(name="t", max_steps=7)]
 
 
@@ -348,6 +358,21 @@ def test_raising_bind_task_aborts_before_any_rollout(tmp_path: Path) -> None:
         eval(_task(max_steps=5), ScriptedPolicy(), "bind-raises-cubepick", log_dir=str(tmp_path))
     assert not list(tmp_path.glob("*.json"))  # no rollout started, no log written
     assert _CLOSED == ["closed"]  # registry-owned embodiment still released
+
+
+def test_bind_task_runs_before_the_compatibility_check(tmp_path: Path) -> None:
+    """The hook fires pre-compat: a raising bind_task wins over an incompatible pairing."""
+
+    class _WidePolicy(ScriptedPolicy):
+        def __init__(self) -> None:
+            super().__init__()
+            self.info = PolicyInfo(
+                name="wide",
+                action_space=Box(shape=(9,), semantics=ActionSemantics("joint_pos")),
+            )
+
+    with pytest.raises(RuntimeError, match="refusing this task"):
+        eval(_task(max_steps=5), _WidePolicy(), "bind-raises-cubepick", log_dir=str(tmp_path))
 
 
 def test_embodiment_base_bind_task_is_a_noop() -> None:

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -20,7 +20,7 @@ from inspect_robots.rollout import TrialRecord
 from inspect_robots.scene import Scene
 from inspect_robots.scorer import min_distance_to_goal, operator_scorer, success_at_end
 from inspect_robots.spaces import ActionSemantics, Box
-from inspect_robots.task import Epochs, Task
+from inspect_robots.task import Epochs, Task, TaskEnvelope
 from inspect_robots.types import Action, ActionChunk, Observation, StepResult
 
 _BOX = Box(shape=(2,), semantics=ActionSemantics(control_mode="eef_delta_pos", frame="world"))
@@ -284,6 +284,85 @@ def test_eval_binds_adaptive_policy_before_compat(tmp_path: Path) -> None:
     logs = eval(_task(max_steps=60), adaptive, CubePickEmbodiment(), log_dir=str(tmp_path))
     assert adaptive.bound_names == ["cubepick"]
     assert logs[0].status == "success"
+
+
+def test_eval_binds_task_envelope_before_reset(tmp_path: Path) -> None:
+    """bind_task fires once per eval with the task's envelope, before any reset."""
+
+    class _HorizonAware(CubePickEmbodiment):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls: list[object] = []
+
+        def bind_task(self, envelope: TaskEnvelope) -> None:
+            self.calls.append(envelope)
+
+        def reset(self, scene: Scene, *, seed: int | None = None) -> Observation:
+            self.calls.append("reset")
+            return super().reset(scene, seed=seed)
+
+    aware = _HorizonAware()
+    (log,) = eval(_task(epochs=2, max_steps=7), ScriptedPolicy(), aware, log_dir=str(tmp_path))
+    assert log.status == "success"
+    assert aware.calls[0] == TaskEnvelope(name="t", max_steps=7)
+    # Exactly one bind per eval, even across multiple epochs; resets follow it.
+    assert aware.calls.count("reset") == 2
+    assert [c for c in aware.calls if c != "reset"] == [TaskEnvelope(name="t", max_steps=7)]
+
+
+def test_bind_task_rebinds_per_eval_latest_wins(tmp_path: Path) -> None:
+    class _HorizonAware(CubePickEmbodiment):
+        def __init__(self) -> None:
+            super().__init__()
+            self.envelopes: list[TaskEnvelope] = []
+
+        def bind_task(self, envelope: TaskEnvelope) -> None:
+            self.envelopes.append(envelope)
+
+    aware = _HorizonAware()
+    eval(_task(max_steps=5), ScriptedPolicy(), aware, log_dir=str(tmp_path))
+    eval(_task(max_steps=9), ScriptedPolicy(), aware, log_dir=str(tmp_path))
+    assert [e.max_steps for e in aware.envelopes] == [5, 9]
+
+
+def test_eval_ignores_non_callable_bind_task(tmp_path: Path) -> None:
+    class _OddAttr(CubePickEmbodiment):
+        bind_task = "not a hook"
+
+    (log,) = eval(_task(max_steps=5), ScriptedPolicy(), _OddAttr(), log_dir=str(tmp_path))
+    assert log.status == "success"
+    assert _OddAttr.bind_task == "not a hook"
+
+
+class _BindRaisesEmbodiment(_ClosableEmbodiment):
+    def bind_task(self, envelope: TaskEnvelope) -> None:
+        raise RuntimeError("refusing this task")
+
+
+embodiment_decorator("bind-raises-cubepick")(_BindRaisesEmbodiment)
+
+
+def test_raising_bind_task_aborts_before_any_rollout(tmp_path: Path) -> None:
+    _CLOSED.clear()
+    with pytest.raises(RuntimeError, match="refusing this task"):
+        eval(_task(max_steps=5), ScriptedPolicy(), "bind-raises-cubepick", log_dir=str(tmp_path))
+    assert not list(tmp_path.glob("*.json"))  # no rollout started, no log written
+    assert _CLOSED == ["closed"]  # registry-owned embodiment still released
+
+
+def test_embodiment_base_bind_task_is_a_noop() -> None:
+    from inspect_robots.embodiment import EmbodimentBase
+
+    class _Minimal(EmbodimentBase):
+        info = CubePickEmbodiment().info
+
+        def reset(self, scene: Scene, *, seed: int | None = None) -> Observation:
+            return CubePickEmbodiment().reset(scene, seed=seed)
+
+        def step(self, action: Action) -> StepResult:
+            raise NotImplementedError
+
+    _Minimal().bind_task(TaskEnvelope(name="t", max_steps=1))  # must exist and do nothing
 
 
 def test_policy_base_bind_is_a_noop() -> None:

--- a/tests/test_types_spaces.py
+++ b/tests/test_types_spaces.py
@@ -97,6 +97,17 @@ def test_observation_space_rejects_inconsistent_state_keys() -> None:
         ObservationSpace(state_keys=frozenset({"eef_pos"}), state=spec)
 
 
+def test_task_envelope_is_a_frozen_view_of_the_horizon() -> None:
+    from inspect_robots.scene import Scene
+    from inspect_robots.task import Task, TaskEnvelope
+
+    scene = Scene(id="s", instruction="x")
+    task = Task(name="t", scenes=[scene], scorer="success_at_end", max_steps=80)
+    assert task.envelope == TaskEnvelope(name="t", max_steps=80)
+    with pytest.raises(AttributeError):
+        task.envelope.max_steps = 81  # type: ignore[misc]
+
+
 def test_task_validation_and_scorer_names() -> None:
     from inspect_robots.errors import ConfigError
     from inspect_robots.scene import Scene


### PR DESCRIPTION
Closes #79.

Mirrors the mechanics of the policy-side `bind(embodiment_info)` precedent (plan 0008 §3c) on the embodiment side: `eval()` calls an optional duck-typed `bind_task(envelope)` before the compatibility check, handing the embodiment a frozen `TaskEnvelope` (`name`, `max_steps`) exposed as `Task.envelope`.

This kills display-only horizon duplication in adapters: the yam plugin's `max_steps_hint` ("Bounds nothing") gets replaced by the real horizon in a follow-up (inspect-robots-yam#41), so the operator countdown can never disagree with what the rollout loop will do.

Design doc: [plans/0013-embodiment-bind-task-info.md](https://github.com/robocurve/inspect-robots/blob/feat/bind-task-info/plans/0013-embodiment-bind-task-info.md) (two critique rounds; round 2 verdict OK).

## Changes

- `task.py`: frozen `TaskEnvelope(name, max_steps)` + `Task.envelope` property. Deliberately no `control_hz`: the loop does no pacing yet, a `SELF_PACED` embodiment paces at its own rate, and R1's chunk-level rate is unknowable pre-inference, so a task-layer rate would only mislead adapters. Not named `TaskInfo`: Inspect AI exports a `TaskInfo` of a different shape and plan 0001 §11 binds API fidelity, so that name stays reserved.
- `embodiment.py`: Protocol docstring documents the optional hook and its adapter contract (optional input that never fires on direct `rollout()` or older cores, so keep a fallback; once per `eval()`, latest envelope wins). `EmbodimentBase` no-op default. Not a Protocol change: existing embodiments stay conformant.
- `eval.py`: duck-typed call next to the policy bind, before `assert_compatible`; a raising `bind_task` aborts before any rollout with no log written, and registry-owned embodiments still close.
- `__all__` + api snapshot: `TaskEnvelope` exported (updated together per repo rule); CLAUDE.md module map updated.

## Verification

- Gates green locally: full suite at 100% coverage, ruff check + format, mypy strict.
- Ordering pinned behaviorally: per-scene binding and after-compat placement were applied as mutations and each fails a test.
- Public-API demo: a `CubePickEmbodiment` subclass defining `bind_task` printed `t = 0s / 120s` for a `max_steps=1200` task with zero configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
