### PR TITLE
feat: persist policy transcripts in the eval log

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Run the LLM on the robot:
 inspect-robots "place the fork on the plate" --policy agent -P model=anthropic/claude-fable-5
 ```
 
+Read the recorded agent conversation with `inspect-robots inspect LOG.json --transcript`.
+
 ### Run in simulation
 
 The same instruction runs on your configured simulator instead of the

--- a/plans/0015-policy-transcript-persistence.md
+++ b/plans/0015-policy-transcript-persistence.md
@@ -1,0 +1,261 @@
+# 0015 — Policy transcript persistence (issue #100)
+
+## Problem
+
+An `agent`-policy episode is unauditable after the fact. The LLM conversation
+(assistant text, tool calls, tool results) lives only in
+`LLMAgentPolicy._messages` and dies with the process. The eval log records what
+the run *was* (config, metrics, termination reasons) and the frames sidecar
+records what the model *saw*, but nothing records what the model *said or did*.
+For an LLM-driven policy that conversation is most of the forensic value of a
+log, especially for failed episodes.
+
+Terminology note: the repo already uses "transcript" for the typed `Event`
+stream (`transcript.py`, `TrialRecord.events`) — that stream never reaches the
+persisted log. This feature is the **policy transcript** (the policy's own
+audit record); all user-facing copy says "policy transcript" or "agent
+conversation" so a future event-stream viewer is not boxed out of the bare
+word. The CLI flag is `--transcript` (there is no competing flag today).
+
+## Design
+
+### 1. Hook: optional, duck-typed `transcript()` on the policy
+
+Mirrors the existing optional `bind()` hook: not part of the `Policy`
+Protocol, so every existing policy remains conformant. `PolicyBase` ships a
+default returning `None` (same precedent as `bind()`'s no-op default).
+
+```python
+def transcript(self) -> Any | None:
+    """JSON-serializable audit record of the policy's decision process for
+    the current trial (e.g. an LLM conversation), or None."""
+```
+
+Contract (documented in the `Policy` Protocol docstring, alongside `bind()`):
+
+- The framework calls it **once per trial, at trial end** (after the loop
+  exits or the trial errors) — but the hook must be idempotent and safe to
+  call at any point between `reset()` calls: direct `rollout()` callers (and
+  anyone holding the policy object) may call it too.
+- It must not mutate policy state, and mutating its return value must not
+  affect the live policy. Called on the rollout thread; no thread-safety
+  obligations beyond that.
+- The return value must be JSON-serializable and *small* (text-scale, not
+  binary-scale). Camera images must not be embedded; they are already on disk
+  via `frames_dir`. The framework enforces both properties defensively (§3).
+- Best-effort: a raising or misbehaving `transcript()` must never change the
+  trial's outcome (it degrades to an error marker in the log, see §3).
+
+### 2. Record and log schema (stays schema v1)
+
+- `TrialRecord.policy_transcript: Any = None` — new field, populated by
+  `rollout()`. Sinks see it via `on_trial_end` (e.g. a future viewer).
+- `SceneResult.policy_transcripts: tuple[Any, ...] = ()` — new field, strictly
+  parallel to `epochs` (the established pattern of `operator_judgements` and
+  `termination_reasons`): one entry per recorded trial, `None` when the policy
+  has no hook (or it returned `None`). Errored trials keep their transcript —
+  that is when it matters most.
+- `EvalLog.from_dict` coerces the new field with
+  `tuple(sample.get("policy_transcripts", ()))` (the `tuple()` wrap matches
+  the three existing coercions — a bare list in the frozen dataclass would
+  break round-trip equality) so logs written before this field
+  existed still read back (the schema's newer-reads-older guarantee; same move
+  as the two prior field additions, no version bump).
+- `eval()` threads `record.policy_transcript` into the per-scene list in both
+  the errored and the scored branches, storing the normalized object as-is.
+  Like the other dict-valued log fields, the entries are not deep-frozen;
+  extend `log.py`'s shallow-immutability docstring to name
+  `policy_transcripts` (a sink mutating the record's transcript in
+  `on_trial_end` would alias the log — same standing caveat, now stated).
+
+Storing inline (not a sidecar) is deliberate: after image-stripping the
+transcript is metadata-scale (a 100-call conversation is ~100–500 KB of text),
+and plan 0001 §3.9 reserves sidecars for large binaries. The size guard below
+keeps the inline guarantee honest.
+
+### 3. Collection point: `rollout()`, one site, all post-reset paths
+
+`rollout()` initializes a local `policy_reset_ok = False` **before** the
+`try` (a literal implementation without the init would `NameError` inside
+`finally` on the reset-failure path and mask the typed error), then sets it
+`True` immediately after `policy.reset(scene)` returns. In the existing
+`finally` block (next to the latency preservation):
+
+```python
+if policy_reset_ok:
+    record.policy_transcript = _collect_transcript(policy)
+```
+
+The guard prevents stale-transcript misattribution: if `policy.reset()` itself
+raised, the policy may still hold the *previous* trial's conversation, and
+recording it as this trial's audit data would be actively wrong. Every other
+exit path — normal return, mid-trial `PolicyError`, `EmbodimentFault` (incl.
+embodiment-reset failure), `SafetyAbort` — is covered by the single `finally`
+site. `_record_failure` attaches `record` to the exception *before* the raise
+unwinds through `finally`, and the `finally` mutates that same object, so
+`exc.record` carries the transcript too.
+
+`_collect_transcript(policy)` (module-private in `rollout.py`), with the
+**entire** sequence below inside one `except Exception` backstop so a broken
+audit hook can never mask a trial outcome or break the "eval() must always
+persist a log" invariant (`BaseException` — e.g. Ctrl-C mid-hook — is
+deliberately not caught; no log survives it anyway):
+
+1. `getattr(policy, "transcript", None)`; not callable → `None`.
+2. `raw = policy.transcript()`; `None` → `None`.
+3. Normalize: `json.loads(json.dumps(raw, default=str))`. This guarantees
+   `JsonLogSink` can never crash on a non-serializable transcript, and
+   deep-copies so later policy-side mutation cannot alias the record.
+   `default=str` makes stray objects (non-float64 numpy scalars such as
+   `np.float32`, Paths, dataclass instances) degrade to strings instead of
+   failing (`np.float64` is a `float` subclass and serializes as a JSON
+   number without hitting `default`). Known lossy edge: a numpy *array*
+   leaf becomes its truncated repr string — acceptable degradation, pinned by
+   a test so it stays chosen rather than accidental.
+4. Size guard: if `len(dumped.encode())` exceeds `_TRANSCRIPT_BYTE_LIMIT`
+   (2 MiB), store a small marker instead:
+   `{"transcript_dropped": True, "bytes": n, "note": "exceeds inline limit; policies must not embed binary data"}`.
+   2 MiB is ~4–20x the stated text-scale worst case but keeps a 100-trial
+   overnight run's log bounded (~200 MB absolute worst case vs ~1 GB at
+   10 MiB; the limit measures the compact `dumps` — `JsonLogSink` writes
+   `indent=2`, so on-disk size exceeds it by a small constant factor).
+   Dropping beats truncating: a syntactically-broken half transcript
+   is worse than an honest marker.
+5. Any exception from steps 2–4 (undumpable keys, circular refs,
+   `RecursionError` — all `Exception` subclasses) → error marker
+   `{"transcript_error": "<ExceptionType>: <message>"}`, so a broken hook is
+   visible in the log instead of silently reading as "policy has no hook".
+   Marker construction is made unconditionally safe by formatting the
+   message defensively:
+
+   ```python
+   try:
+       detail = f"{type(exc).__name__}: {exc}"
+   except Exception:
+       detail = type(exc).__name__
+   return {"transcript_error": detail}
+   ```
+
+   Both branches are tested (a raising hook, and an exception whose
+   `__str__` itself raises) — no untestable line survives for the 100%
+   coverage gate.
+
+### 4. CLI
+
+- `inspect-robots inspect LOG.json --transcript` **appends** the policy
+  transcript rendering after the standard summary, per scene and trial. Exit
+  code stays status-based (`0 if log.status == "success" else 1`) — the flag
+  never changes exit semantics. The renderer is shape-tolerant:
+  - OpenAI-style chat list (dicts with a `"role"` key): print `role`, text
+    content (list-of-parts content collapses non-text parts to `[image]`),
+    tool calls as `-> name(arguments)`, tool results indented under the call.
+  - Anything else: `json.dumps(..., indent=2)`.
+  - No transcripts in the log: print `no policy transcripts recorded` (not an
+    error; exit code unchanged).
+- Plain `inspect` (no flag) appends a `policy transcripts: recorded
+  (--transcript to print)` line when any transcript is present.
+- The post-run summary hint gains a second line when the log has transcripts:
+  `hint: agent conversation: inspect-robots inspect LOG --transcript`.
+
+### 5. Plugin: `LLMAgentPolicy.transcript()`
+
+Returns a sanitized deep copy of `self._messages`:
+
+- Every `{"type": "image_url", ...}` content part is replaced by
+  `{"type": "text", "text": "[image omitted: streamed camera frame]"}`. The
+  adjacent `camera '<name>':` text part (already emitted by
+  `_observation_content`) keeps the camera attribution readable.
+- Everything else (system prompt, goal, state text, assistant messages, tool
+  calls, tool results) is preserved verbatim.
+- Returns `None` before the first `reset()` (no conversation exists).
+- Pure function of current state: does not mutate `self._messages`; mutating
+  the returned structure does not affect the live conversation (deep copy).
+
+Plugin version bumps 0.2.2 → 0.3.0 (new public capability).
+
+## Alternatives rejected
+
+- **Sidecar transcript file written by the plugin**: the policy does not know
+  the log path/dir (and must not — sinks own persistence), and a sidecar
+  breaks the one-file immutable-log story for text-scale data.
+- **New `Event` kind in the typed transcript stream**: `TrialRecord.events`
+  never reaches the persisted `EvalLog` either; routing chat messages through
+  step-indexed events distorts both abstractions (LLM turns are not aligned
+  with control steps — one `act()` may span several LLM turns).
+- **Collecting in `eval()` instead of `rollout()`**: direct `rollout()` callers
+  and sinks would never see transcripts; `rollout()` owns `TrialRecord`
+  assembly.
+
+## Tests (TDD, core gate at 100% coverage)
+
+Fixture note: hand-built `SceneResult` fixtures must use already-normalized,
+list-only shapes (JSON round-trips turn tuples into lists, so a tuple-bearing
+fixture would fail `from_dict(to_dict(x)) == x`).
+
+Core — extend the existing files, do not create parallel ones:
+
+- `tests/test_eval_log.py`: round-trip a log with `policy_transcripts`; a v1
+  dict *without* the field reads back to `()` (golden backward-compat path).
+- `tests/test_rollout_hardening.py`: hook present → captured on success;
+  captured on the partial record of a mid-trial `PolicyError` (via
+  `exc.record`); NOT collected when `policy.reset()` raises (stale-state
+  guard); hook raising → `transcript_error` marker; exception whose
+  `__str__` raises → type-name-only marker; hookless policy → `None`;
+  `PolicyBase` default → `None`; `np.float32` leaf → string, numpy-array
+  leaf → truncated-repr string (pinned); circular reference →
+  `transcript_error` marker; oversized return → `transcript_dropped` marker.
+- `tests/test_eval_orchestration.py`: `SceneResult.policy_transcripts`
+  parallel to `epochs` for scored and errored trials; hookless policy yields
+  all-`None` entries.
+- `tests/test_registry_cli.py`: `--transcript` renders chat-shaped and
+  unknown-shaped transcripts after the summary; exit code still reflects log
+  status with the flag on an errored log; "no policy transcripts recorded"
+  path; hint lines (post-run summary and plain `inspect`).
+- `tests/test_strict_json.py`: a log carrying a transcript passes the strict
+  RFC 8259 write path (non-finite floats in transcript leaves sanitize to
+  null).
+- API snapshot: unchanged (`SceneResult`/`TrialRecord` already exported; no
+  new names in `__all__`).
+
+Plugin (`plugins/inspect-robots-agent/tests/`):
+
+- `transcript()` strips image parts, preserves text/tool structure, returns
+  `None` pre-reset, and is decoupled from live state (mutation isolation both
+  directions).
+- e2e through the existing `httpx.MockTransport` harness
+  (`test_policy_e2e.py`): after `eval()` on the mock world, the returned
+  `EvalLog` contains the conversation with the scripted tool calls visible and
+  no `data:` URLs anywhere in the serialized JSON.
+
+## Docs
+
+- `Policy` Protocol docstring: document the second optional hook (contract
+  above); `PolicyBase.transcript()` default with docstring.
+- `src/inspect_robots/CLAUDE.md` module map rows (`policy.py`, `rollout.py`,
+  `log.py`, `cli.py`).
+- `log.py` module docstring: add `policy_transcripts` to the
+  shallow-immutability caveat list.
+- README: one line in the agent-policy section pointing at
+  `inspect --transcript`.
+- Plugin README (if it documents the policy surface): mention `transcript()`.
+
+## Files touched
+
+```
+src/inspect_robots/
+  policy.py        (Protocol docstring + PolicyBase.transcript() default)
+  rollout.py       (TrialRecord.policy_transcript, _collect_transcript, finally hook)
+  log.py           (SceneResult.policy_transcripts, from_dict coercion, docstring)
+  eval.py          (thread record → SceneResult)
+  cli.py           (--transcript flag, renderer, hint lines)
+  CLAUDE.md        (module map)
+tests/
+  test_eval_log.py / test_rollout_hardening.py / test_eval_orchestration.py /
+  test_registry_cli.py / test_strict_json.py (per above)
+plugins/inspect-robots-agent/
+  pyproject.toml   (0.2.2 → 0.3.0)
+  src/inspect_robots_agent/policy.py (transcript())
+  tests/test_policy_e2e.py (+ unit tests)
+README.md
+plans/0015-policy-transcript-persistence.md (this file)
+```

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -69,6 +69,8 @@ Configuration knobs (all `-P key=value`): `model`, `base_url`, `api_key_env`,
 `max_llm_calls` (default `100`), `temperature`, `effort`, `max_speed_frac`.
 The speed fraction defaults to `0.1` and applies only to absolute modes.
 
+`LLMAgentPolicy.transcript()` returns the current conversation as a deep copy with streamed camera frames replaced by omission markers, ready for core eval-log persistence.
+
 Reasoning effort defaults to `low`: robot control is latency-sensitive (the
 arm stands still while the model thinks), safety guardrails sit below the
 model either way, and frontier models at low effort remain strong at this

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.2.2"
+version = "0.3.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -10,6 +10,7 @@ chain — this module contains no safety-critical code path of its own
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 from dataclasses import dataclass
@@ -150,6 +151,23 @@ class LLMAgentPolicy(PolicyBase):
             {"role": "user", "content": f"Goal: {scene.instruction}"},
         ]
         self._calls_used = 0
+
+    def transcript(self) -> list[dict[str, Any]] | None:
+        """Return an image-free deep copy of the current trial's conversation."""
+        if not self._messages:
+            return None
+        messages = copy.deepcopy(self._messages)
+        for message in messages:
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for index, part in enumerate(content):
+                if isinstance(part, dict) and part.get("type") == "image_url":
+                    content[index] = {
+                        "type": "text",
+                        "text": "[image omitted: streamed camera frame]",
+                    }
+        return messages
 
     # -- the loop ------------------------------------------------------------------
 

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,5 +6,5 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.2.2"
+    assert inspect_robots_agent.__version__ == "0.3.0"
     assert callable(inspect_robots_agent.agent_policy)

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -171,6 +171,69 @@ def test_goal_runs_to_done_and_config_lands_in_log(tmp_path: Path) -> None:
     assert logs[0].eval.policy_config["model"] == "test/model"
     assert logs[0].eval.policy_config["max_llm_calls"] == 100
     assert logs[0].eval.policy_config["max_speed_frac"] == 0.1
+    (transcript,) = logs[0].samples[0].policy_transcripts
+    serialized = json.dumps(logs[0].to_dict())
+    assert transcript is not None
+    assert "move_by" in serialized and "done" in serialized
+    assert "data:" not in serialized
+
+
+def test_transcript_is_none_before_first_reset() -> None:
+    policy = _policy(_Script([_text_response("unused")]))
+    assert policy.transcript() is None
+
+
+def test_transcript_strips_images_and_preserves_text_and_tools() -> None:
+    policy = _policy(_Script([_text_response("unused")]))
+    policy.reset(Scene(id="s0", instruction="reach"))
+    tool_call = {
+        "id": "call_move",
+        "type": "function",
+        "function": {"name": "move_by", "arguments": '{"dx": 0.1}'},
+    }
+    policy._messages.extend(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "camera 'top':"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,secret"},
+                    },
+                ],
+            },
+            {"role": "assistant", "content": None, "tool_calls": [tool_call]},
+            {"role": "tool", "tool_call_id": "call_move", "content": "moved"},
+        ]
+    )
+
+    transcript = policy.transcript()
+
+    assert transcript is not None
+    assert transcript[-3]["content"] == [
+        {"type": "text", "text": "camera 'top':"},
+        {"type": "text", "text": "[image omitted: streamed camera frame]"},
+    ]
+    assert transcript[-2]["tool_calls"] == [tool_call]
+    assert transcript[-1] == {
+        "role": "tool",
+        "tool_call_id": "call_move",
+        "content": "moved",
+    }
+
+
+def test_transcript_is_deeply_isolated_in_both_directions() -> None:
+    policy = _policy(_Script([_text_response("unused")]))
+    policy.reset(Scene(id="s0", instruction="reach"))
+    first = policy.transcript()
+    assert first is not None
+
+    first[0]["content"] = "changed return"
+    assert policy._messages[0]["content"] != "changed return"
+
+    policy._messages[1]["content"] = "changed live state"
+    assert first[1]["content"] == "Goal: reach"
 
 
 def test_outbound_messages_carry_state_images_and_tools(tmp_path: Path) -> None:

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -9,24 +9,24 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 |--------|----------------|
 | `types.py` | `Observation`, `Action`, `ActionChunk`, `StepResult` (frozen, NumPy-native) |
 | `spaces.py` | `Box`, `ObservationSpace`, `ActionSemantics`, `StateSpec` + canonical state vocab |
-| `policy.py` | `Policy` Protocol + `PolicyBase` ABC, `PolicyInfo`, `PolicyConfig`; optional duck-typed `bind(embodiment_info)` hook for embodiment-adaptive policies (called by `eval()` before compat) |
+| `policy.py` | `Policy` Protocol + `PolicyBase` ABC, `PolicyInfo`, `PolicyConfig`; optional duck-typed `bind(embodiment_info)` hook for embodiment-adaptive policies and `transcript()` hook for per-trial audit records |
 | `embodiment.py` | `Embodiment` Protocol + `EmbodimentBase` ABC, `EmbodimentInfo`, capability flags; optional duck-typed `bind_task(envelope)` hook for horizon-aware adapters (called by `eval()` before compat; optional input — never fires on direct `rollout()`, keep a fallback) |
 | `scene.py` | `Scene` (the Inspect `Sample` analog), `Target`, `ListSceneDataset` |
 | `task.py` | `Task` (scenes + scorer + horizon), `Epochs`, `TaskEnvelope` (`Task.envelope` — the adapter-safe identity+limits view passed to `bind_task` hooks) |
 | `scorer.py` | `Score`/`Scorer`, epoch reducers, builtin scorers (incl. operator/VLM) |
 | `controller.py` | `Controller` middleware: `DefaultController` (open-loop chunking), `SmoothingController` |
 | `approver.py` | `Approver` safety gate: `AutoApprover`, `ClampApprover`, `DeltaLimitApprover` (semantics-aware no-wild-swings limit), `ChainApprover` |
-| `rollout.py` | `rollout()` closed loop, `TrialRecord`/`StepRecord`, per-trial seeding; honors a policy-requested stop via pre-review `action.meta["request_stop"]` (truncation; embodiment termination wins; not preserved under ensembling) |
+| `rollout.py` | `rollout()` closed loop, `TrialRecord`/`StepRecord`, per-trial seeding and best-effort normalized policy-transcript capture; honors a policy-requested stop via pre-review `action.meta["request_stop"]` (truncation; embodiment termination wins; not preserved under ensembling) |
 | `frames.py` | `FrameStore`/`FrameRef` — stream camera frames to disk (R5) |
 | `transcript.py` | typed event stream (reset/inference/step/approval/operator/error) |
 | `compat.py` | `check_compatibility`/`assert_compatible` — fail-fast before rollout |
 | `conformance.py` | adapter conformance kit: `check_embodiment`/`assert_embodiment_conformant` for declarative guardrail/agent readiness; `missing_runtime_requirements` provides runtime-dependency preflight; `DeviceSlot`/`device_slots` declare and defensively read embodiment device slots |
 | `errors.py` | error taxonomy (continue vs halt) |
 | `eval.py` | `eval()` / `eval_set()` orchestration |
-| `log.py` | immutable, schema-versioned `EvalLog` + `read_eval_log` |
+| `log.py` | immutable, schema-versioned `EvalLog` + `read_eval_log`, including per-trial policy transcripts parallel to epochs |
 | `logging/` | `LogSink` protocol, `JsonLogSink` (atomic), optional `RerunSink` (non-blocking worker thread; drops frames, never delays control) |
 | `registry.py` | decorators + entry-point discovery; `_builtins.py` registers in-tree components |
-| `cli.py` | `inspect-robots list` / `run` / `inspect` / `config set|show` / `setup` (first-run wizard) / `doctor` (adapter conformance), plus the zero-config form `inspect-robots "<instruction>"` (ad-hoc single-scene task; operator prompt on TTY). Every run wires guardrails (Clamp + DeltaLimit) by default; `--disable-guardrails` is the loud opt-out and the chain degrades per component with stderr warnings |
+| `cli.py` | `inspect-robots list` / `run` / `inspect` (with `--transcript` policy-audit rendering) / `config set|show` / `setup` (first-run wizard) / `doctor` (adapter conformance), plus the zero-config form `inspect-robots "<instruction>"` (ad-hoc single-scene task; operator prompt on TTY). Every run wires guardrails (Clamp + DeltaLimit) by default; `--disable-guardrails` is the loud opt-out and the chain degrades per component with stderr warnings |
 | `_defaults.py` | user default policy/embodiment (+ `--sim` counterpart) for the zero-config CLI: env vars > `~/.config/inspect-robots/config.ini` (INI — py3.10 has no tomllib; deliberately no project-local file); `set_default` backs `config set` |
 | `_dotenv.py` | dependency-free `.env` parsing and working-directory auto-loading with real environment variables taking precedence |
 | `_setup.py` | the `inspect-robots setup` wizard (plans 0009 and 0011): IO-injected prompts for `[defaults]`, plugin-declared V4L2/CAN/serial device slots with unplug-to-identify and CAN udev guidance, fallback camera discovery, headless-rerun warning; renders config.ini itself (comments survive) and carries unmanaged sections/keys through raw |

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -8,7 +8,8 @@ Subcommands:
   components from the registry. Pass constructor args with ``-T/-P/-E k=v``;
   ``--epochs``, ``--fail-on-error``, and ``--store-frames`` tune the run. The
   written log's path is printed at the end.
-- ``inspect-robots inspect LOG.json`` — print a saved eval log.
+- ``inspect-robots inspect LOG.json [--transcript]`` — print a saved eval log and
+  optionally append recorded policy conversations.
 - ``inspect-robots setup`` — interactively configure defaults and camera devices.
 
 Zero-config form (plan 0005): ``inspect-robots "place the spoon on the plate"``
@@ -23,6 +24,7 @@ single-word instructions use the explicit ``run --instruction`` form.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 from collections.abc import Sequence
@@ -204,6 +206,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_inspect = sub.add_parser("inspect", help="print a saved eval log")
     p_inspect.add_argument("log", help="path to an EvalLog JSON file")
+    p_inspect.add_argument(
+        "--transcript",
+        action="store_true",
+        help="append recorded policy transcripts",
+    )
 
     p_doctor = sub.add_parser(
         "doctor",
@@ -441,6 +448,82 @@ def _print_step_limit_notice(log: EvalLog, is_adhoc: bool) -> None:
     print(_styled(hint, _DIM))
 
 
+def _has_policy_transcripts(log: EvalLog) -> bool:
+    """Whether any recorded trial carries a policy audit record."""
+    return any(
+        transcript is not None for scene in log.samples for transcript in scene.policy_transcripts
+    )
+
+
+def _chat_content(content: object) -> str | None:
+    """Render text from an OpenAI-style content value, collapsing media parts."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return None
+    parts: list[str] = []
+    for part in content:
+        if isinstance(part, dict) and part.get("type") == "text":
+            parts.append(str(part.get("text", "")))
+        else:
+            parts.append("[image]")
+    return "\n".join(parts)
+
+
+def _is_chat_transcript(transcript: object) -> bool:
+    """Recognize a list of role-bearing message dictionaries."""
+    return isinstance(transcript, list) and all(
+        isinstance(message, dict) and "role" in message for message in transcript
+    )
+
+
+def _render_chat_transcript(transcript: list[object]) -> None:
+    """Print roles, text, tool calls, and their indented results."""
+    for raw_message in transcript:
+        if not isinstance(raw_message, dict):
+            continue
+        role = str(raw_message["role"])
+        content = _chat_content(raw_message.get("content"))
+        if role == "tool":
+            suffix = "" if content is None else f" {content}"
+            print(f"        tool:{suffix}")
+            continue
+        suffix = "" if content is None else f" {content}"
+        print(f"    {role}:{suffix}")
+        tool_calls = raw_message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for raw_call in tool_calls:
+            if not isinstance(raw_call, dict):
+                continue
+            function = raw_call.get("function")
+            if not isinstance(function, dict):
+                continue
+            name = str(function.get("name", "unknown"))
+            arguments = function.get("arguments", "")
+            if not isinstance(arguments, str):
+                arguments = json.dumps(arguments)
+            print(f"      -> {name}({arguments})")
+
+
+def _print_policy_transcripts(log: EvalLog) -> None:
+    """Append each available policy audit record in a tolerant human-readable form."""
+    if not _has_policy_transcripts(log):
+        print("no policy transcripts recorded")
+        return
+    print("policy transcripts:")
+    for scene in log.samples:
+        for trial, transcript in enumerate(scene.policy_transcripts):
+            if transcript is None:
+                continue
+            print(f"scene {scene.scene_id}, trial {trial}:")
+            if _is_chat_transcript(transcript):
+                _render_chat_transcript(transcript)
+                continue
+            for line in json.dumps(transcript, indent=2).splitlines():
+                print(f"    {line}")
+
+
 def _print_run_summary(log: EvalLog, log_path: str, is_adhoc: bool) -> None:
     """Print the compact post-run summary and failure diagnostics."""
     failed = log.status != "success"
@@ -467,6 +550,13 @@ def _print_run_summary(log: EvalLog, log_path: str, is_adhoc: bool) -> None:
     # Every run ends with the copy-pasteable read-back command (issue #90):
     # a bare path teaches a first-time user nothing about what to do next.
     print(_styled(f"hint: view it with: inspect-robots inspect {log_path}", _DIM))
+    if _has_policy_transcripts(log):
+        print(
+            _styled(
+                f"hint: agent conversation: inspect-robots inspect {log_path} --transcript",
+                _DIM,
+            )
+        )
 
 
 def _cmd_run(args: argparse.Namespace) -> int:
@@ -635,7 +725,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
     return 0 if log.status == "success" else 1
 
 
-def _cmd_inspect(path: str) -> int:
+def _cmd_inspect(path: str, *, transcript: bool = False) -> int:
     from inspect_robots import read_eval_log
 
     log = read_eval_log(path)
@@ -663,6 +753,10 @@ def _cmd_inspect(path: str) -> int:
         print(f"  [{scene.status}] {scene.scene_id}: {'  '.join(details)}")
     if log.error:
         print(f"error: {log.error}")
+    if transcript:
+        _print_policy_transcripts(log)
+    elif _has_policy_transcripts(log):
+        print("policy transcripts: recorded (--transcript to print)")
     return 0 if log.status == "success" else 1
 
 
@@ -758,7 +852,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "run":
         return _cmd_run(args)
     if args.command == "inspect":
-        return _cmd_inspect(args.log)
+        return _cmd_inspect(args.log, transcript=args.transcript)
     if args.command == "config":
         return _cmd_config(args)
     if args.command == "setup":

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -455,6 +455,17 @@ def _has_policy_transcripts(log: EvalLog) -> bool:
     )
 
 
+def _print_degraded(line: str) -> None:
+    """Print transcript-derived text, replacing unencodable code points.
+
+    Transcripts are foreign data: a hostile or buggy model server can put lone
+    UTF-16 surrogates in message content, and they survive the log's JSON
+    round-trip but crash ``print`` on a strict-UTF-8 stdout. The forensic
+    reader must degrade, never crash, on the episodes it exists to explain.
+    """
+    print(line.encode("utf-8", errors="replace").decode("utf-8"))
+
+
 def _chat_content(content: object) -> str | None:
     """Render text from an OpenAI-style content value, collapsing media parts."""
     if isinstance(content, str):
@@ -471,9 +482,11 @@ def _chat_content(content: object) -> str | None:
 
 
 def _is_chat_transcript(transcript: object) -> bool:
-    """Recognize a list of role-bearing message dictionaries."""
-    return isinstance(transcript, list) and all(
-        isinstance(message, dict) and "role" in message for message in transcript
+    """Recognize a non-empty list of role-bearing message dictionaries."""
+    return (
+        isinstance(transcript, list)
+        and bool(transcript)
+        and all(isinstance(message, dict) and "role" in message for message in transcript)
     )
 
 
@@ -486,10 +499,10 @@ def _render_chat_transcript(transcript: list[object]) -> None:
         content = _chat_content(raw_message.get("content"))
         if role == "tool":
             suffix = "" if content is None else f" {content}"
-            print(f"        tool:{suffix}")
+            _print_degraded(f"        tool:{suffix}")
             continue
         suffix = "" if content is None else f" {content}"
-        print(f"    {role}:{suffix}")
+        _print_degraded(f"    {role}:{suffix}")
         tool_calls = raw_message.get("tool_calls")
         if not isinstance(tool_calls, list):
             continue
@@ -503,7 +516,7 @@ def _render_chat_transcript(transcript: list[object]) -> None:
             arguments = function.get("arguments", "")
             if not isinstance(arguments, str):
                 arguments = json.dumps(arguments)
-            print(f"      -> {name}({arguments})")
+            _print_degraded(f"      -> {name}({arguments})")
 
 
 def _print_policy_transcripts(log: EvalLog) -> None:
@@ -516,12 +529,12 @@ def _print_policy_transcripts(log: EvalLog) -> None:
         for trial, transcript in enumerate(scene.policy_transcripts):
             if transcript is None:
                 continue
-            print(f"scene {scene.scene_id}, trial {trial}:")
+            _print_degraded(f"scene {scene.scene_id}, trial {trial}:")
             if _is_chat_transcript(transcript):
                 _render_chat_transcript(transcript)
                 continue
             for line in json.dumps(transcript, indent=2).splitlines():
-                print(f"    {line}")
+                _print_degraded(f"    {line}")
 
 
 def _print_run_summary(log: EvalLog, log_path: str, is_adhoc: bool) -> None:

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -18,7 +18,7 @@ from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 from statistics import mean
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from inspect_robots import __version__
 from inspect_robots.approver import Approver, AutoApprover
@@ -289,6 +289,7 @@ def _run_eval(
         epoch_dicts: list[dict[str, float]] = []
         judgements: list[str | None] = []
         termination_reasons: list[str | None] = []
+        policy_transcripts: list[Any] = []
         scene_status = "success"
         scene_error: str | None = None
 
@@ -343,6 +344,7 @@ def _run_eval(
                     errored_trials += 1
                     judgements.append(None)
                     termination_reasons.append(record.termination_reason)
+                    policy_transcripts.append(record.policy_transcript)
                 else:
                     if before_scoring is not None:
                         # The only trials the hook sees are the ones scorers
@@ -357,6 +359,7 @@ def _run_eval(
                     epoch_dicts.append(epoch_values)
                     judgements.append(record.operator_judgement)
                     termination_reasons.append(record.termination_reason)
+                    policy_transcripts.append(record.policy_transcript)
                 bus.on_trial_end(record)
 
             if halted:
@@ -399,6 +402,7 @@ def _run_eval(
                 instruction=scene.instruction,
                 operator_judgements=tuple(judgements),
                 termination_reasons=tuple(termination_reasons),
+                policy_transcripts=tuple(policy_transcripts),
             )
         )
         if stopped:

--- a/src/inspect_robots/log.py
+++ b/src/inspect_robots/log.py
@@ -7,9 +7,10 @@ guarantee enforced by golden tests in a later step).
 
 Immutability is *shallow*: the dataclasses are frozen and sequence fields are
 tuples, so reassigning a field or mutating the sample list is impossible — but
-dict-valued fields (``SceneResult.reduced``, the per-epoch score dicts,
-``EvalResults.metrics``, ``EvalSpec.policy_config`` / ``embodiment_info``)
-remain plain mutable dicts. Treat a log as read-only; nothing deep-freezes it.
+dict-valued fields (``SceneResult.reduced``, the per-epoch score dicts and
+``policy_transcripts``, ``EvalResults.metrics``, ``EvalSpec.policy_config`` /
+``embodiment_info``) remain plain mutable dicts. Treat a log as read-only;
+nothing deep-freezes it.
 """
 
 from __future__ import annotations
@@ -69,6 +70,9 @@ class SceneResult:
     # Strictly parallel to ``epochs``: why each recorded trial ended, or
     # ``None`` for errored trials. The default keeps older schema-v1 logs readable.
     termination_reasons: tuple[str | None, ...] = ()
+    # Strictly parallel to ``epochs``: the policy's audit record per trial,
+    # ``None`` when unavailable. The default keeps older schema-v1 logs readable.
+    policy_transcripts: tuple[Any, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -120,6 +124,7 @@ class EvalLog:
             sample["epochs"] = tuple(sample.get("epochs", ()))
             sample["operator_judgements"] = tuple(sample.get("operator_judgements", ()))
             sample["termination_reasons"] = tuple(sample.get("termination_reasons", ()))
+            sample["policy_transcripts"] = tuple(sample.get("policy_transcripts", ()))
             samples.append(SceneResult(**sample))
         return cls(
             version=data["version"],

--- a/src/inspect_robots/log.py
+++ b/src/inspect_robots/log.py
@@ -7,10 +7,11 @@ guarantee enforced by golden tests in a later step).
 
 Immutability is *shallow*: the dataclasses are frozen and sequence fields are
 tuples, so reassigning a field or mutating the sample list is impossible — but
-dict-valued fields (``SceneResult.reduced``, the per-epoch score dicts and
-``policy_transcripts``, ``EvalResults.metrics``, ``EvalSpec.policy_config`` /
-``embodiment_info``) remain plain mutable dicts. Treat a log as read-only;
-nothing deep-freezes it.
+dict-valued fields (``SceneResult.reduced``, the per-epoch score dicts,
+``EvalResults.metrics``, ``EvalSpec.policy_config`` / ``embodiment_info``)
+remain plain mutable dicts, and ``SceneResult.policy_transcripts`` entries are
+arbitrary mutable JSON values. Treat a log as read-only; nothing deep-freezes
+it.
 """
 
 from __future__ import annotations

--- a/src/inspect_robots/policy.py
+++ b/src/inspect_robots/policy.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from inspect_robots.scene import Scene
 from inspect_robots.spaces import Box, ObservationSpace
@@ -54,12 +54,19 @@ class PolicyInfo:
 class Policy(Protocol):
     """The VLA contract.
 
-    Policies may additionally define an **optional** ``bind(embodiment_info)``
-    hook (not part of this Protocol, so existing policies stay conformant):
-    ``eval()`` calls it after resolving both components and before the
-    compatibility check, letting embodiment-adaptive policies — e.g. an LLM
-    agent that drives whatever it is paired with — adopt the embodiment's
-    spaces. ``PolicyBase`` ships a no-op default.
+    Policies may additionally define two optional hooks, neither part of this
+    Protocol so existing policies stay conformant. ``bind(embodiment_info)``
+    lets embodiment-adaptive policies adopt the embodiment's spaces; ``eval()``
+    calls it after resolving both components and before compatibility checking.
+    ``transcript()`` returns a small JSON-serializable audit record for the
+    current trial, such as an LLM conversation. The framework calls it once per
+    trial at trial end after a successful ``reset()``, including errored trials.
+    It must be idempotent and safe between resets, must not mutate policy state,
+    and its return value must not alias live state. Camera images must not be
+    embedded because frame sidecars already persist them. Collection runs on
+    the rollout thread and is best-effort: the framework normalizes and bounds
+    the result, and a raising or misbehaving hook cannot change trial outcome.
+    ``PolicyBase`` ships defaults for both hooks.
     """
 
     info: PolicyInfo
@@ -85,6 +92,10 @@ class PolicyBase(ABC):
 
     def reset(self, scene: Scene) -> None:  # noqa: B027 - intentional no-op default
         """Default: stateless policies need no per-scene reset."""
+
+    def transcript(self) -> Any | None:
+        """Return a JSON-serializable audit record for the current trial, or None."""
+        return None
 
     @abstractmethod
     def act(self, observation: Observation) -> ActionChunk:

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -9,6 +9,7 @@ gate, logging each step to the sinks, and returns an immutable
 
 from __future__ import annotations
 
+import json
 import zlib
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
@@ -35,6 +36,8 @@ from inspect_robots.types import Action, Observation, StepResult
 
 if TYPE_CHECKING:
     from inspect_robots.logging.sink import LogSink
+
+_TRANSCRIPT_BYTE_LIMIT = 2 * 1024 * 1024
 
 
 def derive_seed(eval_seed: int | None, scene_seed: int | None, epoch: int) -> int:
@@ -83,6 +86,37 @@ class TrialRecord:
     operator_judgement: str | None = None
     # Typed transcript of what happened during the trial.
     events: list[Event] = field(default_factory=list)
+    # The policy's optional per-trial audit record (e.g. an LLM conversation),
+    # collected via the duck-typed transcript() hook and normalized to plain
+    # JSON types by _collect_transcript. None when the policy has no hook.
+    policy_transcript: Any = None
+
+
+def _collect_transcript(policy: object) -> Any:
+    """Normalize a policy's optional audit hook without affecting trial outcome."""
+    try:
+        transcript = getattr(policy, "transcript", None)
+        if not callable(transcript):
+            return None
+        raw = transcript()
+        if raw is None:
+            return None
+        dumped = json.dumps(raw, default=str)
+        normalized = json.loads(dumped)
+        size = len(dumped.encode())
+        if size > _TRANSCRIPT_BYTE_LIMIT:
+            return {
+                "transcript_dropped": True,
+                "bytes": size,
+                "note": "exceeds inline limit; policies must not embed binary data",
+            }
+        return normalized
+    except Exception as exc:
+        try:
+            detail = f"{type(exc).__name__}: {exc}"
+        except Exception:
+            detail = type(exc).__name__
+        return {"transcript_error": detail}
 
 
 def _effective_control_hz(
@@ -159,10 +193,12 @@ def rollout(
     record.events.append(reset_event(seed))
     store: dict[str, Any] = {}
     expected_dim = embodiment.info.action_space.dim
+    policy_reset_ok = False
 
     try:
         try:
             policy.reset(scene)
+            policy_reset_ok = True
         except InspectRobotsError as exc:
             _record_failure(record, exc, -1)
             raise
@@ -268,4 +304,6 @@ def rollout(
         record.inference_latencies = [
             lat for lat, _ in store.get(_INFER_KEY, []) if lat is not None
         ]
+        if policy_reset_ok:  # pragma: no branch - false only while an exception unwinds
+            record.policy_transcript = _collect_transcript(policy)
     return record

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -53,6 +53,12 @@ def _golden_log() -> EvalLog:
                 instruction="reach the cube",
                 operator_judgements=("yes",),
                 termination_reasons=("success",),
+                policy_transcripts=(
+                    [
+                        {"role": "user", "content": "reach the cube"},
+                        {"role": "assistant", "content": "moving"},
+                    ],
+                ),
             ),
         ),
     )
@@ -84,6 +90,12 @@ def test_golden_log_reads_back(tmp_path: Path) -> None:
     assert restored.samples[0].instruction == "reach the cube"
     assert restored.samples[0].operator_judgements == ("yes",)
     assert restored.samples[0].termination_reasons == ("success",)
+    assert restored.samples[0].policy_transcripts == (
+        [
+            {"role": "user", "content": "reach the cube"},
+            {"role": "assistant", "content": "moving"},
+        ],
+    )
     assert restored.eval.max_steps == 1200
 
 
@@ -95,6 +107,7 @@ def test_v1_log_without_additive_fields_reads_back(tmp_path: Path) -> None:
         del sample["instruction"]
         del sample["operator_judgements"]
         del sample["termination_reasons"]
+        del sample["policy_transcripts"]
     path = tmp_path / "old.json"
     path.write_text(json.dumps(data), encoding="utf-8")
     restored = read_eval_log(str(path))
@@ -102,6 +115,7 @@ def test_v1_log_without_additive_fields_reads_back(tmp_path: Path) -> None:
     assert restored.samples[0].instruction is None
     assert restored.samples[0].operator_judgements == ()
     assert restored.samples[0].termination_reasons == ()
+    assert restored.samples[0].policy_transcripts == ()
     assert restored.eval.max_steps is None
 
 

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -604,6 +604,25 @@ def test_policy_transcripts_parallel_scored_and_errored_epochs(tmp_path: Path) -
     assert len(scene.policy_transcripts) == len(scene.epochs)
 
 
+def test_halted_trial_transcript_reaches_the_persisted_log(tmp_path: Path) -> None:
+    class _TranscriptScripted(ScriptedPolicy):
+        def transcript(self) -> object:
+            return [{"role": "assistant", "content": "walking to the cube"}]
+
+    (log,) = eval(
+        _task(epochs=2),
+        _TranscriptScripted(),
+        _FaultAfterEpochsEmbodiment(good_epochs=1),
+        log_dir=str(tmp_path),
+    )
+    scene = log.samples[0]
+    assert log.status == "error"
+    assert len(scene.policy_transcripts) == len(scene.epochs) == 2
+    # The faulted second trial keeps its transcript: forensics matter most
+    # exactly when the trial died.
+    assert scene.policy_transcripts[1] == [{"role": "assistant", "content": "walking to the cube"}]
+
+
 def test_hookless_policy_yields_all_none_transcripts(tmp_path: Path) -> None:
     class _HooklessPolicy:
         def __init__(self) -> None:

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -585,3 +585,37 @@ def test_eval_set_forwards_before_scoring(tmp_path: Path) -> None:
     assert success
     assert logs[0].samples[0].operator_judgements == ("pass",)
     assert logs[0].results.metrics["operator"] == 1.0
+
+
+def test_policy_transcripts_parallel_scored_and_errored_epochs(tmp_path: Path) -> None:
+    class _TranscriptBoomOnSecondEpoch(_BoomOnSecondEpochPolicy):
+        def transcript(self) -> object:
+            return {"reset": self._resets}
+
+    (log,) = eval(
+        _task(epochs=2),
+        _TranscriptBoomOnSecondEpoch(),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+    )
+    scene = log.samples[0]
+    assert scene.epochs[0] and scene.epochs[1] == {}
+    assert scene.policy_transcripts == ({"reset": 1}, {"reset": 2})
+    assert len(scene.policy_transcripts) == len(scene.epochs)
+
+
+def test_hookless_policy_yields_all_none_transcripts(tmp_path: Path) -> None:
+    class _HooklessPolicy:
+        def __init__(self) -> None:
+            self._delegate = ScriptedPolicy()
+            self.info = self._delegate.info
+            self.config = self._delegate.config
+
+        def reset(self, scene: Scene) -> None:
+            self._delegate.reset(scene)
+
+        def act(self, observation: Observation) -> ActionChunk:
+            return self._delegate.act(observation)
+
+    (log,) = eval(_task(epochs=2), _HooklessPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path))
+    assert log.samples[0].policy_transcripts == (None, None)

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -407,6 +407,126 @@ def _step_limit_log(
     )
 
 
+def _transcript_log(*, status: str = "success") -> EvalLog:
+    chat = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look at the workspace"},
+                {"type": "image_url", "image_url": {"url": "omitted"}},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_move",
+                    "type": "function",
+                    "function": {"name": "move_by", "arguments": '{"dx": 0.1}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_move", "content": "moved 2 steps"},
+    ]
+    return EvalLog(
+        version=1,
+        status=status,
+        eval=EvalSpec(
+            task="agent-task",
+            policy="agent",
+            embodiment="e",
+            created="x",
+            inspect_robots_version="0",
+        ),
+        results=EvalResults(total_scenes=1, total_trials=3, metrics={}),
+        stats=EvalStats(started_at="a", completed_at="b", duration_s=0.0, total_steps=1),
+        samples=(
+            SceneResult(
+                scene_id="s0",
+                status=status,
+                epochs=({}, {}, {}),
+                policy_transcripts=(chat, None, {"custom": [1, 2]}),
+            ),
+        ),
+        error="trial failed" if status == "error" else None,
+    )
+
+
+def test_inspect_transcript_renders_chat_and_unknown_shapes_after_summary(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = tmp_path / "transcripts.json"
+    path.write_text(json.dumps(_transcript_log().to_dict()), encoding="utf-8")
+
+    assert main(["inspect", str(path), "--transcript"]) == 0
+
+    out = capsys.readouterr().out
+    assert out.index("policy transcripts:") > out.index("[success] s0")
+    assert "scene s0, trial 0:" in out
+    assert "user: look at the workspace\n[image]" in out
+    assert '-> move_by({"dx": 0.1})' in out
+    assert "moved 2 steps" in out
+    assert '  "custom": [' in out
+
+
+def test_inspect_transcript_keeps_error_status_exit_code(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = tmp_path / "error.json"
+    path.write_text(json.dumps(_transcript_log(status="error").to_dict()), encoding="utf-8")
+    assert main(["inspect", str(path), "--transcript"]) == 1
+    assert "policy transcripts:" in capsys.readouterr().out
+
+
+def test_inspect_transcript_reports_when_none_recorded(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = tmp_path / "none.json"
+    path.write_text(json.dumps(_step_limit_log(reasons=("success",)).to_dict()), encoding="utf-8")
+    assert main(["inspect", str(path), "--transcript"]) == 0
+    assert "no policy transcripts recorded" in capsys.readouterr().out
+
+
+def test_plain_inspect_mentions_recorded_policy_transcripts(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = tmp_path / "transcripts.json"
+    path.write_text(json.dumps(_transcript_log().to_dict()), encoding="utf-8")
+    assert main(["inspect", str(path)]) == 0
+    out = capsys.readouterr().out
+    assert "policy transcripts: recorded (--transcript to print)" in out
+    assert "scene s0, trial 0:" not in out
+
+
+def test_run_summary_adds_agent_conversation_hint_when_recorded(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    cli._print_run_summary(_transcript_log(), "run.json", is_adhoc=False)
+    out = capsys.readouterr().out
+    assert "hint: view it with: inspect-robots inspect run.json" in out
+    assert "hint: agent conversation: inspect-robots inspect run.json --transcript" in out
+
+
+def test_chat_renderer_tolerates_malformed_tool_call_entries(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    cli._render_chat_transcript(
+        [
+            "not a message",
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    "not a call",
+                    {"function": "not a function"},
+                    {"function": {"name": "move", "arguments": {"dx": 1}}},
+                ],
+            },
+        ]
+    )
+    assert '-> move({"dx": 1})' in capsys.readouterr().out
+
+
 @pytest.mark.parametrize(
     ("control_hz", "parenthetical"),
     [

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import sys
 from pathlib import Path
@@ -506,6 +507,45 @@ def test_run_summary_adds_agent_conversation_hint_when_recorded(
     out = capsys.readouterr().out
     assert "hint: view it with: inspect-robots inspect run.json" in out
     assert "hint: agent conversation: inspect-robots inspect run.json --transcript" in out
+
+
+def test_transcript_rendering_degrades_lone_surrogates_instead_of_crashing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A hostile/buggy model server can emit lone UTF-16 surrogates; they
+    # survive the log's JSON round-trip (ensure_ascii escapes them on disk)
+    # and must degrade at print time, not crash the forensic reader.
+    log = _transcript_log()
+    hostile = dataclasses.replace(
+        log.samples[0],
+        policy_transcripts=([{"role": "assistant", "content": "bad \ud800 data"}],),
+        epochs=({},),
+    )
+    path = tmp_path / "hostile.json"
+    path.write_text(
+        json.dumps(dataclasses.replace(log, samples=(hostile,)).to_dict()), encoding="utf-8"
+    )
+
+    assert main(["inspect", str(path), "--transcript"]) == 0
+
+    out = capsys.readouterr().out
+    assert "\ud800" not in out
+    assert "bad � data" in out or "bad ? data" in out
+
+
+def test_transcript_empty_list_falls_back_to_json_rendering(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # all() is vacuously true on [], which must not classify as a chat
+    # transcript: the JSON fallback at least prints the empty list.
+    log = _transcript_log()
+    empty = dataclasses.replace(log.samples[0], policy_transcripts=([],), epochs=({},))
+    path = tmp_path / "empty.json"
+    path.write_text(
+        json.dumps(dataclasses.replace(log, samples=(empty,)).to_dict()), encoding="utf-8"
+    )
+    assert main(["inspect", str(path), "--transcript"]) == 0
+    assert "    []" in capsys.readouterr().out
 
 
 def test_chat_renderer_tolerates_malformed_tool_call_entries(

--- a/tests/test_rollout_hardening.py
+++ b/tests/test_rollout_hardening.py
@@ -15,7 +15,7 @@ from inspect_robots.errors import EmbodimentFault, PolicyError, SafetyAbort
 from inspect_robots.frames import FrameStore
 from inspect_robots.logging.sink import NullSink
 from inspect_robots.mock import CubePickEmbodiment, ScriptedPolicy
-from inspect_robots.policy import PolicyConfig, PolicyInfo
+from inspect_robots.policy import PolicyBase, PolicyConfig, PolicyInfo
 from inspect_robots.rollout import TrialRecord, derive_seed, rollout
 from inspect_robots.scene import Scene
 from inspect_robots.scorer import success_at_end
@@ -413,3 +413,119 @@ def test_fail_on_error_proportion_halts(tmp_path: Path) -> None:
     # Every trial raises -> proportion 1.0 >= 0.5 threshold -> eval status error.
     logs = eval(task, _BoomPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path), fail_on_error=0.5)
     assert logs[0].status == "error"
+
+
+# --------------------------------------------------------------------------- #
+# Policy transcripts: best-effort capture on every post-reset exit path.
+# --------------------------------------------------------------------------- #
+class _TranscriptPolicy(_StopPolicy):
+    """Stops after one action and exposes a configurable audit payload."""
+
+    def __init__(self, transcript: object) -> None:
+        super().__init__({"request_stop": True})
+        self._transcript = transcript
+
+    def transcript(self) -> object:
+        return self._transcript
+
+
+def test_policy_transcript_captured_on_success() -> None:
+    raw = [{"role": "assistant", "content": "done"}]
+    record = _run(_TranscriptPolicy(raw), CubePickEmbodiment())
+    assert record.policy_transcript == raw
+    assert record.policy_transcript is not raw
+
+
+def test_policy_transcript_captured_on_partial_policy_error() -> None:
+    class _TranscriptBoomLater(_BoomLaterPolicy):
+        def transcript(self) -> object:
+            return {"calls": self._calls}
+
+    with pytest.raises(PolicyError) as excinfo:
+        _run(_TranscriptBoomLater(), CubePickEmbodiment())
+    assert excinfo.value.record is not None
+    assert excinfo.value.record.policy_transcript == {"calls": 2}
+
+
+def test_policy_transcript_not_collected_when_policy_reset_fails() -> None:
+    class _StaleTranscriptPolicy(_ResetBoomPolicy):
+        def __init__(self) -> None:
+            super().__init__()
+            self.transcript_calls = 0
+
+        def transcript(self) -> object:
+            self.transcript_calls += 1
+            return {"stale": True}
+
+    policy = _StaleTranscriptPolicy()
+    with pytest.raises(PolicyError) as excinfo:
+        _run(policy, CubePickEmbodiment())
+    assert policy.transcript_calls == 0
+    assert excinfo.value.record is not None
+    assert excinfo.value.record.policy_transcript is None
+
+
+def test_raising_policy_transcript_becomes_error_marker() -> None:
+    class _RaisingTranscriptPolicy(_StopPolicy):
+        def transcript(self) -> object:
+            raise RuntimeError("audit exploded")
+
+    record = _run(_RaisingTranscriptPolicy({"request_stop": True}), CubePickEmbodiment())
+    assert record.policy_transcript == {"transcript_error": "RuntimeError: audit exploded"}
+
+
+def test_unprintable_transcript_exception_uses_type_only_marker() -> None:
+    class _UnprintableError(Exception):
+        def __str__(self) -> str:
+            raise RuntimeError("cannot format")
+
+    class _RaisingTranscriptPolicy(_StopPolicy):
+        def transcript(self) -> object:
+            raise _UnprintableError
+
+    record = _run(_RaisingTranscriptPolicy({"request_stop": True}), CubePickEmbodiment())
+    assert record.policy_transcript == {"transcript_error": "_UnprintableError"}
+
+
+def test_hookless_policy_records_none_transcript() -> None:
+    record = _run(_StopPolicy({"request_stop": True}), CubePickEmbodiment())
+    assert record.policy_transcript is None
+
+
+def test_policy_base_default_transcript_is_none() -> None:
+    class _MinimalPolicy(PolicyBase):
+        info = PolicyInfo(name="minimal", action_space=_BOX)
+
+        def act(self, observation: Observation) -> ActionChunk:
+            return ActionChunk(actions=[Action(data=np.zeros(2))])
+
+    policy = _MinimalPolicy()
+    assert policy.transcript() is None
+    assert _run(policy, CubePickEmbodiment()).policy_transcript is None
+
+
+def test_policy_transcript_normalizes_numpy_leaves_to_strings() -> None:
+    array = np.arange(10_000)
+    raw = {"scalar": np.float32(1.25), "array": array}
+    record = _run(_TranscriptPolicy(raw), CubePickEmbodiment())
+    assert record.policy_transcript == {"scalar": "1.25", "array": str(array)}
+    assert "..." in record.policy_transcript["array"]
+
+
+def test_circular_policy_transcript_becomes_error_marker() -> None:
+    circular: list[object] = []
+    circular.append(circular)
+    record = _run(_TranscriptPolicy(circular), CubePickEmbodiment())
+    assert record.policy_transcript == {
+        "transcript_error": "ValueError: Circular reference detected"
+    }
+
+
+def test_oversized_policy_transcript_becomes_dropped_marker() -> None:
+    payload = "x" * (2 * 1024 * 1024)
+    record = _run(_TranscriptPolicy(payload), CubePickEmbodiment())
+    assert record.policy_transcript == {
+        "transcript_dropped": True,
+        "bytes": 2 * 1024 * 1024 + 2,
+        "note": "exceeds inline limit; policies must not embed binary data",
+    }

--- a/tests/test_strict_json.py
+++ b/tests/test_strict_json.py
@@ -135,3 +135,17 @@ def test_scene_instruction_and_judgements_serialize_strict(tmp_path: Path) -> No
     assert isinstance(sample, dict)
     assert sample["instruction"] == "reach"
     assert sample["operator_judgements"] == [None]
+
+
+def test_policy_transcript_non_finite_floats_write_as_null(tmp_path: Path) -> None:
+    class _NonFiniteTranscriptPolicy(ScriptedPolicy):
+        def transcript(self) -> object:
+            return {"inf": float("inf"), "nan": float("nan")}
+
+    eval(_task(), _NonFiniteTranscriptPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path))
+    (path,) = tmp_path.glob("*.json")
+    data = _read_strict(path)
+    samples = data["samples"]
+    assert isinstance(samples, list)
+    transcript = samples[0]["policy_transcripts"][0]
+    assert transcript == {"inf": None, "nan": None}

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #100

## What

An `agent`-policy episode was unauditable: the LLM conversation lived only in `LLMAgentPolicy._messages` and died with the process. This PR persists it end to end.

- **Core hook (duck-typed, like `bind()`):** policies may define `transcript()` returning a JSON-serializable per-trial audit record; `PolicyBase` ships a `None` default. `rollout()` collects it once per trial in the `finally` block (success and all error paths), guarded by `policy_reset_ok` so a failed `reset()` can never misattribute the previous trial's conversation.
- **Robustness:** collection is best-effort and can never change a trial outcome. The return value is normalized through a JSON round-trip (`default=str`), oversized payloads (> 2 MiB) become an explicit `transcript_dropped` marker, and a raising hook becomes a visible `transcript_error` marker instead of silently reading as "no hook".
- **Schema (stays v1):** `SceneResult.policy_transcripts`, strictly parallel to `epochs` — the same additive pattern as `operator_judgements` and `termination_reasons`; old logs read back to `()`.
- **CLI:** `inspect-robots inspect LOG.json --transcript` appends a shape-tolerant turn-by-turn rendering after the summary (exit code stays status-based); plain `inspect` and the post-run summary hint at it when transcripts are present.
- **Plugin (0.2.2 → 0.3.0):** `LLMAgentPolicy.transcript()` returns a deep copy of the conversation with inline PNG data URLs replaced by omission markers (frames are already on disk via `frames_dir`).

Design doc: `plans/0015-policy-transcript-persistence.md` (two adversarial critique rounds folded in).

## Testing

- 519 core tests (was 502) at 100% coverage; 98 plugin tests (was 95). ruff + mypy strict clean.
- Manual end-to-end smoke: mock-world eval with a transcript-bearing policy, then both `inspect` modes render as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)