### PR TITLE
feat(agent): slower factory defaults (max_speed_frac 0.1, max_llm_calls 100)

### DIFF
--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -33,11 +33,14 @@ Model strings are OpenRouter-style `provider/model`, resolved from
 
 Motion tool calls state where to go, not how long to move. For absolute modes,
 `move_joints` interpolates named partial targets from the observed state at a
-fixed safe speed. The default `max_speed_frac=0.5` allows half of each
+fixed safe speed. The default `max_speed_frac=0.1` allows a tenth of each
 dimension's range per second, subject to a 5%-of-range per-step ceiling that
-matches the core's default delta backstop. The tool result reports the computed
-step count and, when the embodiment declares `control_hz`, the corresponding
-playout time. `duration_s` is not part of either motion tool.
+matches the core's default delta backstop. At that default a near-full-range
+move exceeds the 10 s per-call playout cap, so the agent receives a
+split-the-move error and issues it as two smaller motions; raise the fraction
+(up to `0.5` before the ceiling binds at 10 Hz) for faster arms. The tool
+result reports the computed step count and, when the embodiment declares
+`control_hz`, the corresponding playout time. `duration_s` is not part of either motion tool.
 
 For displacement modes, `move_by` splits the requested total so every action
 fits the box side in that direction. The action box is the embodiment author's
@@ -63,8 +66,8 @@ motion fall short of the tool's requested total.
 > on real hardware** unless you fully trust the policy and the rig.
 
 Configuration knobs (all `-P key=value`): `model`, `base_url`, `api_key_env`,
-`max_llm_calls`, `temperature`, `effort`, `max_speed_frac`. The speed fraction
-defaults to `0.5` and applies only to absolute modes.
+`max_llm_calls` (default `100`), `temperature`, `effort`, `max_speed_frac`.
+The speed fraction defaults to `0.1` and applies only to absolute modes.
 
 Reasoning effort defaults to `low`: robot control is latency-sensitive (the
 arm stands still while the model thinks), safety guardrails sit below the

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.2.1"
+version = "0.2.2"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/__init__.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/__init__.py
@@ -21,8 +21,12 @@ it shows up in ``inspect-robots list policies`` without being imported first.
 
 from __future__ import annotations
 
+from importlib.metadata import version
+
 from inspect_robots_agent.policy import AgentPolicyConfig, LLMAgentPolicy, agent_policy
 
 __all__ = ["AgentPolicyConfig", "LLMAgentPolicy", "agent_policy"]
 
