### PR TITLE
feat(agent): speed-limited playout replaces duration_s

### DIFF
--- a/plans/0014-agent-speed-limited-playout.md
+++ b/plans/0014-agent-speed-limited-playout.md
@@ -59,8 +59,11 @@ Resolved knobs (user decisions, 2026-07-14):
   motion is interpolated at a fixed safe speed and reports its step count.
 - Per-dimension *per-step* limit:
   `step_frac = min(max_speed_frac / hz, _BACKSTOP_STEP_FRAC)` with
-  `_BACKSTOP_STEP_FRAC = 0.05`, so the per-step change is
-  `step_frac * (high - low)`. The wall-clock speed is
+  `_BACKSTOP_STEP_FRAC = 0.05`, giving `step_frac * (high - low)` — then
+  elementwise-min'd with `0.05 * (high - low)` computed in the box's
+  *native dtype*: `DeltaLimitApprover` derives its default without
+  promoting, so a low-precision box (e.g. float16 bounds) rounds the
+  backstop *below* the float64 value and the plugin must not outrun it. The wall-clock speed is
   `max_speed_frac * range` per second whenever `hz >= max_speed_frac / 0.05`
   (i.e. ≥ 10 Hz at the default frac); on slower embodiments the per-step cap
   wins and the motion plays proportionally slower rather than provoking the
@@ -92,7 +95,9 @@ Resolved knobs (user decisions, 2026-07-14):
     with zero distance to the observed state likewise contribute nothing.
 - Non-finite observed state: if the proprioceptive reference vector contains
   a non-finite value, `execute` raises `ValueError` (the rollout wraps it as
-  `PolicyError` and the trial errors). A broken sensor is not an
+  `PolicyError` and the trial errors). This check runs *before* the
+  per-dimension target validation: a broken sensor must end the trial even
+  when the tool call happens to contain its own correctable mistake. A broken sensor is not an
   LLM-correctable condition, so it does not use the structured-error
   channel; without this guard the steps formula would poison `ceil`/`max`
   with NaN and crash uncontrolled.
@@ -185,6 +190,17 @@ with actionable messages (same stance as `DeltaLimitApprover`):
   binds fine and makes most motions hit the §3c error; that is a truthful
   reflection of an embodiment that genuinely cannot move far in 10 s, not a
   configuration the plugin second-guesses.
+- Derived-quantity guards, all `ToolsetError` at bind time: a declared
+  `control_hz` whose `10 * hz` playout cap overflows to `inf`; a
+  `max_speed_frac` whose `frac / hz` underflows to exactly zero (it would
+  misreport every dimension as fixed); a `high - low` range that overflows
+  to `inf` despite finite endpoints (e.g. `[-1e308, 1e308]`); and non-1-D
+  action-space shapes (the toolset's indexing and bounds text are
+  vector-only).
+- Tool-call values: a JSON number is coerced with `float()` before the
+  finiteness check — arbitrary-precision integers (`10**400`) overflow
+  `float()` and crash `np.isfinite` outright, and both must return the
+  standard "must be a finite number" structured error.
 - The "no bounds; move conservatively" `bounds_text` fallback becomes dead
   in both modes (finite bounds are now required everywhere) and is removed
   outright.

--- a/plans/0014-agent-speed-limited-playout.md
+++ b/plans/0014-agent-speed-limited-playout.md
@@ -35,8 +35,11 @@ last *approved command* held in the trial store, while `move_joints`
 interpolates from the *observed* state. When the two diverge (hardware
 tracking error, a prior clamp, an operator nudge), the first steps of a new
 chunk can still exceed `max_delta` relative to the stored reference and get
-clamped. That is the backstop doing its job; the plugin's claim is only that
-it never *provokes* clamping through its own step sizing.
+clamped. Similarly, if proprioception reads slightly *outside* the box, the
+early actions interpolated from that state are out-of-box and
+`ClampApprover` trims them. Both are the guardrails doing their job; the
+plugin's claim is only that it never provokes clamping through its own step
+sizing from in-box state.
 
 Resolved knobs (user decisions, 2026-07-14):
 
@@ -67,13 +70,10 @@ Resolved knobs (user decisions, 2026-07-14):
   the backstop is per-step. Zero-width dimensions (`high == low`, common
   padding in VLA action spaces) have a zero limit and are legal at bind
   time.
-- Per call, for each *named* dimension, validated in this order:
-  - `target_i` outside `[low_i, high_i]` returns a structured error
-    (`"target for {label} is outside [{low}, {high}]"`). Letting it through
-    would recreate §1's silent divergence: the sizing satisfies the delta
-    limiter while `ClampApprover` pins every step at the bound and the note
-    claims the full motion executed. Bounds are guaranteed finite by §3d,
-    so the check is always meaningful.
+- Per call, for each *named* dimension, validated in this order (zero-width
+  first — a zero-width dimension's off-value targets are also out of its
+  degenerate `[v, v]` box, so the bounds check would otherwise shadow the
+  more instructive error):
   - Zero-width dimensions (`limit == 0`): `target_i != low_i` returns
     `"dimension {label} is fixed at {value}"`. The comparison is against
     the *bound*, not the observed state — on hardware the observation
@@ -82,6 +82,12 @@ Resolved knobs (user decisions, 2026-07-14):
     because the schema's `bounds_text` renders at 4 significant figures
     (`.4g`) and may not match on the first attempt; the error then teaches
     the exact value.
+  - Otherwise, `target_i` outside `[low_i, high_i]` returns a structured
+    error (`"target for {label} is outside [{low}, {high}]"`). Letting it
+    through would recreate §1's silent divergence: the sizing satisfies the
+    delta limiter while `ClampApprover` pins every step at the bound and
+    the note claims the full motion executed. Bounds are guaranteed finite
+    by §3d, so the check is always meaningful.
   - Zero-width dimensions contribute nothing to the step count; dimensions
     with zero distance to the observed state likewise contribute nothing.
 - Non-finite observed state: if the proprioceptive reference vector contains
@@ -135,8 +141,16 @@ Resolved knobs (user decisions, 2026-07-14):
 computed `steps > max_steps` returns a structured `ToolResult(error=...)`
 telling the LLM the request exceeds the playout cap and to split the move
 into smaller motions — advice that always works, because the computed steps
-shrink toward 1 as the motion shrinks. At the default speed a
-full-range `move_joints` needs 2 s, so in practice only large `move_by`
+shrink toward 1 as the motion shrinks. The distance/limit ratios are
+computed with NumPy float64 (inf-tolerant: a huge finite `move_by` delta
+like `1e308` overflows the division to `inf`, never raising) and the cap
+comparison runs *before* `ceil` — `math.ceil(inf)` raises `OverflowError`,
+which would escape as a trial-killing `PolicyError` for what is an
+LLM-correctable mistake, violating the module's errors-not-exceptions
+contract. (`move_joints` cannot reach this: targets are bounds-checked
+first, so its ratio is capped at `1 / step_frac`.) At the default speed a
+full-range `move_joints` needs 21 steps (2.1 s at 10 Hz — the §3a headroom
+bumps the exact 20-split), so in practice only large `move_by`
 totals hit this.
 
 ### 3d. Bind-time bound requirements (never guess)
@@ -155,8 +169,9 @@ with actionable messages (same stance as `DeltaLimitApprover`):
 - Both modes: a declared `control_hz` that is non-finite or `<= 0` is
   rejected at bind time (`None` stays allowed and falls back to
   `_FALLBACK_HZ` for step computation). Core never validates `control_hz`,
-  and `hz = 0` would make §3a floor every motion to a single step while §3c
-  errors every call — contradictory outcomes this check makes unreachable.
+  and `hz = 0` would make §3c's `max_steps = 0`, turning every call into an
+  error — a nonsense configuration this check rejects with a clear message
+  instead.
 - The "no bounds; move conservatively" `bounds_text` fallback becomes dead
   in both modes (finite bounds are now required everywhere) and is removed
   outright.
@@ -167,9 +182,12 @@ motions in them were never actually speed-safe.
 ### 3e. Toolset construction
 
 `Toolset.__init__` / `build_toolset` grow `max_speed_frac: float` (default
-`0.5`) and precompute the per-dimension speed (absolute) or per-side
-per-step limits (displacement). `bounds_text` keeps documenting the box to
-the LLM.
+`0.5`) and precompute the per-dimension per-step limits (absolute) or
+per-side per-step limits (displacement). `build_toolset` owns frac
+validation for direct constructions (`ToolsetError` for non-finite or
+`<= 0`); `LLMAgentPolicy.__init__` additionally validates with `ValueError`
+so a bad `-P max_speed_frac` fails at construction, before any LLM call
+(§4). `bounds_text` keeps documenting the box to the LLM.
 
 ## 4. Policy changes (`policy.py`)
 
@@ -255,7 +273,9 @@ cap" claim.
 - Over-cap request errors with the split-the-move message; boundary exactly
   at `max_steps` succeeds. Covered for both tools: `move_by` with a large
   total, and `move_joints` with a tiny frac (e.g. `max_speed_frac=0.01` →
-  a full-range move needs 100 s).
+  a full-range move needs 1001 steps, 100.1 s).
+- Huge finite `move_by` delta (`1e308`) returns the split-the-move error —
+  never raises (the §3c inf-tolerant cap check).
 - Schemas no longer advertise `duration_s`; a call carrying a stray
   `duration_s` key still succeeds (extra keys were and remain ignored).
 - `control_hz=None`: steps computed at the 10 Hz fallback, chunk emitted
@@ -269,7 +289,9 @@ cap" claim.
   displacement boxes not containing zero are rejected; declared
   `control_hz` of `0`, negative, or non-finite is rejected while `None`
   binds.
-- `max_speed_frac` validation errors (0, negative, non-finite).
+- `max_speed_frac` validation errors (0, negative, non-finite) at both
+  layers: `build_toolset` (`ToolsetError`) and `LLMAgentPolicy.__init__`
+  (`ValueError`; lives in the policy tests).
 - Speed derivation honors non-default frac (absolute modes).
 
 `tests/test_policy_e2e.py`: existing flows updated (tool calls no longer

--- a/plans/0014-agent-speed-limited-playout.md
+++ b/plans/0014-agent-speed-limited-playout.md
@@ -95,9 +95,10 @@ Resolved knobs (user decisions, 2026-07-14):
     with zero distance to the observed state likewise contribute nothing.
 - Non-finite observed state: if the proprioceptive reference vector contains
   a non-finite value, `execute` raises `ValueError` (the rollout wraps it as
-  `PolicyError` and the trial errors). This check runs *before* the
-  per-dimension target validation: a broken sensor must end the trial even
-  when the tool call happens to contain its own correctable mistake. A broken sensor is not an
+  `PolicyError` and the trial errors). This check runs before *any* tool
+  argument validation (labels, value types, per-dimension checks): a broken
+  sensor must end the trial even when the tool call happens to contain its
+  own correctable mistake. A broken sensor is not an
   LLM-correctable condition, so it does not use the structured-error
   channel; without this guard the steps formula would poison `ceil`/`max`
   with NaN and crash uncontrolled.
@@ -192,8 +193,9 @@ with actionable messages (same stance as `DeltaLimitApprover`):
   configuration the plugin second-guesses.
 - Derived-quantity guards, all `ToolsetError` at bind time: a declared
   `control_hz` whose `10 * hz` playout cap overflows to `inf`; a
-  `max_speed_frac` whose `frac / hz` underflows to exactly zero (it would
-  misreport every dimension as fixed); a `high - low` range that overflows
+  `max_speed_frac` whose `frac / hz` underflows to exactly zero, or whose
+  product with any movable dimension's range underflows the derived
+  per-step limit to zero (either would misreport dimensions as fixed); a `high - low` range that overflows
   to `inf` despite finite endpoints — checked in *both* float64 and the
   box's native dtype, since `DeltaLimitApprover` subtracts without
   promoting (float32 `[-3e38, 3e38]` overflows only natively); non-1-D

--- a/plans/0014-agent-speed-limited-playout.md
+++ b/plans/0014-agent-speed-limited-playout.md
@@ -9,62 +9,101 @@ The agent toolset (plan 0008 §4c) makes the LLM pick `duration_s` for every
 motion. Speed is not a quantity the LLM should reason about: the loop is
 open-loop per turn (the model re-observes after the chunk plays out) and the
 trial budget is per LLM call, not per second. Worse, a too-short duration does
-not fail — the core `DeltaLimitApprover` clamps the chunk per step, so the arm
-moves at the speed limit and stops short of the target, while the tool result
-note still claims the full motion executed. The LLM discovers the divergence
-only from the next observation.
+not fail — the core guardrails clamp the chunk per step (`DeltaLimitApprover`
+in absolute modes; `ClampApprover`'s box clamp in displacement modes, where
+the delta limiter adds nothing by default), so the arm moves at the limit and
+stops short of the requested motion, while the tool result note still claims
+the full motion executed. The LLM discovers the divergence only from the next
+observation.
 
 ## 2. Decision
 
 Drop `duration_s` from both motion tools. The toolset computes the playout
-time from a speed cap, so the full requested displacement is always reached;
+time from a speed cap, so the full requested displacement is emitted;
 large motions simply play out over more steps. Guardrails below the plugin
 are unchanged (the plugin still contains no safety-critical code path); at the
-default speed the per-step change stays within the core backstop, so the
-backstop stops biting and tool notes become truthful.
+default speed every emitted per-step change stays strictly within the core
+backstop's 5%-of-range default, so at default settings the backstop does not
+clamp what the plugin emits.
+
+Honest scoping of that guarantee: `DeltaLimitApprover` measures against the
+last *approved command* held in the trial store, while `move_joints`
+interpolates from the *observed* state. When the two diverge (hardware
+tracking error, a prior clamp, an operator nudge), the first steps of a new
+chunk can still exceed `max_delta` relative to the stored reference and get
+clamped. That is the backstop doing its job; the plugin's claim is only that
+it never *provokes* clamping through its own step sizing.
 
 Resolved knobs (user decisions, 2026-07-14):
 
 - Plugin-only; no core controller middleware.
 - `duration_s` is removed, not made optional.
-- Default speed: `max_speed_frac = 0.5` — half the joint's range per second,
-  which equals the core backstop's implied speed (5% of range per step at
-  10 Hz).
+- Default speed: `max_speed_frac = 0.5` — half the joint's range per second
+  for absolute modes, which matches the core backstop's implied speed (5% of
+  range per step at 10 Hz). `max_speed_frac` applies to absolute modes only;
+  see §3b for why `move_by` has no frac.
 
 ## 3. Toolset changes (`_tools.py`)
 
 ### 3a. `move_joints` (absolute modes: `joint_pos`, `eef_abs_pose`)
 
 - Schema: `targets` only; `required: ["targets"]`. Description explains the
-  motion is interpolated at a fixed safe speed and reports its duration.
+  motion is interpolated at a fixed safe speed and reports its step count.
 - Per-dimension speed: `speed = max_speed_frac * (high - low)` per second
-  (float64 vector).
-- Steps: `steps = max(1, ceil(max_i(|target_i - current_i| / speed_i) * hz))`
-  computed only over dimensions named in the call (unnamed dimensions hold
-  and contribute zero distance). `hz` falls back to `_FALLBACK_HZ = 10.0` as
-  today.
+  (float64 vector). Zero-width dimensions (`high == low`, common padding in
+  VLA action spaces) have `speed == 0` and are legal at bind time.
+- Per call, for each *named* dimension: if `speed_i == 0` and
+  `target_i != current_i`, return a structured error
+  (`"dimension {label} is fixed at {value}"`). Dimensions with zero distance
+  (including zero-width ones re-sent at their fixed value) contribute
+  nothing to the step count.
+- Steps: `steps = max(1, ceil(max_i(|target_i - current_i| / speed_i) * hz
+  / (1 - 1e-6)))`, the max taken over named dimensions with positive
+  distance and positive speed; an empty max (all named targets equal the
+  current state) yields `steps = 1`. The `1e-6` relative headroom exists
+  because `linspace` interpolation accumulates ~1 ulp of float error per
+  step: without it, a step count that divides the distance exactly (e.g.
+  range 2.0, distance 1.5, 15 steps, limit 0.1) emits consecutive deltas of
+  `0.1 + 1 ulp` and the backstop clamps spuriously at the default boundary.
+  `hz` falls back to `_FALLBACK_HZ = 10.0` as today.
 - Interpolation is unchanged (`linspace` fractions from current observed
   state).
 
 ### 3b. `move_by` (displacement modes: `eef_delta_pos`, `eef_delta_pose`, `joint_delta`)
 
 - Schema: `deltas` only; `required: ["deltas"]`.
