### PR TITLE
docs: correct canonical gripper polarity comment to 1 = open

### DIFF
--- a/src/inspect_robots/spaces.py
+++ b/src/inspect_robots/spaces.py
@@ -111,7 +111,7 @@ CANONICAL_STATE_UNITS: dict[str, str] = {
     "eef_pos": "m",
     "eef_pose": "m+quat",
     "eef_quat": "unit_quat",
-    "gripper": "normalized",  # 0 (open) .. 1 (closed)
+    "gripper": "normalized",  # 0 (closed) .. 1 (open)
     "gripper_width": "m",
 }
 


### PR DESCRIPTION
Closes #89

One-line comment fix: `CANONICAL_STATE_UNITS` documented the gripper convention as 0 = open, 1 = closed — backwards relative to the ecosystem this framework targets (i2rt normalizes over [closed, open] with 1 = fully open; LeRobot-format datasets like allenai/MolmoAct2-BimanualYAM-Dataset record ~0.99 = open at episode start; MolmoAct2 consumes that convention). inspect-robots-yam ships 1 = open as of robocurve/inspect-robots-yam#46.

Comment-only; no runtime behavior. Full gates green locally (488 tests, 100% coverage, ruff, mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)