### PR TITLE
docs: stop recommending uv run to end users

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,18 @@ uv venv && uv pip install inspect-robots
 ```
 
 Any venv workflow works the same way (`python3 -m venv .venv` and that venv's
-`pip` and console scripts). With uv, activate the venv once
-(`source .venv/bin/activate`) and call `inspect-robots` directly, as shown
-below.
+`pip` and console scripts). Either way, activate the venv once
+(`source .venv/bin/activate`; `.venv\Scripts\activate` on Windows) and call
+`inspect-robots` directly, as shown below.
 
 > [!NOTE]
 > Invoke the CLI as plain `inspect-robots`, not `uv run inspect-robots`.
 > Inside a uv project, `uv run` first re-syncs the environment to the
-> project's lockfile, which uninstalls or downgrades whatever the
-> `uv pip install` commands above just added. To use `uv run` anyway, pass
-> `--no-sync`, or declare everything as real dependencies with
-> `uv add inspect-robots` plus your plugins.
+> project's lockfile, downgrading whatever the `uv pip install` commands
+> above just added back to the locked versions; the only trace is an
+> easy-to-miss "Uninstalled N / Installed N packages" line. To use
+> `uv run` anyway, pass `--no-sync`, or declare everything as real
+> dependencies with `uv add inspect-robots` plus your plugins.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,17 @@ uv venv && uv pip install inspect-robots
 ```
 
 Any venv workflow works the same way (`python3 -m venv .venv` and that venv's
-`pip` and console scripts); with uv, run commands through `uv run` as shown
-below and no activation is needed.
+`pip` and console scripts). With uv, activate the venv once
+(`source .venv/bin/activate`) and call `inspect-robots` directly, as shown
+below.
+
+> [!NOTE]
+> Invoke the CLI as plain `inspect-robots`, not `uv run inspect-robots`.
+> Inside a uv project, `uv run` first re-syncs the environment to the
+> project's lockfile, which uninstalls or downgrades whatever the
+> `uv pip install` commands above just added. To use `uv run` anyway, pass
+> `--no-sync`, or declare everything as real dependencies with
+> `uv add inspect-robots` plus your plugins.
 
 ## Quickstart
 
@@ -72,8 +81,9 @@ Install the plugin for your rig (the wizard suggests this one's components)
 and set your defaults once:
 
 ```bash
+source .venv/bin/activate
 uv pip install inspect-robots-yam   # provides the molmoact2 policy + yam_arms rig
-uv run inspect-robots setup
+inspect-robots setup
 ```
 
 The wizard picks your defaults and finds your cameras (unplug one when asked
@@ -85,7 +95,7 @@ by hand, see [the CLI guide](https://inspectrobots.org/guide/cli/).
 Then tell the robot what to do:
 
 ```bash
-uv run inspect-robots "place the fork on the plate"
+inspect-robots "place the fork on the plate"
 ```
 
 Every run opens a live Rerun viewer streaming the cameras, proprioception,
@@ -118,7 +128,7 @@ uv pip install inspect-robots-agent
 Run the LLM on the robot:
 
 ```bash
-uv run inspect-robots "place the fork on the plate" --policy agent -P model=anthropic/claude-fable-5
+inspect-robots "place the fork on the plate" --policy agent -P model=anthropic/claude-fable-5
 ```
 
 ### Run in simulation
@@ -127,7 +137,7 @@ The same instruction runs on your configured simulator instead of the
 real robot:
 
 ```bash
-uv run inspect-robots "place the fork on the plate" --sim
+inspect-robots "place the fork on the plate" --sim
 ```
 
 ### More CLI commands
@@ -136,19 +146,19 @@ The full command line resolves any registered task/policy/embodiment
 (builtins + installed plugins). List what is registered:
 
 ```bash
-uv run inspect-robots list
+inspect-robots list
 ```
 
 Run a registered task with explicit components:
 
 ```bash
-uv run inspect-robots run --task cubepick-reach --policy scripted --embodiment cubepick
+inspect-robots run --task cubepick-reach --policy scripted --embodiment cubepick
 ```
 
 Pretty-print a saved eval log:
 
 ```bash
-uv run inspect-robots inspect logs/cubepick-reach_*.json
+inspect-robots inspect logs/cubepick-reach_*.json
 ```
 
 ### Python API

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -1048,6 +1048,6 @@ def run_setup(
             [f"setup complete, but {count} runtime {dependency} missing:", *runtime_lines]
         )
         print(_paint(block, _YELLOW, out), file=out)
-    next_cmd = 'uv run inspect-robots "place the fork on the plate"'
+    next_cmd = 'inspect-robots "place the fork on the plate"'
     print(f"Next: {_paint(next_cmd, _CYAN, out)}", file=out)
     return 0

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -550,7 +550,7 @@ def test_run_setup_defaults_and_numbered_cameras_write_golden_config(tmp_path: P
     assert f"Found 3 camera device(s) under {by_id}:" in output
     assert f"  1. {Path(devices[0]).name}" in output
     assert f"Wrote {path}" in output
-    assert 'Next: uv run inspect-robots "place the fork on the plate"' in output
+    assert 'Next: inspect-robots "place the fork on the plate"' in output
 
 
 def test_run_setup_headless_defaults_rerun_false_and_explains(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #81.

`uv run` inside any uv project re-syncs to that project's lockfile before
executing, downgrading lockfile-tracked packages that `uv pip install` just
upgraded; the only trace is an easy-to-miss "Uninstalled N / Installed N"
line. Our quickstart and the wizard's own printed next-step hint both
recommended exactly that mix; on a yam rig today it downgraded a fresh 0.8.1
install to 0.8.0 mid-quickstart, resurrecting the pre-#70 camera wizard and
ending in a runtime `EmbodimentFault` pointing at a depth node.

- README install section now instructs activating the venv once and calling
  plain `inspect-robots` everywhere, with a NOTE alert stating uv run's
  actual inexact-sync behavior (empirically verified during review: locked
  packages get downgraded, lock-absent ones survive) and the escape hatches
  (`--no-sync`, `uv add`). Contributor dev-loop `uv run` usage is unchanged,
  since running repo tools against the repo's own lock is what `uv run` is
  for.
- `_setup.py` next-step hint drops the `uv run` prefix; test assertion
  updated.

Swept docs/, examples/, plugins/*/README.md, CONTRIBUTING.md: already clean.
plans/ still shows the old hint in 0009's transcript; left as-is per the
point-in-time convention for design docs.

Gates green locally (ruff, mypy strict, pytest --cov 100%). Fresh-eye
subagent review round 1: one blocking wording fix (applied), verdict approve
after fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
