### PR TITLE
feat: always hint how to view the eval log after a run

### DIFF
--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -464,8 +464,9 @@ def _print_run_summary(log: EvalLog, log_path: str, is_adhoc: bool) -> None:
     for name, value in sorted(log.results.metrics.items()):
         print(f"  {name}: {_styled(f'{value:.4g}', _BOLD)}")
     print(f"{_styled('log:', _CYAN)} {_styled(log_path, _DIM)}")
-    if failed or errored_count:
-        print(_styled(f"hint: inspect-robots inspect {log_path}", _DIM))
+    # Every run ends with the copy-pasteable read-back command (issue #90):
+    # a bare path teaches a first-time user nothing about what to do next.
+    print(_styled(f"hint: view it with: inspect-robots inspect {log_path}", _DIM))
 
 
 def _cmd_run(args: argparse.Namespace) -> int:

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -106,7 +106,9 @@ def test_cli_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     (written,) = tmp_path.glob("*.json")
     assert f"log: {written}" in out  # the CLI tells the user where the log went
     assert "error:" not in out
-    assert "hint:" not in out
+    # A clean run still teaches how to read the log — and nothing else hints.
+    assert f"hint: view it with: inspect-robots inspect {written}" in out
+    assert out.count("hint:") == 1
 
 
 def test_cli_run_embodiment_fault_prints_error_scene_and_inspect_hint(
@@ -157,7 +159,7 @@ def test_cli_run_embodiment_fault_prints_error_scene_and_inspect_hint(
     assert "scene-0" not in out  # successful scenes are not failure context
     assert out.count("EmbodimentFault: reset exploded") == 1
     (written,) = tmp_path.glob("*.json")
-    assert f"hint: inspect-robots inspect {written}" in out
+    assert f"hint: view it with: inspect-robots inspect {written}" in out
 
 
 def test_cli_run_prints_distinct_scene_error(
@@ -238,7 +240,7 @@ def test_cli_all_errored_run_exits_nonzero_with_diagnostics(
     assert "[error] scene-0: PolicyError: invalid API key" in out
     assert "trials: 1 (1 errored)" in out
     (written,) = tmp_path.glob("*.json")
-    assert f"hint: inspect-robots inspect {written}" in out
+    assert f"hint: view it with: inspect-robots inspect {written}" in out
     # And `inspect` on the written log shows the same headline facts.
     assert main(["inspect", str(written)]) == 1
     out = capsys.readouterr().out
@@ -291,7 +293,7 @@ def test_cli_partial_errors_stay_success_but_are_visible(
     assert "trials: 2 (1 errored)" in out
     assert "[error] scene-1: PolicyError: policy reset exploded" in out
     (written,) = tmp_path.glob("*.json")
-    assert f"hint: inspect-robots inspect {written}" in out
+    assert f"hint: view it with: inspect-robots inspect {written}" in out
 
 
 def test_cli_run_epochs_fail_on_error_store_frames(


### PR DESCRIPTION
Closes #90

## What

The post-run summary printed the log path bare on success; the `hint: inspect-robots inspect <path>` line only appeared when the run failed or had errored trials. Now every run ends with a copy-pasteable read-back command:

```
log: logs/adhoc_b22a1737.json
hint: view it with: inspect-robots inspect logs/adhoc_b22a1737.json
```

This follows Inspect AI's pattern of always pairing the log location with an actionable next step (its results footer plus `inspect view` / `inspect eval-retry <log>` hints).

## Tests

- Success-path test upgraded from a blanket `"hint:" not in out` to asserting the view hint is present and is the only hint (`out.count("hint:") == 1`), preserving the hint-silence guard's mutation-catching power for diagnostic hints.
- Failure/partial-error tests updated to the new wording.
- Gates: ruff, ruff format, mypy strict, 488 tests, 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)