### PR TITLE
fix: bound the spawned Rerun viewer's memory; bound eval exit against a wedged viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ inspect-robots "place the fork on the plate"
 
 Every run opens a live Rerun viewer streaming the cameras, proprioception,
 and actions straight from the eval pipeline, so you watch exactly what the
-policy sees while the robot moves. CLI flags override any default
+policy sees while the robot moves. The viewer starts with a 2 GiB memory cap
+so long sessions stay responsive; after upgrading, kill any already-running
+Rerun viewer once so the cap applies. CLI flags override any default
 (`--no-rerun`, `--no-store-frames`, `--max-steps 300`, ...).
 
 ### Drive the robot with an LLM

--- a/plans/0014-rerun-spawn-memory-limit.md
+++ b/plans/0014-rerun-spawn-memory-limit.md
@@ -1,0 +1,213 @@
+# 0014 — Bound the spawned Rerun viewer's memory; bound the exit path against a wedged viewer
+
+Issue: [#95](https://github.com/robocurve/inspect-robots/issues/95)
+
+## Problem
+
+`RerunSink(spawn=True)` calls `rr.init(app_id, spawn=True)`, which spawns the
+viewer with rerun's default options, notably `--memory-limit=75%`. That is 75%
+of *system* RAM (~46 GiB on a 64 GiB workstation). Because `spawn` reuses any
+viewer already listening on port 9876, every eval run of a working day stacks
+its recording (full camera streams) into the same viewer process. Observed on
+the omen rig after ~11 runs: 6.8 GiB RSS, ~73% CPU sustained for 6 hours,
+frozen UI, and ingest backpressure (`quota_channel` warnings, ~355 KB stuck in
+the client socket send buffer).
+
+Second-order failure: with the viewer wedged, the eval CLI wrote its log and
+then hung at interpreter exit for 75+ seconds, until the viewer was killed.
+
+### Where the exit hang actually lives (empirical, rerun-sdk 0.34.1)
+
+Reproduced against a TCP peer that accepts but never reads:
+
+- `rr.log` is non-blocking: 35 calls totaling ~105 MB returned in 0.07 s. The
+  data queues inside the SDK client (dropping via `quota_channel`), so the
+  sink's worker thread stays fast, `RerunSink.flush()` succeeds, and the
+  sink's existing `wedged` detection in `_shutdown()` never fires. The sink
+  finishes cleanly; the hang is *not* in the sink.
+- The hang is the SDK's own atexit hook (`rerun_shutdown` →
+  `bindings.shutdown()`, registered at import), which flushes the stream
+  unboundedly.
+- `rr.disconnect()` is not a fix: it flushes *before* swapping the sink and
+  blocks indefinitely against a wedged peer ("Flushing the gRPC stream has
+  taken over 10.0s…", still stuck when killed at 60 s).
+- `rr.unregister_shutdown()` returns immediately even on a wedged stream and
+  the process then exits cleanly; it is present and exported in both 0.20 and
+  0.34.1.
+- A second `rr.init` in the same process also blocks forever on a wedged
+  stream (`bindings.flush_and_cleanup_orphaned_recordings()` at the top of
+  `init`), so a wedged sink instance must never re-init.
+
+## Fix
+
+Two changes, both in `src/inspect_robots/logging/rerun_sink.py`.
+
+### 1. Spawn with a bounded viewer memory limit
+
+- Add a constructor parameter `spawn_memory_limit: str = "2GiB"` to
+  `RerunSink`; documented as consulted only when `spawn=True` (no new
+  mutual-exclusion rules).
+- In `on_eval_start`, replace
+
+  ```python
+  rr.init(self.application_id, spawn=self.spawn)
+  ```
+
+  with
+
+  ```python
+  rr.init(self.application_id)
+  if self.spawn:
+      rr.spawn(memory_limit=self.spawn_memory_limit)
+  ```
+
+  Semantic equivalence verified in both 0.20.0 and 0.34.1 sources:
+  `init(spawn=True)` literally calls `spawn(default_blueprint=...)` after
+  initializing logging, with the same port 9876, `connect=True` default and
+  port-reuse behavior, and the sink passes no blueprint in either form.
+  `spawn(memory_limit=...)` exists at the 0.20 floor.
+- With the limit bounded, the viewer purges the oldest events instead of
+  accumulating a full day of recordings. 2 GiB comfortably holds several
+  JPEG-compressed runs (the SDK's own `server_memory_limit` default is
+  "1GiB", so the string format is canonical).
+- The calls stay inside the existing `try/except` in `on_eval_start`, so any
+  spawn failure degrades to the existing warned no-op.
+- Known limitation (documented, not solved): the limit applies only to
+  viewers *this package spawns*. A viewer already running on port 9876 —
+  launched manually or before the upgrade — keeps its old limit; `rr.spawn`
+  just connects to it. Release note: "kill any running Rerun viewer once
+  after upgrading; the cap applies from the next spawn."
+
+### 2. Bound the exit path: probe with a bounded flush, unregister the SDK atexit hook on wedge
+
+Runs unconditionally in `_shutdown()` (i.e. from `on_eval_end`), on the
+caller thread, regardless of the sink-level `wedged` flag (which the incident
+shows stays False). It must run *before* `_shutdown()`'s early return for the
+no-worker case — the probe is gated on `self._rr is not None` (init happened),
+not on a worker having started, so an eval that connected but logged no steps
+is still bounded.
+
+1. Obtain the stream: `get_rec = getattr(rr, "get_global_data_recording",
+   None)`; `rec = get_rec() if get_rec is not None else None`. If `rec` is
+   `None` (never inited, or unknown SDK surface), do nothing.
+2. Resolve the flush surface first: `flush = getattr(rec, "flush", None)`.
+   `RecordingStream.flush` first appears in rerun-sdk **0.22.0** (as
+   `flush(blocking: bool = True)`; the `timeout_sec=` kwarg is newer still) —
+   0.20/0.21 expose no Python-accessible flush at all. If `flush` is `None`,
+   the probe is *inconclusive*: skip it, keep the atexit hook, do **not**
+   disable the sink. On 0.20/0.21 the exit path therefore keeps today's
+   behavior (no regression, but no new protection either); the bounded exit
+   guarantee requires rerun-sdk >= 0.22.
+3. Bounded flush probe: run `flush()` on a fresh daemon thread and
+   `join(self.flush_timeout)`. The thread bound (not a `timeout_sec=` kwarg)
+   is deliberate: 0.22's `flush` has no timeout parameter, and a daemon
+   thread bounds *any* signature uniformly — same disowning pattern the sink
+   already uses for its wedged worker. Exceptions raised by an existing
+   `flush` are swallowed inside the probe thread and count as a completed
+   (healthy) probe. Empirically verified sound on 0.34.1: the native flush
+   releases the GIL, `join(timeout)` returns on time against a wedged peer,
+   and a leaked probe thread finishing late is harmless.
+4. If the flush completed in time: healthy connection. The tail is drained;
+   leave the SDK's atexit hook alone (it will be fast at exit). Nothing else
+   changes.
+5. If the flush timed out: the stream is wedged.
+   - `unregister = getattr(rr, "unregister_shutdown", None)`; if present,
+     call it inside `try/except Exception: pass` — this removes the SDK's
+     unbounded atexit flush so interpreter exit cannot hang.
+   - Set `self._disabled = True` so this sink instance never calls `rr.init`
+     again (re-init verified to hang; see above).
+   - Warn (`RuntimeWarning`, style of the existing shutdown warnings): the
+     viewer connection is stalled; visualization is disabled for this sink;
+     queued SDK-side data was abandoned.
+6. Documented known limitations: a *new* `RerunSink` constructed in the same
+   process against the same wedged viewer can still hang inside `rr.init`
+   (the SDK offers no bounded init), and the probe only runs on paths that
+   reach `on_eval_end` — Ctrl-C or scorer/hook exceptions that skip it keep
+   the SDK's unbounded atexit hook (a sink-registered atexit is possible
+   future hardening). Single-run CLI usage reaching eval end (the incident
+   shape) is fully covered.
+
+Worst-case `on_eval_end` latency becomes ~3× `flush_timeout` (sink flush +
+worker join + SDK flush probe) = 30 s at defaults, in exchange for an exit
+that — for any eval reaching `on_eval_end` on rerun-sdk >= 0.22 — can never
+hang indefinitely.
+
+Threading note: the flush probe and `unregister_shutdown` run off the worker
+thread, which the module docstring currently forbids ("all SDK calls after
+init happen on the worker"). That invariant exists because SDK *timeline*
+state is thread-local; `RecordingStream.flush` is internally synchronized and
+`unregister_shutdown` is pure atexit manipulation, so both are safe. Amend
+the module docstring to state the shutdown-path exception and why.
+
+## Tests (TDD, extend `tests/test_rerun_sink.py` fakes)
+
+Spawn path:
+
+1. `spawn=True` calls `rr.init` **without** `spawn=` and then `rr.spawn` with
+   `memory_limit="2GiB"` (capture kwargs on the fake).
+2. `spawn_memory_limit="4GiB"` is forwarded verbatim.
+3. `spawn=False` (default) never calls `rr.spawn`.
+4. `connect_url=...` path unchanged: `init` then `connect_grpc`, no `spawn`.
+5. `rr.spawn` raising disables the sink with the existing "RerunSink
+   disabled" warning. Keep the existing init-raise test
+   (`test_viewer_failure_disables_sink_instead_of_crashing`) for init-failure
+   coverage but fix its name/docstring — after the split, a missing viewer
+   binary surfaces from `rr.spawn`, not `rr.init`.
+
+Exit path (fake `rec` object returned by a fake `get_global_data_recording`):
+
+6. Flush probe timeout: construct the sink with a small `flush_timeout`
+   (existing wedged tests use 0.05 — the default would cost 10 s of suite
+   wall time), and block the fake `flush` on `gate.wait(timeout=30.0)` (the
+   existing pattern) so the leaked daemon probe thread eventually unblocks
+   instead of outliving the pytest run. Assert: `unregister_shutdown` is
+   called, the sink is disabled (`_disabled` / subsequent `on_eval_start` is
+   a no-op), and the stall warning is emitted.
+7. Healthy flush (returns instantly): `unregister_shutdown` is **not**
+   called, sink stays enabled — a healthy run must keep the SDK's atexit
+   flush.
+8. Shim paths: fake without `get_global_data_recording`; `get_rec` returning
+   `None`; `rec` without `flush` (inconclusive: no disable, no unregister,
+   hook kept — the 0.20/0.21 posture); wedged path with
+   `unregister_shutdown` absent; `unregister_shutdown` raising (swallowed).
+   All shut down cleanly.
+9. Make the interaction with the existing wedged-worker test explicit: the
+   current `_install_fake_rerun` fake has none of the new attributes, so
+   `test_wedged_worker_is_disowned_and_backlog_dropped` will exercise the
+   attribute-missing shim path — assert that intentionally rather than by
+   accident.
+10. An exception raised by an *existing* `flush` is swallowed inside the
+    probe thread and treated as a completed probe (missing `flush` is the
+    separate inconclusive path of test 8, never a "completed" probe).
+
+Integration (non-gating, `pytest.importorskip("rerun")` so it skips in core
+CI where rerun-sdk is not a dev dependency; runs on dev machines with
+`[all]`): subprocess that inits a real recording, connects to a local TCP
+listener that accepts but never reads, logs a payload, and exits — assert the
+subprocess terminates within a hard timeout. This is the only test that could
+have caught the `disconnect()` blocker; fakes assert wiring, not liveness.
+
+Existing mutual-exclusion and lifecycle tests stay green; 100% coverage holds
+(`--cov-fail-under=100`) — every new branch above is reachable with the fake
+pattern.
+
+## Out of scope
+
+- No new CLI flag: the bounded default fixes the failure mode; a
+  `--rerun-memory-limit` flag can follow if anyone needs a different ceiling.
+- No change to `connect_url` mode: a remote viewer's memory policy belongs to
+  whoever launched it. (Note `DEFAULT_RERUN_CONNECT_URL` in `cli.py` points
+  at the same 127.0.0.1:9876 — a manually-launched unbounded viewer there is
+  the user's choice.)
+- No attempt to reconfigure an already-running viewer: rerun offers no API
+  for that; the limit applies from the next fresh spawn.
+
+## Docs
+
+- Module docstring: bounded-spawn default; amended threading invariant
+  (shutdown-path exception, and why it is safe); wedged-exit behavior
+  (bounded probe, atexit unregister, sink disables itself).
+- `RerunSink` class/param docstrings: `spawn_memory_limit`.
+- README rerun section (if it mentions spawning): one sentence noting the
+  viewer is spawned with a 2 GiB cap so long sessions stay responsive, plus
+  the upgrade note about killing a pre-existing viewer.

--- a/src/inspect_robots/logging/rerun_sink.py
+++ b/src/inspect_robots/logging/rerun_sink.py
@@ -331,7 +331,7 @@ class RerunSink:
 
     def _probe_recording_flush(self) -> None:
         rr = self._rr
-        if rr is None:
+        if rr is None or self._disabled:
             return
         get_rec = getattr(rr, "get_global_data_recording", None)
         rec = get_rec() if get_rec is not None else None
@@ -368,7 +368,7 @@ class RerunSink:
             "RerunSink viewer connection is stalled; visualization is disabled "
             "for this sink and queued SDK-side data was abandoned",
             RuntimeWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
 
     def on_eval_start(self, spec: EvalSpec) -> None:

--- a/src/inspect_robots/logging/rerun_sink.py
+++ b/src/inspect_robots/logging/rerun_sink.py
@@ -2,7 +2,10 @@
 
 Logs camera images, proprioception, action vectors, and success markers to
 `Rerun <https://github.com/rerun-io/rerun>`_. The sink can write a ``.rrd``
-recording, spawn a local viewer, or connect over gRPC to a remote viewer.
+recording, spawn a local viewer, or connect over gRPC to a remote viewer. A
+viewer spawned by the sink has a 2 GiB memory limit by default, which makes
+the viewer purge its oldest events instead of accumulating an unbounded
+session history.
 ``rerun-sdk`` is imported lazily *inside* methods so the core package never
 depends on it; if it is not installed, the sink warns once and becomes a no-op
 (so unattended runs and the core-only import gate are unaffected).
@@ -18,10 +21,23 @@ mid-run loses at most the current trial's queued tail. Camera frames are
 JPEG-compressed by default (``jpeg_quality=75``); pass ``jpeg_quality=None``
 for lossless raw frames. If compression is unavailable (an SDK without
 ``Image.compress``, or pillow missing), the sink warns once and logs raw
-frames. All Rerun SDK calls after ``init``/``connect_grpc``/``save`` happen on
-the worker because the SDK's timeline state is thread-local; worker state is
+frames. All Rerun SDK calls after ``init``/``spawn``/``connect_grpc``/``save``
+happen on the worker because the SDK's timeline state is thread-local, except
+for the shutdown-path flush probe and ``unregister_shutdown`` on the caller path. The
+probe invokes ``RecordingStream.flush`` on a bounded daemon thread; flush is
+internally synchronized, and ``unregister_shutdown`` only manipulates an
+``atexit`` hook, so neither depends on timeline state. Worker state is
 generation-scoped so a worker wedged in a blocked SDK call is disowned at
-shutdown and can never double-consume after a restart.
+shutdown and can never double-consume after a restart. If the SDK flush probe
+also wedges, the sink unregisters the SDK's unbounded ``atexit`` flush,
+disables itself, and abandons queued SDK-side data.
+
+The viewer limit applies only to viewers this package spawns; a viewer already
+running on the default port keeps the limit it started with. The bounded exit
+probe requires rerun-sdk 0.22 or newer because older recording streams expose
+no ``flush`` method. A new sink in the same process can still hang in
+``rr.init`` after a connection wedges, and paths such as Ctrl-C that skip
+``on_eval_end`` retain the SDK's unbounded ``atexit`` hook.
 
 Each trial's entities are namespaced under ``trial/<scene_id>/e<epoch>`` so
 successive trials never overwrite one another on the shared step timeline.
@@ -72,7 +88,10 @@ class _WorkerState:
 
 
 class RerunSink:
-    """Write a ``.rrd``, spawn a local viewer, or connect over gRPC to a remote one."""
+    """Write a ``.rrd``, spawn a bounded local viewer, or connect to a remote one.
+
+    ``spawn_memory_limit`` is passed verbatim to Rerun only when ``spawn=True``.
+    """
 
     def __init__(
         self,
@@ -80,11 +99,16 @@ class RerunSink:
         *,
         application_id: str = "inspect_robots",
         spawn: bool = False,
+        spawn_memory_limit: str = "2GiB",
         connect_url: str | None = None,
         jpeg_quality: int | None = 75,
         queue_size: int = 64,
         flush_timeout: float = 10.0,
     ):
+        """Configure output mode, buffering, and the local viewer memory ceiling.
+
+        ``spawn_memory_limit`` is consulted only when ``spawn`` is true.
+        """
         # rerun's save/connect/spawn calls each *replace* the global sink, so
         # combining any two modes would silently drop one of the streams.
         if spawn and connect_url is not None:
@@ -98,6 +122,7 @@ class RerunSink:
         self.recording_path = recording_path
         self.application_id = application_id
         self.spawn = spawn
+        self.spawn_memory_limit = spawn_memory_limit
         self.connect_url = connect_url
         self.jpeg_quality = jpeg_quality
         self.queue_size = queue_size
@@ -263,24 +288,28 @@ class RerunSink:
 
     def _shutdown(self) -> None:
         worker, state = self._worker, self._state
+        wedged = False
+        if worker is not None and state is not None:
+            self.flush(timeout=self.flush_timeout)
+            state.stop.set()
+            with self._cond:
+                self._cond.notify_all()
+            worker.join(timeout=self.flush_timeout)
+            self._worker = None
+            wedged = worker.is_alive()
+            with self._cond:
+                self._state = None
+                if wedged:
+                    # Disown the wedged worker: clear its backlog into the drop
+                    # counters so a restarted worker never double-consumes it.
+                    self._dropped_steps += len(self._queue)
+                    self._dropped_frames += sum(len(p.images) for p in self._queue)
+                    self._queue.clear()
+            self._emit_warned = False
+
+        self._probe_recording_flush()
         if worker is None or state is None:
             return
-        self.flush(timeout=self.flush_timeout)
-        state.stop.set()
-        with self._cond:
-            self._cond.notify_all()
-        worker.join(timeout=self.flush_timeout)
-        self._worker = None
-        wedged = worker.is_alive()
-        with self._cond:
-            self._state = None
-            if wedged:
-                # Disown the wedged worker: clear its backlog into the drop
-                # counters so a restarted worker never double-consumes it.
-                self._dropped_steps += len(self._queue)
-                self._dropped_frames += sum(len(p.images) for p in self._queue)
-                self._queue.clear()
-        self._emit_warned = False
         if wedged:
             warnings.warn(
                 "RerunSink shutdown timed out with visualization data still "
@@ -300,13 +329,57 @@ class RerunSink:
             self._dropped_frames = 0
             self._dropped_steps = 0
 
+    def _probe_recording_flush(self) -> None:
+        rr = self._rr
+        if rr is None:
+            return
+        get_rec = getattr(rr, "get_global_data_recording", None)
+        rec = get_rec() if get_rec is not None else None
+        if rec is None:
+            return
+        flush = getattr(rec, "flush", None)
+        if flush is None:
+            return
+
+        def _flush() -> None:
+            try:  # noqa: SIM105 - the probe contract explicitly swallows exceptions
+                flush()
+            except Exception:
+                pass
+
+        probe = threading.Thread(
+            target=_flush,
+            name="inspect-robots-rerun-flush-probe",
+            daemon=True,
+        )
+        probe.start()
+        probe.join(timeout=self.flush_timeout)
+        if not probe.is_alive():
+            return
+
+        unregister = getattr(rr, "unregister_shutdown", None)
+        if unregister is not None:
+            try:  # noqa: SIM105 - keep the compatibility shim as a guarded call
+                unregister()
+            except Exception:
+                pass
+        self._disabled = True
+        warnings.warn(
+            "RerunSink viewer connection is stalled; visualization is disabled "
+            "for this sink and queued SDK-side data was abandoned",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
     def on_eval_start(self, spec: EvalSpec) -> None:
         """Initialize recording, disabling this noncritical sink after startup failure."""
         rr = self._ensure_rerun()
         if rr is None:
             return
         try:
-            rr.init(self.application_id, spawn=self.spawn)
+            rr.init(self.application_id)
+            if self.spawn:
+                rr.spawn(memory_limit=self.spawn_memory_limit)
             if self.connect_url is not None:
                 rr.connect_grpc(self.connect_url)
             if self.recording_path is not None:
@@ -371,5 +444,5 @@ class RerunSink:
             state.stalled = True
 
     def on_eval_end(self, log: EvalLog) -> None:
-        """Flush queued data and stop the worker; waits at most ~2x ``flush_timeout``."""
+        """Stop the worker and probe the SDK flush; waits at most ~3x the timeout."""
         self._shutdown()

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -10,6 +10,7 @@ import textwrap
 import threading
 import time
 import types
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -547,6 +548,26 @@ def test_wedged_recording_flush_unregisters_atexit_and_disables_sink() -> None:
     assert finished.wait(timeout=5.0)
 
 
+def test_disabled_sink_skips_probe_on_later_shutdowns() -> None:
+    """A wedge-disabled sink stays dormant: no repeated stall, warning, or unregister."""
+    gate = threading.Event()
+    finished = threading.Event()
+    unregister_calls: list[None] = []
+    sink = RerunSink(flush_timeout=0.05)
+    sink._rr = _probe_fake(_BlockingRecording(gate, finished), unregister_calls=unregister_calls)
+    try:
+        with pytest.warns(RuntimeWarning, match="viewer connection is stalled"):
+            sink.on_eval_end(None)  # type: ignore[arg-type]
+        assert unregister_calls == [None]
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            sink.on_eval_end(None)  # type: ignore[arg-type]
+        assert unregister_calls == [None]
+    finally:
+        gate.set()
+    assert finished.wait(timeout=5.0)
+
+
 def test_healthy_recording_flush_keeps_atexit_and_sink_enabled() -> None:
     """A completed SDK flush leaves the normal Rerun atexit cleanup registered."""
     unregister_calls: list[None] = []
@@ -671,7 +692,9 @@ def test_trial_end_skips_flush_once_stalled(monkeypatch: pytest.MonkeyPatch) -> 
 
 def test_real_rerun_process_exits_when_tcp_peer_never_reads() -> None:
     """The real SDK atexit path is bounded after a connected peer stops reading."""
-    pytest.importorskip("rerun")
+    rr = pytest.importorskip("rerun")
+    if not hasattr(rr, "connect_grpc"):
+        pytest.skip("pre-gRPC rerun-sdk cannot run the connect-mode wedge scenario")
     server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     server.bind(("127.0.0.1", 0))
@@ -736,3 +759,5 @@ def test_real_rerun_process_exits_when_tcp_peer_never_reads() -> None:
 
     assert accepted.is_set(), completed.stderr
     assert completed.returncode == 0, completed.stderr
+    # Guard against the trivial pass: the wedge branch must actually fire.
+    assert "viewer connection is stalled" in completed.stderr, completed.stderr

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import importlib.util
+import socket
+import subprocess
 import sys
+import textwrap
 import threading
 import time
 import types
@@ -55,31 +58,75 @@ def test_recording_and_connect_are_mutually_exclusive() -> None:
         RerunSink("run.rrd", connect_url="rerun+http://127.0.0.1:9876/proxy")
 
 
-def test_connect_grpc_is_called_only_when_configured() -> None:
-    """Startup connects to the configured URL and skips gRPC when it is unset."""
+class _StartupRR:
+    """Capture startup calls made through the fake Rerun SDK surface."""
 
-    class _FakeRR:
-        def __init__(self) -> None:
-            self.init_count = 0
-            self.connect_urls: list[str] = []
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object]] = []
 
-        def init(self, *args: object, **kwargs: object) -> None:
-            self.init_count += 1
+    def init(self, application_id: str, **kwargs: object) -> None:
+        """Capture initialization arguments."""
+        self.calls.append(("init", (application_id, kwargs)))
 
-        def connect_grpc(self, url: str) -> None:
-            self.connect_urls.append(url)
+    def spawn(self, **kwargs: object) -> None:
+        """Capture viewer-spawn arguments."""
+        self.calls.append(("spawn", kwargs))
+
+    def connect_grpc(self, url: str) -> None:
+        """Capture the remote viewer URL."""
+        self.calls.append(("connect_grpc", url))
+
+
+def test_spawn_uses_bounded_memory_limit_after_plain_init() -> None:
+    """Local startup initializes without spawn= and applies the 2 GiB viewer cap."""
+    fake = _StartupRR()
+    sink = RerunSink(spawn=True)
+    sink._rr = fake
+
+    sink.on_eval_start(None)  # type: ignore[arg-type]
+
+    assert fake.calls == [
+        ("init", ("inspect_robots", {})),
+        ("spawn", {"memory_limit": "2GiB"}),
+    ]
+
+
+def test_custom_spawn_memory_limit_is_forwarded_verbatim() -> None:
+    """A caller-provided viewer memory limit reaches rr.spawn unchanged."""
+    fake = _StartupRR()
+    sink = RerunSink(spawn=True, spawn_memory_limit="4GiB")
+    sink._rr = fake
+
+    sink.on_eval_start(None)  # type: ignore[arg-type]
+
+    assert fake.calls[-1] == ("spawn", {"memory_limit": "4GiB"})
+
+
+def test_default_startup_never_spawns_a_viewer() -> None:
+    """The default non-spawn mode only initializes the recording."""
+    fake = _StartupRR()
+    sink = RerunSink()
+    sink._rr = fake
+
+    sink.on_eval_start(None)  # type: ignore[arg-type]
+
+    assert fake.calls == [("init", ("inspect_robots", {}))]
+
+
+def test_connect_grpc_follows_init_without_spawning() -> None:
+    """Remote startup initializes, connects to the URL, and never spawns locally."""
 
     url = "rerun+http://127.0.0.1:9876/proxy"
-    fake = _FakeRR()
-    connected = RerunSink(connect_url=url)
-    connected._rr = fake
-    connected.on_eval_start(None)  # type: ignore[arg-type]
-    unconnected = RerunSink()
-    unconnected._rr = fake
-    unconnected.on_eval_start(None)  # type: ignore[arg-type]
+    fake = _StartupRR()
+    sink = RerunSink(connect_url=url)
+    sink._rr = fake
 
-    assert fake.init_count == 2
-    assert fake.connect_urls == [url]
+    sink.on_eval_start(None)  # type: ignore[arg-type]
+
+    assert fake.calls == [
+        ("init", ("inspect_robots", {})),
+        ("connect_grpc", url),
+    ]
 
 
 @pytest.mark.skipif(_RERUN_INSTALLED, reason="rerun installed; testing the absent path")
@@ -110,8 +157,8 @@ def test_rerun_sink_writes_recording(tmp_path: Path) -> None:
     assert rrd.exists()
 
 
-def test_viewer_failure_disables_sink_instead_of_crashing() -> None:
-    """A missing viewer binary (rr.init raising) must not kill the eval."""
+def test_init_failure_disables_sink_instead_of_crashing() -> None:
+    """A recording initialization failure must warn instead of killing the eval."""
     from inspect_robots.log import EvalSpec
 
     class _FakeRR:
@@ -128,6 +175,23 @@ def test_viewer_failure_disables_sink_instead_of_crashing() -> None:
         )
     assert sink.available is False  # dormant from here on
     sink.log_step(0, None, None, None)  # type: ignore[arg-type]  # must not raise
+
+
+def test_spawn_failure_disables_sink_instead_of_crashing() -> None:
+    """A missing viewer binary reported by rr.spawn must leave the sink dormant."""
+
+    class _FakeRR:
+        def init(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        def spawn(self, **kwargs: object) -> None:
+            raise RuntimeError("Failed to find Rerun Viewer executable in PATH.")
+
+    sink = RerunSink(spawn=True)
+    sink._rr = _FakeRR()
+    with pytest.warns(RuntimeWarning, match="RerunSink disabled"):
+        sink.on_eval_start(None)  # type: ignore[arg-type]
+    assert sink.available is False
 
 
 def test_connection_failure_disables_sink_instead_of_crashing() -> None:
@@ -197,6 +261,59 @@ def _install_fake_rerun(
     fake.TextLog = lambda t: ("TextLog", t)  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "rerun", fake)
     return logged
+
+
+class _BlockingRecording:
+    """Fake recording whose flush remains blocked until the test releases it."""
+
+    def __init__(self, gate: threading.Event, finished: threading.Event) -> None:
+        self._gate = gate
+        self._finished = finished
+
+    def flush(self) -> None:
+        """Wait long enough to exceed the sink's bounded probe timeout."""
+        self._gate.wait(timeout=30.0)
+        self._finished.set()
+
+
+class _HealthyRecording:
+    """Fake recording with an immediately completed flush."""
+
+    def flush(self) -> None:
+        """Return immediately to represent a healthy SDK connection."""
+
+
+class _ExplodingRecording:
+    """Fake recording whose available flush surface raises an exception."""
+
+    def flush(self) -> None:
+        """Raise so the probe can treat the completed call as healthy."""
+        raise RuntimeError("flush failed")
+
+
+class _RecordingWithoutFlush:
+    """Represent the rerun-sdk 0.20/0.21 recording surface."""
+
+
+def _probe_fake(
+    recording: object | None,
+    *,
+    unregister_calls: list[None] | None = None,
+    unregister_error: Exception | None = None,
+) -> types.ModuleType:
+    """Build a fake SDK exposing the recording probe and optional atexit shim."""
+    fake = types.ModuleType("rerun")
+    fake.init = lambda *a, **k: None  # type: ignore[attr-defined]
+    fake.get_global_data_recording = lambda: recording  # type: ignore[attr-defined]
+    if unregister_calls is not None:
+
+        def _unregister_shutdown() -> None:
+            unregister_calls.append(None)
+            if unregister_error is not None:
+                raise unregister_error
+
+        fake.unregister_shutdown = _unregister_shutdown  # type: ignore[attr-defined]
+    return fake
 
 
 def _obs(*, with_image: bool = True) -> Observation:
@@ -377,6 +494,7 @@ def test_wedged_worker_is_disowned_and_backlog_dropped(
     """A worker stuck in the SDK is abandoned; a restarted worker owns the queue alone."""
     gate = threading.Event()
     logged = _install_fake_rerun(monkeypatch, gate=gate)
+    assert not hasattr(sys.modules["rerun"], "get_global_data_recording")
     sink = RerunSink(flush_timeout=0.05)
     try:
         _log_one(sink, 0)
@@ -400,6 +518,113 @@ def test_wedged_worker_is_disowned_and_backlog_dropped(
     camera = [p for p, _ in logged if p == "trial/camera/cam"]
     assert len(camera) == 2  # A's in-flight payload 0, B's payload 2; payload 1 dropped
     sink.on_eval_end(None)  # type: ignore[arg-type]
+
+
+def test_wedged_recording_flush_unregisters_atexit_and_disables_sink() -> None:
+    """A timed-out SDK flush abandons queued data and prevents unsafe re-init."""
+    gate = threading.Event()
+    finished = threading.Event()
+    unregister_calls: list[None] = []
+    fake = _probe_fake(_BlockingRecording(gate, finished), unregister_calls=unregister_calls)
+    init_calls: list[None] = []
+
+    def _init(*args: object, **kwargs: object) -> None:
+        init_calls.append(None)
+
+    fake.init = _init  # type: ignore[attr-defined]
+    sink = RerunSink(flush_timeout=0.05)
+    sink._rr = fake
+    try:
+        with pytest.warns(RuntimeWarning, match="viewer connection is stalled"):
+            sink.on_eval_end(None)  # type: ignore[arg-type]
+        assert unregister_calls == [None]
+        assert sink._disabled
+        sink.on_eval_start(None)  # type: ignore[arg-type]
+        assert sink._rr is fake
+        assert init_calls == []
+    finally:
+        gate.set()
+    assert finished.wait(timeout=5.0)
+
+
+def test_healthy_recording_flush_keeps_atexit_and_sink_enabled() -> None:
+    """A completed SDK flush leaves the normal Rerun atexit cleanup registered."""
+    unregister_calls: list[None] = []
+    sink = RerunSink()
+    sink._rr = _probe_fake(_HealthyRecording(), unregister_calls=unregister_calls)
+
+    sink.on_eval_end(None)  # type: ignore[arg-type]
+
+    assert unregister_calls == []
+    assert not sink._disabled
+
+
+def test_shutdown_probe_shims_leave_inconclusive_sinks_enabled() -> None:
+    """Missing recording APIs keep the older SDK's existing atexit posture unchanged."""
+    uninitialized = RerunSink()
+    uninitialized.on_eval_end(None)  # type: ignore[arg-type]
+    assert not uninitialized._disabled
+
+    no_get_recording = types.ModuleType("rerun")
+    no_recording = _probe_fake(None)
+    unregister_calls: list[None] = []
+    no_flush = _probe_fake(_RecordingWithoutFlush(), unregister_calls=unregister_calls)
+
+    for fake in (no_get_recording, no_recording, no_flush):
+        sink = RerunSink()
+        sink._rr = fake
+        sink.on_eval_end(None)  # type: ignore[arg-type]
+        assert not sink._disabled
+
+    assert unregister_calls == []
+
+
+def test_wedged_recording_without_unregister_shutdown_still_disables() -> None:
+    """A missing unregister shim cannot prevent the wedged sink from going dormant."""
+    gate = threading.Event()
+    finished = threading.Event()
+    sink = RerunSink(flush_timeout=0.05)
+    sink._rr = _probe_fake(_BlockingRecording(gate, finished))
+    try:
+        with pytest.warns(RuntimeWarning, match="viewer connection is stalled"):
+            sink.on_eval_end(None)  # type: ignore[arg-type]
+        assert sink._disabled
+    finally:
+        gate.set()
+    assert finished.wait(timeout=5.0)
+
+
+def test_unregister_shutdown_failure_is_swallowed() -> None:
+    """A failing atexit-unregister shim does not escape the shutdown path."""
+    gate = threading.Event()
+    finished = threading.Event()
+    unregister_calls: list[None] = []
+    sink = RerunSink(flush_timeout=0.05)
+    sink._rr = _probe_fake(
+        _BlockingRecording(gate, finished),
+        unregister_calls=unregister_calls,
+        unregister_error=RuntimeError("cannot unregister"),
+    )
+    try:
+        with pytest.warns(RuntimeWarning, match="viewer connection is stalled"):
+            sink.on_eval_end(None)  # type: ignore[arg-type]
+        assert unregister_calls == [None]
+        assert sink._disabled
+    finally:
+        gate.set()
+    assert finished.wait(timeout=5.0)
+
+
+def test_recording_flush_exception_counts_as_completed_probe() -> None:
+    """An exception from an available flush is swallowed and treated as non-wedged."""
+    unregister_calls: list[None] = []
+    sink = RerunSink()
+    sink._rr = _probe_fake(_ExplodingRecording(), unregister_calls=unregister_calls)
+
+    sink.on_eval_end(None)  # type: ignore[arg-type]
+
+    assert unregister_calls == []
+    assert not sink._disabled
 
 
 def test_eval_end_reports_dropped_data(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -442,3 +667,72 @@ def test_trial_end_skips_flush_once_stalled(monkeypatch: pytest.MonkeyPatch) -> 
         gate.set()
     assert sink.flush(timeout=5.0)
     sink.on_eval_end(None)  # type: ignore[arg-type]
+
+
+def test_real_rerun_process_exits_when_tcp_peer_never_reads() -> None:
+    """The real SDK atexit path is bounded after a connected peer stops reading."""
+    pytest.importorskip("rerun")
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen()
+    port = server.getsockname()[1]
+    accepted = threading.Event()
+    release_listener = threading.Event()
+
+    def _accept_without_reading() -> None:
+        try:
+            connection, _ = server.accept()
+        except OSError:
+            return
+        with connection:
+            accepted.set()
+            release_listener.wait(timeout=45.0)
+
+    listener = threading.Thread(target=_accept_without_reading, daemon=True)
+    listener.start()
+    script = textwrap.dedent(
+        """
+        import sys
+
+        import numpy as np
+
+        from inspect_robots.logging import RerunSink
+        from inspect_robots.types import Action, Observation, StepResult
+
+        sink = RerunSink(
+            connect_url=sys.argv[1],
+            jpeg_quality=None,
+            flush_timeout=0.2,
+        )
+        sink.on_eval_start(None)
+        image = np.random.default_rng(0).integers(
+            0, 256, size=(4096, 4096, 3), dtype=np.uint8
+        )
+        observation = Observation(images={"camera": image})
+        result = StepResult(observation=Observation(), reward=1.0)
+        sink.log_step(0, observation, Action(data=np.array([0.5])), result)
+        assert sink.flush(timeout=10.0)
+        sink.on_eval_end(None)
+        """
+    )
+    try:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                script,
+                f"rerun+http://127.0.0.1:{port}/proxy",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30.0,
+        )
+    finally:
+        release_listener.set()
+        server.close()
+        listener.join(timeout=5.0)
+
+    assert accepted.is_set(), completed.stderr
+    assert completed.returncode == 0, completed.stderr


### PR DESCRIPTION
Closes #95

Two fixes in `RerunSink` (plan: `plans/0014-rerun-spawn-memory-limit.md`, three critique rounds plus an independent fresh-eye review, with empirical verification against rerun-sdk 0.20/0.21/0.22/0.34.1):

1. **Bounded spawn:** `spawn=True` now spawns the viewer via `rr.spawn(memory_limit="2GiB")` (new `spawn_memory_limit` param) instead of `rr.init(spawn=True)`'s default `--memory-limit=75%` of system RAM, so a day of runs reusing the same viewer purges old recordings instead of wedging at multi-GiB.
2. **Bounded exit:** `_shutdown()` gains a bounded flush probe (daemon thread + `join(flush_timeout)`) of the SDK's global recording stream; on timeout it calls `rr.unregister_shutdown()` (removing the SDK's unbounded atexit flush that hung the CLI for 75+ s in the incident) and disables the sink so it neither re-inits into a hang nor re-pays the stall on later evals. Healthy runs keep the atexit hook. Requires rerun-sdk >= 0.22 for the probe (`RecordingStream.flush` first appears there); 0.20/0.21 keep today's behavior.

Empirical findings that shaped the design (all reproduced against a wedged TCP peer): `rr.log` never blocks (so sink-level wedge detection can't fire), `rr.disconnect()` hangs forever, a second `rr.init` hangs forever, `rr.unregister_shutdown()` returns instantly. A real-SDK subprocess integration test pins the bounded-exit behavior (asserting the stall warning fired, so it cannot pass trivially); it skips where rerun-sdk is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)