### PR TITLE
fix: setup wizard probes Enter-accepted stale camera devices

### DIFF
--- a/plans/0013-setup-probe-accepted-current.md
+++ b/plans/0013-setup-probe-accepted-current.md
@@ -1,7 +1,9 @@
 # Probe Enter-accepted stale camera devices in the setup wizard
 
 Date: 2026-07-14
-Status: draft; subagent critique round 1 in progress
+Status: revised after subagent critique round 1 (probe-True acceptance, both
+listings checked before probing, discriminator dropped, dual hint sites,
+explicit test updates); round 2 pending
 
 ## Problem
 
@@ -15,9 +17,9 @@ rig on 2026-07-14; see #82).
 Separately, when udev's by-id table is missing capture-capable nodes that
 by-path has (same rig: the D435 color node `/dev/video16` had no by-id
 symlink at all), the only clue is the count-mismatch hint, whose stated cause
-("identical cameras without serials collide") is wrong for this failure
-mode. The correct device is not selectable from the default listing while
-the wrong one is Enter-acceptable. This is the sharp end of #71.
+("identical cameras without serials collide") is one possible cause of
+several, and whose remedy (the `p` toggle) is easy to miss. This is the
+sharp end of #71.
 
 ## Requirements
 
@@ -28,60 +30,117 @@ the wrong one is Enter-acceptable. This is the sharp end of #71.
    when the evidence is definitive.
 3. A second Enter always accepts, so scripted or headless Enter-through runs
    terminate.
-4. When the by-id listing cannot show a capture-capable node that by-path
-   can, the wizard says so per device section instead of relying on the
-   operator discovering the `p` toggle.
-5. No public API changes; `tests/test_api_snapshot.py` unchanged.
+4. A healthy device never triggers new friction, including one configured
+   via by-path or a raw `/dev/videoN` path while the by-id listing is
+   active ("not detected" is listing-relative).
+5. The count-mismatch hint names its possible causes and the `p` remedy
+   without overclaiming what the fallback scan cannot know.
+6. No public API changes; `tests/test_api_snapshot.py` unchanged.
 
 ## Design
 
 ### A. Probe on Enter-accept of a not-detected current value (v4l2 slots only)
 
 In the `elif not entered and current is not None` branch of
-`_prompt_device_slot`: when `kind == "v4l2"` and `current not in devices`:
+`_prompt_device_slot`, when `kind == "v4l2"`:
 