-- Displacement boxes are per-action sized by convention, and `ClampApprover`
-  clamps each step to the box — so the box side is the per-step limit and
-  splitting to fit it is the only non-lossy choice.
+- The plugin treats displacement boxes as per-action sized — a plugin-level
+  convention (core explicitly refuses to assume this, which is exactly why
+  the delta limiter derives no default there). Under that convention, and
+  because `ClampApprover` clamps each step to the box, the box side is the
+  per-step limit and splitting to fit it is the only non-lossy choice.
+- `max_speed_frac` deliberately does not apply here: the box *is* the
+  embodiment author's per-step speed statement, and scaling it by a fraction
+  of itself has no principled unit. The README documents this asymmetry; a
+  test pins that `move_by` ignores the knob.
 - Per-step limit per dimension: `high_i` for a positive component, `|low_i|`
   for a negative one.
+- Per call, for each named dimension with a nonzero value: if the limit on
+  the requested side is zero, return a structured error
+  (`"dimension {label} cannot move in that direction"`).
 - Steps: `steps = max(1, ceil(max_i(|delta_i| / limit_i)))` over named
-  dimensions with nonzero values; each action is `vector / steps` (unchanged
-  emission shape).
+  dimensions with nonzero values; all-zero deltas (legal today, a hold) get
+  `steps = 1`, emitting a single zero action. Each action is
+  `vector / steps` (unchanged emission shape). No float headroom is needed:
+  each emitted action is exactly `vector / steps`, whose magnitude is
+  `<= limit` by construction of `ceil`, and no cumulative interpolation is
+  involved.
 
 ### 3c. Chunk cap
 
-`_MAX_DURATION_S = 10.0` stays, reinterpreted: `max_steps = ceil(10 * hz)`.
-A computed `steps > max_steps` returns a structured `ToolResult(error=...)`
-telling the LLM the request exceeds the 10 s playout cap and to split the
-move. At the default speed a full-range `move_joints` needs 2 s, so in
-practice only absurd `move_by` totals hit this.
+`_MAX_DURATION_S = 10.0` stays, reinterpreted: `max_steps = ceil(10 * hz)`
+(with `hz` the same fallback-resolved rate used for step computation). A
+computed `steps > max_steps` returns a structured `ToolResult(error=...)`
+telling the LLM the request exceeds the playout cap and to split the move
+into smaller motions — advice that always works, because a smaller distance
+or delta strictly reduces the computed steps. At the default speed a
+full-range `move_joints` needs 2 s, so in practice only large `move_by`
+totals hit this.
 
 ### 3d. Bind-time bound requirements (never guess)
 
@@ -72,14 +111,12 @@ practice only absurd `move_by` totals hit this.
 with actionable messages (same stance as `DeltaLimitApprover`):
 
 - Absolute modes: every dimension needs finite `low` and `high` (speed is
-  derived from the range). The existing "no bounds; move conservatively"
-  fallback text disappears for absolute modes since unbounded absolute spaces
-  are now rejected.
-- Displacement modes: every dimension needs a finite bound on each side
-  (`low_i < 0 < high_i` finite both sides; a zero bound on a side simply
-  means that direction cannot move, which the box already enforces — no
-  special-casing, division guards use the bound only for the direction
-  requested).
+  derived from the range). `high == low` is allowed (handled per call, §3a).
+  The existing "no bounds; move conservatively" fallback text disappears for
+  absolute modes since unbounded absolute spaces are now rejected.
+- Displacement modes: every dimension needs finite `low` and `high`. A zero
+  bound on one side is allowed (that direction simply cannot move; handled
+  per call, §3b).
 
 Previously such spaces "worked" only because the LLM supplied a duration;
 motions in them were never actually speed-safe.
@@ -101,26 +138,37 @@ the LLM.
 - `bind()` forwards it to `build_toolset`.
 - `_SYSTEM_TEMPLATE`: no duration mention today, so only the tool
   descriptions change; keep "small, deliberate motions" guidance.
-- CLI passthrough needs no change (`-P max_speed_frac=0.5` already coerces
+- CLI passthrough needs no change (`-P max_speed_frac=0.25` already coerces
   via the existing `-P` machinery).
 
-Values of `max_speed_frac` above the backstop's implied speed (5% of range
-per step; e.g. > 0.5 at 10 Hz, or any value whose `frac / hz > 0.05`) mean
-the core `DeltaLimitApprover` clamps again and motions truncate. Safe but
-lossy; documented in the README, not prevented — the plugin cannot know the
-CLI's `--max-action-delta`.
+Truncation caveats, documented in the README rather than prevented (the
+plugin cannot know the CLI's `--max-action-delta`):
+
+- Absolute modes: `max_speed_frac / hz > 0.05` (e.g. frac above 0.5 at
+  10 Hz) means the default backstop clamps again and motions truncate.
+- Displacement modes: an explicit `--max-action-delta` tighter than the box
+  reintroduces truncation for `move_by` (the delta limiter intersects the
+  box with `±max_delta`).
 
 ## 5. Reporting
 
-Success note: `executing move_joints over {steps} steps ({steps/hz:.1f}s at
-the speed cap)` (analogous for `move_by`). The note is now truthful by
-construction at default settings.
+Success note: `executing move_joints over {steps} steps ({steps/hz:.1f}s)`
+when the embodiment declares `control_hz`; when `control_hz` is `None` the
+note reports only the step count — the chunk plays at the embodiment's
+native rate, which the plugin cannot know, so any seconds figure would be a
+guess. For the same reason, when `control_hz` is `None` the speed cap and
+the §3c playout cap are step-count constructs (computed at the 10 Hz
+fallback), not wall-clock guarantees; the README states that the wall-clock
+speed cap is only meaningful for declared-rate embodiments. Moves floored at
+`steps = 1` run below the cap, not at it — the note makes no "at the speed
+cap" claim.
 
 ## 6. Docs
 
 - Plugin README: rewrite "How it works" — tool calls state *where* to go;
   the plugin times the motion at a fixed safe speed; `duration_s` is gone;
-  document `max_speed_frac` in the knobs list and the over-backstop caveat.
+  document `max_speed_frac` in the knobs list (absolute modes only, §3b),
+  both truncation caveats (§4), and the `control_hz=None` scoping (§5).
 - Docstrings updated (`_tools.py` module docstring describes the timing
   rule).
 
@@ -128,21 +176,34 @@ construction at default settings.
 
 `tests/test_tools_motion.py`:
 
-- `move_joints` computes steps from distance and range (e.g. range 2.0,
-  frac 0.5 → speed 1.0/s; distance 1.5 at 10 Hz → 15 steps) and reaches the
-  exact target in the final action.
-- Small move → `steps == 1` floor.
+- `move_joints` computes steps from distance and range (range 2.0, frac 0.5
+  → speed 1.0/s; distance 1.5 at 10 Hz → 16 steps with the §3a headroom)
+  and reaches the exact target in the final action.
+- The headroom guarantee itself: for the boundary case above, every
+  consecutive per-step delta of the emitted chunk is `<=` the backstop's
+  `0.05 * (high - low)` — the spurious-clamp regression test.
+- Small move → `steps == 1` floor; all named targets equal to current →
+  `steps == 1`.
+- Zero-width dimension: re-sending the fixed value succeeds and contributes
+  no steps; targeting a different value returns the "fixed at" error.
 - `move_by` splits by box side: `high = 0.05`, delta `+0.2` → 4 steps of
   0.05; asymmetric `low = -0.1` with delta `-0.2` → 2 steps.
+- `move_by` with all-zero deltas → 1 zero-action step (hold).
+- `move_by` into a zero-bound direction → the "cannot move in that
+  direction" error.
+- `move_by` ignores `max_speed_frac` (same split at frac 0.5 and 0.1).
 - Over-cap request errors with the split-the-move message; boundary exactly
   at `max_steps` succeeds.
-- `duration_s` provided by the LLM anyway → unknown-argument tolerance:
-  extra keys are ignored today (dict lookup); assert schemas no longer
-  advertise it and that a call without it succeeds.
-- Bind-time `ToolsetError` for missing/non-finite bounds per 3d (absolute
-  and displacement variants).
-- `max_speed_frac` validation errors.
-- Speed derivation honors non-default frac.
+- Schemas no longer advertise `duration_s`; a call carrying a stray
+  `duration_s` key still succeeds (extra keys were and remain ignored).
+- `control_hz=None`: steps computed at the 10 Hz fallback, chunk emitted
+  with `control_hz=None`, note contains no seconds figure (replaces the
+  existing `test_control_hz_none_falls_back_to_default`, which passes
+  `duration_s` and dies with it).
+- Bind-time `ToolsetError` for missing/non-finite bounds per §3d (absolute
+  and displacement variants); zero-width and zero-sided bounds bind fine.
+- `max_speed_frac` validation errors (0, negative, non-finite).
+- Speed derivation honors non-default frac (absolute modes).
 
 `tests/test_policy_e2e.py`: existing flows updated (tool calls no longer
 send `duration_s`); config snapshot includes `max_speed_frac`.
@@ -153,7 +214,7 @@ send `duration_s`); config snapshot includes `max_speed_frac`.
 
 Bump plugin `version` in `plugins/inspect-robots-agent/pyproject.toml`
 `0.1.0 → 0.2.0` (tool-surface break). Publishes with the next core release
-via the existing `publish-inspect-robots-agent` job.
+via the existing `publish-agent` job in `release.yml`.
 
 ## 9. Out of scope
 

--- a/plans/0014-agent-speed-limited-playout.md
+++ b/plans/0014-agent-speed-limited-playout.md
@@ -8,7 +8,10 @@ core is untouched.
 The agent toolset (plan 0008 §4c) makes the LLM pick `duration_s` for every
 motion. Speed is not a quantity the LLM should reason about: the loop is
 open-loop per turn (the model re-observes after the chunk plays out) and the
-trial budget is per LLM call, not per second. Worse, a too-short duration does
+budget it manages is per LLM call, not per second. (Trials also carry a
+control-step horizon — `Task.max_steps` — and speed-limited playout consumes
+more of it per motion than a short-duration call did; that is the accepted
+cost of never truncating, and the step-cap error in §3c bounds it per call.) Worse, a too-short duration does
 not fail — the core guardrails clamp the chunk per step (`DeltaLimitApprover`
 in absolute modes; `ClampApprover`'s box clamp in displacement modes, where
 the delta limiter adds nothing by default), so the arm moves at the limit and
@@ -53,10 +56,12 @@ Resolved knobs (user decisions, 2026-07-14):
   (float64 vector). Zero-width dimensions (`high == low`, common padding in
   VLA action spaces) have `speed == 0` and are legal at bind time.
 - Per call, for each *named* dimension: if `speed_i == 0` and
-  `target_i != current_i`, return a structured error
-  (`"dimension {label} is fixed at {value}"`). Dimensions with zero distance
-  (including zero-width ones re-sent at their fixed value) contribute
-  nothing to the step count.
+  `target_i != low_i`, return a structured error
+  (`"dimension {label} is fixed at {value}"`). The comparison is against the
+  *bound*, not the observed state — on hardware the observation carries
+  noise, and re-sending the documented fixed value must always succeed.
+  Zero-width dimensions contribute nothing to the step count; dimensions
+  with zero distance to the observed state likewise contribute nothing.
 - Steps: `steps = max(1, ceil(max_i(|target_i - current_i| / speed_i) * hz
   / (1 - 1e-6)))`, the max taken over named dimensions with positive
   distance and positive speed; an empty max (all named targets equal the
@@ -86,13 +91,14 @@ Resolved knobs (user decisions, 2026-07-14):
 - Per call, for each named dimension with a nonzero value: if the limit on
   the requested side is zero, return a structured error
   (`"dimension {label} cannot move in that direction"`).
-- Steps: `steps = max(1, ceil(max_i(|delta_i| / limit_i)))` over named
-  dimensions with nonzero values; all-zero deltas (legal today, a hold) get
-  `steps = 1`, emitting a single zero action. Each action is
-  `vector / steps` (unchanged emission shape). No float headroom is needed:
-  each emitted action is exactly `vector / steps`, whose magnitude is
-  `<= limit` by construction of `ceil`, and no cumulative interpolation is
-  involved.
+- Steps: `steps = max(1, ceil(max_i(|delta_i| / limit_i) / (1 - 1e-6)))`
+  over named dimensions with nonzero values; all-zero deltas (legal today, a
+  hold) get `steps = 1`, emitting a single zero action. Each action is
+  `vector / steps` (unchanged emission shape). The same `1e-6` headroom as
+  §3a applies: `ceil` alone does not bound the per-step magnitude in float
+  arithmetic — for some `(delta, limit)` pairs `delta / limit` rounds down
+  to an exact integer `n` while `delta / n` rounds 1 ulp *above* the limit,
+  and `ClampApprover` would clamp and log a spurious approval event.
 
 ### 3c. Chunk cap
 
@@ -112,11 +118,20 @@ with actionable messages (same stance as `DeltaLimitApprover`):
 
 - Absolute modes: every dimension needs finite `low` and `high` (speed is
   derived from the range). `high == low` is allowed (handled per call, §3a).
-  The existing "no bounds; move conservatively" fallback text disappears for
-  absolute modes since unbounded absolute spaces are now rejected.
-- Displacement modes: every dimension needs finite `low` and `high`. A zero
-  bound on one side is allowed (that direction simply cannot move; handled
-  per call, §3b).
+- Displacement modes: every dimension needs finite `low` and `high` with
+  `low <= 0 <= high` (core's `Box` only validates `low <= high`, so a
+  displacement box not containing zero would make the §3b side-limits
+  negative and the split nonsensical; such spaces also cannot hold still and
+  are rejected). A zero bound on one side is allowed (that direction simply
+  cannot move; handled per call, §3b).
+- Both modes: a declared `control_hz` that is non-finite or `<= 0` is
+  rejected at bind time (`None` stays allowed and falls back to
+  `_FALLBACK_HZ` for step computation). Core never validates `control_hz`,
+  and `hz = 0` would make §3a floor every motion to a single step while §3c
+  errors every call — contradictory outcomes this check makes unreachable.
+- The "no bounds; move conservatively" `bounds_text` fallback becomes dead
+  in both modes (finite bounds are now required everywhere) and is removed
+  outright.
 
 Previously such spaces "worked" only because the LLM supplied a duration;
 motions in them were never actually speed-safe.
@@ -184,10 +199,15 @@ cap" claim.
   `0.05 * (high - low)` — the spurious-clamp regression test.
 - Small move → `steps == 1` floor; all named targets equal to current →
   `steps == 1`.
-- Zero-width dimension: re-sending the fixed value succeeds and contributes
-  no steps; targeting a different value returns the "fixed at" error.
-- `move_by` splits by box side: `high = 0.05`, delta `+0.2` → 4 steps of
-  0.05; asymmetric `low = -0.1` with delta `-0.2` → 2 steps.
+- Zero-width dimension: targeting the bound value succeeds and contributes
+  no steps *even when the observed state differs from the bound* (sensor
+  noise); targeting any other value returns the "fixed at" error.
+- `move_by` splits by box side: `high = 0.05`, delta `+0.2` → 5 steps of
+  0.04 (the §3b headroom pushes the float-exact 4-step split to 5);
+  asymmetric `low = -0.1` with delta `-0.2` → 3 steps.
+- `move_by` ulp regression: every emitted per-step magnitude is `<=` the box
+  side for a non-float-clean pair (e.g. delta `0.29`, limit `0.11287...`-
+  style values from a property-style spot check).
 - `move_by` with all-zero deltas → 1 zero-action step (hold).
 - `move_by` into a zero-bound direction → the "cannot move in that
   direction" error.
@@ -200,13 +220,27 @@ cap" claim.
   with `control_hz=None`, note contains no seconds figure (replaces the
   existing `test_control_hz_none_falls_back_to_default`, which passes
   `duration_s` and dies with it).
+- Declared-rate note: with `control_hz=20`, the note's seconds figure is
+  `steps / 20` (pins the units; a `steps * hz` bug must fail).
 - Bind-time `ToolsetError` for missing/non-finite bounds per §3d (absolute
-  and displacement variants); zero-width and zero-sided bounds bind fine.
+  and displacement variants); zero-width and zero-sided bounds bind fine;
+  displacement boxes not containing zero are rejected; declared
+  `control_hz` of `0`, negative, or non-finite is rejected while `None`
+  binds.
 - `max_speed_frac` validation errors (0, negative, non-finite).
 - Speed derivation honors non-default frac (absolute modes).
 
 `tests/test_policy_e2e.py`: existing flows updated (tool calls no longer
-send `duration_s`); config snapshot includes `max_speed_frac`.
+send `duration_s`); config snapshot includes `max_speed_frac`. One test is
+redesigned, not updated: `test_wild_swing_is_clamped_by_guardrails_but_not_without`
+provokes a clamp by sending `move_by` `dx=5.0`, but under the new surface
+the toolset splits that into in-box steps — no default guardrail can bite,
+by design, and the split would blow the task's 40-step horizon anyway. It
+becomes a test of the §4 caveat instead: build the guardrail chain with an
+explicit `max_delta` *tighter than the box*, request a `move_by` sized so
+its computed steps fit the horizon, and assert `delta_clamped` approval
+events occur with guardrails and the emitted per-step values pass through
+untouched without them.
 
 `tests/test_llm.py`, `tests/test_package.py`: untouched unless imports move.
 