-__version__ = "0.1.0"
+# Derived from package metadata so it can never drift from pyproject again
+# (0.2.0 and 0.2.1 shipped with a stale hardcoded "0.1.0").
+__version__ = version("inspect-robots-agent")

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -327,7 +327,7 @@ def build_toolset(
     action_space: Box,
     observation_space: ObservationSpace,
     control_hz: float | None,
-    max_speed_frac: float = 0.5,
+    max_speed_frac: float = 0.1,
 ) -> Toolset:
     """Validate an embodiment's spaces and build its agent-facing tools.
 

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -55,9 +55,9 @@ class AgentPolicyConfig(PolicyConfig):
     model: str | None = None
     base_url: str | None = None
     api_key_env: str | None = None
-    max_llm_calls: int = 50
+    max_llm_calls: int = 100
     effort: str | None = "low"
-    max_speed_frac: float = 0.5
+    max_speed_frac: float = 0.1
 
 
 class LLMAgentPolicy(PolicyBase):
@@ -73,10 +73,10 @@ class LLMAgentPolicy(PolicyBase):
         model: str | None = None,
         base_url: str | None = None,
         api_key_env: str | None = None,
-        max_llm_calls: int = 50,
+        max_llm_calls: int = 100,
         temperature: float | None = None,
         effort: str | None = "low",
-        max_speed_frac: float = 0.5,
+        max_speed_frac: float = 0.1,
         transport: httpx.BaseTransport | None = None,
         env: dict[str, str] | None = None,
     ):

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -4,5 +4,7 @@ from __future__ import annotations
 def test_package_imports_and_exports() -> None:
     import inspect_robots_agent
 
-    assert inspect_robots_agent.__version__
+    # Pinned so a version bump that misses either side fails loudly (the
+    # 0.1.0 hardcode shipped stale through two releases unnoticed).
+    assert inspect_robots_agent.__version__ == "0.2.2"
     assert callable(inspect_robots_agent.agent_policy)

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -169,8 +169,8 @@ def test_goal_runs_to_done_and_config_lands_in_log(tmp_path: Path) -> None:
     # Headroom splits a box-sized move into two steps, then done holds once.
     assert len(record.steps) == 3
     assert logs[0].eval.policy_config["model"] == "test/model"
-    assert logs[0].eval.policy_config["max_llm_calls"] == 50
-    assert logs[0].eval.policy_config["max_speed_frac"] == 0.5
+    assert logs[0].eval.policy_config["max_llm_calls"] == 100
+    assert logs[0].eval.policy_config["max_speed_frac"] == 0.1
 
 
 def test_outbound_messages_carry_state_images_and_tools(tmp_path: Path) -> None:

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -77,7 +77,7 @@ def _execute_absolute(
     current: float = 0.0,
     *,
     control_hz: float | None = 10.0,
-    max_speed_frac: float = 0.5,
+    max_speed_frac: float = 0.1,
 ) -> ToolResult:
     toolset = build_toolset(
         _absolute_space(),
@@ -264,7 +264,10 @@ def test_low_precision_bounds_never_outrun_native_backstop() -> None:
         high=np.array([1.0], dtype=np.float16),
         semantics=ActionSemantics("joint_pos", dim_labels=("joint",)),
     )
-    toolset = build_toolset(space, _absolute_obs_space(), control_hz=10.0)
+    # frac 0.5 puts the frac-derived limit (0.1) above the float16-native
+    # backstop, so the elementwise min actually binds; the 0.1 default would
+    # pass this test without the native-dtype fix at all.
+    toolset = build_toolset(space, _absolute_obs_space(), control_hz=10.0, max_speed_frac=0.5)
     result = toolset.execute(
         _call("move_joints", targets={"joint": 0.9999}),
         _obs({"q": np.array([0.0])}),
@@ -309,11 +312,13 @@ def test_schemas_match_control_mode_and_remove_duration() -> None:
 
 
 def test_move_joints_derives_steps_and_snaps_bit_exact_target() -> None:
+    # Factory default frac 0.1 at 10 Hz: 1% of range per step, distance 1.5
+    # over range 2.0 with headroom -> 76 steps.
     result = _execute_absolute(1.0, current=-0.5)
     assert result.error is None and result.chunk is not None
-    assert len(result.chunk.actions) == 16
+    assert len(result.chunk.actions) == 76
     assert result.chunk.actions[-1].data[0] == 1.0
-    assert result.note == "executing move_joints over 16 steps (1.6s)"
+    assert result.note == "executing move_joints over 76 steps (7.6s)"
 
     # Pins the snap itself: 0.3 is interior (clip cannot repair it) and plain
     # linspace arithmetic lands on 0.30000000000000004 instead.
@@ -380,6 +385,9 @@ def test_move_joints_rejects_out_of_bounds_but_accepts_bound() -> None:
     )
     assert accepted.error is None and accepted.chunk is not None
     assert accepted.chunk.actions[-1].data[0] == -1.0
+    # Also pins build_toolset's factory default (no frac passed): 0.1 at
+    # 10 Hz over range 2.0, distance 1.0 -> 51 steps.
+    assert len(accepted.chunk.actions) == 51
 
 
 def test_zero_width_target_uses_bound_not_noisy_observation_and_no_steps() -> None:
@@ -637,13 +645,13 @@ def test_stray_duration_key_is_ignored() -> None:
 def test_control_hz_none_uses_fallback_without_seconds_note() -> None:
     result = _execute_absolute(1.0, control_hz=None)
     assert result.error is None and result.chunk is not None
-    assert len(result.chunk.actions) == 11
+    assert len(result.chunk.actions) == 51
     assert result.chunk.control_hz is None
-    assert result.note == "executing move_joints over 11 steps"
+    assert result.note == "executing move_joints over 51 steps"
 
 
 def test_declared_rate_note_divides_steps_by_hz() -> None:
     result = _execute_absolute(0.5, control_hz=20.0)
     assert result.chunk is not None
-    assert len(result.chunk.actions) == 11
-    assert result.note == "executing move_joints over 11 steps (0.6s)"
+    assert len(result.chunk.actions) == 51
+    assert result.note == "executing move_joints over 51 steps (2.5s)"

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -459,7 +459,10 @@ def test_move_joints_over_cap_returns_structured_error() -> None:
 
 def test_absolute_chunks_pass_default_approvers_across_calls() -> None:
     space = _absolute_space()
-    toolset = build_toolset(space, _absolute_obs_space(), control_hz=10.0)
+    # frac 0.5 pins the stress case where the per-step size sits exactly at
+    # the backstop boundary (the 0.1 default runs far below it, and its
+    # full-range second move would hit the per-call playout cap).
+    toolset = build_toolset(space, _absolute_obs_space(), control_hz=10.0, max_speed_frac=0.5)
     chain = ChainApprover(ClampApprover(space), DeltaLimitApprover(space))
     store: dict[str, Any] = {}
 

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Requested defaults change: `max_speed_frac` 0.5 → 0.1 (a tenth of each dimension's range per second), `max_llm_calls` 50 → 100.

Consequence documented in the README: at the new default a near-full-range `move_joints` exceeds the 10 s per-call playout cap and the agent receives a split-the-move error (two smaller calls complete it). The approver-boundary integration test pins `max_speed_frac=0.5` explicitly since its purpose is stressing the exact backstop boundary.

Plugin bumped to 0.2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)