### PR TITLE
feat(agent): pose-mode surfaces get move_to with Cartesian contracts

### DIFF
--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -32,8 +32,9 @@ Model strings are OpenRouter-style `provider/model`, resolved from
 ## How it works
 
 Motion tool calls state where to go, not how long to move. For absolute modes,
-`move_joints` interpolates named partial targets from the observed state at a
-fixed safe speed. The default `max_speed_frac=0.1` allows a tenth of each
+the move tool (`move_joints` for joint spaces, `move_to` for Cartesian pose
+modes) interpolates named partial targets from the observed state at a fixed
+safe speed. The default `max_speed_frac=0.1` allows a tenth of each
 dimension's range per second, subject to a 5%-of-range per-step ceiling that
 matches the core's default delta backstop. At that default a near-full-range
 move exceeds the 10 s per-call playout cap, so the agent receives a

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.3.0"
+version = "0.4.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -66,15 +66,22 @@ class Toolset:
         low: npt.NDArray[np.float64],
         high: npt.NDArray[np.float64],
         step_limits: npt.NDArray[np.float64],
+        pose: bool = False,
     ):
         self._absolute = absolute
+        self._pose = pose
         self._labels = labels
         self._index_by_label = {label: i for i, label in enumerate(labels)}
         self._state_key = state_key
         self._hz = control_hz
         self._resolved_hz = control_hz if control_hz is not None else _FALLBACK_HZ
         self._max_steps = math.ceil(_MAX_DURATION_S * self._resolved_hz)
-        self._move_tool = "move_joints" if absolute else "move_by"
+        if pose:
+            # Cartesian surfaces get a Cartesian name; the LLM should think in
+            # workspace terms, not joints.
+            self._move_tool = "move_to" if absolute else "move_by"
+        else:
+            self._move_tool = "move_joints" if absolute else "move_by"
         self._bounds_text = bounds_text
         self._low = low
         self._high = high
@@ -88,7 +95,23 @@ class Toolset:
 
     def schemas(self) -> list[dict[str, Any]]:
         """Return OpenAI-format tool definitions for this embodiment."""
-        if self._absolute:
+        if self._absolute and self._pose:
+            move_description = (
+                "Move to absolute Cartesian end-effector targets (meters for "
+                "positions, radians for rotations, per the dimension labels). "
+                "The motion is a straight line interpolated at a fixed safe "
+                "speed and the result reports its step count. Unnamed "
+                "dimensions hold their current value. Coordinates are absolute "
+                "in the embodiment's declared frame; on multi-arm embodiments "
+                "each arm uses its own base frame and axes may differ between "
+                "arms depending on mounting. Rotation dimensions are absolute "
+                "targets measured relative to the trial's start orientation "
+                "(0 means the start orientation) and interpolate linearly "
+                "without wrapping, so prefer intermediate values for large "
+                "rotations. " + self._bounds_text
+            )
+            values_key = "targets"
+        elif self._absolute:
             move_description = (
                 "Move to absolute joint/dimension targets. The motion is smoothly "
                 "interpolated at a fixed safe speed and the result reports its step "
@@ -447,4 +470,5 @@ def build_toolset(
         low=low64,
         high=high64,
         step_limits=step_limits,
+        pose=mode in _POSE_MODES,
     )

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,5 +6,5 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.3.0"
+    assert inspect_robots_agent.__version__ == "0.4.0"
     assert callable(inspect_robots_agent.agent_policy)

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -655,3 +655,49 @@ def test_declared_rate_note_divides_steps_by_hz() -> None:
     assert result.chunk is not None
     assert len(result.chunk.actions) == 51
     assert result.note == "executing move_joints over 51 steps (2.5s)"
+
+
+def _pose_space() -> Box:
+    return Box(
+        shape=(4,),
+        low=np.array([0.1, -0.3, 0.03, -np.pi]),
+        high=np.array([0.5, 0.3, 0.4, np.pi]),
+        semantics=ActionSemantics(
+            "eef_abs_pose",
+            rotation_repr="none",
+            frame="base",
+            dim_labels=("x", "y", "z", "yaw"),
+        ),
+    )
+
+
+def test_pose_mode_tool_is_move_to_with_cartesian_contracts() -> None:
+    obs_space = ObservationSpace(state=StateSpec(fields=(StateField(key="eef", shape=(4,)),)))
+    toolset = build_toolset(_pose_space(), obs_space, control_hz=10.0)
+    move = toolset.schemas()[0]["function"]
+    assert move["name"] == "move_to"
+    description = move["description"]
+    assert "end-effector" in description
+    assert "its own base frame" in description
+    assert "relative to the trial's start orientation" in description
+    assert "without wrapping" in description
+    assert "Per-dimension bounds" in description
+    # The executor accepts the renamed tool and still rejects the old name.
+    result = toolset.execute(
+        _call("move_to", targets={"x": 0.3}),
+        Observation(state={"eef": np.array([0.2, 0.0, 0.1, 0.0])}),
+    )
+    assert result.error is None and result.chunk is not None
+    stale = toolset.execute(
+        _call("move_joints", targets={"x": 0.3}),
+        Observation(state={"eef": np.array([0.2, 0.0, 0.1, 0.0])}),
+    )
+    assert stale.error is not None and "move_to" in stale.error
+
+
+def test_joint_mode_tool_name_and_description_unchanged() -> None:
+    toolset = build_toolset(_absolute_space(), _absolute_obs_space(), control_hz=10.0)
+    move = toolset.schemas()[0]["function"]
+    assert move["name"] == "move_joints"
+    assert "end-effector" not in move["description"]
+    assert "start orientation" not in move["description"]

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -701,3 +701,18 @@ def test_joint_mode_tool_name_and_description_unchanged() -> None:
     assert move["name"] == "move_joints"
     assert "end-effector" not in move["description"]
     assert "start orientation" not in move["description"]
+
+
+def test_displacement_pose_mode_keeps_move_by() -> None:
+    space = Box(
+        shape=(3,),
+        low=np.array([-0.05, -0.05, -0.1]),
+        high=np.array([0.05, 0.05, 0.1]),
+        semantics=ActionSemantics(
+            "eef_delta_pose", rotation_repr="none", dim_labels=("dx", "dy", "dyaw")
+        ),
+    )
+    toolset = build_toolset(space, ObservationSpace(), control_hz=10.0)
+    move = toolset.schemas()[0]["function"]
+    assert move["name"] == "move_by"
+    assert move["description"].startswith("Move BY")

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #102

Plan 0006 §8 companion (yam side merged as robocurve/inspect-robots-yam#50, released v0.10.0). Absolute pose modes advertise `move_to` with a Cartesian description carrying the frame and rotation contracts; joint modes unchanged. Plugin 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)