--- a/plans/0014-agent-speed-limited-playout.md
+++ b/plans/0014-agent-speed-limited-playout.md
@@ -1,0 +1,163 @@
+# 0014 — Agent plugin: speed-limited playout replaces `duration_s`
+
+Issue: robocurve/inspect-robots#92. Scope: `plugins/inspect-robots-agent` only;
+core is untouched.
+
+## 1. Problem
+
+The agent toolset (plan 0008 §4c) makes the LLM pick `duration_s` for every
+motion. Speed is not a quantity the LLM should reason about: the loop is
+open-loop per turn (the model re-observes after the chunk plays out) and the
+trial budget is per LLM call, not per second. Worse, a too-short duration does
+not fail — the core `DeltaLimitApprover` clamps the chunk per step, so the arm
+moves at the speed limit and stops short of the target, while the tool result
+note still claims the full motion executed. The LLM discovers the divergence
+only from the next observation.
+
+## 2. Decision
+
+Drop `duration_s` from both motion tools. The toolset computes the playout
+time from a speed cap, so the full requested displacement is always reached;
+large motions simply play out over more steps. Guardrails below the plugin
+are unchanged (the plugin still contains no safety-critical code path); at the
+default speed the per-step change stays within the core backstop, so the
+backstop stops biting and tool notes become truthful.
+
+Resolved knobs (user decisions, 2026-07-14):
+
+- Plugin-only; no core controller middleware.
+- `duration_s` is removed, not made optional.
+- Default speed: `max_speed_frac = 0.5` — half the joint's range per second,
+  which equals the core backstop's implied speed (5% of range per step at
+  10 Hz).
+
+## 3. Toolset changes (`_tools.py`)
+
+### 3a. `move_joints` (absolute modes: `joint_pos`, `eef_abs_pose`)
+
+- Schema: `targets` only; `required: ["targets"]`. Description explains the
+  motion is interpolated at a fixed safe speed and reports its duration.
+- Per-dimension speed: `speed = max_speed_frac * (high - low)` per second
+  (float64 vector).
+- Steps: `steps = max(1, ceil(max_i(|target_i - current_i| / speed_i) * hz))`
+  computed only over dimensions named in the call (unnamed dimensions hold
+  and contribute zero distance). `hz` falls back to `_FALLBACK_HZ = 10.0` as
+  today.
+- Interpolation is unchanged (`linspace` fractions from current observed
+  state).
+
+### 3b. `move_by` (displacement modes: `eef_delta_pos`, `eef_delta_pose`, `joint_delta`)
+
+- Schema: `deltas` only; `required: ["deltas"]`.
+- Displacement boxes are per-action sized by convention, and `ClampApprover`
+  clamps each step to the box — so the box side is the per-step limit and
+  splitting to fit it is the only non-lossy choice.
+- Per-step limit per dimension: `high_i` for a positive component, `|low_i|`
+  for a negative one.
+- Steps: `steps = max(1, ceil(max_i(|delta_i| / limit_i)))` over named
+  dimensions with nonzero values; each action is `vector / steps` (unchanged
+  emission shape).
+
+### 3c. Chunk cap
+
+`_MAX_DURATION_S = 10.0` stays, reinterpreted: `max_steps = ceil(10 * hz)`.
+A computed `steps > max_steps` returns a structured `ToolResult(error=...)`
+telling the LLM the request exceeds the 10 s playout cap and to split the
+move. At the default speed a full-range `move_joints` needs 2 s, so in
+practice only absurd `move_by` totals hit this.
+
+### 3d. Bind-time bound requirements (never guess)
+
+`build_toolset` gains the checks; failures raise `ToolsetError` at bind time
+with actionable messages (same stance as `DeltaLimitApprover`):
+
+- Absolute modes: every dimension needs finite `low` and `high` (speed is
+  derived from the range). The existing "no bounds; move conservatively"
+  fallback text disappears for absolute modes since unbounded absolute spaces
+  are now rejected.
+- Displacement modes: every dimension needs a finite bound on each side
+  (`low_i < 0 < high_i` finite both sides; a zero bound on a side simply
+  means that direction cannot move, which the box already enforces — no
+  special-casing, division guards use the bound only for the direction
+  requested).
+
+Previously such spaces "worked" only because the LLM supplied a duration;
+motions in them were never actually speed-safe.
+
+### 3e. Toolset construction
+
+`Toolset.__init__` / `build_toolset` grow `max_speed_frac: float` (default
+`0.5`) and precompute the per-dimension speed (absolute) or per-side
+per-step limits (displacement). `bounds_text` keeps documenting the box to
+the LLM.
+
+## 4. Policy changes (`policy.py`)
+
+- `LLMAgentPolicy.__init__` and `agent_policy` accept
+  `max_speed_frac: float = 0.5`; validation: finite and `> 0`
+  (`ValueError` otherwise).
+- `AgentPolicyConfig` gains `max_speed_frac: float = 0.5` — recorded in
+  `EvalSpec.policy_config` for free via `dataclasses.asdict`.
+- `bind()` forwards it to `build_toolset`.
+- `_SYSTEM_TEMPLATE`: no duration mention today, so only the tool
+  descriptions change; keep "small, deliberate motions" guidance.
+- CLI passthrough needs no change (`-P max_speed_frac=0.5` already coerces
+  via the existing `-P` machinery).
+
+Values of `max_speed_frac` above the backstop's implied speed (5% of range
+per step; e.g. > 0.5 at 10 Hz, or any value whose `frac / hz > 0.05`) mean
+the core `DeltaLimitApprover` clamps again and motions truncate. Safe but
+lossy; documented in the README, not prevented — the plugin cannot know the
+CLI's `--max-action-delta`.
+
+## 5. Reporting
+
+Success note: `executing move_joints over {steps} steps ({steps/hz:.1f}s at
+the speed cap)` (analogous for `move_by`). The note is now truthful by
+construction at default settings.
+
+## 6. Docs
+
+- Plugin README: rewrite "How it works" — tool calls state *where* to go;
+  the plugin times the motion at a fixed safe speed; `duration_s` is gone;
+  document `max_speed_frac` in the knobs list and the over-backstop caveat.
+- Docstrings updated (`_tools.py` module docstring describes the timing
+  rule).
+
+## 7. Tests (TDD; plugin's own pytest scope, not the core 100% gate)
+
+`tests/test_tools_motion.py`:
+
+- `move_joints` computes steps from distance and range (e.g. range 2.0,
+  frac 0.5 → speed 1.0/s; distance 1.5 at 10 Hz → 15 steps) and reaches the
+  exact target in the final action.
+- Small move → `steps == 1` floor.
+- `move_by` splits by box side: `high = 0.05`, delta `+0.2` → 4 steps of
+  0.05; asymmetric `low = -0.1` with delta `-0.2` → 2 steps.
+- Over-cap request errors with the split-the-move message; boundary exactly
+  at `max_steps` succeeds.
+- `duration_s` provided by the LLM anyway → unknown-argument tolerance:
+  extra keys are ignored today (dict lookup); assert schemas no longer
+  advertise it and that a call without it succeeds.
+- Bind-time `ToolsetError` for missing/non-finite bounds per 3d (absolute
+  and displacement variants).
+- `max_speed_frac` validation errors.
+- Speed derivation honors non-default frac.
+
+`tests/test_policy_e2e.py`: existing flows updated (tool calls no longer
+send `duration_s`); config snapshot includes `max_speed_frac`.
+
+`tests/test_llm.py`, `tests/test_package.py`: untouched unless imports move.
+
+## 8. Versioning / release
+
+Bump plugin `version` in `plugins/inspect-robots-agent/pyproject.toml`
+`0.1.0 → 0.2.0` (tool-surface break). Publishes with the next core release
+via the existing `publish-inspect-robots-agent` job.
+
+## 9. Out of scope
+
+- A core rate-limiting controller middleware (revisit if a second policy
+  plugin needs re-timing).
+- Changing core guardrail defaults or `--max-action-delta` semantics.
+- Per-dimension `max_speed_frac`.

--- a/plans/0014-agent-speed-limited-playout.md
+++ b/plans/0014-agent-speed-limited-playout.md
@@ -105,8 +105,15 @@ Resolved knobs (user decisions, 2026-07-14):
   range 2.0, distance 1.5, 15 steps, limit 0.1) emits consecutive deltas of
   `0.1 + 1 ulp` and the backstop clamps spuriously at the default boundary.
   `hz` falls back to `_FALLBACK_HZ = 10.0` as today.
-- Interpolation is unchanged (`linspace` fractions from current observed
-  state).
+- Interpolation: `linspace` fractions from the current observed state as
+  today, with two float repairs. The final action is *snapped* to the exact
+  target (`current + (target - current) * 1.0` is not `target` in float
+  arithmetic — e.g. `-0.1 + 0.4 = 0.30000000000000004`), and every emitted
+  action is then clipped into the box: interpolants can overshoot a bound
+  by 1–2 ulp from fully in-box inputs, and `ClampApprover` would flag a
+  spurious approval event. Clipping is a per-dimension projection of a
+  monotone sequence, so it cannot enlarge consecutive step deltas — the
+  §3a headroom guarantee survives it.
 
 ### 3b. `move_by` (displacement modes: `eef_delta_pos`, `eef_delta_pose`, `joint_delta`)
 
@@ -147,8 +154,11 @@ like `1e308` overflows the division to `inf`, never raising) and the cap
 comparison runs *before* `ceil` — `math.ceil(inf)` raises `OverflowError`,
 which would escape as a trial-killing `PolicyError` for what is an
 LLM-correctable mistake, violating the module's errors-not-exceptions
-contract. (`move_joints` cannot reach this: targets are bounds-checked
-first, so its ratio is capped at `1 / step_frac`.) At the default speed a
+contract. The pre-ceil cap check applies to *both* tools: `move_joints`'
+ratio numerator is `|target - current|` with `current` from the
+*observation*, which is only checked for finiteness — a grossly-off finite
+reading can push the ratio past the cap or to `inf`, and must land in the
+structured over-cap error, not an exception. At the default speed a
 full-range `move_joints` needs 21 steps (2.1 s at 10 Hz — the §3a headroom
 bumps the exact 20-split), so in practice only large `move_by`
 totals hit this.
@@ -171,7 +181,10 @@ with actionable messages (same stance as `DeltaLimitApprover`):
   `_FALLBACK_HZ` for step computation). Core never validates `control_hz`,
   and `hz = 0` would make §3c's `max_steps = 0`, turning every call into an
   error — a nonsense configuration this check rejects with a clear message
-  instead.
+  instead. A positive-but-tiny declared rate (e.g. 0.1 Hz → `max_steps = 1`)
+  binds fine and makes most motions hit the §3c error; that is a truthful
+  reflection of an embodiment that genuinely cannot move far in 10 s, not a
+  configuration the plugin second-guesses.
 - The "no bounds; move conservatively" `bounds_text` fallback becomes dead
   in both modes (finite bounds are now required everywhere) and is removed
   outright.
@@ -242,7 +255,13 @@ cap" claim.
 
 - `move_joints` computes steps from distance and range (range 2.0, frac 0.5
   → speed 1.0/s; distance 1.5 at 10 Hz → 16 steps with the §3a headroom)
-  and reaches the exact target in the final action.
+  and reaches the *bit-exact* target in the final action (valid to assert
+  with `==` only because §3a snaps it; plain linspace arithmetic lands
+  1 ulp off).
+- Interpolation clipping regression: a move from in-box state to a target
+  exactly at a bound emits no action outside the box (checks every
+  interpolant, not just the final action — e.g. `current=-0.1, high=0.3`,
+  which overshoots by 1 ulp without the §3a clip).
 - The headroom guarantee itself: for the boundary case above, every
   consecutive per-step delta of the emitted chunk is `<=` the backstop's
   `0.05 * (high - low)` — the spurious-clamp regression test.
@@ -276,6 +295,15 @@ cap" claim.
   a full-range move needs 1001 steps, 100.1 s).
 - Huge finite `move_by` delta (`1e308`) returns the split-the-move error —
   never raises (the §3c inf-tolerant cap check).
+- `move_joints` with an absurd finite observed state (e.g. `1e308`) likewise
+  returns the over-cap error, never an exception (§3c applies to both
+  tools).
+- Default-chain integration: a plugin-emitted absolute-mode chunk run
+  through `ChainApprover(ClampApprover, DeltaLimitApprover)` with default
+  settings — including a target exactly at a bound and a second chunk
+  reusing the store — produces zero modified actions (the §2 promise,
+  exercised against the real approvers and the store-held reference; unit
+  level, since the CubePick e2e world is displacement-mode).
 - Schemas no longer advertise `duration_s`; a call carrying a stray
   `duration_s` key still succeeds (extra keys were and remain ignored).
 - `control_hz=None`: steps computed at the 10 Hz fallback, chunk emitted

--- a/plans/0014-agent-speed-limited-playout.md
+++ b/plans/0014-agent-speed-limited-playout.md
@@ -24,10 +24,11 @@ observation.
 Drop `duration_s` from both motion tools. The toolset computes the playout
 time from a speed cap, so the full requested displacement is emitted;
 large motions simply play out over more steps. Guardrails below the plugin
-are unchanged (the plugin still contains no safety-critical code path); at the
-default speed every emitted per-step change stays strictly within the core
-backstop's 5%-of-range default, so at default settings the backstop does not
-clamp what the plugin emits.
+are unchanged (the plugin still contains no safety-critical code path); the
+§3a per-step ceiling keeps every emitted per-step change strictly within the
+core backstop's 5%-of-range default — at any `max_speed_frac` and any
+declared control rate — so the default backstop never clamps what the plugin
+emits.
 
 Honest scoping of that guarantee: `DeltaLimitApprover` measures against the
 last *approved command* held in the trial store, while `move_joints`
@@ -43,8 +44,9 @@ Resolved knobs (user decisions, 2026-07-14):
 - `duration_s` is removed, not made optional.
 - Default speed: `max_speed_frac = 0.5` — half the joint's range per second
   for absolute modes, which matches the core backstop's implied speed (5% of
-  range per step at 10 Hz). `max_speed_frac` applies to absolute modes only;
-  see §3b for why `move_by` has no frac.
+  range per step at 10 Hz); on slower embodiments the §3a per-step ceiling
+  wins and the motion is proportionally slower. `max_speed_frac` applies to
+  absolute modes only; see §3b for why `move_by` has no frac.
 
 ## 3. Toolset changes (`_tools.py`)
 
@@ -52,20 +54,46 @@ Resolved knobs (user decisions, 2026-07-14):
 
 - Schema: `targets` only; `required: ["targets"]`. Description explains the
   motion is interpolated at a fixed safe speed and reports its step count.
