### PR TITLE
feat: stream to a remote Rerun viewer via --rerun-connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- Remote Rerun streaming via `inspect-robots run --rerun-connect [URL]`, so
+  headless evaluations can connect over gRPC to a viewer on another machine
+  (including through an SSH reverse tunnel) (#86).
 - Plugin-declared embodiment device slots for V4L2 cameras, SocketCAN
   interfaces, and serial devices. `inspect-robots setup` probes and interviews
   declared slots, enforces grouped all-or-none assignments, and suggests udev

--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -62,9 +62,21 @@ Rerun.
 
 ```python
 RerunSink("run.rrd")                   # record to a file, view later
-RerunSink(spawn=True)                  # live viewer (what the CLI wires up)
+RerunSink(spawn=True)                  # live viewer on this machine (CLI: --rerun)
+RerunSink(connect_url="rerun+http://127.0.0.1:9876/proxy")  # stream to a running viewer
 RerunSink(spawn=True, jpeg_quality=None, queue_size=128)  # lossless, deeper buffer
 ```
+
+The three modes are mutually exclusive: rerun's `save`/`spawn`/`connect_grpc`
+calls each replace the SDK's global sink, so combining them raises `ValueError`
+rather than silently dropping a stream.
+
+On a headless robot box, `spawn=True` has nowhere to open a window. Run the
+viewer on your own machine instead and stream to it: `rerun` on your laptop,
+`ssh -R 9876:localhost:9876 <robot>` for the tunnel, then
+`inspect-robots run ... --rerun-connect` (a bare `--rerun-connect` targets the
+tunnel's localhost URL above; pass a URL to reach a viewer elsewhere). Viewer
+and SDK versions must match for live connections.
 
 ## Frame side-cars
 

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -209,6 +209,7 @@ def _prompt_defaults(
             print(
                 _paint(
                     "no display detected (SSH?): the rerun viewer cannot open here; "
+                    "use --rerun-connect to stream to a viewer on another machine; "
                     "frames still record with store_frames",
                     _YELLOW,
                     out,

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -85,6 +85,8 @@ _SUBCOMMANDS = ("list", "run", "inspect", "config", "setup", "doctor")
 
 _ENV_BY_KIND = {"policy": ENV_POLICY, "embodiment": ENV_EMBODIMENT}
 
+DEFAULT_RERUN_CONNECT_URL = "rerun+http://127.0.0.1:9876/proxy"
+
 
 def _parse_kvs(pairs: Sequence[str] | None) -> dict[str, Any]:
     out: dict[str, Any] = {}
@@ -174,6 +176,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="stream the rollout (cameras, state, actions) to a live Rerun "
         "viewer window; needs rerun-sdk (--no-rerun overrides a rerun config "
         "default)",
+    )
+    p_run.add_argument(
+        "--rerun-connect",
+        nargs="?",
+        const=DEFAULT_RERUN_CONNECT_URL,
+        default=None,
+        metavar="URL",
+        help="stream the rollout to a Rerun viewer already running elsewhere "
+        "(e.g. your laptop via an SSH reverse tunnel: ssh -R 9876:localhost:9876 ...); "
+        f"URL defaults to {DEFAULT_RERUN_CONNECT_URL}",
     )
     p_run.add_argument(
         "--disable-guardrails",
@@ -584,7 +596,12 @@ def _cmd_run(args: argparse.Namespace) -> int:
         # Construct the sink explicitly so we can tell the user where the log went.
         sink = JsonLogSink(args.log_dir)
         sinks: list[LogSink] = [sink]
-        if args.rerun if args.rerun is not None else defaults.rerun:
+        if args.rerun_connect is not None:
+            from inspect_robots.logging.rerun_sink import RerunSink
+
+            sinks.append(RerunSink(connect_url=args.rerun_connect))
+            print(f"{_styled('rerun:', _CYAN)} connect {args.rerun_connect}")
+        elif args.rerun if args.rerun is not None else defaults.rerun:
             from inspect_robots.logging.rerun_sink import RerunSink
 
             # spawn=True opens the live viewer; the sink itself degrades to a

--- a/src/inspect_robots/logging/rerun_sink.py
+++ b/src/inspect_robots/logging/rerun_sink.py
@@ -39,6 +39,10 @@ class RerunSink:
     ):
         if spawn and connect_url is not None:
             raise ValueError("spawn and connect_url are mutually exclusive")
+        if recording_path is not None and connect_url is not None:
+            # rerun's save/connect/spawn calls each *replace* the global sink,
+            # so combining them would silently drop the live stream.
+            raise ValueError("recording_path and connect_url are mutually exclusive")
         self.recording_path = recording_path
         self.application_id = application_id
         self.spawn = spawn

--- a/src/inspect_robots/logging/rerun_sink.py
+++ b/src/inspect_robots/logging/rerun_sink.py
@@ -37,11 +37,13 @@ class RerunSink:
         spawn: bool = False,
         connect_url: str | None = None,
     ):
+        # rerun's save/connect/spawn calls each *replace* the global sink, so
+        # combining any two modes would silently drop one of the streams.
         if spawn and connect_url is not None:
             raise ValueError("spawn and connect_url are mutually exclusive")
+        if spawn and recording_path is not None:
+            raise ValueError("spawn and recording_path are mutually exclusive")
         if recording_path is not None and connect_url is not None:
-            # rerun's save/connect/spawn calls each *replace* the global sink,
-            # so combining them would silently drop the live stream.
             raise ValueError("recording_path and connect_url are mutually exclusive")
         self.recording_path = recording_path
         self.application_id = application_id

--- a/src/inspect_robots/logging/rerun_sink.py
+++ b/src/inspect_robots/logging/rerun_sink.py
@@ -1,10 +1,11 @@
 """Optional Rerun visualization sink.
 
-Logs camera images, proprioception, action vectors, and success markers to a
-`Rerun <https://github.com/rerun-io/rerun>`_ recording. ``rerun-sdk`` is imported
-lazily *inside* methods so the core package never depends on it; if it is not
-installed, the sink warns once and becomes a no-op (so unattended runs and the
-core-only import gate are unaffected).
+Logs camera images, proprioception, action vectors, and success markers to
+`Rerun <https://github.com/rerun-io/rerun>`_. The sink can write a ``.rrd``
+recording, spawn a local viewer, or connect over gRPC to a remote viewer.
+``rerun-sdk`` is imported lazily *inside* methods so the core package never
+depends on it; if it is not installed, the sink warns once and becomes a no-op
+(so unattended runs and the core-only import gate are unaffected).
 
 Each trial's entities are namespaced under ``trial/<scene_id>/e<epoch>`` so
 successive trials never overwrite one another on the shared step timeline.
@@ -26,7 +27,7 @@ if TYPE_CHECKING:
 
 
 class RerunSink:
-    """Stream a rollout to a Rerun recording (``.rrd``) or a live viewer."""
+    """Write a ``.rrd``, spawn a local viewer, or connect over gRPC to a remote one."""
 
     def __init__(
         self,
@@ -34,10 +35,14 @@ class RerunSink:
         *,
         application_id: str = "inspect_robots",
         spawn: bool = False,
+        connect_url: str | None = None,
     ):
+        if spawn and connect_url is not None:
+            raise ValueError("spawn and connect_url are mutually exclusive")
         self.recording_path = recording_path
         self.application_id = application_id
         self.spawn = spawn
+        self.connect_url = connect_url
         self._rr: Any | None = None
         self._warned = False
         self._disabled = False
@@ -89,12 +94,15 @@ class RerunSink:
             return
         try:
             rr.init(self.application_id, spawn=self.spawn)
+            if self.connect_url is not None:
+                rr.connect_grpc(self.connect_url)
             if self.recording_path is not None:
                 rr.save(self.recording_path)
         except Exception as exc:
             # A visualization sink must never take the eval down with it — a
-            # missing viewer binary (spawn) or unwritable recording path
-            # degrades to a warned no-op, exactly like a missing rerun-sdk.
+            # missing viewer binary (spawn), unreachable viewer (connect), or
+            # unwritable recording path degrades to a warned no-op, exactly
+            # like a missing rerun-sdk.
             warnings.warn(
                 f"RerunSink disabled: could not start the Rerun recording/viewer ({exc})",
                 RuntimeWarning,

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -1284,8 +1284,15 @@ class _FakeRerunSink:
 
     instances: ClassVar[list[_FakeRerunSink]] = []
 
-    def __init__(self, recording_path: str | None = None, *, spawn: bool = False) -> None:
+    def __init__(
+        self,
+        recording_path: str | None = None,
+        *,
+        spawn: bool = False,
+        connect_url: str | None = None,
+    ) -> None:
         self.spawn = spawn
+        self.connect_url = connect_url
         self.steps = 0
         _FakeRerunSink.instances.append(self)
 
@@ -1345,6 +1352,36 @@ def test_rerun_flag_enables_without_config(
     rc = main(["reach the cube", "--log-dir", str(tmp_path / "logs"), "--rerun"])
     assert rc == 0
     assert len(_fake_rerun.instances) == 1
+
+
+def test_bare_rerun_connect_uses_default_url(
+    _hermetic_defaults: Path, tmp_path: Path, _fake_rerun: type[_FakeRerunSink]
+) -> None:
+    """A bare --rerun-connect streams to the documented localhost URL."""
+    assert _run_adhoc(_hermetic_defaults, tmp_path, "--rerun-connect") == 0
+    (sink,) = _fake_rerun.instances
+    assert sink.connect_url == cli.DEFAULT_RERUN_CONNECT_URL
+    assert sink.spawn is False
+
+
+def test_rerun_connect_honors_explicit_url(
+    _hermetic_defaults: Path, tmp_path: Path, _fake_rerun: type[_FakeRerunSink]
+) -> None:
+    """An explicit --rerun-connect URL is passed through to RerunSink."""
+    url = "rerun+http://viewer.example:9988/proxy"
+    assert _run_adhoc(_hermetic_defaults, tmp_path, "--rerun-connect", url) == 0
+    (sink,) = _fake_rerun.instances
+    assert sink.connect_url == url
+
+
+def test_rerun_connect_takes_precedence_over_rerun(
+    _hermetic_defaults: Path, tmp_path: Path, _fake_rerun: type[_FakeRerunSink]
+) -> None:
+    """Remote connection wins when both --rerun modes are requested."""
+    assert _run_adhoc(_hermetic_defaults, tmp_path, "--rerun", "--rerun-connect") == 0
+    (sink,) = _fake_rerun.instances
+    assert sink.connect_url == cli.DEFAULT_RERUN_CONNECT_URL
+    assert sink.spawn is False
 
 
 def test_styled_plain_when_not_a_tty(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -37,6 +37,12 @@ def test_spawn_and_connect_are_mutually_exclusive() -> None:
         RerunSink(spawn=True, connect_url="rerun+http://127.0.0.1:9876/proxy")
 
 
+def test_recording_and_connect_are_mutually_exclusive() -> None:
+    """A sink cannot record to .rrd and stream to a remote viewer at once."""
+    with pytest.raises(ValueError, match="recording_path and connect_url are mutually exclusive"):
+        RerunSink("run.rrd", connect_url="rerun+http://127.0.0.1:9876/proxy")
+
+
 def test_connect_grpc_is_called_only_when_configured() -> None:
     """Startup connects to the configured URL and skips gRPC when it is unset."""
 

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -31,6 +31,39 @@ def test_rerun_sink_registered() -> None:
     assert "rerun" in registered("sink")
 
 
+def test_spawn_and_connect_are_mutually_exclusive() -> None:
+    """A sink cannot spawn locally and connect to a remote viewer."""
+    with pytest.raises(ValueError, match="spawn and connect_url are mutually exclusive"):
+        RerunSink(spawn=True, connect_url="rerun+http://127.0.0.1:9876/proxy")
+
+
+def test_connect_grpc_is_called_only_when_configured() -> None:
+    """Startup connects to the configured URL and skips gRPC when it is unset."""
+
+    class _FakeRR:
+        def __init__(self) -> None:
+            self.init_count = 0
+            self.connect_urls: list[str] = []
+
+        def init(self, *args: object, **kwargs: object) -> None:
+            self.init_count += 1
+
+        def connect_grpc(self, url: str) -> None:
+            self.connect_urls.append(url)
+
+    url = "rerun+http://127.0.0.1:9876/proxy"
+    fake = _FakeRR()
+    connected = RerunSink(connect_url=url)
+    connected._rr = fake
+    connected.on_eval_start(None)  # type: ignore[arg-type]
+    unconnected = RerunSink()
+    unconnected._rr = fake
+    unconnected.on_eval_start(None)  # type: ignore[arg-type]
+
+    assert fake.init_count == 2
+    assert fake.connect_urls == [url]
+
+
 @pytest.mark.skipif(_RERUN_INSTALLED, reason="rerun installed; testing the absent path")
 def test_noop_and_warns_when_absent() -> None:
     sink = RerunSink()
@@ -77,3 +110,20 @@ def test_viewer_failure_disables_sink_instead_of_crashing() -> None:
         )
     assert sink.available is False  # dormant from here on
     sink.log_step(0, None, None, None)  # type: ignore[arg-type]  # must not raise
+
+
+def test_connection_failure_disables_sink_instead_of_crashing() -> None:
+    """An unreachable gRPC viewer must warn and leave the sink dormant."""
+
+    class _FakeRR:
+        def init(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        def connect_grpc(self, url: str) -> None:
+            raise RuntimeError(f"could not connect to {url}")
+
+    sink = RerunSink(connect_url="rerun+http://127.0.0.1:9876/proxy")
+    sink._rr = _FakeRR()
+    with pytest.warns(RuntimeWarning, match="RerunSink disabled"):
+        sink.on_eval_start(None)  # type: ignore[arg-type]
+    assert sink.available is False

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -37,6 +37,12 @@ def test_spawn_and_connect_are_mutually_exclusive() -> None:
         RerunSink(spawn=True, connect_url="rerun+http://127.0.0.1:9876/proxy")
 
 
+def test_spawn_and_recording_are_mutually_exclusive() -> None:
+    """A sink cannot spawn a local viewer and record to .rrd at once."""
+    with pytest.raises(ValueError, match="spawn and recording_path are mutually exclusive"):
+        RerunSink("run.rrd", spawn=True)
+
+
 def test_recording_and_connect_are_mutually_exclusive() -> None:
     """A sink cannot record to .rrd and stream to a remote viewer at once."""
     with pytest.raises(ValueError, match="recording_path and connect_url are mutually exclusive"):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -558,6 +558,7 @@ def test_run_setup_headless_defaults_rerun_false_and_explains(tmp_path: Path) ->
     out = io.StringIO()
     note = (
         "no display detected (SSH?): the rerun viewer cannot open here; "
+        "use --rerun-connect to stream to a viewer on another machine; "
         "frames still record with store_frames"
     )
 


### PR DESCRIPTION
Closes #86.

## What

Adds a third `RerunSink` mode — streaming to an already-running remote viewer over gRPC — and exposes it on the CLI:

- `RerunSink(connect_url=...)` calls `rr.connect_grpc(url)` after `rr.init`; mutually exclusive with `spawn` (raises `ValueError`).
- `inspect-robots run --rerun-connect [URL]` wires it up. The bare flag defaults to `rerun+http://127.0.0.1:9876/proxy`, so the SSH-reverse-tunnel workflow needs no argument. `--rerun-connect` takes precedence over `--rerun`/config default.
- Fail-soft behavior is unchanged: an unreachable viewer warns once ("RerunSink disabled: ...") and the sink goes dormant — the eval never dies for visualization.
- The headless setup wizard's "no display detected (SSH?)" note now points at `--rerun-connect`.

## Why

`--rerun` spawns the viewer on the eval machine, which is useless when the robot box is headless and reached over SSH — our standard setup. Rerun natively supports viewer-on-laptop / SDK-on-robot over gRPC; this exposes it:

```bash
# operator laptop
rerun                                   # viewer listens on 9876
ssh -R 9876:localhost:9876 robocurve@omen

# robot box (inside the SSH session)
inspect-robots run ... --rerun-connect
```

## Testing

- `uv run ruff check .` / `uv run ruff format --check .` — clean
- `uv run mypy` — clean (54 files)
- `uv run pytest --cov` — 457 passed, 1 skipped, **100.00%** coverage
- New tests: mutual-exclusion `ValueError`; `connect_grpc` called only when configured; connection failure warns and disables the sink; CLI passes the default URL, honors an explicit URL, and prefers connect over spawn.

Note: viewer/SDK versions must match for live connections — with rerun-sdk 0.34.x on the robot, install viewer 0.34.x on the laptop (`pipx install rerun-sdk==0.34.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)