-- Path missing: warn once in the existing foreign-machine tone ("does not
-  exist here (ok if this config is for another machine)") and re-prompt; a
-  second Enter keeps the value.
-- Path exists: call `_v4l2_color_capture(Path(current))`:
+- Skip all new logic when `current` is present in either scan
+  (`by_id_devices` or `by_path_devices`), not just the active listing: a
+  device the other listing knows is healthy, and probing it again is
+  pointless (requirement 4).
+- Otherwise, if the path does not exist: warn once in the existing
+  foreign-machine tone ("does not exist here (ok if this config is for
+  another machine)") and re-prompt; a second Enter keeps the value.
+- Otherwise call `_v4l2_color_capture(Path(current))`:
+  - `True` or `None`: accept silently, exactly as today. `None` covers
+    Windows (`fcntl` ImportError), open/QUERYCAP `OSError`, and other
+    inconclusive outcomes; never nag on those.
   - `False`: yellow warning that the device offers no color capture format
-    (likely a depth or metadata node); re-prompt once; a second Enter keeps
-    it.
-  - `None` (inconclusive): accept silently, exactly as today.
-- One re-prompt per slot at most (local flag scoped to the prompt loop), so
-  repeated Enters terminate and deliberate unusual devices stay usable.
+    (likely a depth or metadata node); re-prompt; a second Enter keeps it.
+    Yellow, not the issue's "red": the wizard palette (`_setup.py:18-22`)
+    defines no red and yellow is its warning convention; note the deviation
+    in the PR body.
+- Re-prompt bookkeeping: one local `warned_current` flag scoped to the
+  prompt loop of the slot. Semantics: (i) the second Enter accepts
+  unconditionally, with no re-probe; (ii) the flag survives `p` toggles and
+  `u` rescans within the slot (the verdict is a property of the node, not
+  the listing); (iii) the warning path must `continue` before the generic
+  instruction block at `_setup.py:413-423` so the operator never gets two
+  stacked messages; (iv) the group-retry loop (`_setup.py:691`) re-invokes
+  `prompt_slot`, resetting the flag and warning again on a fresh pass;
+  acceptable because it is operator-bounded.
 - CAN and serial slots keep today's behavior (no probe exists for them).
 
-### B. Name the by-id gap instead of hand-waving
+### B. One honest hint, both sites
 
-Where the count-mismatch hint prints: compute the set of by-path
-color-capable nodes whose resolved target has no by-id entry (compare
-resolved-path sets of the two scans). When non-empty, state the actual
-situation: N capture-capable nodes have no by-id entry; press `p` to pick
-them from the by-path listing (stable per physical USB port). Keep the
-serial-collision wording only for the case where the resolved sets match
-(pure name collision). No behavior change to listings or toggle logic.
+The count-mismatch hint prints in two places with identical text:
+`_camera_section` (`_setup.py:488-497`) and `_device_section`
+(`_setup.py:631-641`). Extract a shared helper (D1 docstring) and change the
+message once:
+
+- Compute how many by-path scan entries resolve (via `Path.resolve()` or
+  `os.path.realpath`) to targets that no by-id scan entry resolves to.
+- When that count is positive and the by-id listing is active, print: N of
+  the detected camera nodes have no by-id entry (udev serial collision or
+  missing symlink); by-path names are stable per physical USB port; press
+  `p` to switch listing.
+- When the active listing is already by-path (fresh systems where by-id is
+  empty: `_setup.py:470/585` set `active_is_by_id = False`), drop the `p`
+  clause; the operator is already looking at the right list.
+- Do not claim the extra nodes are capture-capable: `_scan_cameras`
+  (`_setup.py:736-743`) returns all entries when no node probes `True`
+  (fallback mode) and discards per-entry verdicts, so capability is unknown
+  here. Say "camera nodes". Threading verdicts out of the scan is #71's
+  work, not this PR's.
+- No realpath-set "collision vs missing symlink" discriminator: a serial
+  collision also leaves the collided-away node's realpath absent from the
+  by-id set, so the two causes are indistinguishable by construction and the
+  old wording would be dead code. One message, both causes named.
 
 ## Tests
 
 TDD against the existing `tests/test_setup.py` patterns (fake `input_fn`,
-injected scans, monkeypatched `_v4l2_color_capture`):
+`_make_devices` fixtures, monkeypatched `inspect_robots._setup._v4l2_color_capture`):
 
 1. Enter on a not-detected current whose probe returns `False`: warning
    printed, re-prompt; second Enter accepts and writes the value.
 2. Same, but the operator picks a number after the warning: the picked
    device wins.
-3. Probe returns `None`: accepted immediately, no warning.
-4. Current path does not exist: foreign-machine warning, re-prompt once.
-5. Detected current (in the active listing): no probe call at all (assert
-   via monkeypatch counter); zero new friction on the happy path.
-6. by-path-only capture-capable nodes present: new hint text names the count
-   and the `p` toggle; resolved sets equal: old collision wording.
-7. CAN slot with a not-detected current: unchanged single-Enter accept.
+3. Probe returns `None`: accepted immediately, no warning. Same for `True`.
+4. Current path exists in the by-path scan while by-id is active: accepted
+   immediately, probe not called for that path (count probe invocations
+   whose argument equals the current path, or drive `_prompt_device_slot`
+   directly per the established private-helper import pattern,
+   `tests/test_setup.py:16-30`; a blanket call counter cannot work because
+   `_scan_cameras` probes every entry).
+5. Current path does not exist: foreign-machine warning, re-prompt once,
+   second Enter accepts.
+6. Hint: by-path entries resolving to targets absent from by-id → new text
+   with the count and the `p` clause; active listing already by-path → no
+   `p` clause. Symlink fixtures pointing into a shared target dir, wrapped
+   in the existing `pytest.skip` on `OSError` pattern
+   (`tests/test_setup.py:89`) for the Windows advisory tier.
+7. CAN slot with a not-detected current: unchanged single-Enter accept
+   (guards `tests/test_setup.py:2251` behavior).
+
+Existing tests that must be updated (they break by design):
+
+- `tests/test_setup.py:1536` `test_run_setup_marks_undetected_current_camera_defaults`:
+  currents are nonexistent `/remote/*` paths with a `[""] * 10` script; the
+  new missing-path re-prompt consumes three extra Enters. Extend the script
+  and assert the new warning.
+- `tests/test_setup.py:1442-1449` and `:2305`: assert the exact old
+  collision wording; update to the new message (their `_make_devices`
+  fixtures live in disjoint tmp dirs, so the by-path-extras branch fires).
 
 ## Constraints
 
 - 100% coverage, mypy strict (src and tests), ruff D1 docstrings on new
   helpers. Core stays NumPy-only; the probe already lazily imports `fcntl`.