-- Per-dimension speed: `speed = max_speed_frac * (high - low)` per second
-  (float64 vector). Zero-width dimensions (`high == low`, common padding in
-  VLA action spaces) have `speed == 0` and are legal at bind time.
-- Per call, for each *named* dimension: if `speed_i == 0` and
-  `target_i != low_i`, return a structured error
-  (`"dimension {label} is fixed at {value}"`). The comparison is against the
-  *bound*, not the observed state — on hardware the observation carries
-  noise, and re-sending the documented fixed value must always succeed.
-  Zero-width dimensions contribute nothing to the step count; dimensions
-  with zero distance to the observed state likewise contribute nothing.
-- Steps: `steps = max(1, ceil(max_i(|target_i - current_i| / speed_i) * hz
-  / (1 - 1e-6)))`, the max taken over named dimensions with positive
-  distance and positive speed; an empty max (all named targets equal the
-  current state) yields `steps = 1`. The `1e-6` relative headroom exists
+- Per-dimension *per-step* limit:
+  `step_frac = min(max_speed_frac / hz, _BACKSTOP_STEP_FRAC)` with
+  `_BACKSTOP_STEP_FRAC = 0.05`, so the per-step change is
+  `step_frac * (high - low)`. The wall-clock speed is
+  `max_speed_frac * range` per second whenever `hz >= max_speed_frac / 0.05`
+  (i.e. ≥ 10 Hz at the default frac); on slower embodiments the per-step cap
+  wins and the motion plays proportionally slower rather than provoking the
+  backstop. `_BACKSTOP_STEP_FRAC` deliberately mirrors
+  `DeltaLimitApprover`'s derived default (5% of range per step) — that is
+  the constant being matched, and the guarantee in §2 is per-step, because
+  the backstop is per-step. Zero-width dimensions (`high == low`, common
+  padding in VLA action spaces) have a zero limit and are legal at bind
+  time.
+- Per call, for each *named* dimension, validated in this order:
+  - `target_i` outside `[low_i, high_i]` returns a structured error
+    (`"target for {label} is outside [{low}, {high}]"`). Letting it through
+    would recreate §1's silent divergence: the sizing satisfies the delta
+    limiter while `ClampApprover` pins every step at the bound and the note
+    claims the full motion executed. Bounds are guaranteed finite by §3d,
+    so the check is always meaningful.
+  - Zero-width dimensions (`limit == 0`): `target_i != low_i` returns
+    `"dimension {label} is fixed at {value}"`. The comparison is against
+    the *bound*, not the observed state — on hardware the observation
+    carries noise, and re-sending the documented fixed value must always
+    succeed. `{value}` is rendered with `repr()` (JSON round-trip exact),
+    because the schema's `bounds_text` renders at 4 significant figures
+    (`.4g`) and may not match on the first attempt; the error then teaches
+    the exact value.
+  - Zero-width dimensions contribute nothing to the step count; dimensions
+    with zero distance to the observed state likewise contribute nothing.
+- Non-finite observed state: if the proprioceptive reference vector contains
+  a non-finite value, `execute` raises `ValueError` (the rollout wraps it as
+  `PolicyError` and the trial errors). A broken sensor is not an
+  LLM-correctable condition, so it does not use the structured-error
+  channel; without this guard the steps formula would poison `ceil`/`max`
+  with NaN and crash uncontrolled.
+- Steps: `steps = max(1, ceil(max_i(|target_i - current_i| /
+  (step_frac * range_i)) / (1 - 1e-6)))`, the max taken over named
+  dimensions with positive distance and positive range; an empty max (all
+  named targets equal the current state) yields `steps = 1`. The `1e-6` relative headroom exists
   because `linspace` interpolation accumulates ~1 ulp of float error per
   step: without it, a step count that divides the distance exactly (e.g.
   range 2.0, distance 1.5, 15 steps, limit 0.1) emits consecutive deltas of
@@ -106,8 +134,8 @@ Resolved knobs (user decisions, 2026-07-14):
 (with `hz` the same fallback-resolved rate used for step computation). A
 computed `steps > max_steps` returns a structured `ToolResult(error=...)`
 telling the LLM the request exceeds the playout cap and to split the move
-into smaller motions — advice that always works, because a smaller distance
-or delta strictly reduces the computed steps. At the default speed a
+into smaller motions — advice that always works, because the computed steps
+shrink toward 1 as the motion shrinks. At the default speed a
 full-range `move_joints` needs 2 s, so in practice only large `move_by`
 totals hit this.
 
@@ -159,8 +187,11 @@ the LLM.
 Truncation caveats, documented in the README rather than prevented (the
 plugin cannot know the CLI's `--max-action-delta`):
 
-- Absolute modes: `max_speed_frac / hz > 0.05` (e.g. frac above 0.5 at
-  10 Hz) means the default backstop clamps again and motions truncate.
+- Absolute modes: the §3a per-step ceiling means no `max_speed_frac` value
+  can provoke the *default* backstop (frac above `0.05 * hz` is simply
+  capped — the knob slows motion, never outruns the guardrail). The
+  remaining truncation risk is an explicit `--max-action-delta` tighter
+  than 5% of range.
 - Displacement modes: an explicit `--max-action-delta` tighter than the box
   reintroduces truncation for `move_by` (the delta limiter intersects the
   box with `±max_delta`).
@@ -199,9 +230,18 @@ cap" claim.
   `0.05 * (high - low)` — the spurious-clamp regression test.
 - Small move → `steps == 1` floor; all named targets equal to current →
   `steps == 1`.
+- Out-of-bounds target returns the "outside [low, high]" error; a target
+  exactly at a bound succeeds.
 - Zero-width dimension: targeting the bound value succeeds and contributes
   no steps *even when the observed state differs from the bound* (sensor
-  noise); targeting any other value returns the "fixed at" error.
+  noise); targeting any other value returns the "fixed at" error, and the
+  error's value renders `repr()`-exact for a non-`.4g`-clean bound (e.g.
+  `0.30000000000000004`).
+- Per-step ceiling: declared `control_hz=5` at default frac emits 5%-of-range
+  steps (not 10%); `max_speed_frac=1.0` at 10 Hz likewise stays at 5%/step
+  (the knob cannot outrun the default backstop).
+- Non-finite observed state (NaN in the proprioceptive reference) raises
+  `ValueError` from `execute` rather than returning a structured error.
 - `move_by` splits by box side: `high = 0.05`, delta `+0.2` → 5 steps of
   0.04 (the §3b headroom pushes the float-exact 4-step split to 5);
   asymmetric `low = -0.1` with delta `-0.2` → 3 steps.
@@ -213,7 +253,9 @@ cap" claim.
   direction" error.
 - `move_by` ignores `max_speed_frac` (same split at frac 0.5 and 0.1).
 - Over-cap request errors with the split-the-move message; boundary exactly
-  at `max_steps` succeeds.
+  at `max_steps` succeeds. Covered for both tools: `move_by` with a large
+  total, and `move_joints` with a tiny frac (e.g. `max_speed_frac=0.01` →
+  a full-range move needs 100 s).
 - Schemas no longer advertise `duration_s`; a call carrying a stray
   `duration_s` key still succeeds (extra keys were and remain ignored).
 - `control_hz=None`: steps computed at the 10 Hz fallback, chunk emitted
@@ -231,7 +273,10 @@ cap" claim.
 - Speed derivation honors non-default frac (absolute modes).
 
 `tests/test_policy_e2e.py`: existing flows updated (tool calls no longer
-send `duration_s`); config snapshot includes `max_speed_frac`. One test is
+send `duration_s`); config snapshot includes `max_speed_frac`; one e2e run
+uses a non-default frac and asserts the resulting step count, pinning that
+`bind()` actually forwards the knob to `build_toolset` (the toolset-level
+frac tests cannot catch a forgotten forward). One test is
 redesigned, not updated: `test_wild_swing_is_clamped_by_guardrails_but_not_without`
 provokes a clamp by sending `move_by` `dx=5.0`, but under the new surface
 the toolset splits that into in-box steps — no default guardrail can bite,

--- a/plans/0014-agent-speed-limited-playout.md
+++ b/plans/0014-agent-speed-limited-playout.md
@@ -194,9 +194,18 @@ with actionable messages (same stance as `DeltaLimitApprover`):
   `control_hz` whose `10 * hz` playout cap overflows to `inf`; a
   `max_speed_frac` whose `frac / hz` underflows to exactly zero (it would
   misreport every dimension as fixed); a `high - low` range that overflows
-  to `inf` despite finite endpoints (e.g. `[-1e308, 1e308]`); and non-1-D
+  to `inf` despite finite endpoints — checked in *both* float64 and the
+  box's native dtype, since `DeltaLimitApprover` subtracts without
+  promoting (float32 `[-3e38, 3e38]` overflows only natively); non-1-D
   action-space shapes (the toolset's indexing and bounds text are
-  vector-only).
+  vector-only); and, in absolute modes, bounds whose float spacing at
+  their magnitude exceeds `5e-7 *` the native backstop (offset boxes like
+  `[1e16, 1e16 + 2]` or ranges whose 5% underflows to zero) — interpolants
+  snap to the float grid there, emitted steps jump past the backstop, and
+  motions would silently truncate.
+- `move_by` per-step underflow: a subnormal requested delta can make
+  `vector / steps` exactly zero; a success note over a zero-motion chunk
+  would lie, so this returns a structured "too small to split" error.
 - Tool-call values: a JSON number is coerced with `float()` before the
   finiteness check — arbitrary-precision integers (`10**400`) overflow
   `float()` and crash `np.isfinite` outright, and both must return the

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -31,20 +31,40 @@ Model strings are OpenRouter-style `provider/model`, resolved from
 
 ## How it works
 
-Each LLM tool call becomes one smooth, open-loop action chunk: named partial
-joint targets are interpolated at the embodiment's control rate
-(`move_joints`), displacements are split across steps (`move_by`), and
-`done`/`give_up` end the trial through the core's policy-stop channel. Every
-action still passes the CLI's default safety approvers (bounds clamp plus
-per-step delta limit); the plugin contains no safety-critical code path of
-its own.
+Motion tool calls state where to go, not how long to move. For absolute modes,
+`move_joints` interpolates named partial targets from the observed state at a
+fixed safe speed. The default `max_speed_frac=0.5` allows half of each
+dimension's range per second, subject to a 5%-of-range per-step ceiling that
+matches the core's default delta backstop. The tool result reports the computed
+step count and, when the embodiment declares `control_hz`, the corresponding
+playout time. `duration_s` is not part of either motion tool.
+
+For displacement modes, `move_by` splits the requested total so every action
+fits the box side in that direction. The action box is the embodiment author's
+per-step speed statement, so `max_speed_frac` does not apply to displacement
+modes. `done` and `give_up` end the trial through the core's policy-stop
+channel.
+
+When `control_hz` is `None`, the plugin uses a 10 Hz fallback to compute step
+counts and the per-call playout cap, but leaves the emitted chunk rate unset.
+The embodiment then plays the chunk at its native rate. In this case the speed
+and playout caps are step-count constructs, not wall-clock guarantees, and the
+tool result does not report seconds.
+
+Every action still passes the CLI's default safety approvers (bounds clamp plus
+per-step delta limit); the plugin contains no safety-critical code path of its
+own. An explicit `--max-action-delta` tighter than 5% of range can truncate
+absolute interpolants. In displacement modes, a value tighter than the action
+box can truncate each `move_by` step. Either setting can make the executed
+motion fall short of the tool's requested total.
 
 > [!WARNING]
 > Guardrails are on by default at the CLI. **Never pass `--disable-guardrails`
 > on real hardware** unless you fully trust the policy and the rig.
 
 Configuration knobs (all `-P key=value`): `model`, `base_url`, `api_key_env`,
-`max_llm_calls`, `temperature`, `effort`.
+`max_llm_calls`, `temperature`, `effort`, `max_speed_frac`. The speed fraction
+defaults to `0.5` and applies only to absolute modes.
 
 Reasoning effort defaults to `low`: robot control is latency-sensitive (the
 arm stands still while the model thinks), safety guardrails sit below the

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.1.0"
+version = "0.2.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -1,24 +1,20 @@
-"""The agent's tool surface over a bound action space (plan 0008 §4b/§4c).
+"""The agent's speed-limited tool surface over a bound action space.
 
-Tools are generated from the embodiment's spaces — the plugin never knows
-what a "YAM" or an "arm" is. The control mode picks the motion tool:
+Tools are generated from the embodiment's spaces, so the plugin never needs
+embodiment-specific motion knowledge. Absolute targets are interpolated with a
+per-step limit of ``min(max_speed_frac / hz, 0.05)`` times each dimension's
+range. Displacements are split by the available box side, which the plugin
+treats as the embodiment author's per-action limit.
 
