### PR TITLE
feat(agent): effort="none" wire value + quoted -P literal escape hatch

### DIFF
--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -70,4 +70,9 @@ Reasoning effort defaults to `low`: robot control is latency-sensitive (the
 arm stands still while the model thinks), safety guardrails sit below the
 model either way, and frontier models at low effort remain strong at this
 task shape. Raise it for hard manipulation problems (`-P effort=high`) or
-pass `-P effort=none` to omit the parameter for endpoints that reject it.
+pass `-P effort=none` to omit the parameter for endpoints that reject it
+(the CLI reads a bare `none` as null). To send the literal wire value
+`none` and disable reasoning, quote it: `-P effort="'none'"`. GPT-5.x on
+chat completions requires the literal `none` when function tools are in
+play (any other value, or omitting the field, is a 400). In Python,
+`effort=None` omits the field and `effort="none"` sends the wire value.

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.2.0"
+version = "0.2.1"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -31,7 +31,7 @@ _MAX_CONSECUTIVE_FAILURES = 3
 
 # reasoning_effort values accepted across OpenAI-compatible endpoints
 # (Anthropic compat maps these to thinking effort; OpenRouter forwards them).
-_EFFORT_LEVELS = frozenset({"minimal", "low", "medium", "high", "xhigh", "max"})
+_EFFORT_LEVELS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max"})
 
 _SYSTEM_TEMPLATE = """You are controlling a real robot embodiment named {name!r} \
 through tool calls. Each observation message gives you the current \

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -93,7 +93,8 @@ class LLMAgentPolicy(PolicyBase):
             raise ValueError("max_llm_calls must be >= 1")
         if effort is not None and effort not in _EFFORT_LEVELS:
             raise ValueError(
-                f"effort must be one of {sorted(_EFFORT_LEVELS)} or none, got {effort!r}"
+                f"effort must be one of {sorted(_EFFORT_LEVELS)}, or None to omit "
+                f"the field, got {effort!r}"
             )
         self._client = ChatClient(provider, transport=transport)
         self._max_llm_calls = max_llm_calls

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -327,7 +327,7 @@ def test_effort_defaults_low_and_is_tunable(tmp_path: Path) -> None:
     ir_eval(_task(), _policy(script, effort="none"), CubePickEmbodiment(), log_dir=str(tmp_path))
     assert script.requests[0]["reasoning_effort"] == "none"
 
-    with pytest.raises(ValueError, match="effort"):
+    with pytest.raises(ValueError, match=r"or None to omit the field, got 'turbo'"):
         _policy(_Script([]), effort="turbo")
 
 

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -320,6 +320,13 @@ def test_effort_defaults_low_and_is_tunable(tmp_path: Path) -> None:
     ir_eval(_task(), _policy(script, effort=None), CubePickEmbodiment(), log_dir=str(tmp_path))
     assert "reasoning_effort" not in script.requests[0]
 
+    # "none" is a wire value, distinct from None (omit the field): GPT-5.x
+    # rejects function tools on chat completions unless reasoning_effort is
+    # explicitly "none", and omitting the field 400s the same way.
+    script = _Script([_tool_response("done", {"summary": "ok"})])
+    ir_eval(_task(), _policy(script, effort="none"), CubePickEmbodiment(), log_dir=str(tmp_path))
+    assert script.requests[0]["reasoning_effort"] == "none"
+
     with pytest.raises(ValueError, match="effort"):
         _policy(_Script([]), effort="turbo")
 

--- a/src/inspect_robots/_defaults.py
+++ b/src/inspect_robots/_defaults.py
@@ -32,7 +32,15 @@ ADHOC_MAX_STEPS_FALLBACK = 300
 
 
 def parse_value(text: str) -> Any:
-    """Best-effort scalar parse for ``k=v`` args (bool/int/float/None/str)."""
+    """Best-effort scalar parse for ``k=v`` args (bool/int/float/None/str).
+
+    A value wrapped in matching single or double quotes is returned as the
+    literal inner string with no coercion — the escape hatch for strings the
+    heuristics would otherwise claim (``-P effort="'none'"`` sends the wire
+    string ``none`` instead of omitting the parameter).
+    """
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
+        return text[1:-1]
     low = text.lower()
     if low in ("true", "false"):
         return low == "true"

--- a/tests/test_coverage_completion.py
+++ b/tests/test_coverage_completion.py
@@ -79,6 +79,20 @@ def test_parse_value_variants() -> None:
     assert _parse_value("hello") == "hello"
 
 
+def test_parse_value_quoted_strings_bypass_coercion() -> None:
+    # The escape hatch for strings the heuristics would claim: quoted values
+    # come back as the literal inner string, uncoerced.
+    assert _parse_value("'none'") == "none"
+    assert _parse_value('"none"') == "none"
+    assert _parse_value("'7'") == "7"
+    assert _parse_value("'true'") == "true"
+    assert _parse_value("''") == ""
+    # Mismatched or single quotes are not treated as wrapping.
+    assert _parse_value("'none\"") == "'none\""
+    assert _parse_value("'") == "'"
+    assert _parse_value("don't") == "don't"
+
+
 def test_parse_kvs_rejects_bad_pair() -> None:
     with pytest.raises(SystemExit):
         _parse_kvs(["no-equals-sign"])

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #97

- Plugin: `_EFFORT_LEVELS` accepts `"none"` (sends the literal wire value GPT-5.x requires with function tools); `effort=None` still omits the field.
- Core: `parse_value` returns matching-quoted values as literal uncoerced strings, so the CLI can spell it: `-P effort="'none'"`.
- README documents the CLI/Python split; plugin bumped to 0.2.1.

Originated as an orphaned working-tree change on the main checkout; rebased onto post-#93 main, with the README claim corrected (the original said `-P effort=none` sends the wire value, but the CLI coerces bare `none` to null — the escape hatch makes it actually reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)