-- Respect #70's review resolutions (Bayer fourccs, bounded enumeration,
-  Windows skips, native-endian structs).
+- Respect #70's review resolutions (Bayer fourccs, 64-entry bounded
+  enumeration, native-endian structs, Windows ImportError → None), all
+  reused unmodified.
+- Known probe caveat, acceptable: an `OSError` mid `ENUM_FMT` returns
+  `False` (`_setup.py:725-727`), so an I/O-flaky device draws the warning
+  with an imprecise cause; the "likely a depth or metadata node" hedge is
+  the mitigation.

--- a/plans/0013-setup-probe-accepted-current.md
+++ b/plans/0013-setup-probe-accepted-current.md
@@ -1,0 +1,87 @@
+# Probe Enter-accepted stale camera devices in the setup wizard
+
+Date: 2026-07-14
+Status: draft; subagent critique round 1 in progress
+
+## Problem
+
+`_prompt_device_slot` (`src/inspect_robots/_setup.py`) Enter-accepts a
+`(current, not detected)` config value with no validation: the accepted path
+is never run through the color-capture probe added in #70. A stale pre-#70
+config carrying a RealSense depth node sails through setup and fails minutes
+later at runtime as `EmbodimentFault: cannot open top_cam` (observed on a yam
+rig on 2026-07-14; see #82).
+
+Separately, when udev's by-id table is missing capture-capable nodes that
+by-path has (same rig: the D435 color node `/dev/video16` had no by-id
+symlink at all), the only clue is the count-mismatch hint, whose stated cause
+("identical cameras without serials collide") is wrong for this failure
+mode. The correct device is not selectable from the default listing while
+the wrong one is Enter-acceptable. This is the sharp end of #71.
+
+## Requirements
+
+1. Enter-accepting a camera device that the wizard can tell is wrong warns
+   the operator at setup time, not minutes later at runtime.
+2. Inconclusive probes never block acceptance (Windows workstations, unusual
+   devices, configs authored for another machine). #71's lesson: only speak
+   when the evidence is definitive.
+3. A second Enter always accepts, so scripted or headless Enter-through runs
+   terminate.
+4. When the by-id listing cannot show a capture-capable node that by-path
+   can, the wizard says so per device section instead of relying on the
+   operator discovering the `p` toggle.
+5. No public API changes; `tests/test_api_snapshot.py` unchanged.
+
+## Design
+
+### A. Probe on Enter-accept of a not-detected current value (v4l2 slots only)
+
+In the `elif not entered and current is not None` branch of
+`_prompt_device_slot`: when `kind == "v4l2"` and `current not in devices`:
+
+- Path missing: warn once in the existing foreign-machine tone ("does not
+  exist here (ok if this config is for another machine)") and re-prompt; a
+  second Enter keeps the value.
+- Path exists: call `_v4l2_color_capture(Path(current))`:
+  - `False`: yellow warning that the device offers no color capture format
+    (likely a depth or metadata node); re-prompt once; a second Enter keeps
+    it.
+  - `None` (inconclusive): accept silently, exactly as today.
+- One re-prompt per slot at most (local flag scoped to the prompt loop), so
+  repeated Enters terminate and deliberate unusual devices stay usable.
+- CAN and serial slots keep today's behavior (no probe exists for them).
+
+### B. Name the by-id gap instead of hand-waving
+
+Where the count-mismatch hint prints: compute the set of by-path
+color-capable nodes whose resolved target has no by-id entry (compare
+resolved-path sets of the two scans). When non-empty, state the actual
+situation: N capture-capable nodes have no by-id entry; press `p` to pick
+them from the by-path listing (stable per physical USB port). Keep the
+serial-collision wording only for the case where the resolved sets match
+(pure name collision). No behavior change to listings or toggle logic.
+
+## Tests
+
+TDD against the existing `tests/test_setup.py` patterns (fake `input_fn`,
+injected scans, monkeypatched `_v4l2_color_capture`):
+
+1. Enter on a not-detected current whose probe returns `False`: warning
+   printed, re-prompt; second Enter accepts and writes the value.
+2. Same, but the operator picks a number after the warning: the picked
+   device wins.
+3. Probe returns `None`: accepted immediately, no warning.
+4. Current path does not exist: foreign-machine warning, re-prompt once.
+5. Detected current (in the active listing): no probe call at all (assert
+   via monkeypatch counter); zero new friction on the happy path.
+6. by-path-only capture-capable nodes present: new hint text names the count
+   and the `p` toggle; resolved sets equal: old collision wording.
+7. CAN slot with a not-detected current: unchanged single-Enter accept.
+
+## Constraints
+
+- 100% coverage, mypy strict (src and tests), ruff D1 docstrings on new
+  helpers. Core stays NumPy-only; the probe already lazily imports `fcntl`.
+- Respect #70's review resolutions (Bayer fourccs, bounded enumeration,
+  Windows skips, native-endian structs).

--- a/plans/0013-setup-probe-accepted-current.md
+++ b/plans/0013-setup-probe-accepted-current.md
@@ -1,9 +1,10 @@
 # Probe Enter-accepted stale camera devices in the setup wizard
 
 Date: 2026-07-14
-Status: revised after subagent critique round 1 (probe-True acceptance, both
-listings checked before probing, discriminator dropped, dual hint sites,
-explicit test updates); round 2 pending
+Status: approved for implementation; revised after critique round 1
+(probe-True acceptance, both listings checked before probing, discriminator
+dropped, dual hint sites, explicit test updates) and round 2 (verdict ready;
+six clarifications folded in below)
 
 ## Problem
 
@@ -29,7 +30,9 @@ sharp end of #71.
    devices, configs authored for another machine). #71's lesson: only speak
    when the evidence is definitive.
 3. A second Enter always accepts, so scripted or headless Enter-through runs