-- Absolute-target modes (``joint_pos``, ``eef_abs_pose``): ``move_joints``
-  with named partial targets, linearly interpolated from the current
-  observed state; hold-still repeats the current state.
-- Displacement modes (``eef_delta_pos``, ``eef_delta_pose``,
-  ``joint_delta``): ``move_by`` splits the requested displacement evenly
-  across the chunk's steps; hold-still is all zeros.
-
-Tool mistakes (unknown label, non-finite value, bad duration, malformed
-JSON) come back as structured error strings the LLM sees and can correct —
-never exceptions. Unsupported configurations fail at build (= ``bind``)
-time with a clear message.
+Tool mistakes come back as structured error strings the LLM can correct.
+Broken observations still raise, and unsupported configurations fail at build
+(bind) time with a clear message.
 """
 
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass
 from typing import Any
 
@@ -35,6 +31,8 @@ _SAFE_ROT = frozenset({"none", "rot6d"})
 
 _FALLBACK_HZ = 10.0
 _MAX_DURATION_S = 10.0
+_BACKSTOP_STEP_FRAC = 0.05
+_RELATIVE_HEADROOM = 1e-6
 
 
 class ToolsetError(Exception):
@@ -55,7 +53,7 @@ class ToolResult:
 
 
 class Toolset:
-    """Schemas + execution for one bound embodiment. Built via ``build_toolset``."""
+    """Schemas and execution for one embodiment, built via ``build_toolset``."""
 
     def __init__(
         self,
@@ -65,30 +63,45 @@ class Toolset:
         state_key: str | None,
         control_hz: float | None,
         bounds_text: str,
+        low: npt.NDArray[np.float64],
+        high: npt.NDArray[np.float64],
+        max_speed_frac: float = 0.5,
     ):
         self._absolute = absolute
         self._labels = labels
         self._index_by_label = {label: i for i, label in enumerate(labels)}
         self._state_key = state_key
         self._hz = control_hz
+        self._resolved_hz = control_hz if control_hz is not None else _FALLBACK_HZ
+        self._max_steps = math.ceil(_MAX_DURATION_S * self._resolved_hz)
         self._move_tool = "move_joints" if absolute else "move_by"
         self._bounds_text = bounds_text
-
-    # -- schemas ---------------------------------------------------------------
+        self._low = low
+        self._high = high
+        if absolute:
+            step_frac = min(max_speed_frac / self._resolved_hz, _BACKSTOP_STEP_FRAC)
+            self._step_limits = step_frac * (high - low)
+            self._positive_limits = np.zeros_like(high)
+            self._negative_limits = np.zeros_like(low)
+        else:
+            self._step_limits = np.zeros_like(high)
+            self._positive_limits = high
+            self._negative_limits = np.abs(low)
 
     def schemas(self) -> list[dict[str, Any]]:
-        """OpenAI-format tool definitions for this embodiment."""
+        """Return OpenAI-format tool definitions for this embodiment."""
         if self._absolute:
             move_description = (
-                "Move to absolute joint/dimension targets, smoothly interpolated "
-                "from the current pose over duration_s. Unnamed dimensions hold "
-                "their current value. " + self._bounds_text
+                "Move to absolute joint/dimension targets. The motion is smoothly "
+                "interpolated at a fixed safe speed and the result reports its step "
+                "count. Unnamed dimensions hold their current value. " + self._bounds_text
             )
             values_key = "targets"
         else:
             move_description = (
-                "Move BY the given displacement per dimension, split evenly over "
-                "duration_s. Unnamed dimensions do not move. " + self._bounds_text
+                "Move BY the given displacement per dimension. The motion is split "
+                "into steps that fit the per-action bounds and the result reports its "
+                "step count. Unnamed dimensions do not move. " + self._bounds_text
             )
             values_key = "deltas"
         move = {
@@ -106,14 +119,8 @@ class Toolset:
                                 + ", ".join(self._labels)
                             ),
                         },
-                        "duration_s": {
-                            "type": "number",
-                            "description": (
-                                f"Motion duration in seconds (0 < d <= {_MAX_DURATION_S})"
-                            ),
-                        },
                     },
-                    "required": [values_key, "duration_s"],
+                    "required": [values_key],
                 },
             },
         }
@@ -145,10 +152,8 @@ class Toolset:
         }
         return [move, done, give_up]
 
-    # -- execution ---------------------------------------------------------------
-
     def execute(self, call: Any, observation: Observation) -> ToolResult:
-        """Turn one tool call into an ActionChunk, or an error string for the LLM."""
+        """Turn one tool call into an action chunk or an error string for the LLM."""
         try:
             arguments = json.loads(call.arguments)
         except (TypeError, ValueError):
@@ -169,9 +174,7 @@ class Toolset:
         return np.asarray(observation.state[self._state_key], dtype=np.float64)
 
     def _stop(self, name: str, arguments: dict[str, Any], observation: Observation) -> ToolResult:
-        # Hold still per control mode: repeat the pose (absolute) or move by
-        # nothing (displacement), flagged for rollout's policy-stop channel.
-        data = self._current_state(observation) if self._absolute else np.zeros(len(self._labels))
+        data = self._current_state(observation)
         detail = str(arguments.get("summary") or arguments.get("reason") or "")
         action = Action(
             data=data,
@@ -185,17 +188,11 @@ class Toolset:
     def _move(self, arguments: dict[str, Any], observation: Observation) -> ToolResult:
         values_key = "targets" if self._absolute else "deltas"
         values = arguments.get(values_key)
-        duration = arguments.get("duration_s")
         if not isinstance(values, dict) or not values:
             return ToolResult(error=f"{values_key} must be a non-empty object of name: value")
-        if not isinstance(duration, (int, float)) or isinstance(duration, bool):
-            return ToolResult(error="duration_s must be a number")
-        if not 0 < float(duration) <= _MAX_DURATION_S:
-            return ToolResult(
-                error=f"duration_s must be in (0, {_MAX_DURATION_S}] seconds, got {duration}"
-            )
 
         vector = np.zeros(len(self._labels))
+        named_indices: list[int] = []
         for label, raw in values.items():
             index = self._index_by_label.get(str(label))
             if index is None:
@@ -205,33 +202,115 @@ class Toolset:
             if isinstance(raw, bool) or not isinstance(raw, (int, float)) or not np.isfinite(raw):
                 return ToolResult(error=f"value for {label!r} must be a finite number, got {raw!r}")
             vector[index] = float(raw)
+            named_indices.append(index)
 
-        hz = self._hz if self._hz is not None else _FALLBACK_HZ
-        steps = max(1, round(float(duration) * hz))
         if self._absolute:
-            current = self._current_state(observation)
-            target = current.copy()
-            for label in values:
-                target[self._index_by_label[str(label)]] = vector[self._index_by_label[str(label)]]
-            fractions = np.linspace(1.0 / steps, 1.0, steps)
-            actions = [Action(data=current + (target - current) * f) for f in fractions]
-        else:
-            per_step = vector / steps
-            actions = [Action(data=per_step.copy()) for _ in range(steps)]
+            return self._move_absolute(values, vector, named_indices, observation)
+        return self._move_displacement(vector, named_indices)
+
+    def _move_absolute(
+        self,
+        values: dict[Any, Any],
+        vector: npt.NDArray[np.float64],
+        named_indices: list[int],
+        observation: Observation,
+    ) -> ToolResult:
+        current = self._current_state(observation)
+        if not bool(np.all(np.isfinite(current))):
+            raise ValueError("proprioceptive reference contains a non-finite value")
+
+        target = current.copy()
+        for label, index in zip(values, named_indices, strict=True):
+            value = vector[index]
+            if self._step_limits[index] == 0:
+                if value != self._low[index]:
+                    return ToolResult(
+                        error=f"dimension {label} is fixed at {float(self._low[index])!r}"
+                    )
+            elif value < self._low[index] or value > self._high[index]:
+                return ToolResult(
+                    error=(
+                        f"target for {label} is outside "
+                        f"[{float(self._low[index])!r}, {float(self._high[index])!r}]"
+                    )
+                )
+            target[index] = value
+
+        ratios: list[np.float64] = []
+        with np.errstate(over="ignore", invalid="ignore", divide="ignore"):
+            for index in named_indices:
+                distance = np.abs(np.subtract(target[index], current[index]))
+                limit = self._step_limits[index]
+                if distance > 0 and limit > 0:
+                    ratios.append(np.divide(distance, limit))
+            ratio = max(ratios, default=np.float64(0.0))
+            headed_ratio = np.divide(ratio, 1.0 - _RELATIVE_HEADROOM)
+        if headed_ratio > self._max_steps:
+            return self._cap_error()
+        steps = max(1, math.ceil(float(headed_ratio)))
+
+        fractions = np.linspace(1.0 / steps, 1.0, steps)
+        actions = [
+            Action(data=np.clip(current + (target - current) * fraction, self._low, self._high))
+            for fraction in fractions
+        ]
+        actions[-1] = Action(data=np.clip(target.copy(), self._low, self._high))
+        return self._success(actions, steps)
+
+    def _move_displacement(
+        self,
+        vector: npt.NDArray[np.float64],
+        named_indices: list[int],
+    ) -> ToolResult:
+        ratios: list[np.float64] = []
+        with np.errstate(over="ignore", invalid="ignore", divide="ignore"):
+            for index in named_indices:
+                value = vector[index]
+                if value == 0:
+                    continue
+                limit = self._positive_limits[index] if value > 0 else self._negative_limits[index]
+                if limit == 0:
+                    return ToolResult(
+                        error=f"dimension {self._labels[index]} cannot move in that direction"
+                    )
+                ratios.append(np.divide(np.abs(value), limit))
+            ratio = max(ratios, default=np.float64(0.0))
+            headed_ratio = np.divide(ratio, 1.0 - _RELATIVE_HEADROOM)
+        if headed_ratio > self._max_steps:
+            return self._cap_error()
+        steps = max(1, math.ceil(float(headed_ratio)))
+        per_step = vector / steps
+        actions = [Action(data=per_step.copy()) for _ in range(steps)]
+        return self._success(actions, steps)
+
+    def _cap_error(self) -> ToolResult:
+        return ToolResult(
+            error=(
+                f"requested motion exceeds the {_MAX_DURATION_S:g}s playout cap; "
+                "split the move into smaller motions"
+            )
+        )
+
+    def _success(self, actions: list[Action], steps: int) -> ToolResult:
+        note = f"executing {self._move_tool} over {steps} steps"
+        if self._hz is not None:
+            note += f" ({steps / self._hz:.1f}s)"
         return ToolResult(
             chunk=ActionChunk(actions=actions, control_hz=self._hz),
-            note=f"executing {self._move_tool} over {steps} steps ({duration}s)",
+            note=note,
         )
 
 
 def build_toolset(
-    action_space: Box, observation_space: ObservationSpace, control_hz: float | None
+    action_space: Box,
+    observation_space: ObservationSpace,
+    control_hz: float | None,
+    max_speed_frac: float = 0.5,
 ) -> Toolset:
-    """Validate a (action space, observation space) pairing and build its tools.
+    """Validate an embodiment's spaces and build its agent-facing tools.
 
-    Raises [`ToolsetError`][inspect_robots_agent._tools.ToolsetError] with a
-    clear message for configurations the motion layer cannot drive — at bind
-    time, never mid-trial.
+    Raises [`ToolsetError`][inspect_robots_agent._tools.ToolsetError] for
+    configurations the motion layer cannot drive, before a trial begins.
     """
     semantics = action_space.semantics
     if semantics is None:
@@ -247,6 +326,10 @@ def build_toolset(
         )
     if mode not in _ABSOLUTE_MODES | _DISPLACEMENT_MODES:
         raise ToolsetError(f"control_mode {mode!r} is not supported by the agent policy yet")
+    if control_hz is not None and (not np.isfinite(control_hz) or control_hz <= 0):
+        raise ToolsetError("control_hz must be finite and > 0 when declared")
+    if not np.isfinite(max_speed_frac) or max_speed_frac <= 0:
+        raise ToolsetError("max_speed_frac must be finite and > 0")
 
     absolute = mode in _ABSOLUTE_MODES
     dim = action_space.dim
@@ -258,7 +341,7 @@ def build_toolset(
                 "absolute-target control needs a StateSpec on the embodiment's "
                 "observation space to locate the proprioceptive reference"
             )
-        matching = [f.key for f in spec.fields if f.shape == (dim,)]
+        matching = [field.key for field in spec.fields if field.shape == (dim,)]
         if len(matching) != 1:
             raise ToolsetError(
                 f"absolute-target control needs exactly one state field with shape "
@@ -266,16 +349,25 @@ def build_toolset(
             )
         state_key = matching[0]
 
-    labels = semantics.dim_labels or tuple(str(i) for i in range(dim))
     low, high = action_space.low, action_space.high
-    if low is not None and high is not None:
-        pairs = ", ".join(
-            f"{label}: [{lo:.4g}, {hi:.4g}]"
-            for label, lo, hi in zip(labels, low.tolist(), high.tolist(), strict=False)
-        )
-        bounds_text = f"Per-dimension bounds: {pairs}."
-    else:
-        bounds_text = "The action space declares no bounds; move conservatively."
+    if (
+        low is None
+        or high is None
+        or not bool(np.all(np.isfinite(low)) and np.all(np.isfinite(high)))
+    ):
+        mode_name = "absolute-target" if absolute else "displacement"
+        raise ToolsetError(f"{mode_name} control needs finite low and high bounds")
+    low64 = np.asarray(low, dtype=np.float64)
+    high64 = np.asarray(high, dtype=np.float64)
+    if not absolute and (bool(np.any(low64 > 0)) or bool(np.any(high64 < 0))):
+        raise ToolsetError("displacement control bounds must contain zero in every dimension")
+
+    labels = semantics.dim_labels or tuple(str(i) for i in range(dim))
+    pairs = ", ".join(
+        f"{label}: [{lo:.4g}, {hi:.4g}]"
+        for label, lo, hi in zip(labels, low64.tolist(), high64.tolist(), strict=False)
+    )
+    bounds_text = f"Per-dimension bounds: {pairs}."
 
     return Toolset(
         absolute=absolute,
@@ -283,4 +375,7 @@ def build_toolset(
         state_key=state_key,
         control_hz=control_hz,
         bounds_text=bounds_text,
+        low=low64,
+        high=high64,
+        max_speed_frac=max_speed_frac,
     )

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -65,8 +65,7 @@ class Toolset:
         bounds_text: str,
         low: npt.NDArray[np.float64],
         high: npt.NDArray[np.float64],
-        native_backstop: npt.NDArray[np.float64],
-        max_speed_frac: float = 0.5,
+        step_limits: npt.NDArray[np.float64],
     ):
         self._absolute = absolute
         self._labels = labels
@@ -79,16 +78,11 @@ class Toolset:
         self._bounds_text = bounds_text
         self._low = low
         self._high = high
+        self._step_limits = step_limits
         if absolute:
-            step_frac = min(max_speed_frac / self._resolved_hz, _BACKSTOP_STEP_FRAC)
-            # The elementwise min with the backstop derived in the box's native
-            # dtype: DeltaLimitApprover computes 0.05 * (high - low) without
-            # promoting, so low-precision boxes round it below our float64 value.
-            self._step_limits = np.minimum(step_frac * (high - low), native_backstop)
             self._positive_limits = np.zeros_like(high)
             self._negative_limits = np.zeros_like(low)
         else:
-            self._step_limits = np.zeros_like(high)
             self._positive_limits = high
             self._negative_limits = np.abs(low)
 
@@ -190,6 +184,15 @@ class Toolset:
         )
 
     def _move(self, arguments: dict[str, Any], observation: Observation) -> ToolResult:
+        current: npt.NDArray[np.float64] | None = None
+        if self._absolute:
+            # A broken sensor must end the trial before any argument
+            # validation: a malformed tool call must not mask it behind a
+            # correctable structured error.
+            current = self._current_state(observation)
+            if not bool(np.all(np.isfinite(current))):
+                raise ValueError("proprioceptive reference contains a non-finite value")
+
         values_key = "targets" if self._absolute else "deltas"
         values = arguments.get(values_key)
         if not isinstance(values, dict) or not values:
@@ -217,7 +220,8 @@ class Toolset:
             named_indices.append(index)
 
         if self._absolute:
-            return self._move_absolute(values, vector, named_indices, observation)
+            assert current is not None
+            return self._move_absolute(values, vector, named_indices, current)
         return self._move_displacement(vector, named_indices)
 
     def _move_absolute(
@@ -225,12 +229,8 @@ class Toolset:
         values: dict[Any, Any],
         vector: npt.NDArray[np.float64],
         named_indices: list[int],
-        observation: Observation,
+        current: npt.NDArray[np.float64],
     ) -> ToolResult:
-        current = self._current_state(observation)
-        if not bool(np.all(np.isfinite(current))):
-            raise ValueError("proprioceptive reference contains a non-finite value")
-
         target = current.copy()
         for label, index in zip(values, named_indices, strict=True):
             value = vector[index]
@@ -405,6 +405,7 @@ def build_toolset(
     # DeltaLimitApprover derives its default limit in the box's native dtype;
     # reproduce that arithmetic exactly so our ceiling can never exceed it.
     native_backstop = np.asarray(_BACKSTOP_STEP_FRAC * (high - low), dtype=np.float64)
+    step_limits = np.zeros_like(high64)
     if absolute:
         # Interpolants snap to the float grid at the bounds' magnitude. If that
         # grid is coarse relative to the backstop (offset boxes like
@@ -417,6 +418,17 @@ def build_toolset(
             raise ToolsetError(
                 "bounds are too coarse at this magnitude for speed-limited "
                 "interpolation (float spacing exceeds the per-step budget)"
+            )
+        resolved = control_hz if control_hz is not None else _FALLBACK_HZ
+        step_frac = min(max_speed_frac / resolved, _BACKSTOP_STEP_FRAC)
+        step_limits = np.minimum(step_frac * (high64 - low64), native_backstop)
+        # The frac/hz quotient can be nonzero yet still underflow to a zero
+        # limit once multiplied by a small range; a movable dimension with a
+        # zero limit would be misreported as fixed.
+        if bool(np.any(movable & (step_limits == 0))):
+            raise ToolsetError(
+                f"max_speed_frac {max_speed_frac!r} underflows the derived "
+                "per-step limit for a movable dimension; increase it"
             )
 
     labels = semantics.dim_labels or tuple(str(i) for i in range(dim))
@@ -434,6 +446,5 @@ def build_toolset(
         bounds_text=bounds_text,
         low=low64,
         high=high64,
-        native_backstop=native_backstop,
-        max_speed_frac=max_speed_frac,
+        step_limits=step_limits,
     )

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -292,6 +292,16 @@ class Toolset:
             return self._cap_error()
         steps = max(1, math.ceil(float(headed_ratio)))
         per_step = vector / steps
+        for index in named_indices:
+            # Subnormal deltas can underflow the split to exactly zero; a
+            # success note over a zero-motion chunk would be a silent lie.
+            if vector[index] != 0 and per_step[index] == 0:
+                return ToolResult(
+                    error=(
+                        f"delta for {self._labels[index]} is too small to split "
+                        "into executable steps"
+                    )
+                )
         actions = [Action(data=per_step.copy()) for _ in range(steps)]
         return self._success(actions, steps)
 
@@ -383,13 +393,31 @@ def build_toolset(
         raise ToolsetError(f"{mode_name} control needs finite low and high bounds")
     low64 = np.asarray(low, dtype=np.float64)
     high64 = np.asarray(high, dtype=np.float64)
-    if not bool(np.all(np.isfinite(high64 - low64))):
+    # The range must be finite in the box's native dtype, not just in float64:
+    # DeltaLimitApprover subtracts without promoting, so float32 bounds like
+    # [-3e38, 3e38] overflow for it even though the float64 difference is fine.
+    with np.errstate(over="ignore"):
+        native_range = np.asarray(high - low, dtype=np.float64)
+    if not bool(np.all(np.isfinite(native_range)) and np.all(np.isfinite(high64 - low64))):
         raise ToolsetError("action-space range (high - low) overflows; bounds are too large")
     if not absolute and (bool(np.any(low64 > 0)) or bool(np.any(high64 < 0))):
         raise ToolsetError("displacement control bounds must contain zero in every dimension")
     # DeltaLimitApprover derives its default limit in the box's native dtype;
     # reproduce that arithmetic exactly so our ceiling can never exceed it.
     native_backstop = np.asarray(_BACKSTOP_STEP_FRAC * (high - low), dtype=np.float64)
+    if absolute:
+        # Interpolants snap to the float grid at the bounds' magnitude. If that
+        # grid is coarse relative to the backstop (offset boxes like
+        # [1e16, 1e16 + 2], or ranges whose 5% underflows to zero), emitted
+        # steps jump by more than the backstop allows and motions silently
+        # truncate — the exact failure this plugin exists to remove.
+        spacing = np.spacing(np.maximum(np.abs(low64), np.abs(high64)))
+        movable = high64 > low64
+        if bool(np.any(movable & (spacing > 5e-7 * native_backstop))):
+            raise ToolsetError(
+                "bounds are too coarse at this magnitude for speed-limited "
+                "interpolation (float spacing exceeds the per-step budget)"
+            )
 
     labels = semantics.dim_labels or tuple(str(i) for i in range(dim))
     pairs = ", ".join(

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -65,6 +65,7 @@ class Toolset:
         bounds_text: str,
         low: npt.NDArray[np.float64],
         high: npt.NDArray[np.float64],
+        native_backstop: npt.NDArray[np.float64],
         max_speed_frac: float = 0.5,
     ):
         self._absolute = absolute
@@ -80,7 +81,10 @@ class Toolset:
         self._high = high
         if absolute:
             step_frac = min(max_speed_frac / self._resolved_hz, _BACKSTOP_STEP_FRAC)
-            self._step_limits = step_frac * (high - low)
+            # The elementwise min with the backstop derived in the box's native
+            # dtype: DeltaLimitApprover computes 0.05 * (high - low) without
+            # promoting, so low-precision boxes round it below our float64 value.
+            self._step_limits = np.minimum(step_frac * (high - low), native_backstop)
             self._positive_limits = np.zeros_like(high)
             self._negative_limits = np.zeros_like(low)
         else:
@@ -199,9 +203,17 @@ class Toolset:
                 return ToolResult(
                     error=f"unknown dimension {label!r}; valid names: {', '.join(self._labels)}"
                 )
-            if isinstance(raw, bool) or not isinstance(raw, (int, float)) or not np.isfinite(raw):
+            if isinstance(raw, bool) or not isinstance(raw, (int, float)):
                 return ToolResult(error=f"value for {label!r} must be a finite number, got {raw!r}")
-            vector[index] = float(raw)
+            try:
+                # Arbitrary-precision JSON integers overflow float() (and crash
+                # np.isfinite outright); both must stay structured errors.
+                coerced = float(raw)
+            except OverflowError:
+                return ToolResult(error=f"value for {label!r} must be a finite number, got {raw!r}")
+            if not np.isfinite(coerced):
+                return ToolResult(error=f"value for {label!r} must be a finite number, got {raw!r}")
+            vector[index] = coerced
             named_indices.append(index)
 
         if self._absolute:
@@ -330,6 +342,18 @@ def build_toolset(
         raise ToolsetError("control_hz must be finite and > 0 when declared")
     if not np.isfinite(max_speed_frac) or max_speed_frac <= 0:
         raise ToolsetError("max_speed_frac must be finite and > 0")
+    resolved_hz = control_hz if control_hz is not None else _FALLBACK_HZ
+    if not math.isfinite(_MAX_DURATION_S * resolved_hz):
+        raise ToolsetError(f"control_hz {control_hz!r} is too large to derive a playout cap")
+    if max_speed_frac / resolved_hz == 0.0:
+        raise ToolsetError(
+            f"max_speed_frac {max_speed_frac!r} underflows to a zero per-step "
+            f"limit at control_hz {resolved_hz!r}"
+        )
+    if len(action_space.shape) != 1:
+        raise ToolsetError(
+            f"only 1-D (vector) action spaces are supported, got shape {action_space.shape}"
+        )
 
     absolute = mode in _ABSOLUTE_MODES
     dim = action_space.dim
@@ -359,8 +383,13 @@ def build_toolset(
         raise ToolsetError(f"{mode_name} control needs finite low and high bounds")
     low64 = np.asarray(low, dtype=np.float64)
     high64 = np.asarray(high, dtype=np.float64)
+    if not bool(np.all(np.isfinite(high64 - low64))):
+        raise ToolsetError("action-space range (high - low) overflows; bounds are too large")
     if not absolute and (bool(np.any(low64 > 0)) or bool(np.any(high64 < 0))):
         raise ToolsetError("displacement control bounds must contain zero in every dimension")
+    # DeltaLimitApprover derives its default limit in the box's native dtype;
+    # reproduce that arithmetic exactly so our ceiling can never exceed it.
+    native_backstop = np.asarray(_BACKSTOP_STEP_FRAC * (high - low), dtype=np.float64)
 
     labels = semantics.dim_labels or tuple(str(i) for i in range(dim))
     pairs = ", ".join(
@@ -377,5 +406,6 @@ def build_toolset(
         bounds_text=bounds_text,
         low=low64,
         high=high64,
+        native_backstop=native_backstop,
         max_speed_frac=max_speed_frac,
     )

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -57,6 +57,7 @@ class AgentPolicyConfig(PolicyConfig):
     api_key_env: str | None = None
     max_llm_calls: int = 50
     effort: str | None = "low"
+    max_speed_frac: float = 0.5
 
 
 class LLMAgentPolicy(PolicyBase):
@@ -75,9 +76,12 @@ class LLMAgentPolicy(PolicyBase):
         max_llm_calls: int = 50,
         temperature: float | None = None,
         effort: str | None = "low",
+        max_speed_frac: float = 0.5,
         transport: httpx.BaseTransport | None = None,
         env: dict[str, str] | None = None,
     ):
+        if not np.isfinite(max_speed_frac) or max_speed_frac <= 0:
+            raise ValueError("max_speed_frac must be finite and > 0")
         environ = dict(os.environ) if env is None else env
         provider = resolve_provider(
             model=model or environ.get(ENV_MODEL),
@@ -98,6 +102,7 @@ class LLMAgentPolicy(PolicyBase):
         # (the arm stands still while the model thinks; safety guardrails sit
         # below the model, so effort trades thinking time, not safety).
         self._effort = effort
+        self._max_speed_frac = max_speed_frac
         self.config = AgentPolicyConfig(
             temperature=temperature,
             model=provider.model,
@@ -105,6 +110,7 @@ class LLMAgentPolicy(PolicyBase):
             api_key_env=api_key_env,
             max_llm_calls=max_llm_calls,
             effort=effort,
+            max_speed_frac=max_speed_frac,
         )
         # Placeholder until bind(); eval() always binds before compat/rollout.
         self.info = PolicyInfo(name="agent", action_space=Box(shape=(1,)))
@@ -121,6 +127,7 @@ class LLMAgentPolicy(PolicyBase):
             embodiment_info.action_space,
             embodiment_info.observation_space,
             embodiment_info.control_hz,
+            self._max_speed_frac,
         )
         self._embodiment_name = embodiment_info.name
         self.info = PolicyInfo(

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -17,13 +17,18 @@ import pytest
 
 from inspect_robots import eval as ir_eval
 from inspect_robots.approver import ChainApprover, ClampApprover, DeltaLimitApprover
+from inspect_robots.embodiment import EmbodimentInfo
 from inspect_robots.logging.sink import NullSink
 from inspect_robots.mock import CubePickEmbodiment
 from inspect_robots.rollout import TrialRecord
 from inspect_robots.scene import Scene
 from inspect_robots.scorer import success_at_end
+from inspect_robots.spaces import ActionSemantics, Box, ObservationSpace, StateField, StateSpec
 from inspect_robots.task import Task
+from inspect_robots.types import Action, Observation, StepResult
 from inspect_robots_agent import LLMAgentPolicy
+from inspect_robots_agent._llm import ChatClient, resolve_provider
+from inspect_robots_agent._png import encode_png
 
 # --- scripted-conversation harness ---------------------------------------------
 
@@ -50,6 +55,27 @@ def _tool_response(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
 
 def _text_response(text: str) -> dict[str, Any]:
     return {"choices": [{"message": {"role": "assistant", "content": text}}]}
+
+
+def _multi_tool_response(calls: list[tuple[str, dict[str, Any]]]) -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": f"call_{index}",
+                            "type": "function",
+                            "function": {"name": name, "arguments": json.dumps(arguments)},
+                        }
+                        for index, (name, arguments) in enumerate(calls)
+                    ],
+                }
+            }
+        ]
+    }
 
 
 class _Script:
@@ -92,13 +118,43 @@ class _RecordingSink(NullSink):
         self.records.append(record)
 
 
+class _AbsoluteEmbodiment:
+    def __init__(self) -> None:
+        self._q = np.array([0.0])
+        self.info = EmbodimentInfo(
+            name="absolute-test",
+            action_space=Box(
+                shape=(1,),
+                low=np.array([-1.0]),
+                high=np.array([1.0]),
+                semantics=ActionSemantics("joint_pos", dim_labels=("joint",)),
+            ),
+            observation_space=ObservationSpace(
+                state=StateSpec(fields=(StateField(key="q", shape=(1,)),))
+            ),
+            control_hz=10.0,
+            is_simulated=True,
+        )
+
+    def reset(self, scene: Scene, *, seed: int | None = None) -> Observation:
+        self._q = np.array([0.0])
+        return Observation(state={"q": self._q.copy()}, instruction=scene.instruction)
+
+    def step(self, action: Action) -> StepResult:
+        self._q = np.asarray(action.data, dtype=np.float64).copy()
+        return StepResult(observation=Observation(state={"q": self._q.copy()}))
+
+    def close(self) -> None:
+        return None
+
+
 # --- tests -----------------------------------------------------------------------
 
 
 def test_goal_runs_to_done_and_config_lands_in_log(tmp_path: Path) -> None:
     script = _Script(
         [
-            _tool_response("move_by", {"deltas": {"dx": 0.1, "dy": 0.1}, "duration_s": 0.5}),
+            _tool_response("move_by", {"deltas": {"dx": 0.1, "dy": 0.1}}),
             _tool_response("done", {"summary": "close enough"}),
         ]
     )
@@ -110,10 +166,11 @@ def test_goal_runs_to_done_and_config_lands_in_log(tmp_path: Path) -> None:
     (record,) = sink.records
     assert record.truncated is True
     assert record.termination_reason == "done"
-    # 5 interpolated steps + 1 hold-still stop action.
-    assert len(record.steps) == 6
+    # Headroom splits a box-sized move into two steps, then done holds once.
+    assert len(record.steps) == 3
     assert logs[0].eval.policy_config["model"] == "test/model"
     assert logs[0].eval.policy_config["max_llm_calls"] == 50
+    assert logs[0].eval.policy_config["max_speed_frac"] == 0.5
 
 
 def test_outbound_messages_carry_state_images_and_tools(tmp_path: Path) -> None:
@@ -135,7 +192,7 @@ def test_wild_swing_is_clamped_by_guardrails_but_not_without(tmp_path: Path) -> 
     def run(approver: Any) -> TrialRecord:
         script = _Script(
             [
-                _tool_response("move_by", {"deltas": {"dx": 5.0}, "duration_s": 0.5}),
+                _tool_response("move_by", {"deltas": {"dx": 0.08}}),
                 _tool_response("done", {"summary": "stop"}),
             ]
         )
@@ -151,18 +208,19 @@ def test_wild_swing_is_clamped_by_guardrails_but_not_without(tmp_path: Path) -> 
         return sink.records[0]
 
     space = CubePickEmbodiment().info.action_space
-    guarded = run(ChainApprover(ClampApprover(space), DeltaLimitApprover(space)))
+    guarded = run(ChainApprover(ClampApprover(space), DeltaLimitApprover(space, max_delta=0.02)))
     approvals = [e for e in guarded.events if e.kind == "approval"]
-    assert approvals, "the 1.0-per-step swing must be clamped to the 0.1 bound"
-    assert all(abs(float(np.asarray(s.action.data)[0])) <= 0.1 for s in guarded.steps)
+    assert approvals
+    assert any(e.data.get("detail") == "delta_clamped" for e in approvals)
+    assert float(np.asarray(guarded.steps[0].action.data)[0]) == 0.02
 
     unguarded = run(None)  # eval()'s Python-API default is the permissive AutoApprover
     assert not [e for e in unguarded.events if e.kind == "approval"]
-    assert any(abs(float(np.asarray(s.action.data)[0])) > 0.1 for s in unguarded.steps)
+    assert float(np.asarray(unguarded.steps[0].action.data)[0]) == 0.08
 
 
 def test_llm_call_budget_forces_give_up(tmp_path: Path) -> None:
-    script = _Script([_tool_response("move_by", {"deltas": {"dx": 0.05}, "duration_s": 0.5})])
+    script = _Script([_tool_response("move_by", {"deltas": {"dx": 0.05}})])
     sink = _RecordingSink()
     logs = ir_eval(
         _task(),
@@ -194,8 +252,8 @@ def test_persistent_non_tool_output_becomes_policy_error(tmp_path: Path) -> None
 def test_recoverable_tool_error_is_fed_back_and_corrected(tmp_path: Path) -> None:
     script = _Script(
         [
-            _tool_response("move_by", {"deltas": {"dz": 0.1}, "duration_s": 0.5}),  # bad dim
-            _tool_response("move_by", {"deltas": {"dx": 0.1}, "duration_s": 0.5}),
+            _tool_response("move_by", {"deltas": {"dz": 0.1}}),  # bad dim
+            _tool_response("move_by", {"deltas": {"dx": 0.1}}),
             _tool_response("done", {"summary": "recovered"}),
         ]
     )
@@ -210,6 +268,40 @@ def test_recoverable_tool_error_is_fed_back_and_corrected(tmp_path: Path) -> Non
         m for request in script.requests for m in request["messages"] if m.get("role") == "tool"
     ]
     assert any("unknown dimension 'dz'" in str(m["content"]) for m in tool_messages)
+
+
+def test_persistent_tool_errors_become_policy_error(tmp_path: Path) -> None:
+    script = _Script([_tool_response("move_by", {"deltas": {"dz": 0.1}})])
+    sink = _RecordingSink()
+    logs = ir_eval(
+        _task(), _policy(script), CubePickEmbodiment(), log_dir=str(tmp_path), sinks=[sink]
+    )
+    assert logs[0].status == "error"
+    assert sink.records[0].error is not None
+    assert "tool calls kept failing" in sink.records[0].error
+
+
+def test_extra_tool_calls_are_answered_but_not_executed(tmp_path: Path) -> None:
+    script = _Script(
+        [
+            _multi_tool_response(
+                [
+                    ("move_by", {"deltas": {"dx": 0.05}}),
+                    ("give_up", {"reason": "extra"}),
+                ]
+            ),
+            _tool_response("done", {"summary": "only the first call ran"}),
+        ]
+    )
+    sink = _RecordingSink()
+    ir_eval(_task(), _policy(script), CubePickEmbodiment(), log_dir=str(tmp_path), sinks=[sink])
+    assert sink.records[0].termination_reason == "done"
+    ignored = [
+        message
+        for message in script.requests[1]["messages"]
+        if message.get("content") == "ignored: one tool call per turn"
+    ]
+    assert len(ignored) == 1
 
 
 def test_effort_defaults_low_and_is_tunable(tmp_path: Path) -> None:
@@ -237,6 +329,75 @@ def test_registry_resolves_agent_policy() -> None:
 
     policy = resolve("policy", "agent", model="m", base_url="http://x/v1")
     assert isinstance(policy, LLMAgentPolicy)
+
+
+def test_non_default_speed_fraction_is_forwarded_through_bind(tmp_path: Path) -> None:
+    script = _Script(
+        [
+            _tool_response("move_joints", {"targets": {"joint": 0.5}}),
+            _tool_response("done", {"summary": "moved"}),
+        ]
+    )
+    sink = _RecordingSink()
+    ir_eval(
+        _task(max_steps=20),
+        _policy(script, max_speed_frac=0.25),
+        _AbsoluteEmbodiment(),
+        log_dir=str(tmp_path),
+        sinks=[sink],
+    )
+    # Distance 0.5 / (0.25 / 10 * range 2) plus relative headroom.
+    assert len(sink.records[0].steps) == 12  # 11 motion steps + done
+
+
+@pytest.mark.parametrize("max_speed_frac", [0.0, -0.1, float("inf"), float("nan")])
+def test_policy_rejects_invalid_max_speed_frac(max_speed_frac: float) -> None:
+    with pytest.raises(ValueError, match="max_speed_frac must be finite and > 0"):
+        _policy(_Script([]), max_speed_frac=max_speed_frac)
+
+
+def test_policy_rejects_empty_call_budget_and_reads_process_environment() -> None:
+    with pytest.raises(ValueError, match="max_llm_calls must be >= 1"):
+        LLMAgentPolicy(
+            model="test/model",
+            base_url="http://llm.test/v1",
+            max_llm_calls=0,
+            env={},
+        )
+
+    policy = LLMAgentPolicy(
+        model="test/model",
+        base_url="http://llm.test/v1",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)),
+    )
+    assert policy.info.name == "agent"
+
+
+def test_chat_transport_failure_and_close_are_well_defined() -> None:
+    provider = resolve_provider(
+        model="test/model",
+        base_url="http://llm.test/v1",
+        api_key_env=None,
+        env={},
+    )
+
+    def fail(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("offline", request=request)
+
+    client = ChatClient(
+        provider,
+        transport=httpx.MockTransport(fail),
+        max_retries=1,
+        backoff_s=0.0,
+    )
+    with pytest.raises(RuntimeError, match="offline"):
+        client.complete(messages=[], tools=[])
+    client.close()
+
+
+def test_png_encoder_accepts_float_grayscale_frames() -> None:
+    encoded = encode_png(np.array([[0.5]], dtype=np.float64))
+    assert encoded.startswith(b"\x89PNG\r\n\x1a\n")
 
 
 def test_unbound_act_raises_clear_error() -> None:

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -202,6 +202,54 @@ def test_control_hz_none_binds() -> None:
     build_toolset(_delta_space(), ObservationSpace(), control_hz=None)
 
 
+def test_build_rejects_degenerate_derivations() -> None:
+    with pytest.raises(ToolsetError, match="too large to derive a playout cap"):
+        build_toolset(_delta_space(), ObservationSpace(), control_hz=1e308)
+
+    with pytest.raises(ToolsetError, match="underflows to a zero per-step limit"):
+        build_toolset(
+            _absolute_space(),
+            _absolute_obs_space(),
+            control_hz=10.0,
+            max_speed_frac=5e-324,
+        )
+
+    huge = _absolute_space(low=np.array([-1e308]), high=np.array([1e308]))
+    with pytest.raises(ToolsetError, match=r"range .* overflows"):
+        build_toolset(huge, _absolute_obs_space(), control_hz=10.0)
+
+    matrix = Box(
+        shape=(2, 2),
+        low=np.zeros((2, 2)),
+        high=np.ones((2, 2)),
+        semantics=ActionSemantics("joint_pos"),
+    )
+    with pytest.raises(ToolsetError, match="only 1-D"):
+        build_toolset(matrix, _absolute_obs_space(dim=4), control_hz=10.0)
+
+
+def test_low_precision_bounds_never_outrun_native_backstop() -> None:
+    # DeltaLimitApprover derives 0.05 * (high - low) in the box's dtype;
+    # float16 rounds that to 0.0999755859375, below the float64 0.1. Every
+    # emitted step must respect the *native* value or the backstop clamps.
+    space = Box(
+        shape=(1,),
+        low=np.array([-1.0], dtype=np.float16),
+        high=np.array([1.0], dtype=np.float16),
+        semantics=ActionSemantics("joint_pos", dim_labels=("joint",)),
+    )
+    toolset = build_toolset(space, _absolute_obs_space(), control_hz=10.0)
+    result = toolset.execute(
+        _call("move_joints", targets={"joint": 0.9999}),
+        _obs({"q": np.array([0.0])}),
+    )
+    assert result.chunk is not None
+    chain = ChainApprover(ClampApprover(space), DeltaLimitApprover(space))
+    store: dict[str, Any] = {}
+    for action in result.chunk.actions:
+        assert chain.review(action, store) is action
+
+
 @pytest.mark.parametrize("max_speed_frac", [0.0, -0.1, float("inf"), float("nan")])
 def test_build_rejects_invalid_max_speed_frac(max_speed_frac: float) -> None:
     with pytest.raises(ToolsetError, match="max_speed_frac must be finite and > 0"):
@@ -240,6 +288,12 @@ def test_move_joints_derives_steps_and_snaps_bit_exact_target() -> None:
     assert len(result.chunk.actions) == 16
     assert result.chunk.actions[-1].data[0] == 1.0
     assert result.note == "executing move_joints over 16 steps (1.6s)"
+
+    # Pins the snap itself: 0.3 is interior (clip cannot repair it) and plain
+    # linspace arithmetic lands on 0.30000000000000004 instead.
+    snapped = _execute_absolute(0.3, current=-0.1)
+    assert snapped.chunk is not None
+    assert snapped.chunk.actions[-1].data[0] == 0.3
 
 
 def test_move_joints_clips_every_interpolant_into_box() -> None:
@@ -466,6 +520,19 @@ def test_huge_finite_move_by_returns_cap_error() -> None:
     result = toolset.execute(_call("move_by", deltas={"0": 1e308}), _obs({}))
     assert result.chunk is None
     assert result.error is not None and "split the move into smaller motions" in result.error
+
+
+def test_arbitrary_precision_json_integer_is_a_structured_error() -> None:
+    toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+    # 10**400 overflows float() and crashes np.isfinite; both int sizes must
+    # come back as errors the LLM can correct, never exceptions.
+    overflowing = toolset.execute(_call("move_by", deltas={"0": 10**400}), _obs({}))
+    assert overflowing.chunk is None
+    assert overflowing.error is not None and "must be a finite number" in overflowing.error
+
+    representable = toolset.execute(_call("move_by", deltas={"0": 10**100}), _obs({}))
+    assert representable.chunk is None
+    assert representable.error is not None and "split the move" in representable.error
 
 
 # --- done, notes, and structured errors ---------------------------------------

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -1,16 +1,19 @@
-"""Tool surface + control-mode-aware motion synthesis (plan 0008 §4b/§4c)."""
+"""Tool surface + speed-limited motion synthesis (plan 0014)."""
 
 from __future__ import annotations
 
 import json
+from itertools import pairwise
+from typing import Any
 
 import numpy as np
 import pytest
 
+from inspect_robots.approver import ChainApprover, ClampApprover, DeltaLimitApprover
 from inspect_robots.spaces import ActionSemantics, Box, ObservationSpace, StateField, StateSpec
 from inspect_robots.types import Observation
 from inspect_robots_agent._llm import ToolCall
-from inspect_robots_agent._tools import ToolsetError, build_toolset
+from inspect_robots_agent._tools import ToolResult, ToolsetError, build_toolset
 
 _ARM_LABELS = tuple(
     f"{side}_{part}"
@@ -32,11 +35,31 @@ def _bimanual_obs_space() -> ObservationSpace:
     return ObservationSpace(state=StateSpec(fields=(StateField(key="joint_pos", shape=(14,)),)))
 
 
-def _delta_space() -> Box:
+def _absolute_space(
+    low: np.ndarray | None = None,
+    high: np.ndarray | None = None,
+    labels: tuple[str, ...] | None = ("joint",),
+) -> Box:
+    return Box(
+        shape=(1,),
+        low=np.array([-1.0]) if low is None else low,
+        high=np.array([1.0]) if high is None else high,
+        semantics=ActionSemantics("joint_pos", dim_labels=labels),
+    )
+
+
+def _absolute_obs_space(dim: int = 1, key: str = "q") -> ObservationSpace:
+    return ObservationSpace(state=StateSpec(fields=(StateField(key=key, shape=(dim,)),)))
+
+
+def _delta_space(
+    low: np.ndarray | None = None,
+    high: np.ndarray | None = None,
+) -> Box:
     return Box(
         shape=(2,),
-        low=np.array([-0.1, -0.1]),
-        high=np.array([0.1, 0.1]),
+        low=np.array([-0.1, -0.1]) if low is None else low,
+        high=np.array([0.1, 0.1]) if high is None else high,
         semantics=ActionSemantics("eef_delta_pos", frame="world"),
     )
 
@@ -46,7 +69,26 @@ def _call(name: str, **arguments: object) -> ToolCall:
 
 
 def _obs(state: dict[str, np.ndarray] | None = None) -> Observation:
-    return Observation(state=state or {"joint_pos": np.zeros(14)})
+    return Observation(state={"q": np.array([0.0])} if state is None else state)
+
+
+def _execute_absolute(
+    target: float,
+    current: float = 0.0,
+    *,
+    control_hz: float | None = 10.0,
+    max_speed_frac: float = 0.5,
+) -> ToolResult:
+    toolset = build_toolset(
+        _absolute_space(),
+        _absolute_obs_space(),
+        control_hz=control_hz,
+        max_speed_frac=max_speed_frac,
+    )
+    return toolset.execute(
+        _call("move_joints", targets={"joint": target}),
+        _obs({"q": np.array([current])}),
+    )
 
 
 # --- bind-time validation ------------------------------------------------------
@@ -57,11 +99,21 @@ def test_build_refuses_unsupported_configurations() -> None:
     with pytest.raises(ToolsetError, match="semantics"):
         build_toolset(no_sem, _bimanual_obs_space(), control_hz=10.0)
 
-    vel = Box(shape=(2,), semantics=ActionSemantics("joint_vel"))
+    vel = Box(
+        shape=(2,),
+        low=-np.ones(2),
+        high=np.ones(2),
+        semantics=ActionSemantics("joint_vel"),
+    )
     with pytest.raises(ToolsetError, match="joint_vel"):
         build_toolset(vel, _bimanual_obs_space(), control_hz=10.0)
 
-    quat = Box(shape=(7,), semantics=ActionSemantics("eef_abs_pose", rotation_repr="quat_wxyz"))
+    quat = Box(
+        shape=(7,),
+        low=-np.ones(7),
+        high=np.ones(7),
+        semantics=ActionSemantics("eef_abs_pose", rotation_repr="quat_wxyz"),
+    )
     with pytest.raises(ToolsetError, match="rotation_repr"):
         build_toolset(quat, _bimanual_obs_space(), control_hz=10.0)
 
@@ -69,7 +121,7 @@ def test_build_refuses_unsupported_configurations() -> None:
 def test_absolute_mode_requires_exactly_one_aligned_state_field() -> None:
     space = _bimanual_space()
     with pytest.raises(ToolsetError, match="StateSpec"):
-        build_toolset(space, ObservationSpace(), control_hz=10.0)  # no StateSpec at all
+        build_toolset(space, ObservationSpace(), control_hz=10.0)
 
     none_match = ObservationSpace(state=StateSpec(fields=(StateField(key="eef", shape=(3,)),)))
     with pytest.raises(ToolsetError, match="exactly one"):
@@ -82,117 +134,401 @@ def test_absolute_mode_requires_exactly_one_aligned_state_field() -> None:
         build_toolset(space, two_match, control_hz=10.0)
 
 
+@pytest.mark.parametrize(
+    ("low", "high"),
+    [
+        (None, np.array([1.0])),
+        (np.array([-1.0]), None),
+        (np.array([float("-inf")]), np.array([1.0])),
+        (np.array([-1.0]), np.array([float("inf")])),
+        (np.array([float("nan")]), np.array([1.0])),
+    ],
+)
+def test_absolute_mode_requires_finite_bounds(
+    low: np.ndarray | None, high: np.ndarray | None
+) -> None:
+    space = Box(
+        shape=(1,),
+        low=low,
+        high=high,
+        semantics=ActionSemantics("joint_pos", dim_labels=("joint",)),
+    )
+    with pytest.raises(ToolsetError, match="finite low and high bounds"):
+        build_toolset(space, _absolute_obs_space(), control_hz=10.0)
+
+
+@pytest.mark.parametrize(
+    ("low", "high", "message"),
+    [
+        (None, np.array([0.1, 0.1]), "finite low and high bounds"),
+        (np.array([-0.1, -0.1]), None, "finite low and high bounds"),
+        (np.array([-np.inf, -0.1]), np.array([0.1, 0.1]), "finite low and high bounds"),
+        (np.array([-0.1, -0.1]), np.array([0.1, np.inf]), "finite low and high bounds"),
+        (np.array([0.01, -0.1]), np.array([0.1, 0.1]), "contain zero"),
+        (np.array([-0.1, -0.1]), np.array([-0.01, 0.1]), "contain zero"),
+    ],
+)
+def test_displacement_mode_requires_finite_zero_containing_bounds(
+    low: np.ndarray | None, high: np.ndarray | None, message: str
+) -> None:
+    space = Box(
+        shape=(2,),
+        low=low,
+        high=high,
+        semantics=ActionSemantics("eef_delta_pos"),
+    )
+    with pytest.raises(ToolsetError, match=message):
+        build_toolset(space, ObservationSpace(), control_hz=10.0)
+
+
+def test_zero_width_and_zero_sided_bounds_bind() -> None:
+    fixed = _absolute_space(low=np.array([0.3]), high=np.array([0.3]))
+    build_toolset(fixed, _absolute_obs_space(), control_hz=10.0)
+
+    build_toolset(
+        _delta_space(low=np.array([0.0, -0.1]), high=np.array([0.1, 0.0])),
+        ObservationSpace(),
+        control_hz=10.0,
+    )
+
+
+@pytest.mark.parametrize("control_hz", [0.0, -1.0, float("inf"), float("-inf"), float("nan")])
+def test_declared_control_hz_must_be_finite_and_positive(control_hz: float) -> None:
+    with pytest.raises(ToolsetError, match="control_hz must be finite and > 0"):
+        build_toolset(_delta_space(), ObservationSpace(), control_hz=control_hz)
+
+
+def test_control_hz_none_binds() -> None:
+    build_toolset(_delta_space(), ObservationSpace(), control_hz=None)
+
+
+@pytest.mark.parametrize("max_speed_frac", [0.0, -0.1, float("inf"), float("nan")])
+def test_build_rejects_invalid_max_speed_frac(max_speed_frac: float) -> None:
+    with pytest.raises(ToolsetError, match="max_speed_frac must be finite and > 0"):
+        build_toolset(
+            _absolute_space(),
+            _absolute_obs_space(),
+            control_hz=10.0,
+            max_speed_frac=max_speed_frac,
+        )
+
+
 # --- schemas -------------------------------------------------------------------
 
 
-def test_schemas_match_control_mode_and_embed_labels() -> None:
+def test_schemas_match_control_mode_and_remove_duration() -> None:
     absolute = build_toolset(_bimanual_space(), _bimanual_obs_space(), control_hz=10.0)
     names = [t["function"]["name"] for t in absolute.schemas()]
     assert names == ["move_joints", "done", "give_up"]
     move_schema = json.dumps(absolute.schemas()[0])
     assert "left_j0" in move_schema and "right_gripper" in move_schema
+    assert "duration_s" not in move_schema
+    assert absolute.schemas()[0]["function"]["parameters"]["required"] == ["targets"]
 
     displacement = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
     names = [t["function"]["name"] for t in displacement.schemas()]
     assert names == ["move_by", "done", "give_up"]
+    assert displacement.schemas()[0]["function"]["parameters"]["required"] == ["deltas"]
 
 
 # --- absolute-mode synthesis ---------------------------------------------------
 
 
-def test_move_joints_interpolates_named_partial_targets() -> None:
-    toolset = build_toolset(_bimanual_space(), _bimanual_obs_space(), control_hz=10.0)
+def test_move_joints_derives_steps_and_snaps_bit_exact_target() -> None:
+    result = _execute_absolute(1.0, current=-0.5)
+    assert result.error is None and result.chunk is not None
+    assert len(result.chunk.actions) == 16
+    assert result.chunk.actions[-1].data[0] == 1.0
+    assert result.note == "executing move_joints over 16 steps (1.6s)"
+
+
+def test_move_joints_clips_every_interpolant_into_box() -> None:
+    space = _absolute_space(low=np.array([-1.0]), high=np.array([0.3]))
+    toolset = build_toolset(space, _absolute_obs_space(), control_hz=10.0)
     result = toolset.execute(
-        _call("move_joints", targets={"right_j2": 0.4, "right_gripper": 1.0}, duration_s=1.0),
-        _obs(),
+        _call("move_joints", targets={"joint": 0.3}),
+        _obs({"q": np.array([-0.1])}),
     )
     assert result.error is None and result.chunk is not None
-    chunk = result.chunk
-    assert len(chunk.actions) == 10
-    assert chunk.control_hz == 10.0
-    final = np.asarray(chunk.actions[-1].data)
-    assert final[9] == pytest.approx(0.4)  # right_j2 is dim 7 + 2
-    assert final[13] == pytest.approx(1.0)  # right_gripper
-    assert np.allclose(np.delete(final, [9, 13]), 0.0)  # unnamed dims hold
-    mid = np.asarray(chunk.actions[4].data)
-    assert mid[9] == pytest.approx(0.2)  # linear halfway
+    assert all(-1.0 <= float(action.data[0]) <= 0.3 for action in result.chunk.actions)
 
 
-def test_move_joints_index_fallback_without_labels() -> None:
+def test_move_joints_headroom_stays_within_default_backstop() -> None:
+    current = -0.5
+    result = _execute_absolute(1.0, current=current)
+    assert result.chunk is not None
+    emitted = [current, *(float(action.data[0]) for action in result.chunk.actions)]
+    assert all(right - left <= 0.1 for left, right in pairwise(emitted))
+
+
+@pytest.mark.parametrize(("target", "current"), [(0.01, 0.0), (0.4, 0.4)])
+def test_move_joints_has_one_step_floor(target: float, current: float) -> None:
+    result = _execute_absolute(target, current=current)
+    assert result.chunk is not None
+    assert len(result.chunk.actions) == 1
+
+
+def test_move_joints_preserves_unnamed_dimensions_and_index_labels() -> None:
     space = Box(
-        shape=(2,), low=np.zeros(2), high=np.ones(2), semantics=ActionSemantics("joint_pos")
+        shape=(2,),
+        low=np.zeros(2),
+        high=np.ones(2),
+        semantics=ActionSemantics("joint_pos"),
     )
-    obs_space = ObservationSpace(state=StateSpec(fields=(StateField(key="q", shape=(2,)),)))
+    obs_space = _absolute_obs_space(dim=2)
     toolset = build_toolset(space, obs_space, control_hz=10.0)
     result = toolset.execute(
-        _call("move_joints", targets={"1": 0.6}, duration_s=0.5),
-        Observation(state={"q": np.array([0.2, 0.2])}),
+        _call("move_joints", targets={"1": 0.6}),
+        _obs({"q": np.array([0.2, 0.2])}),
     )
     assert result.error is None and result.chunk is not None
     final = np.asarray(result.chunk.actions[-1].data)
-    assert final[0] == pytest.approx(0.2) and final[1] == pytest.approx(0.6)
+    assert final[0] == 0.2 and final[1] == 0.6
 
 
-# --- displacement-mode synthesis ------------------------------------------------
+def test_move_joints_rejects_out_of_bounds_but_accepts_bound() -> None:
+    toolset = build_toolset(_absolute_space(), _absolute_obs_space(), control_hz=10.0)
+    rejected = toolset.execute(
+        _call("move_joints", targets={"joint": 1.01}),
+        _obs(),
+    )
+    assert rejected.error == "target for joint is outside [-1.0, 1.0]"
+
+    accepted = toolset.execute(
+        _call("move_joints", targets={"joint": -1.0}),
+        _obs(),
+    )
+    assert accepted.error is None and accepted.chunk is not None
+    assert accepted.chunk.actions[-1].data[0] == -1.0
 
 
-def test_move_by_splits_displacement_across_steps() -> None:
-    toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
-    result = toolset.execute(_call("move_by", deltas={"0": 0.1}, duration_s=0.5), _obs({}))
+def test_zero_width_target_uses_bound_not_noisy_observation_and_no_steps() -> None:
+    bound = 0.30000000000000004
+    space = _absolute_space(low=np.array([bound]), high=np.array([bound]), labels=("fixed",))
+    toolset = build_toolset(space, _absolute_obs_space(), control_hz=10.0)
+
+    accepted = toolset.execute(
+        _call("move_joints", targets={"fixed": bound}),
+        _obs({"q": np.array([0.31])}),
+    )
+    assert accepted.error is None and accepted.chunk is not None
+    assert len(accepted.chunk.actions) == 1
+    assert accepted.chunk.actions[0].data[0] == bound
+
+    rejected = toolset.execute(
+        _call("move_joints", targets={"fixed": 0.3}),
+        _obs({"q": np.array([bound])}),
+    )
+    assert rejected.error == "dimension fixed is fixed at 0.30000000000000004"
+
+
+@pytest.mark.parametrize(("control_hz", "max_speed_frac"), [(5.0, 0.5), (10.0, 1.0)])
+def test_move_joints_per_step_ceiling_matches_default_backstop(
+    control_hz: float, max_speed_frac: float
+) -> None:
+    result = _execute_absolute(
+        1.0,
+        current=-1.0,
+        control_hz=control_hz,
+        max_speed_frac=max_speed_frac,
+    )
+    assert result.chunk is not None
+    assert len(result.chunk.actions) == 21
+    emitted = [-1.0, *(float(action.data[0]) for action in result.chunk.actions)]
+    assert all(right - left <= 0.1 for left, right in pairwise(emitted))
+
+
+def test_move_joints_honors_non_default_speed_fraction() -> None:
+    result = _execute_absolute(0.5, max_speed_frac=0.25)
+    assert result.chunk is not None
+    assert len(result.chunk.actions) == 11
+
+
+@pytest.mark.parametrize("bad_state", [float("nan"), float("inf"), float("-inf")])
+def test_move_joints_rejects_non_finite_observed_state(bad_state: float) -> None:
+    with pytest.raises(ValueError, match="non-finite"):
+        _execute_absolute(0.5, current=bad_state)
+
+
+def test_move_joints_absurd_finite_state_returns_cap_error() -> None:
+    result = _execute_absolute(0.0, current=1e308)
+    assert result.chunk is None
+    assert result.error is not None and "split the move into smaller motions" in result.error
+
+
+def test_move_joints_over_cap_returns_structured_error() -> None:
+    result = _execute_absolute(1.0, current=-1.0, max_speed_frac=0.01)
+    assert result.chunk is None
+    assert result.error is not None and "split the move into smaller motions" in result.error
+
+    boundary = _execute_absolute(0.98, current=-1.0, max_speed_frac=0.1)
+    assert boundary.error is None and boundary.chunk is not None
+    assert len(boundary.chunk.actions) == 100
+
+
+def test_absolute_chunks_pass_default_approvers_across_calls() -> None:
+    space = _absolute_space()
+    toolset = build_toolset(space, _absolute_obs_space(), control_hz=10.0)
+    chain = ChainApprover(ClampApprover(space), DeltaLimitApprover(space))
+    store: dict[str, Any] = {}
+
+    first = toolset.execute(
+        _call("move_joints", targets={"joint": 1.0}),
+        _obs({"q": np.array([-0.5])}),
+    )
+    second = toolset.execute(
+        _call("move_joints", targets={"joint": -1.0}),
+        _obs({"q": np.array([1.0])}),
+    )
+    assert first.chunk is not None and second.chunk is not None
+    for action in (*first.chunk.actions, *second.chunk.actions):
+        assert chain.review(action, store) is action
+
+
+# --- displacement-mode synthesis ----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("low", "high", "delta", "expected_steps", "expected_value"),
+    [
+        (-0.1, 0.05, 0.2, 5, 0.04),
+        (-0.1, 0.05, -0.2, 3, -0.2 / 3),
+    ],
+)
+def test_move_by_splits_by_directional_box_side(
+    low: float, high: float, delta: float, expected_steps: int, expected_value: float
+) -> None:
+    space = _delta_space(low=np.array([low, -0.1]), high=np.array([high, 0.1]))
+    toolset = build_toolset(space, ObservationSpace(), control_hz=10.0)
+    result = toolset.execute(_call("move_by", deltas={"0": delta}), _obs({}))
     assert result.error is None and result.chunk is not None
-    actions = [np.asarray(a.data) for a in result.chunk.actions]
-    assert len(actions) == 5
-    for a in actions:
-        assert a[0] == pytest.approx(0.02) and a[1] == 0.0
+    assert len(result.chunk.actions) == expected_steps
+    assert all(
+        float(action.data[0]) == pytest.approx(expected_value) for action in result.chunk.actions
+    )
 
 
-# --- done / give_up -------------------------------------------------------------
+def test_move_by_headroom_avoids_one_ulp_box_overrun() -> None:
+    limit = 0.8137309994111953
+    delta = 4.068654997055977
+    space = _delta_space(high=np.array([limit, 0.1]))
+    toolset = build_toolset(space, ObservationSpace(), control_hz=10.0)
+    result = toolset.execute(_call("move_by", deltas={"0": delta}), _obs({}))
+    assert result.chunk is not None
+    assert len(result.chunk.actions) == 6
+    assert all(abs(float(action.data[0])) <= limit for action in result.chunk.actions)
 
 
-def test_done_emits_hold_still_with_request_stop() -> None:
-    toolset = build_toolset(_bimanual_space(), _bimanual_obs_space(), control_hz=10.0)
+def test_move_by_all_zero_is_one_step_hold() -> None:
+    toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+    result = toolset.execute(_call("move_by", deltas={"0": 0.0, "1": 0.0}), _obs({}))
+    assert result.error is None and result.chunk is not None
+    assert len(result.chunk.actions) == 1
+    assert np.array_equal(result.chunk.actions[0].data, np.zeros(2))
+
+
+@pytest.mark.parametrize(
+    ("low", "high", "delta"),
+    [(0.0, 0.1, -0.01), (-0.1, 0.0, 0.01)],
+)
+def test_move_by_rejects_zero_bound_direction(low: float, high: float, delta: float) -> None:
+    space = _delta_space(low=np.array([low, -0.1]), high=np.array([high, 0.1]))
+    toolset = build_toolset(space, ObservationSpace(), control_hz=10.0)
+    result = toolset.execute(_call("move_by", deltas={"0": delta}), _obs({}))
+    assert result.error == "dimension 0 cannot move in that direction"
+
+
+def test_move_by_ignores_max_speed_frac() -> None:
+    lengths = []
+    for frac in (0.5, 0.1):
+        toolset = build_toolset(
+            _delta_space(), ObservationSpace(), control_hz=10.0, max_speed_frac=frac
+        )
+        result = toolset.execute(_call("move_by", deltas={"0": 0.2}), _obs({}))
+        assert result.chunk is not None
+        lengths.append(len(result.chunk.actions))
+    assert lengths == [3, 3]
+
+
+def test_move_by_over_cap_errors_and_boundary_succeeds() -> None:
+    toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+    too_large = toolset.execute(_call("move_by", deltas={"0": 10.0}), _obs({}))
+    assert too_large.chunk is None
+    assert too_large.error is not None and "split the move into smaller motions" in too_large.error
+
+    boundary = toolset.execute(_call("move_by", deltas={"0": 9.9}), _obs({}))
+    assert boundary.error is None and boundary.chunk is not None
+    assert len(boundary.chunk.actions) == 100
+
+
+def test_huge_finite_move_by_returns_cap_error() -> None:
+    toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+    result = toolset.execute(_call("move_by", deltas={"0": 1e308}), _obs({}))
+    assert result.chunk is None
+    assert result.error is not None and "split the move into smaller motions" in result.error
+
+
+# --- done, notes, and structured errors ---------------------------------------
+
+
+def test_done_and_give_up_emit_control_mode_hold() -> None:
+    absolute = build_toolset(_bimanual_space(), _bimanual_obs_space(), control_hz=10.0)
     state = np.full(14, 0.3)
-    result = toolset.execute(_call("done", summary="fork placed"), _obs({"joint_pos": state}))
+    result = absolute.execute(
+        _call("done", summary="fork placed"),
+        Observation(state={"joint_pos": state}),
+    )
     assert result.error is None and result.chunk is not None
     (action,) = result.chunk.actions
-    assert np.allclose(action.data, state)  # absolute hold = repeat current state
+    assert np.array_equal(action.data, state)
     assert action.meta["request_stop"] is True
     assert action.meta["stop_reason"] == "done"
 
     displacement = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
-    result = displacement.execute(_call("give_up", reason="cannot see the cube"), _obs({}))
+    result = displacement.execute(_call("give_up", reason="cannot see"), _obs({}))
     assert result.chunk is not None
-    (action,) = result.chunk.actions
-    assert np.allclose(action.data, 0.0)  # displacement hold = zeros
-    assert action.meta["stop_reason"] == "give_up"
-
-
-# --- structured tool errors (fed back to the LLM, never exceptions) -------------
+    assert np.array_equal(result.chunk.actions[0].data, np.zeros(2))
+    assert result.chunk.actions[0].meta["stop_reason"] == "give_up"
 
 
 def test_tool_errors_are_messages_not_exceptions() -> None:
     toolset = build_toolset(_bimanual_space(), _bimanual_obs_space(), control_hz=10.0)
     cases = [
-        _call("move_joints", targets={"left_elbow": 0.1}, duration_s=1.0),  # unknown label
-        _call("move_joints", targets={"left_j0": float("nan")}, duration_s=1.0),
-        _call("move_joints", targets={"left_j0": "fast"}, duration_s=1.0),  # non-numeric
-        _call("move_joints", targets={}, duration_s=1.0),  # nothing to do
-        _call("move_joints", targets={"left_j0": 0.1}, duration_s=0.0),  # bad duration
-        _call("move_joints", targets={"left_j0": 0.1}, duration_s=60.0),  # over the cap
+        _call("move_joints", targets={"left_elbow": 0.1}),
+        _call("move_joints", targets={"left_j0": float("nan")}),
+        _call("move_joints", targets={"left_j0": "fast"}),
+        _call("move_joints", targets={}),
         _call("nonexistent_tool", x=1),
         ToolCall(id="c", name="move_joints", arguments="{not json"),
+        ToolCall(id="c", name="move_joints", arguments="[]"),
     ]
     for call in cases:
-        result = toolset.execute(call, _obs())
+        result = toolset.execute(call, Observation(state={"joint_pos": np.zeros(14)}))
         assert result.chunk is None and result.error, f"expected error for {call}"
-    # Errors name the offender so the model can self-correct.
-    unknown = toolset.execute(cases[0], _obs())
-    assert unknown.error is not None and "left_elbow" in unknown.error
+    assert "left_elbow" in str(
+        toolset.execute(cases[0], Observation(state={"joint_pos": np.zeros(14)})).error
+    )
 
 
-def test_control_hz_none_falls_back_to_default() -> None:
-    toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=None)
-    result = toolset.execute(_call("move_by", deltas={"0": 0.05}, duration_s=1.0), _obs({}))
+def test_stray_duration_key_is_ignored() -> None:
+    toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+    result = toolset.execute(
+        _call("move_by", deltas={"0": 0.05}, duration_s=0.001),
+        _obs({}),
+    )
+    assert result.error is None and result.chunk is not None
+
+
+def test_control_hz_none_uses_fallback_without_seconds_note() -> None:
+    result = _execute_absolute(1.0, control_hz=None)
+    assert result.error is None and result.chunk is not None
+    assert len(result.chunk.actions) == 11
+    assert result.chunk.control_hz is None
+    assert result.note == "executing move_joints over 11 steps"
+
+
+def test_declared_rate_note_divides_steps_by_hz() -> None:
+    result = _execute_absolute(0.5, control_hz=20.0)
     assert result.chunk is not None