-   terminate.
+   terminate (unchanged pre-existing exception: the duplicate-assignment
+   confirm at `_setup.py:433-455` defaults to No and can loop on duplicated
+   currents; this PR neither fixes nor worsens that).
 4. A healthy device never triggers new friction, including one configured
    via by-path or a raw `/dev/videoN` path while the by-id listing is
    active ("not detected" is listing-relative).
@@ -45,9 +48,10 @@ In the `elif not entered and current is not None` branch of
 `_prompt_device_slot`, when `kind == "v4l2"`:
 
 - Skip all new logic when `current` is present in either scan
-  (`by_id_devices` or `by_path_devices`), not just the active listing: a
-  device the other listing knows is healthy, and probing it again is
-  pointless (requirement 4).
+  (`by_id_devices` or `by_path_devices`), not just the active listing.
+  Listing membership is the best available healthiness proxy until #71
+  threads per-entry verdicts out of the scan (in fallback mode membership
+  certifies nothing, but erring toward silence is requirement 2's rule).
 - Otherwise, if the path does not exist: warn once in the existing
   foreign-machine tone ("does not exist here (ok if this config is for
   another machine)") and re-prompt; a second Enter keeps the value.
@@ -66,9 +70,10 @@ In the `elif not entered and current is not None` branch of
   `u` rescans within the slot (the verdict is a property of the node, not
   the listing); (iii) the warning path must `continue` before the generic
   instruction block at `_setup.py:413-423` so the operator never gets two
-  stacked messages; (iv) the group-retry loop (`_setup.py:691`) re-invokes
-  `prompt_slot`, resetting the flag and warning again on a fresh pass;
-  acceptable because it is operator-bounded.
+  stacked messages; (iv) both retry loops (`_camera_section`'s go-back loop
+  at `_setup.py:499-535` and `_device_section`'s group-retry at `:691`)
+  re-invoke the slot prompt, resetting the flag and warning again on a
+  fresh pass; acceptable because both are operator-bounded.
 - CAN and serial slots keep today's behavior (no probe exists for them).
 
 ### B. One honest hint, both sites
@@ -78,12 +83,16 @@ The count-mismatch hint prints in two places with identical text:
 (`_setup.py:631-641`). Extract a shared helper (D1 docstring) and change the
 message once:
 
-- Compute how many by-path scan entries resolve (via `Path.resolve()` or
-  `os.path.realpath`) to targets that no by-id scan entry resolves to.
-- When that count is positive and the by-id listing is active, print: N of
-  the detected camera nodes have no by-id entry (udev serial collision or
-  missing symlink); by-path names are stable per physical USB port; press
-  `p` to switch listing.
+- Compute the by-path scan entries that resolve (via `Path.resolve()`,
+  `strict=False`) to targets no by-id scan entry resolves to.
+- When that set is non-empty and the by-id listing is active, print the
+  affected entry names, not just a count (#82 explicitly asks for naming;
+  the motivating operator needed to find `/dev/video16`): these camera
+  nodes have no by-id entry (udev serial collision or missing symlink),
+  followed by the entry basenames, then: by-path names are stable per
+  physical USB port; press `p` to switch listing.
+- `advertise_path_toggle` (`_setup.py:310-314/:473/:586`) stays len-based
+  and unchanged; only the hint's gate moves to the resolved-set test.
 - When the active listing is already by-path (fresh systems where by-id is
   empty: `_setup.py:470/585` set `active_is_by_id = False`), drop the `p`
   clause; the operator is already looking at the right list.
@@ -132,6 +141,15 @@ Existing tests that must be updated (they break by design):
 - `tests/test_setup.py:1442-1449` and `:2305`: assert the exact old
   collision wording; update to the new message (their `_make_devices`
   fixtures live in disjoint tmp dirs, so the by-path-extras branch fires).
+  Expected named entries there: all by-path fixture entries (3 at `:1425`,
+  2 at `:2281`), because regular-file fixtures share no resolve targets.
+- `tests/test_setup.py:1396-1419`
+  `test_run_setup_path_toggle_is_accepted_when_not_advertised`: its 3-vs-3
+  disjoint regular-file fixture would newly trigger the resolved-set hint,
+  leaving its `:1419` no-hint assertion vacuously green under the old
+  wording. Preserve the test's intent: symlink its by-path entries to the
+  by-id targets (count 0, hint stays silent), with the `pytest.skip` on
+  `OSError` pattern for the Windows advisory tier.
 
 ## Constraints
 

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -245,6 +245,32 @@ def _print_camera_listing(devices: list[str], directory: Path, out: IO[str]) -> 
         print(f"  {number}. {Path(device).name}", file=out)
 
 
+def _print_camera_path_hint(
+    by_id_devices: list[str],
+    by_path_devices: list[str],
+    active_is_by_id: bool,
+    out: IO[str],
+) -> None:
+    """Name by-path camera nodes whose resolved targets have no by-id entry."""
+    by_id_targets = {Path(device).resolve(strict=False) for device in by_id_devices}
+    extra_by_path = [
+        device
+        for device in by_path_devices
+        if Path(device).resolve(strict=False) not in by_id_targets
+    ]
+    if not extra_by_path:
+        return
+    names = ", ".join(Path(device).name for device in extra_by_path)
+    message = (
+        f"{len(extra_by_path)} by-path camera nodes have no by-id entry "
+        f"(udev serial collision or missing symlink): {names}; "
+        "by-path names are stable per physical USB port"
+    )
+    if active_is_by_id:
+        message += "; press 'p' to switch listing"
+    print(_paint(message, _YELLOW, out), file=out)
+
+
 def _identify_by_replug(
     role: str,
     devices: list[str],
@@ -337,6 +363,7 @@ def _prompt_device_slot(
     camera_role: str | None = None,
 ) -> tuple[str | None, bool]:
     """Prompt for one slot and return its device plus active listing state."""
+    warned_current = False
     while True:
         devices = by_id_devices if active_is_by_id else by_path_devices
         device_dir = by_id_dir if active_is_by_id else by_path_dir
@@ -379,6 +406,27 @@ def _prompt_device_slot(
             if selected is None:
                 continue
         elif not entered and current is not None:
+            if (
+                kind == "v4l2"
+                and not warned_current
+                and current not in by_id_devices
+                and current not in by_path_devices
+            ):
+                warning: str | None = None
+                if not Path(current).exists():
+                    warning = (
+                        f"warning: {current} does not exist here "
+                        "(ok if this config is for another machine)"
+                    )
+                elif _v4l2_color_capture(Path(current)) is False:
+                    warning = (
+                        f"warning: {current} offers no color capture format "
+                        "(likely a depth or metadata node)"
+                    )
+                if warning is not None:
+                    print(_paint(warning, _YELLOW, out), file=out)
+                    warned_current = True
+                    continue
             selected = current
         elif kind != "can" and (entered.startswith("/") or Path(entered).is_absolute()):
             # startswith("/") keeps POSIX rig paths accepted on Windows
@@ -484,17 +532,7 @@ def _camera_section(
             _paint("no /dev/v4l devices found (not Linux, or no cameras attached)", _YELLOW, out),
             file=out,
         )
-    if advertise_path_toggle:
-        print(
-            _paint(
-                f"only {len(by_id_devices)} by-id entries for "
-                f"{len(by_path_devices)} detected cameras — identical cameras without serials "
-                "collide there; by-path names are stable per physical USB port",
-                _YELLOW,
-                out,
-            ),
-            file=out,
-        )
+    _print_camera_path_hint(by_id_devices, by_path_devices, active_is_by_id, out)
 
     while True:
         assignments: dict[str, str] = {}
@@ -628,17 +666,8 @@ def _device_section(
         if slot.kind not in listed_kinds:
             _print_slot_listing(slot.kind, current_devices, current_dir, out)
             listed_kinds.add(slot.kind)
-            if slot.kind == "v4l2" and advertise_path_toggle:
-                print(
-                    _paint(
-                        f"only {len(by_id_devices)} by-id entries for "
-                        f"{len(by_path_devices)} detected cameras — identical cameras without "
-                        "serials collide there; by-path names are stable per physical USB port",
-                        _YELLOW,
-                        out,
-                    ),
-                    file=out,
-                )
+            if slot.kind == "v4l2":
+                _print_camera_path_hint(by_id_devices, by_path_devices, active_is_by_id, out)
 
         selected, active_is_by_id = _prompt_device_slot(
             slot.label,

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1451,7 +1451,7 @@ def test_run_setup_path_toggle_is_accepted_when_not_advertised(tmp_path: Path) -
     assert output.count(f"Found 3 camera device(s) under {by_id}:") == 2
     assert output.count(f"Found 3 camera device(s) under {by_path}:") == 1
     assert all("'p'" not in prompt for prompt in role_prompts)
-    assert "only 3 by-id entries" not in output
+    assert "by-path camera nodes have no by-id entry" not in output
     assert f"top_cam_device = {by_id_devices[0]}" in _config_path(tmp_path).read_text(
         encoding="utf-8"
     )

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -19,6 +19,7 @@ from inspect_robots._setup import (
     SUGGESTED,
     _can_serial,
     _identify_by_replug,
+    _prompt_device_slot,
     _read_raw_config,
     _render_config,
     _scan_cameras,
@@ -45,6 +46,35 @@ def _scripted_input(
         return response
 
     return input_fn, prompts
+
+
+def _prompt_current_device(
+    tmp_path: Path,
+    kind: str,
+    by_id_devices: list[str],
+    by_path_devices: list[str],
+    current: str,
+    responses: list[str | BaseException],
+) -> tuple[str | None, list[str], str]:
+    input_fn, prompts = _scripted_input(responses)
+    out = io.StringIO()
+    selected, _active_is_by_id = _prompt_device_slot(
+        "inspection camera" if kind == "v4l2" else "left CAN channel",
+        kind,
+        by_id_devices,
+        by_path_devices,
+        True,
+        tmp_path / "by-id",
+        tmp_path / "by-path",
+        current,
+        {},
+        False,
+        input_fn=input_fn,
+        out=out,
+        rescan_by_id=lambda: by_id_devices,
+        rescan_by_path=lambda: by_path_devices,
+    )
+    return selected, prompts, out.getvalue()
 
 
 def _config_path(tmp_path: Path) -> Path:
@@ -1397,7 +1427,12 @@ def test_run_setup_path_toggle_is_accepted_when_not_advertised(tmp_path: Path) -
     by_id = tmp_path / "by-id"
     by_path = tmp_path / "by-path"
     by_id_devices = _make_devices(by_id)
-    _make_devices(by_path)
+    by_path.mkdir()
+    try:
+        for device in by_id_devices:
+            (by_path / Path(device).name).symlink_to(device)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
     input_fn, prompts = _scripted_input(["", "", "", "", "", "", "", "p", "p", "1", "2", "3"])
     out = io.StringIO()
 
@@ -1440,8 +1475,9 @@ def test_run_setup_advertises_by_path_when_by_id_entries_collide(tmp_path: Path)
     )
 
     explanation = (
-        "only 1 by-id entries for 3 detected cameras — identical cameras without serials "
-        "collide there; by-path names are stable per physical USB port"
+        "3 by-path camera nodes have no by-id entry (udev serial collision or missing symlink): "
+        "camera-1-video-index0, camera-2-video-index0, camera-3-video-index0; "
+        "by-path names are stable per physical USB port; press 'p' to switch listing"
     )
     role_prompts = [prompt for prompt in prompts if " camera — " in prompt]
     text = _config_path(tmp_path).read_text(encoding="utf-8")
@@ -1450,6 +1486,43 @@ def test_run_setup_advertises_by_path_when_by_id_entries_collide(tmp_path: Path)
     assert all("'p' to switch listing" in prompt for prompt in role_prompts)
     assert f"Found 3 camera device(s) under {by_path}:" in out.getvalue()
     assert all(device in text for device in by_path_devices)
+
+
+def test_run_setup_by_path_hint_omits_toggle_when_listing_is_already_active(
+    tmp_path: Path,
+) -> None:
+    by_path = tmp_path / "by-path"
+    targets = tmp_path / "targets"
+    by_path.mkdir()
+    targets.mkdir()
+    entry_names = [f"pci-camera-{number}" for number in range(1, 4)]
+    try:
+        for name in entry_names:
+            target = targets / name
+            target.touch()
+            (by_path / name).symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+    input_fn, _prompts = _scripted_input(["", "", "", "", "", "", "", "1", "2", "3"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path)},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=by_path,
+    )
+
+    explanation = (
+        "3 by-path camera nodes have no by-id entry (udev serial collision or missing symlink): "
+        "pci-camera-1, pci-camera-2, pci-camera-3; "
+        "by-path names are stable per physical USB port"
+    )
+    assert result == 0
+    assert out.getvalue().count(explanation) == 1
+    assert "press 'p' to switch listing" not in out.getvalue()
 
 
 def test_run_setup_declining_duplicate_device_reprompts_role(tmp_path: Path) -> None:
@@ -1533,6 +1606,131 @@ def test_run_setup_enter_accepts_detected_current_camera_defaults(tmp_path: Path
     assert all(device in text for device in devices)
 
 
+def test_prompt_camera_warns_for_probe_false_then_second_enter_accepts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current = tmp_path / "stale-depth-node"
+    current.touch()
+    probe_paths: list[Path] = []
+
+    def probe(path: Path) -> bool:
+        probe_paths.append(path)
+        return False
+
+    monkeypatch.setattr("inspect_robots._setup._v4l2_color_capture", probe)
+
+    selected, prompts, output = _prompt_current_device(
+        tmp_path, "v4l2", [], [], str(current), ["", ""]
+    )
+
+    assert selected == str(current)
+    assert len(prompts) == 2
+    assert probe_paths == [current]
+    assert output.count("offers no color capture format") == 1
+    assert "likely a depth or metadata node" in output
+    assert "enter a device number" not in output
+
+
+def test_prompt_camera_can_pick_number_after_probe_false_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current = tmp_path / "stale-depth-node"
+    current.touch()
+    picked = tmp_path / "by-id" / "camera-1"
+    picked.parent.mkdir()
+    picked.touch()
+    monkeypatch.setattr("inspect_robots._setup._v4l2_color_capture", lambda _path: False)
+
+    selected, prompts, output = _prompt_current_device(
+        tmp_path, "v4l2", [str(picked)], [], str(current), ["", "1"]
+    )
+
+    assert selected == str(picked)
+    assert len(prompts) == 2
+    assert output.count("offers no color capture format") == 1
+
+
+@pytest.mark.parametrize("verdict", [None, True])
+def test_prompt_camera_silently_accepts_inconclusive_or_true_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    verdict: bool | None,
+) -> None:
+    current = tmp_path / "current-camera"
+    current.touch()
+    monkeypatch.setattr("inspect_robots._setup._v4l2_color_capture", lambda _path: verdict)
+
+    selected, prompts, output = _prompt_current_device(tmp_path, "v4l2", [], [], str(current), [""])
+
+    assert selected == str(current)
+    assert len(prompts) == 1
+    assert "warning:" not in output
+
+
+def test_prompt_camera_accepts_by_path_member_without_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current = tmp_path / "by-path" / "camera-1"
+    current.parent.mkdir()
+    current.touch()
+    probe_paths: list[Path] = []
+    monkeypatch.setattr(
+        "inspect_robots._setup._v4l2_color_capture", lambda path: probe_paths.append(path)
+    )
+
+    selected, prompts, output = _prompt_current_device(
+        tmp_path, "v4l2", [], [str(current)], str(current), [""]
+    )
+
+    assert selected == str(current)
+    assert len(prompts) == 1
+    assert probe_paths == []
+    assert "warning:" not in output
+
+
+def test_prompt_camera_warns_for_missing_current_then_second_enter_accepts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current = tmp_path / "remote-camera"
+    probe_paths: list[Path] = []
+    monkeypatch.setattr(
+        "inspect_robots._setup._v4l2_color_capture", lambda path: probe_paths.append(path)
+    )
+
+    selected, prompts, output = _prompt_current_device(
+        tmp_path, "v4l2", [], [], str(current), ["", ""]
+    )
+
+    assert selected == str(current)
+    assert len(prompts) == 2
+    assert probe_paths == []
+    assert (
+        output.count(
+            f"warning: {current} does not exist here (ok if this config is for another machine)"
+        )
+        == 1
+    )
+    assert "enter a device number" not in output
+
+
+def test_prompt_can_not_detected_current_still_accepts_single_enter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    probe_paths: list[Path] = []
+    monkeypatch.setattr(
+        "inspect_robots._setup._v4l2_color_capture", lambda path: probe_paths.append(path)
+    )
+
+    selected, prompts, output = _prompt_current_device(
+        tmp_path, "can", ["can0"], ["can0"], "can9", [""]
+    )
+
+    assert selected == "can9"
+    assert len(prompts) == 1
+    assert probe_paths == []
+    assert "warning:" not in output
+
+
 def test_run_setup_marks_undetected_current_camera_defaults(tmp_path: Path) -> None:
     by_id = tmp_path / "by-id"
     _make_devices(by_id)
@@ -1548,12 +1746,13 @@ def test_run_setup_marks_undetected_current_camera_defaults(tmp_path: Path) -> N
         + "\n",
         encoding="utf-8",
     )
-    input_fn, prompts = _scripted_input([""] * 10)
+    input_fn, prompts = _scripted_input([""] * 13)
+    out = io.StringIO()
 
     result = run_setup(
         {"XDG_CONFIG_HOME": str(tmp_path)},
         input_fn=input_fn,
-        out=io.StringIO(),
+        out=out,
         interactive=True,
         by_id_dir=by_id,
         by_path_dir=tmp_path / "none-path",
@@ -1564,6 +1763,11 @@ def test_run_setup_marks_undetected_current_camera_defaults(tmp_path: Path) -> N
     assert result == 0
     assert all("(current, not detected)" in prompt for prompt in role_prompts)
     assert all(device in text for device in current_devices)
+    assert all(
+        f"warning: {device} does not exist here (ok if this config is for another machine)"
+        in out.getvalue()
+        for device in current_devices
+    )
 
 
 def test_render_config_comment_at_exact_boundary_never_glues(tmp_path: Path) -> None:
@@ -2302,7 +2506,12 @@ def test_run_setup_v4l2_slot_can_switch_to_by_path_listing(
     )
 
     assert result == 0
-    assert "only 1 by-id entries for 2 detected cameras" in out.getvalue()
+    assert (
+        "2 by-path camera nodes have no by-id entry (udev serial collision or missing symlink): "
+        "camera-1-video-index0, camera-2-video-index0; "
+        "by-path names are stable per physical USB port; press 'p' to switch listing"
+        in out.getvalue()
+    )
     assert any("'s' to skip, 'p' to switch listing" in prompt for prompt in prompts)
     assert f"camera_device = {by_path_devices[1]}" in _config_path(tmp_path).read_text(
         encoding="utf-8"


### PR DESCRIPTION
Closes #82. Related: #71, #70.

Spec: plans/0013-setup-probe-accepted-current.md (two adversarial critique
rounds; round 2 verdict ready).

- Enter-accepting a v4l2 current value absent from both scans now validates
  it: a missing path or a definitive probe-False (color-capture check from
  #70) prints one yellow warning and re-prompts; a second Enter always
  accepts. Probe True or inconclusive (None) accepts silently, so Windows
  workstations, foreign-machine configs, and unusual devices see zero new
  friction; same for values present in either listing.
- The by-id/by-path count-mismatch hint is now a shared helper gated on
  by-path entries whose resolved targets have no by-id entry. It names the
  affected nodes (the motivating rig needed to find /dev/video16), states
  both possible causes (udev serial collision or missing symlink), and
  drops the 'p' instruction when the by-path listing is already active.
  The prompt's own 'p' advertisement (advertise_path_toggle) is unchanged.

Deviation from the issue text: the warning is yellow, not red; the wizard
palette defines no red and yellow is its warning convention throughout.

Gates: ruff check, ruff format --check, mypy strict, pytest --cov all green;
459 passed (up from 451), coverage 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