-    assert len(result.chunk.actions) == 10  # 10 Hz fallback
-    assert result.chunk.control_hz is None  # defer to the embodiment's native rate
+    assert len(result.chunk.actions) == 11
+    assert result.note == "executing move_joints over 11 steps (0.6s)"

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -234,6 +234,16 @@ def test_build_rejects_degenerate_derivations() -> None:
     with pytest.raises(ToolsetError, match="too coarse at this magnitude"):
         build_toolset(subnormal_range, _absolute_obs_space(), control_hz=10.0)
 
+    # frac/hz is nonzero but multiplying by a small range underflows the
+    # derived limit to zero; the dimension must not be misreported as fixed.
+    with pytest.raises(ToolsetError, match="underflows the derived per-step limit"):
+        build_toolset(
+            _absolute_space(low=np.array([0.0]), high=np.array([0.1])),
+            _absolute_obs_space(),
+            control_hz=1.0,
+            max_speed_frac=5e-324,
+        )
+
     matrix = Box(
         shape=(2, 2),
         low=np.zeros((2, 2)),
@@ -418,6 +428,17 @@ def test_move_joints_honors_non_default_speed_fraction() -> None:
 def test_move_joints_rejects_non_finite_observed_state(bad_state: float) -> None:
     with pytest.raises(ValueError, match="non-finite"):
         _execute_absolute(0.5, current=bad_state)
+
+
+def test_broken_sensor_raises_even_with_malformed_arguments() -> None:
+    toolset = build_toolset(_absolute_space(), _absolute_obs_space(), control_hz=10.0)
+    # A malformed tool call must not mask a broken sensor behind a
+    # correctable structured error.
+    with pytest.raises(ValueError, match="non-finite"):
+        toolset.execute(
+            _call("move_joints", targets={"unknown_dim": 0.1}),
+            _obs({"q": np.array([float("nan")])}),
+        )
 
 
 def test_move_joints_absurd_finite_state_returns_cap_error() -> None:

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -218,6 +218,22 @@ def test_build_rejects_degenerate_derivations() -> None:
     with pytest.raises(ToolsetError, match=r"range .* overflows"):
         build_toolset(huge, _absolute_obs_space(), control_hz=10.0)
 
+    # float32 bounds whose difference overflows only in the native dtype:
+    # DeltaLimitApprover subtracts without promoting, so this must reject too.
+    huge32 = _absolute_space(
+        low=np.array([-3e38], dtype=np.float32), high=np.array([3e38], dtype=np.float32)
+    )
+    with pytest.raises(ToolsetError, match=r"range .* overflows"):
+        build_toolset(huge32, _absolute_obs_space(), control_hz=10.0)
+
+    offset = _absolute_space(low=np.array([1e16]), high=np.array([1e16 + 2.0]))
+    with pytest.raises(ToolsetError, match="too coarse at this magnitude"):
+        build_toolset(offset, _absolute_obs_space(), control_hz=10.0)
+
+    subnormal_range = _absolute_space(low=np.array([0.0]), high=np.array([5e-324]))
+    with pytest.raises(ToolsetError, match="too coarse at this magnitude"):
+        build_toolset(subnormal_range, _absolute_obs_space(), control_hz=10.0)
+
     matrix = Box(
         shape=(2, 2),
         low=np.zeros((2, 2)),
@@ -520,6 +536,14 @@ def test_huge_finite_move_by_returns_cap_error() -> None:
     result = toolset.execute(_call("move_by", deltas={"0": 1e308}), _obs({}))
     assert result.chunk is None
     assert result.error is not None and "split the move into smaller motions" in result.error
+
+
+def test_subnormal_delta_underflow_is_a_structured_error() -> None:
+    space = _delta_space(low=np.array([-5e-324, -0.1]), high=np.array([5e-324, 0.1]))
+    toolset = build_toolset(space, ObservationSpace(), control_hz=10.0)
+    result = toolset.execute(_call("move_by", deltas={"0": 5e-324}), _obs({}))
+    assert result.chunk is None
+    assert result.error is not None and "too small to split" in result.error
 
 
 def test_arbitrary_precision_json_integer_is_a_structured_error() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #92

Drops `duration_s` from the agent plugin's motion tools. The toolset computes playout time from a speed cap (`max_speed_frac`, default 0.5 of range/s, matching the core backstop), so requested displacements are always reached in full — big moves just play out over more steps. Core guardrails unchanged underneath.

Plan: `plans/0014-agent-speed-limited-playout.md` (critique loop in progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)