### PR TITLE
ROS embodiment plugin: rosbridge-protocol adapter (plugins/inspect-robots-ros)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,40 @@ jobs:
           uv run --no-sync python -m pytest plugins/inspect-robots-xpolicylab/tests -q
           --cov=inspect_robots_xpolicylab --cov-report=term-missing --cov-fail-under=0
 
+  # The ROS adapter's suite needs no ROS install or robot: an in-process
+  # rosbridge stub covers protocol shapes, threading, pacing, reset, and spaces.
+  plugin-ros:
+    name: plugin · ros
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Sync workspace (core + plugins, dev extras)
+        run: uv sync --locked --python 3.11 --all-packages --extra dev
+      - name: Ruff (plugin, lint)
+        run: uv run --no-sync ruff check plugins/inspect-robots-ros
+      - name: Ruff (plugin, format check)
+        run: uv run --no-sync ruff format --check plugins/inspect-robots-ros
+      - name: Mypy (plugin, strict)
+        run: >
+          uv run --no-sync mypy
+          --config-file plugins/inspect-robots-ros/pyproject.toml
+          plugins/inspect-robots-ros/src/inspect_robots_ros
+      - name: Pytest (plugin, with coverage)
+        # Report-only, same rationale as the other first-party plugins.
+        # --cov-fail-under=0 overrides the root 100% core coverage gate.
+        run: >
+          uv run --no-sync python -m pytest plugins/inspect-robots-ros/tests -q
+          --cov=inspect_robots_ros --cov-report=term-missing --cov-fail-under=0
+
   # The agent plugin's suite needs no LLM: httpx.MockTransport scripts the
   # OpenAI-compatible conversations, and the mock cubepick world stands in for
   # hardware — provider resolution, tool/motion synthesis, and the full
@@ -272,7 +306,7 @@ jobs:
   ci-ok:
     name: ci-ok
     if: ${{ always() }}
-    needs: [quality, test, test-rerun, test-extra, core-only-import, plugin-isaacsim, plugin-xpolicylab, plugin-agent]
+    needs: [quality, test, test-rerun, test-extra, core-only-import, plugin-isaacsim, plugin-xpolicylab, plugin-ros, plugin-agent]
     runs-on: ubuntu-latest
     steps:
       - name: Fail unless every needed job succeeded
@@ -285,7 +319,7 @@ jobs:
   alert-red-main:
     name: alert on red main
     if: ${{ failure() && github.event_name == 'push' }}
-    needs: [quality, test, test-rerun, test-extra, core-only-import, plugin-isaacsim, plugin-xpolicylab, plugin-agent]
+    needs: [quality, test, test-rerun, test-extra, core-only-import, plugin-isaacsim, plugin-xpolicylab, plugin-ros, plugin-agent]
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ name: Release
 #   2. Manual: publish a GitHub release by hand — the publish jobs run on the
 #      release event. The tag must point at a commit that contains this file.
 #
-# The isaacsim plugin has its own static version (plugins/*/pyproject.toml);
-# it is published alongside every core release, with skip-existing so an
-# unchanged plugin version is a no-op. To release the plugin, bump its
-# version in a PR, then cut any release.
+# First-party plugins have static versions in plugins/*/pyproject.toml. They are
+# published alongside every core release, with skip-existing so unchanged
+# plugin versions are no-ops. To release a plugin, bump its version in a PR,
+# then cut any release.
 on:
   release:
     types: [published]
@@ -123,6 +123,29 @@ jobs:
         uses: astral-sh/setup-uv@v5
       - name: Build sdist + wheel
         run: uv build --package inspect-robots-xpolicylab
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # The plugin is versioned independently; a core release that doesn't
+          # bump it must not fail on the already-uploaded file.
+          skip-existing: true
+
+  publish-ros:
+    name: publish inspect-robots-ros
+    needs: [cut]
+    if: ${{ !cancelled() && (github.event_name == 'release' || needs.cut.result == 'success') }}
+    runs-on: ubuntu-latest
+    environment: pypi-ros
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.cut.outputs.tag || github.ref }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Build sdist + wheel
+        run: uv build --package inspect-robots-ros
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,10 @@ rollout, scores it, and writes an immutable `EvalLog`. Mirrors Inspect AI's
   ties them in: `uv sync --all-packages --extra dev` installs core + all plugins
   editable. They never count toward the core 100% gate (coverage is scoped to
   `inspect_robots`). E.g. `plugins/inspect-robots-isaacsim/` (Isaac Lab
-  embodiment), `plugins/inspect-robots-xpolicylab/` (policy adapter speaking
-  the XPolicyLab websocket protocol — 40+ served VLAs, no xpolicylab dep), and
+  embodiment), `plugins/inspect-robots-ros/` (ROS 1/ROS 2 embodiment speaking
+  rosbridge with no ROS dependency), `plugins/inspect-robots-xpolicylab/`
+  (policy adapter speaking the XPolicyLab websocket protocol — 40+ served VLAs,
+  no xpolicylab dep), and
   `plugins/inspect-robots-agent/` (LLMs as policies via the OpenAI-compatible
   wire format — httpx only, no provider SDKs; registered as `agent`).
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ adapter shipped from this repo as separate packages:
   `--policy agent` runs ad-hoc instructions and scores on registered tasks
   next to fine-tuned VLAs.
 
-### Real robots via ROS:
+### Real robots via ROS
 
 The ROS embodiment connects to any ROS 1 or ROS 2 arm that exposes standard
 joint, compressed-image, and optional pose topics through `rosbridge_server`.

--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ print(log.status, log.results.metrics)   # success {'success_at_end': 1.0}
 Both halves of an eval (the "body" and the "brain") have a ready-made
 adapter shipped from this repo as separate packages:
 
+- **[inspect-robots-ros](plugins/inspect-robots-ros/)**: run evals on ROS 1 or
+  ROS 2 arms through rosbridge, with no ROS installation on the eval machine
+  (`--embodiment ros`).
 - **[inspect-robots-isaacsim](plugins/inspect-robots-isaacsim/)**: run evals
   against an [Isaac Lab](https://isaac-sim.github.io/IsaacLab/) simulation
   (`--embodiment isaacsim`).
@@ -230,6 +233,28 @@ adapter shipped from this repo as separate packages:
   embodiment through tool calls, as a first-class policy. The same
   `--policy agent` runs ad-hoc instructions and scores on registered tasks
   next to fine-tuned VLAs.
+
+### Real robots via ROS:
+
+The ROS embodiment connects to any ROS 1 or ROS 2 arm that exposes standard
+joint, compressed-image, and optional pose topics through `rosbridge_server`.
+It publishes joint-position commands at a configured control rate and works
+with every compatible policy, including `agent` and XPolicyLab-served VLAs.
+
+```bash
+uv pip install inspect-robots-ros
+
+inspect-robots run --task my-task --policy agent --embodiment ros \
+    -E url=ws://robot:9090 \
+    -E joints=joint1,joint2,joint3,joint4,joint5,joint6 \
+    -E command_topic=/joint_trajectory_controller/joint_trajectory \
+    -E action_low=-3.1,-2.2,-2.9,-3.1,-2.9,-3.1 \
+    -E action_high=3.1,2.2,2.9,3.1,2.9,3.1
+```
+
+Robot bringup, controller mappings, safety requirements, camera configuration,
+and reset behavior are documented in the
+[ROS plugin README](plugins/inspect-robots-ros/).
 
 ```bash
 # Isaac Lab world + a π0 checkpoint served by XPolicyLab, evaluated end to end:

--- a/README.md
+++ b/README.md
@@ -234,6 +234,17 @@ adapter shipped from this repo as separate packages:
   `--policy agent` runs ad-hoc instructions and scores on registered tasks
   next to fine-tuned VLAs.
 
+```bash
+# Isaac Lab world + a π0 checkpoint served by XPolicyLab, evaluated end to end:
+inspect-robots run --task my-task --embodiment isaacsim \
+    --policy xpolicylab -P url=ws://gpu-box:19000 -P cameras=cam_head:base_rgb
+
+# Claude driving the mock world, no hardware or GPU required:
+export ANTHROPIC_API_KEY=sk-ant-...
+inspect-robots "pick up the cube" --policy agent \
+    -P model=anthropic/claude-fable-5 --embodiment cubepick
+```
+
 ### Real robots via ROS
 
 The ROS embodiment connects to any ROS 1 or ROS 2 arm that exposes standard
@@ -255,17 +266,6 @@ inspect-robots run --task my-task --policy agent --embodiment ros \
 Robot bringup, controller mappings, safety requirements, camera configuration,
 and reset behavior are documented in the
 [ROS plugin README](plugins/inspect-robots-ros/).
-
-```bash
-# Isaac Lab world + a π0 checkpoint served by XPolicyLab, evaluated end to end:
-inspect-robots run --task my-task --embodiment isaacsim \
-    --policy xpolicylab -P url=ws://gpu-box:19000 -P cameras=cam_head:base_rgb
-
-# Claude driving the mock world, no hardware or GPU required:
-export ANTHROPIC_API_KEY=sk-ant-...
-inspect-robots "pick up the cube" --policy agent \
-    -P model=anthropic/claude-fable-5 --embodiment cubepick
-```
 
 Safety guardrails (a bounds clamp plus a per-step delta limit derived from
 the embodiment's action space) are wired into every CLI run by default, for

--- a/plans/0016-ros-embodiment-plugin.md
+++ b/plans/0016-ros-embodiment-plugin.md
@@ -59,7 +59,8 @@ ROS-MCP?" (issue #104 has the long form):
   get/set — `step()` publishes to a topic; actions' goal/feedback/result
   lifecycle doesn't fit a control-rate loop.
 - **No TF** — `eef_pose` comes from a pose topic if the user has one
-  (ros2_control publishes one for most arms; otherwise omit it).
+  (some drivers/broadcasters publish one, e.g. UR's `tcp_pose_broadcaster`
+  or ros2_control's recent `pose_broadcaster`; otherwise omit it).
 - **No URDF introspection** — action bounds are explicit config (see §5;
   guardrails need honest bounds, and a wrong guess is worse than a required
   arg).
@@ -78,9 +79,10 @@ ROS-MCP?" (issue #104 has the long form):
   client dead; the next client call raises, the rollout wraps it into
   `EmbodimentFault`, and `EmbodimentFault` halts the eval (`errors.py`) —
   which is the right outcome when the link to a moving robot drops. (A
-  reset-time reconnect path would be nearly unreachable in CLI runs since
-  `eval()` closes registry-resolved embodiments on halt; not worth the
-  code.)
+  reset-time reconnect path would be nearly unreachable: a halt ends the
+  eval and the embodiment is closed — by the CLI's own `finally` for
+  `inspect-robots run`, or by `eval()` for registry-name-resolved
+  embodiments; not worth the code.)
 
 ## 2. Grounding: the rosbridge v2 protocol (verified against spec)
 
@@ -179,8 +181,13 @@ exactly the degenerate loop R1's escape hatch exists for. So:
 - Freshness is a **separate** guarantee, not a side effect of the sleep
   (at a chunk boundary there is no sleep, and a state stream throttled at
   exactly the control rate would only race the deadline): after
-  publishing, `step()` waits for a joint-states message whose receive
-  stamp postdates this step's publish, bounded by `fresh_obs_timeout_s`
+  publishing, `step()` waits for a joint-states message *newer than the
+  cache entry at publish time* — implemented as a per-topic monotonic
+  **sequence number** (the receive thread increments it per message;
+  `step()` captures it just before publishing and waits for `seq >
+  seq_at_publish`), which is immune to equal-timestamp ties that a
+  stamp comparison would race on (and that an injected fake clock would
+  hit deterministically in tests). Bounded by `fresh_obs_timeout_s`
   (default `2/control_hz`; timeout ⇒ staleness fault naming both
   `fresh_obs_timeout_s` and `control_hz` as the knobs). To keep that wait
   short, state topics subscribe at **2× the control rate**
@@ -191,11 +198,17 @@ exactly the degenerate loop R1's escape hatch exists for. So:
   documented rather than hidden.
 - The design assumes the robot's native `joint_states` rate is at least
   ~2× `control_hz` (real arms publish at 25-500 Hz; `throttle_rate` can
-  only thin a stream, never speed one up). `reset()` measures the
-  inter-arrival rate during its first-message wait and warns when the
-  native rate is below 2× `control_hz` ("lower `control_hz` or raise
-  `fresh_obs_timeout_s`"), so a slow publisher is diagnosed up front
-  instead of as a mid-rollout staleness fault on a healthy robot.
+  only thin a stream, never speed one up). The first `reset()` runs a
+  **preflight rate measurement**: it subscribes to `joint_states`
+  *unthrottled*, collects messages for a short window (until 5 messages
+  or 1 s, whichever first), computes the native rate from receive-stamp
+  deltas, warns when it is below 2× `control_hz` ("lower `control_hz` or
+  raise `fresh_obs_timeout_s`"), then resubscribes throttled at 2× for
+  the rollout. Measuring *before* throttling is the point: a throttled
+  stream observes `ceil(throttle/p)·p` intervals and is mathematically
+  capped at 2× `control_hz`, so measuring through it would warn on every
+  healthy robot. Tests must cover both directions — a slow publisher
+  warns *and a fast one does not*.
 - Core stays untouched; if/when core pacing lands, `self_paced` remains
   correct (the framework defers to it).
 
@@ -242,7 +255,8 @@ string→string maps.
 | `command_topic` | **required** | where arm actions go |
 | `command_type` | `"joint_trajectory"` | `"joint_trajectory"` (`trajectory_msgs/JointTrajectory`, one point, `time_from_start` = 1/`control_hz`) or `"float64_multi_array"` (`std_msgs/Float64MultiArray`) |
 | `action_low` / `action_high` | **required** | per-arm-joint bounds, `len(joints)` floats each |
-| `gripper_topic` | `None` | optional command topic for a 1-DoF gripper (`std_msgs/Float64` position); when set, action dim grows by 1 |
+| `gripper_topic` | `None` | optional command topic for a 1-DoF gripper; when set, action dim grows by 1 |
+| `gripper_command_type` | version-dependent | `"float64_multi_array"` (default when `ros_version=2`: the one-joint `forward_command_controller` interface — stock ROS 2 controllers do not consume a bare `Float64`) or `"float64"` (default when `ros_version=1`: the classic `ros_control` `<controller>/command` interface). README maps both to controller families |
 | `gripper_joint` | `None` | joint-states name holding the gripper position (required iff `gripper_topic`) |
 | `gripper_low` / `gripper_high` | `None` | **required iff `gripper_topic`**: the gripper's native command range (rad or m — robot-specific; no default, same honesty rule as arm bounds). Appended to the action `Box` bounds and used to normalize the canonical `gripper` observation to 0..1 |
 | `gripper_closed_at` | `"low"` | `"low"` or `"high"`: which end of the command range is *closed*. The canonical `gripper` observation pins 0 = closed, 1 = open, and `Box` requires low < high, so polarity must be a flag, not a bound swap |
@@ -252,7 +266,7 @@ string→string maps.
 | `fresh_obs_timeout_s` | `2/control_hz` | max wait for a post-publish joint-states message in `step()` (§3); timeout ⇒ staleness fault |
 | `camera_throttle_ms` | `1000/control_hz` | camera subscribe `throttle_rate`; `0` = unthrottled. Default ties camera bandwidth to the control rate — base64 JSON frames on a thin link otherwise queue in the socket and trip the staleness fault |
 | `reset_service` | `None` | optional service called on `reset()` (e.g. a bringup-provided home routine); empty args, must return `result: true` |
-| `operator_reset_confirm` | `False` | when true, `reset()` prints the scene instruction and blocks on Enter (TTY prompt via `input()`) — the "human arranges the scene" path |
+| `operator_reset_confirm` | `False` | when true, `reset()` prints the scene instruction and blocks on Enter (TTY prompt via `input()`) — the "human arranges the scene" path. On a non-TTY stdin `input()` raises `EOFError` → `EmbodimentFault` → halt, which is the *intended* outcome for a confirm-required run with no operator (unlike the CLI's own operator-scorer prompt, which degrades to skip); pinned by a test |
 | `obs_timeout_s` | `5.0` | max wait for the first message on every subscribed topic (reset-time) |
 | `staleness_s` | `2.0` | max age of cached state messages when an observation is assembled; older ⇒ raise (the robot stopped publishing; wrapped into `EmbodimentFault` by the rollout). This is also the **cross-modal skew bound**: a fresh `joint_pos` may pair with an `eef_pose`/camera frame up to `staleness_s` old (up to 20 control periods at the defaults) — `state_time`/`image_times` expose the actual ages, and the README states the bound |
 | `simulated` | `False` | sets `EmbodimentInfo.is_simulated` (Gazebo-behind-rosbridge runs) |
@@ -276,11 +290,15 @@ the one-line rosbridge launch command for ROS 1 and ROS 2.
   value; the field is irrelevant to `joint_pos` mode). `dim_labels` are
   mandatory in practice: conformance errors without them and the agent
   policy's tool surface is built from them; they also pin the gripper to
-  the last dim. Factory validations: an arm joint literally named
-  `"gripper"` alongside `gripper_topic` would duplicate `dim_labels`
-  (conformance error) ⇒ rejected at construction; `gripper_low >=
-  gripper_high` is rejected too (conformance only warns on zero width,
-  but the 0..1 normalization divides by the range).
+  the last dim. Factory validations: duplicate names within `joints`
+  and an arm joint literally named `"gripper"` alongside
+  `gripper_topic` are rejected at construction (either would duplicate
+  `dim_labels` — a conformance error `eval()` never runs, so left
+  unchecked the reorder-by-name would silently duplicate one position
+  across dims and publish repeated `joint_names`); `gripper_low >=
+  gripper_high` is rejected too (`Box` itself allows `low <= high` with
+  equality only drawing a conformance `zero_width` warning, but the
+  0..1 normalization divides by the range).
 - `observation_space.state` (`StateSpec`):
   - `joint_pos`, shape `(d,)` — arm joints in `joints` order, plus the raw
     `gripper_joint` position as the last element when a gripper is
@@ -399,7 +417,8 @@ axis.
   (missing joint ⇒ error listing available names), CompressedImage
   base64→Pillow→RGB (module-top `PIL` import — it's a declared dep),
   PoseStamped xyzw→wxyz reorder, JointTrajectory (per-`ros_version`
-  duration fields) / Float64MultiArray / Float64 builders.
+  duration fields) / Float64MultiArray builders, and the gripper command
+  builders (`float64` and one-element `float64_multi_array`).
 
 ## 7. Tests (no ROS, no hardware, no external processes)
 
@@ -416,8 +435,8 @@ Coverage targets (plugin CI, full-line aim on `embodiment.py`):
   correctly; scalar-coerced 1-DoF bounds (float, not str) normalize too;
   required-arg omissions (incl. `gripper_low/high` when `gripper_topic`)
   raise actionable errors; factory rejections: `d == 7` +
-  `eef_pose_topic`, arm joint named `"gripper"` with a gripper, and
-  `gripper_low >= gripper_high`.
+  `eef_pose_topic`, duplicate names in `joints`, arm joint named
+  `"gripper"` with a gripper, and `gripper_low >= gripper_high`.
 - `.info`: correct spaces/semantics/`dim_labels`/capabilities for all config
   shapes (gripper folds into `joint_pos (d,)` and bounds; normalized
   `gripper` field declared; `self_paced` always on); no network before
@@ -434,7 +453,10 @@ Coverage targets (plugin CI, full-line aim on `embodiment.py`):
 - step: JointTrajectory golden shapes for **both** `ros_version`s
   (`{secs,nsecs}` vs `{sec,nanosec}`, type strings) and Float64MultiArray;
   joint order = config order; `time_from_start` = period; gripper split
-  publishes two messages with the raw (un-normalized) command; pacing:
+  publishes two messages with the raw (un-normalized) command in the
+  version-appropriate default `gripper_command_type` (and the explicit
+  override); the fresh-obs wait keys on the per-topic sequence number
+  (equal-stamp tie test); pacing:
   **every inter-publish interval ≥ the control period under fast
   back-to-back steps** (the assertion that catches a publish-then-sleep
   implementation, which passes weaker "slept once" checks while
@@ -445,11 +467,14 @@ Coverage targets (plugin CI, full-line aim on `embodiment.py`):
   False; observation `gripper` normalized 0..1 and flipped under
   `gripper_closed_at="high"`; `instruction` threaded onto every
   observation; `state_time`/`image_times` follow the §5 convention.
-- reset warnings: slow native `joint_states` rate (< 2× `control_hz`)
-  warns at first reset; the second reset with neither `reset_service`
+- reset warnings: the unthrottled preflight window flags a slow native
+  `joint_states` rate (< 2× `control_hz`) **and stays silent for a fast
+  publisher** (the no-warn direction is the test that catches measuring
+  through the throttle); the second reset with neither `reset_service`
   nor `operator_reset_confirm` warns once about physical-reset absence;
   post-confirm fresh wait is bounded by `obs_timeout_s`, not
-  `fresh_obs_timeout_s`.
+  `fresh_obs_timeout_s`; `operator_reset_confirm` on non-TTY stdin
+  raises (`EOFError` path pinned).
 - messages: JointState reorder (shuffled names), missing-joint error,
   CompressedImage jpeg + png decode to `(H, W, 3)` uint8 RGB, exotic ROS 1
   `format` strings, PoseStamped xyzw→wxyz reorder.

--- a/plans/0016-ros-embodiment-plugin.md
+++ b/plans/0016-ros-embodiment-plugin.md
@@ -1,6 +1,6 @@
 # 0016 — `inspect-robots-ros`: first-class ROS embodiment plugin (rosbridge protocol)
 
-Issue: robocurve/inspect-robots#104.
+Issue: robocurve/inspect-robots#104. PR: #105.
 
 ## 1. Goal
 
@@ -13,13 +13,16 @@ ros2 launch rosbridge_server rosbridge_websocket_launch.xml
 
 # eval side — no ROS installed at all
 inspect-robots run --task my-task --policy agent --embodiment ros \
-    -P url=ws://robot:9090 \
-    -P joints=joint1,joint2,joint3,joint4,joint5,joint6 \
-    -P command_topic=/joint_trajectory_controller/joint_trajectory \
-    -P cameras=wrist:/camera/wrist/image_raw/compressed \
-    -P action_low=-3.1,-2.2,-2.9,-3.1,-2.9,-3.1 \
-    -P action_high=3.1,2.2,2.9,3.1,2.9,3.1
+    -E url=ws://robot:9090 \
+    -E joints=joint1,joint2,joint3,joint4,joint5,joint6 \
+    -E command_topic=/joint_trajectory_controller/joint_trajectory \
+    -E cameras=wrist:/camera/wrist/image_raw/compressed:640x480 \
+    -E action_low=-3.1,-2.2,-2.9,-3.1,-2.9,-3.1 \
+    -E action_high=3.1,2.2,2.9,3.1,2.9,3.1
 ```
+
+(`-E k=v` is the CLI's embodiment-args channel — `cli.py` routes `-P` to the
+policy and `-E` to the embodiment.)
 
 One adapter ⇒ every registered policy becomes runnable on ROS hardware (and on
 ROS-connected simulators like Gazebo): XPolicyLab-served VLAs and, notably, the
@@ -60,11 +63,24 @@ ROS-MCP?" (issue #104 has the long form):
 - **No URDF introspection** — action bounds are explicit config (see §5;
   guardrails need honest bounds, and a wrong guess is worse than a required
   arg).
+- **No `joint_vel` state field** in v1. Two reasons: (a) many real drivers
+  publish `JointState` with empty `velocity` arrays, so declaring it would
+  lie for those rigs; (b) `conformance.py`'s `state_alignment` check matches
+  the proprioceptive reference field **by shape** — for a gripperless arm,
+  `joint_vel (n,)` would collide with `joint_pos (n,)` and fail conformance.
+  Follow-up: propose key-priority matching in core, then add `joint_vel`.
 - **No raw `sensor_msgs/Image`** in v1 — cameras use `CompressedImage`
   (standard `image_transport` output, tiny on the wire). A `cbor`-compression
   raw-image mode is a documented follow-up.
 - **No rosbridge server launching** — the server belongs to the robot bringup;
   we connect to a URL (same stance as plan 0007's no-server-launching).
+- **No mid-eval reconnect.** A socket that dies after connect latches the
+  client dead; the next client call raises, the rollout wraps it into
+  `EmbodimentFault`, and `EmbodimentFault` halts the eval (`errors.py`) —
+  which is the right outcome when the link to a moving robot drops. (A
+  reset-time reconnect path would be nearly unreachable in CLI runs since
+  `eval()` closes registry-resolved embodiments on halt; not worth the
+  code.)
 
 ## 2. Grounding: the rosbridge v2 protocol (verified against spec)
 
@@ -74,9 +90,9 @@ fetched 2026-07-15):
 - Envelope: every message is a JSON object with an `op` field; optional `id`
   correlates request/response pairs.
 - `subscribe`: `topic`, optional `type`, `throttle_rate` (ms between
-  messages), `queue_length`, `compression` ∈ {`none`, `png`, `cbor`,
-  `cbor-raw`}. Incoming traffic arrives as `{"op": "publish", "topic": ...,
-  "msg": {...}}`.
+  messages), `queue_length` (buffer when throttled), `compression` ∈
+  {`none`, `png`, `cbor`, `cbor-raw`}. Incoming traffic arrives as
+  `{"op": "publish", "topic": ..., "msg": {...}}`.
 - `publish`: `topic` + `msg`; servers auto-advertise, but explicit
   `advertise` (`topic` + `type`) is required to *create* a not-yet-existing
   topic with the right type — we always advertise the command topic.
@@ -88,7 +104,7 @@ fetched 2026-07-15):
   configurable verbosity.
 - Transport-agnostic spec; websocket is the default and the one we target.
 
-Message-type facts (standard ROS msgs, stable across ROS 1/2):
+Message-type facts (standard ROS msgs):
 
 - `sensor_msgs/JointState`: parallel arrays `name`, `position`, `velocity`,
   `effort` — name-indexed, order not guaranteed ⇒ the adapter reorders by the
@@ -97,11 +113,18 @@ Message-type facts (standard ROS msgs, stable across ROS 1/2):
   `"rgb8; jpeg compressed bgr8"`) + `data` (base64 in JSON) — decoded via
   Pillow, converted to `(H, W, 3)` RGB uint8.
 - `geometry_msgs/PoseStamped`: `pose.position` xyz + `pose.orientation`
-  xyzw quaternion — reordered to the core's `[x, y, z, qw, qx, qy, qz]`
-  (`eef_pose` canonical form, quat wxyz; same reorder xpolicylab does).
+  **xyzw** quaternion — the adapter reorders to the core's canonical
+  `eef_pose` form `[x, y, z, qw, qx, qy, qz]` (quat wxyz).
 - `trajectory_msgs/JointTrajectory`: `joint_names` + `points[]` with
-  `positions` and `time_from_start` — the standard ros2_control position
-  interface.
+  `positions` and `time_from_start`. **Not identical across ROS versions**:
+  the duration is `{secs, nsecs}` in ROS 1 but `{sec, nanosec}` in ROS 2
+  (`builtin_interfaces/Duration`), and rosbridge's message conversion
+  rejects unknown fields rather than coercing. Type strings also differ
+  (`trajectory_msgs/JointTrajectory` vs `trajectory_msgs/msg/...`). ⇒ a
+  `ros_version` config selects the wire shape; golden tests cover both
+  (verify the exact accepted type-string forms against rosbridge during
+  implementation — ROS 2 rosbridge normalizes the short form, but tests
+  pin whatever we send).
 - `std_msgs/Float64MultiArray`: `data` — the forward-controller interface.
 
 ## 3. The one big decision: an embodiment, not a policy or a tool layer
@@ -112,8 +135,8 @@ on the embodiment axis exactly as `inspect-robots-xpolicylab` mirrors it on
 the policy axis. Everything else falls out of existing machinery:
 
 - The `agent` policy is embodiment-adaptive (`bind()` builds its tool surface
-  from our `ActionSemantics`) ⇒ LLM-on-ROS-robot works with zero agent
-  changes.
+  from our `ActionSemantics.dim_labels` and spaces) ⇒ LLM-on-ROS-robot works
+  with zero agent changes.
 - CLI guardrails (Clamp + DeltaLimit) apply to every run by default —
   which is why §5 makes action bounds required config.
 - `RerunSink` gives live visualization of a real-robot eval for free.
@@ -121,11 +144,33 @@ the policy axis. Everything else falls out of existing machinery:
   (`embodiment.py` docstring): reset may block on an operator, there is no
   privileged success oracle — scorers (operator / VLM) own success.
 
-Dependency policy: `inspect-robots>=0.4`, `numpy`, `websockets>=12`
+Dependency policy: `inspect-robots>=0.6` (the release that shipped the
+conformance kit this plugin's CI asserts against), `numpy`, `websockets>=12`
 (sync client, same floor as xpolicylab), `pillow>=10` (CompressedImage
-decode; already the floor core uses for its `rerun` extra). **No `rclpy`, no
+decode; same floor the core's `rerun` extra uses). Pillow is a declared,
+required dependency, so it is imported at module top like any other dep (the
+lazy-import posture is for optional extras only). **No `rclpy`, no
 `roslibpy`, no ROS message packages** — messages are plain JSON dicts and the
 five shapes we touch are enumerated in §2.
+
+### Pacing: `self_paced`, explicitly
+
+R1 (plan 0001 §9) says the framework owns pacing *unless the embodiment
+declares `self_paced`* — and `rollout.py` documents that framework-side
+real-time pacing is deferred "until the first real-robot adapter" and is
+**not implemented**: today's loop runs as fast as inference allows. An
+unpaced stream of `JointTrajectory` points at LLM/VLA inference cadence is
+exactly the degenerate loop R1's escape hatch exists for. So:
+
+- The embodiment declares the `SELF_PACED` capability.
+- `step()` publishes the command, then sleeps until one control period
+  (`1/control_hz`, monotonic clock, measured from the previous step's
+  publish) has elapsed, then assembles the post-action observation from the
+  topic cache. The sleep doubles as the freshness window: state topics are
+  subscribed at the control rate, so the cache has a post-command message by
+  the time the observation is read.
+- Core stays untouched; if/when core pacing lands, `self_paced` remains
+  correct (the framework defers to it).
 
 ## 4. Deliverable layout
 
@@ -152,28 +197,35 @@ CLAUDE.md                             # plugins list mentions the new package
 ## 5. The adapter: `RosEmbodiment`
 
 `RosEmbodiment(EmbodimentBase)`, constructor all-keyword, every arg reachable
-from `-P k=v` (mapping/list args accept the compact string forms plan 0007
-established: `name:topic,name:topic` and comma-separated lists — topic names
-never contain `,` or the pre-colon camera names we require to be simple
-identifiers):
+from `-E k=v`. The CLI's `parse_value` pre-coerces scalars, so factory
+parsers accept `str | int | float | Sequence` for numeric lists (a 1-DoF
+`action_low=-3.1` arrives as `float`, a 6-DoF one as the uncoerced string
+`"-3.1,-2.2,..."`); mapping args accept dicts programmatically or the
+compact string form (`name:topic:WxH,name:topic:WxH` for cameras — topics
+never contain `,` or `:`, camera names are required to be identifiers).
+The plugin writes these parsers itself; plan 0007's helpers cover only
+string→string maps.
 
 | Arg | Default | Meaning |
 | --- | --- | --- |
 | `url` | `"ws://localhost:9090"` | rosbridge websocket URL (9090 is the rosbridge default) |
-| `joints` | **required** | ordered joint names; defines `joint_pos` order and action dim |
+| `ros_version` | `2` | `1` or `2`; selects `JointTrajectory` duration field names and type strings (§2) |
+| `joints` | **required** | ordered arm joint names; defines `joint_pos` order |
 | `joint_states_topic` | `"/joint_states"` | `sensor_msgs/JointState` source |
-| `command_topic` | **required** | where actions go |
+| `command_topic` | **required** | where arm actions go |
 | `command_type` | `"joint_trajectory"` | `"joint_trajectory"` (`trajectory_msgs/JointTrajectory`, one point, `time_from_start` = 1/`control_hz`) or `"float64_multi_array"` (`std_msgs/Float64MultiArray`) |
-| `action_low` / `action_high` | **required** | per-joint bounds (comma-separated floats); gripper bound appended when `gripper_topic` set |
-| `gripper_topic` | `None` | optional command topic for a 1-DoF gripper (`std_msgs/Float64` position); when set, action dim grows by 1 and observation `gripper` is read from `gripper_joint` in joint states |
-| `gripper_joint` | `None` | joint-states name holding gripper position (required iff `gripper_topic`) |
+| `action_low` / `action_high` | **required** | per-arm-joint bounds, `len(joints)` floats each |
+| `gripper_topic` | `None` | optional command topic for a 1-DoF gripper (`std_msgs/Float64` position); when set, action dim grows by 1 |
+| `gripper_joint` | `None` | joint-states name holding the gripper position (required iff `gripper_topic`) |
+| `gripper_low` / `gripper_high` | `None` | **required iff `gripper_topic`**: the gripper's native command range (rad or m — robot-specific; no default, same honesty rule as arm bounds). Appended to the action `Box` bounds and used to normalize the canonical `gripper` observation to 0..1 |
 | `eef_pose_topic` | `None` | optional `geometry_msgs/PoseStamped` → observation `eef_pose` (7-D, wxyz) |
-| `cameras` | `{}` | camera name → `sensor_msgs/CompressedImage` topic |
-| `control_hz` | `10.0` | declared control rate; also the subscribe `throttle_rate` for state topics |
+| `cameras` | `{}` | camera name → `(topic, height, width)`; compact form `name:topic:WxH`. Resolution is required — `CameraSpec.height/width` are mandatory ints, and an embodiment that declares no `CameraSpec` fails compat against every camera-requiring policy (`missing_camera`) |
+| `control_hz` | `10.0` | control rate; `step()` paces to it (§3) and state subscriptions throttle to it |
+| `camera_throttle_ms` | `1000/control_hz` | camera subscribe `throttle_rate`; `0` = unthrottled. Default ties camera bandwidth to the control rate — base64 JSON frames on a thin link otherwise queue in the socket and trip the staleness fault |
 | `reset_service` | `None` | optional service called on `reset()` (e.g. a bringup-provided home routine); empty args, must return `result: true` |
 | `operator_reset_confirm` | `False` | when true, `reset()` prints the scene instruction and blocks on Enter (TTY prompt via `input()`) — the "human arranges the scene" path |
 | `obs_timeout_s` | `5.0` | max wait for the first message on every subscribed topic (reset-time) |
-| `staleness_s` | `2.0` | max age of cached state messages when an observation is assembled; older ⇒ raise (embodiment fault — the robot stopped publishing) |
+| `staleness_s` | `2.0` | max age of cached state messages when an observation is assembled; older ⇒ raise (the robot stopped publishing; wrapped into `EmbodimentFault` by the rollout) |
 | `simulated` | `False` | sets `EmbodimentInfo.is_simulated` (Gazebo-behind-rosbridge runs) |
 | `name` | `"ros"` | `EmbodimentInfo.name` (users can tag e.g. `"ros:ur5e"`) |
 | `connect_timeout_s` / `request_timeout_s` | `10` / `30` | client timeouts |
@@ -184,22 +236,43 @@ fail-fast compat checks work with no robot. The client connects on first
 `reset()`; connection failure raises an actionable error naming the URL and
 the one-line rosbridge launch command for ROS 1 and ROS 2.
 
-**`EmbodimentInfo`**:
+**`EmbodimentInfo`** (`d = len(joints) + (1 if gripper_topic else 0)`):
 
-- `action_space`: `Box(low=action_low, high=action_high)` with
-  `ActionSemantics(control_mode="joint_pos", gripper="continuous" iff
-  gripper_topic, frame="joint", bounds=explicit)` — sized `len(joints)`
-  (+1 with gripper).
-- `observation_space`: `StateSpec` with `joint_pos` (dim `len(joints)`),
-  plus `gripper` (1) and `eef_pose` (7) when configured; `CameraSpec` per
-  camera **without** resolution (unknown until frames arrive; compat stays
-  meaningful, same stance as plan 0007).
+- `action_space`: `Box(shape=(d,), low=concat(action_low, [gripper_low]),
+  high=concat(action_high, [gripper_high]),
+  semantics=ActionSemantics(control_mode="joint_pos", rotation_repr="none",
+  gripper="continuous" if gripper_topic else "none", frame="base",
+  dim_labels=(*joints, "gripper") or (*joints,)))`. `frame="base"` matches
+  the isaacsim precedent for joint-space control (`Frame` has no joint
+  value; the field is irrelevant to `joint_pos` mode). `dim_labels` are
+  mandatory in practice: conformance errors without them and the agent
+  policy's tool surface is built from them; they also pin the gripper to
+  the last dim.
+- `observation_space.state` (`StateSpec`):
+  - `joint_pos`, shape `(d,)` — arm joints in `joints` order, plus the raw
+    `gripper_joint` position as the last element when a gripper is
+    configured. This is the **proprioceptive reference field**:
+    `conformance.state_alignment` requires exactly one field whose shape
+    equals the action dim, and folding the gripper in keeps observation
+    dim d aligned with command dim d (units: rad for revolute dims; the
+    gripper dim is in its native command unit — documented).
+  - `gripper`, shape `(1,)` — canonical normalized 0..1 (0 closed, 1 open
+    per `CANONICAL_STATE_UNITS`), computed from
+    `(raw - gripper_low) / (gripper_high - gripper_low)`. Declared only
+    when a gripper is configured.
+  - `eef_pose`, shape `(7,)` — declared only when `eef_pose_topic` set.
+    **Known corner**: a 6-DoF arm + gripper (d = 7) + `eef_pose` gives two
+    `(7,)` fields, which fails the shape-based `state_alignment`
+    conformance check (eval itself is unaffected — compat doesn't use
+    alignment). Documented in the README; follow-up core issue: match the
+    reference field by key priority (`joint_pos` first), not shape alone.
+- `observation_space.cameras`: `CameraSpec(name, height, width)` per
+  configured camera; the first received frame is validated against the
+  declared resolution at reset (mismatch ⇒ error naming both).
 - `control_hz` passthrough; `is_simulated` from config.
-- `capabilities`: `{"resettable"}` iff `reset_service` set. **Never**
-  `seedable`, `auto_reset`, or `privileged_success` (real hardware; nothing
-  to seed, no oracle). Not `self_paced`: `step()` returns immediately after
-  the publish and the framework paces the loop — R1's default is exactly
-  what a stream-commanded robot wants.
+- `capabilities`: `{"self_paced"}` (§3) plus `"resettable"` iff
+  `reset_service` set. **Never** `seedable`, `auto_reset`, or
+  `privileged_success` (real hardware; nothing to seed, no oracle).
 - `supported_setups` / `supported_target_kinds`: empty (unconstrained) —
   scene realization on hardware is operator- or bringup-owned; the tracer
   has nothing to check.
@@ -207,10 +280,12 @@ the one-line rosbridge launch command for ROS 1 and ROS 2.
 **`reset(scene, *, seed=None)`**:
 
 1. First call: connect, `advertise` the command (and gripper) topics,
-   `subscribe` to joint states / eef pose / cameras (`throttle_rate` =
-   `1000/control_hz` ms for state, cameras unthrottled), then wait up to
-   `obs_timeout_s` for one message per subscribed topic — a missing topic
-   fails *here*, at reset, with the topic name, not mid-rollout.
+   `subscribe` (always `queue_length=1` — latest-value semantics) to joint
+   states / eef pose (`throttle_rate` = `1000/control_hz` ms) and cameras
+   (`camera_throttle_ms`), then wait up to `obs_timeout_s` for one message
+   per subscribed topic — a missing topic fails *here*, at reset, with the
+   topic name, not mid-rollout. First camera frames validate declared
+   resolutions.
 2. `seed` is accepted and ignored (contract allows it; `seedable` is not
    declared).
 3. If `reset_service`: `call_service`, require `result: true`.
@@ -220,21 +295,24 @@ the one-line rosbridge launch command for ROS 1 and ROS 2.
    cache: reset must observe the *post-reset* world).
 
 **`step(action)`**: split the vector into arm command (+ gripper command),
-build the §2 message shapes, `publish` (two publishes when gripper is
-configured), assemble the current observation from the topic cache
-(staleness-checked), return
-`StepResult(observation=..., reward=None, terminated=False, truncated=False,
-info={"staleness_s": per-topic ages})`. No success oracle ⇒ `terminated`
-is always False; horizons and policy `request_stop` end trials, scorers
-decide success.
+build the §2 message shapes per `ros_version`, `publish` (two publishes when
+gripper is configured), sleep out the control period (§3), assemble the
+current observation from the topic cache (staleness-checked), return
+`StepResult(observation=..., reward=None, terminated=False,
+truncated=False)`. Per-topic message ages ride on the observation's own
+`state_time` / `image_times` fields (that is what they exist for — no
+duplicate `info` payload). No success oracle ⇒ `terminated` is always
+False; horizons and policy `request_stop` end trials, scorers decide
+success.
 
-**`close()`**: unsubscribe/unadvertise best-effort, close the socket,
-idempotent. `eval()` auto-closes registry-resolved embodiments ("close what
-we open"), so no atexit dance is needed on this axis.
+**`close()`**: unsubscribe/unadvertise best-effort, close the socket, join
+the receive thread, idempotent. `eval()` auto-closes registry-resolved
+embodiments ("close what we open"), so no atexit dance is needed on this
+axis.
 
 ## 6. The client: `_protocol.py` + `_client.py`
 
-- `_protocol.py`: builders/parsers for the six ops we use (`subscribe`,
+- `_protocol.py`: builders/parsers for the ops we use (`subscribe`,
   `unsubscribe`, `advertise`, `unadvertise`, `publish`, `call_service` /
   `service_response`, plus `status` parsing). Pure dict↔dataclass, JSON via
   stdlib. `RosbridgeError(code, message)` for `status` errors and failed
@@ -242,19 +320,25 @@ we open"), so no atexit dance is needed on this axis.
 - `_client.py`: `RosbridgeClient` on `websockets.sync.client.connect`
   (`max_size=None`; multi-camera JSON frames are large). One background
   **receive thread** owns `recv()`: it demuxes `publish` ops into a
-  per-topic `(msg, monotonic_stamp)` latest-slot under a lock, resolves
-  pending `call_service` futures by `id`, and surfaces `status: error`
-  ops. Sends happen from the rollout thread — the websockets sync client
-  documents one-reader/one-writer thread safety, which is exactly this
-  split. A dead socket marks the client disconnected; the *next* `reset()`
-  reconnects and replays advertises/subscribes (mid-trial death raises —
-  a dead robot link mid-motion must fault the trial, mirroring
-  `EmbodimentFault` semantics, not silently reconnect).
-- `_msgs.py`: the five message shapes ↔ numpy. JointState reorder-by-name
+  per-topic `(msg, monotonic_stamp)` latest-slot under a lock and resolves
+  pending `call_service` futures by `id`. This threading split is *new
+  design* (xpolicylab's client is single-threaded request/response; only
+  the stub-server test pattern carries over) and relies on the websockets
+  sync client's documented one-thread-receiving / one-thread-sending
+  safety — pin the claim to the installed version's docs during
+  implementation and cover it with a threaded test.
+- **Error latching**: the receive thread can't raise into the rollout
+  thread, and rosbridge reports publish-side type errors asynchronously as
+  `status: error` ops. The thread latches the first error (and any socket
+  death) on the client; every subsequent client call (`publish`,
+  observation read, `call_service`) raises the latched `RosbridgeError` /
+  `ConnectionError` first. The rollout wraps it into `EmbodimentFault`,
+  which halts the eval (§1 non-goals: no reconnect).
+- `_msgs.py`: the message shapes ↔ numpy. JointState reorder-by-name
   (missing joint ⇒ error listing available names), CompressedImage
-  base64→Pillow→RGB (lazy `PIL` import at first frame, matching the core's
-  lazy-import posture), PoseStamped xyzw→wxyz reorder, JointTrajectory /
-  Float64MultiArray builders.
+  base64→Pillow→RGB (module-top `PIL` import — it's a declared dep),
+  PoseStamped xyzw→wxyz reorder, JointTrajectory (per-`ros_version`
+  duration fields) / Float64MultiArray / Float64 builders.
 
 ## 7. Tests (no ROS, no hardware, no external processes)
 
@@ -267,36 +351,47 @@ recording every client op for assertions.
 Coverage targets (plugin CI, full-line aim on `embodiment.py`):
 
 - registry: entry point resolves; `resolve("embodiment", "ros", ...)` with
-  string-form `-P` args (joints, cameras, bounds) normalizes correctly;
-  required-arg omissions raise actionable `TypeError`s.
-- `.info`: correct spaces/semantics/capabilities for all config shapes; no
-  network before first `reset()` (construct with an unroutable URL).
-- reset: subscribes with the right `throttle_rate`; missing topic ⇒ error
-  naming it within `obs_timeout_s`; `reset_service` called and `result:
-  false` raises; fresh-observation wait (a stale pre-reset message is not
-  returned); reconnect-after-drop replays advertise/subscribe.
-- step: JointTrajectory and Float64MultiArray messages have the §2 golden
-  shapes (joint order = config order, `time_from_start` = period); gripper
-  split publishes two messages; staleness beyond `staleness_s` raises;
-  `terminated` always False.
-- messages: JointState reorder (shuffled names), gripper extraction,
+  string-form `-E` args (joints, cameras incl. `WxH`, bounds) normalizes
+  correctly; scalar-coerced 1-DoF bounds (float, not str) normalize too;
+  required-arg omissions (incl. `gripper_low/high` when `gripper_topic`)
+  raise actionable errors.
+- `.info`: correct spaces/semantics/`dim_labels`/capabilities for all config
+  shapes (gripper folds into `joint_pos (d,)` and bounds; normalized
+  `gripper` field declared; `self_paced` always on); no network before
+  first `reset()` (construct with an unroutable URL).
+- conformance: `assert_embodiment_conformant(RosEmbodiment(...).info)`
+  passes for gripperless and gripper configs (no `eef_pose` collision);
+  the documented 6-DoF+gripper+`eef_pose` corner is asserted to fail with
+  `state_alignment` (pinning the known limitation).
+- reset: subscribes with `queue_length=1` and the right `throttle_rate`s;
+  missing topic ⇒ error naming it within `obs_timeout_s`; camera resolution
+  mismatch ⇒ error; `reset_service` called and `result: false` raises;
+  fresh-observation wait (a stale pre-reset message is not returned).
+- step: JointTrajectory golden shapes for **both** `ros_version`s
+  (`{secs,nsecs}` vs `{sec,nanosec}`, type strings) and Float64MultiArray;
+  joint order = config order; `time_from_start` = period; gripper split
+  publishes two messages with the raw (un-normalized) command; pacing
+  sleeps to `control_hz` (monotonic-clock based, tested with a fake
+  clock); staleness beyond `staleness_s` raises; `terminated` always
+  False; observation `gripper` normalized 0..1.
+- messages: JointState reorder (shuffled names), missing-joint error,
   CompressedImage jpeg + png decode to `(H, W, 3)` uint8 RGB, exotic ROS 1
-  `format` strings, PoseStamped wxyz reorder.
+  `format` strings, PoseStamped xyzw→wxyz reorder.
 - protocol golden test: our op dicts match the spec's documented JSON
   shapes verbatim (guards codec drift, mirrors plan 0007's golden wire
   test).
-- lifecycle: close is idempotent, unsubscribes; mid-trial socket death ⇒
-  raise (not silent reconnect); `status: error` from server surfaces as
-  `RosbridgeError`.
-- compat: `check_compatibility(agent_policy-shaped stub / xpolicylab-shaped
-  stub, RosEmbodiment(...))` passes for a matching profile; conformance kit
-  (`assert_embodiment_conformant`) passes against the stub server.
+- client: threaded send-while-receiving test; `status: error` latches and
+  surfaces on the next call; socket death latches; service-call `id`
+  correlation; close is idempotent and joins the thread.
+- compat: `check_compatibility` passes against an agent-shaped and an
+  xpolicylab-shaped policy stub for a matching profile; camera-requiring
+  policy fails compat only when the camera is genuinely undeclared.
 - operator confirm: `input()` path exercised via monkeypatched stdin.
 
 ## 8. CI, workspace, docs
 
 - `pyproject.toml` mirrors xpolicylab's: hatchling, static
-  `version = "0.1.0"`, `inspect-robots>=0.4`, `[tool.uv.sources]
+  `version = "0.1.0"`, `inspect-robots>=0.6`, `[tool.uv.sources]
   inspect-robots = { workspace = true }`, mypy strict, ruff line-length 100.
   `uv lock` after adding; workspace glob picks it up.
 - CI: `plugin-ros` job cloned from `plugin-xpolicylab` (ruff, mypy strict,
@@ -307,25 +402,31 @@ Coverage targets (plugin CI, full-line aim on `embodiment.py`):
 - Entry point: `[project.entry-points."inspect_robots.embodiments"]
   ros = "inspect_robots_ros:ros_embodiment"`.
 - Docs: plugin README (robot-side rosbridge bringup for ROS 1/ROS 2,
-  eval-side quickstart, full config table, ros2_control controller notes,
-  troubleshooting: base64 image bandwidth, throttle_rate, firewalls) —
-  public-facing, so it follows the CLAUDE.md writing-style rules (no em
-  dashes, etc.). Root README gets a "Real robots via ROS" section beside the
-  Isaac/XPolicyLab mentions; root CLAUDE.md plugin list gains the package.
-- **Core is untouched**: no new core deps, no `__all__`/api-snapshot churn.
+  eval-side quickstart, full config table, ros2_control controller notes —
+  which `command_type` pairs with which controller family — plus a leading
+  safety section: e-stop, verified bounds from URDF/datasheet, low
+  `max_speed_frac`, supervised first runs; troubleshooting: base64 image
+  bandwidth, throttle rates, the 6-DoF+gripper+`eef_pose` conformance
+  corner) — public-facing, so it follows the CLAUDE.md writing-style rules
+  (no em dashes, etc.). Root README gets a "Real robots via ROS" section
+  beside the Isaac/XPolicyLab mentions; root CLAUDE.md plugin list gains
+  the package.
+- **Core is untouched**: no new core deps, no `__all__`/api-snapshot churn,
+  no rollout changes (pacing handled via `self_paced`, §3).
 
 ## 9. Risks & mitigations
 
 | Risk | Mitigation |
 | --- | --- |
-| Base64 JSON images too slow at control rate | `CompressedImage` (jpeg) keeps frames tens-of-KB; cameras unthrottled but latest-slot semantics drop backlog; documented follow-up: `cbor` subscription mode |
-| JointState arrives without all configured joints (some drivers split arm/gripper across publishers) | Reorder-by-name errors list missing vs available; `gripper_joint` may come from the same or another topic later — v1 requires same-topic and says so |
-| Wrong `command_type` for the robot's controller stack | README maps the two types to ros2_control controller families; `status: error` from rosbridge (type mismatch) surfaces as `RosbridgeError` at first step |
-| Stale cache read as live state (robot died, cache survives) | `staleness_s` check on every observation assembly ⇒ fault, not silent stale data |
-| Guardrail bounds wrong because user guessed | Bounds are required, never defaulted; README tells users to copy them from their URDF/datasheet and start with `--policy agent -P max_speed_frac=0.05` style caution |
-| websockets sync client thread-safety assumptions | One-reader (receive thread) / one-writer (rollout thread) split is the documented safe pattern; service futures resolved via the receive thread only |
-| Protocol drift (rosbridge adds/changes ops) | We use six stable ops documented since protocol v2.0 (2013); golden shape tests; spec version + fetch date recorded in §2 |
-| Real-robot safety | Every CLI run wires Clamp + DeltaLimit by default; bounds required; `terminated` never fakes success; README leads with a safety section (e-stop, speed fractions, supervised first runs) |
+| Base64 JSON images too slow at control rate | `CompressedImage` (jpeg) keeps frames tens-of-KB; camera subscriptions throttle to the control rate by default (`camera_throttle_ms`); documented follow-up: `cbor` subscription mode |
+| JointState arrives without all configured joints (some drivers split arm/gripper across publishers) | Reorder-by-name errors list missing vs available; v1 requires `gripper_joint` on the same topic and says so; split-topic support is a follow-up |
+| Wrong `command_type` / `ros_version` for the robot's stack | README maps types to controller families; rosbridge `status: error` (type mismatch) latches and surfaces on the next step as `EmbodimentFault` |
+| Stale cache read as live state (robot died, cache survives) | `staleness_s` check on every observation assembly ⇒ fault, not silent stale data; socket death latches the client dead |
+| Guardrail bounds wrong because user guessed | Arm **and gripper** bounds are required, never defaulted; README tells users to copy them from URDF/datasheet and start with low agent speed caps |
+| Unpaced rollout loop on real hardware | `self_paced` + in-`step()` pacing (§3) — the loop cannot outrun `control_hz` regardless of policy inference speed |
+| websockets sync client thread-safety assumptions | One-reader (receive thread) / one-writer (rollout thread) split; claim pinned to installed-version docs; threaded test in CI |
+| Protocol drift (rosbridge adds/changes ops) | We use stable ops documented since protocol v2.0 (2013); golden shape tests; spec version + fetch date recorded in §2 |
+| Real-robot safety | Every CLI run wires Clamp + DeltaLimit by default; bounds required; `terminated` never fakes success; README leads with a safety section |
 
 ## 10. Execution steps (each a commit)
 
@@ -333,10 +434,10 @@ Coverage targets (plugin CI, full-line aim on `embodiment.py`):
    `uv lock`; `uv sync --all-packages --extra dev` green.
 2. `_protocol.py` + golden shape tests.
 3. `_client.py` + stub-server conftest + client tests (threading, cache,
-   service correlation, death/reconnect).
-4. `_msgs.py` + tests (reorder, decode, builders).
-5. `embodiment.py` adapter + tests (info, reset, step, lifecycle, compat,
-   conformance).
+   error latching, service correlation, death latching).
+4. `_msgs.py` + tests (reorder, decode, builders for both `ros_version`s).
+5. `embodiment.py` adapter + tests (info, conformance, reset, step incl.
+   pacing, lifecycle, compat).
 6. CI job + `ci-ok.needs`; `publish-ros` release job; root README + plugin
    README + CLAUDE.md touches.
 7. Gates: `ruff check`, `ruff format --check`, plugin mypy strict, plugin

--- a/plans/0016-ros-embodiment-plugin.md
+++ b/plans/0016-ros-embodiment-plugin.md
@@ -203,12 +203,22 @@ exactly the degenerate loop R1's escape hatch exists for. So:
   *unthrottled*, collects messages for a short window (until 5 messages
   or 1 s, whichever first), computes the native rate from receive-stamp
   deltas, warns when it is below 2× `control_hz` ("lower `control_hz` or
-  raise `fresh_obs_timeout_s`"), then resubscribes throttled at 2× for
-  the rollout. Measuring *before* throttling is the point: a throttled
+  raise `fresh_obs_timeout_s`"), then swaps to the throttled rollout
+  subscription. Measuring *before* throttling is the point: a throttled
   stream observes `ceil(throttle/p)·p` intervals and is mathematically
   capped at 2× `control_hz`, so measuring through it would warn on every
   healthy robot. Tests must cover both directions — a slow publisher
-  warns *and a fast one does not*.
+  warns *and a fast one does not*. Degenerate windows: 0 messages falls
+  through to the `obs_timeout_s` missing-topic error; exactly 1 message
+  (no delta to measure) warns as too-slow-to-measure. **Subscription
+  handoff semantics**: rosbridge aggregates same-topic subscriptions
+  from one client by least-restrictive parameters, keyed by the optional
+  `id` — a naive throttled re-subscribe would leave the unthrottled
+  preflight subscription live and silently defeat the throttle. The
+  preflight subscribe therefore uses an explicit `id`, the handoff is
+  `unsubscribe(preflight id)` → `subscribe(new id, throttled)`, and the
+  stub server models per-id subscriptions so the tests can catch a
+  wrong handoff.
 - Core stays untouched; if/when core pacing lands, `self_paced` remains
   correct (the framework defers to it).
 
@@ -259,9 +269,9 @@ string→string maps.
 | `gripper_command_type` | version-dependent | `"float64_multi_array"` (default when `ros_version=2`: the one-joint `forward_command_controller` interface — stock ROS 2 controllers do not consume a bare `Float64`) or `"float64"` (default when `ros_version=1`: the classic `ros_control` `<controller>/command` interface). README maps both to controller families |
 | `gripper_joint` | `None` | joint-states name holding the gripper position (required iff `gripper_topic`) |
 | `gripper_low` / `gripper_high` | `None` | **required iff `gripper_topic`**: the gripper's native command range (rad or m — robot-specific; no default, same honesty rule as arm bounds). Appended to the action `Box` bounds and used to normalize the canonical `gripper` observation to 0..1 |
-| `gripper_closed_at` | `"low"` | `"low"` or `"high"`: which end of the command range is *closed*. The canonical `gripper` observation pins 0 = closed, 1 = open, and `Box` requires low < high, so polarity must be a flag, not a bound swap |
+| `gripper_closed_at` | `"low"` | `"low"` or `"high"`: which end of the command range is *closed*. The canonical `gripper` observation pins 0 = closed, 1 = open, and the factory requires `gripper_low < gripper_high` (`Box` itself allows equality), so polarity must be a flag, not a bound swap |
 | `eef_pose_topic` | `None` | optional `geometry_msgs/PoseStamped` → observation `eef_pose` (7-D, wxyz) |
-| `cameras` | `{}` | camera name → `(topic, height, width)`; compact form `name:topic:WxH`. Resolution is required — `CameraSpec.height/width` are mandatory ints, and an embodiment that declares no `CameraSpec` fails compat against every camera-requiring policy (`missing_camera`) |
+| `cameras` | `{}` | camera name → `(topic, height, width)`; compact form `name:topic:WxH` where `640x480` means width 640, height 480 (parser test uses a non-square camera so a swapped parse can't hide). Resolution is required — `CameraSpec.height/width` are mandatory ints, and an embodiment that declares no `CameraSpec` fails compat against every camera-requiring policy (`missing_camera`) |
 | `control_hz` | `10.0` | control rate; `step()` paces to it (§3); state subscriptions throttle at 2× it |
 | `fresh_obs_timeout_s` | `2/control_hz` | max wait for a post-publish joint-states message in `step()` (§3); timeout ⇒ staleness fault |
 | `camera_throttle_ms` | `1000/control_hz` | camera subscribe `throttle_rate`; `0` = unthrottled. Default ties camera bandwidth to the control rate — base64 JSON frames on a thin link otherwise queue in the socket and trip the staleness fault |
@@ -290,15 +300,21 @@ the one-line rosbridge launch command for ROS 1 and ROS 2.
   value; the field is irrelevant to `joint_pos` mode). `dim_labels` are
   mandatory in practice: conformance errors without them and the agent
   policy's tool surface is built from them; they also pin the gripper to
-  the last dim. Factory validations: duplicate names within `joints`
-  and an arm joint literally named `"gripper"` alongside
-  `gripper_topic` are rejected at construction (either would duplicate
+  the last dim. Factory validations, all with actionable messages:
+  duplicate names within `joints` and an arm joint literally named
+  `"gripper"` alongside `gripper_topic` (either would duplicate
   `dim_labels` — a conformance error `eval()` never runs, so left
   unchecked the reorder-by-name would silently duplicate one position
   across dims and publish repeated `joint_names`); `gripper_low >=
-  gripper_high` is rejected too (`Box` itself allows `low <= high` with
-  equality only drawing a conformance `zero_width` warning, but the
-  0..1 normalization divides by the range).
+  gripper_high` (`Box` itself allows `low <= high` with equality only
+  drawing a conformance `zero_width` warning, but the 0..1 normalization
+  divides by the range); `control_hz` positive and finite (it divides
+  into every throttle and timeout default); `len(action_low)` /
+  `len(action_high)` vs `len(joints)` checked before `Box` construction
+  ("you gave 5 bounds for 6 joints", not a bare shape mismatch); enum
+  args validated (`ros_version` ∈ {1, 2}, `command_type`,
+  `gripper_command_type`, `gripper_closed_at`); duplicate camera names
+  rejected (the compact-string parser must not silently collapse them).
 - `observation_space.state` (`StateSpec`):
   - `joint_pos`, shape `(d,)` — arm joints in `joints` order, plus the raw
     `gripper_joint` position as the last element when a gripper is
@@ -368,9 +384,11 @@ the one-line rosbridge launch command for ROS 1 and ROS 2.
 
 **`step(action)`**: sleep-gate on the previous publish (§3), split the
 vector into arm command (+ gripper command), build the §2 message shapes
-per `ros_version`, `publish` (two publishes when gripper is configured),
-wait for a post-publish joint-states message (§3), assemble the observation
-(staleness-checked), return `StepResult(observation=..., reward=None,
+per `ros_version`, `publish` (two publishes when gripper is configured —
+the **arm** publish is the single pacing/freshness reference: it
+timestamps the sleep-gate and the `seq` capture, so the inter-publish
+invariant stays well-defined), wait for a post-publish joint-states
+message (§3), assemble the observation (staleness-checked), return `StepResult(observation=..., reward=None,
 terminated=False, truncated=False)`. Timing rides on the observation's own
 fields — no duplicate `info` payload — with the convention stated here
 because no core producer has pinned one yet: `state_time` is the monotonic
@@ -470,7 +488,10 @@ Coverage targets (plugin CI, full-line aim on `embodiment.py`):
 - reset warnings: the unthrottled preflight window flags a slow native
   `joint_states` rate (< 2× `control_hz`) **and stays silent for a fast
   publisher** (the no-warn direction is the test that catches measuring
-  through the throttle); the second reset with neither `reset_service`
+  through the throttle); the preflight→throttled handoff
+  unsubscribes the preflight `id` (per-id stub assertion); a
+  single-message window warns as too-slow-to-measure; the second reset
+  with neither `reset_service`
   nor `operator_reset_confirm` warns once about physical-reset absence;
   post-confirm fresh wait is bounded by `obs_timeout_s`, not
   `fresh_obs_timeout_s`; `operator_reset_confirm` on non-TTY stdin
@@ -507,7 +528,12 @@ Coverage targets (plugin CI, full-line aim on `embodiment.py`):
   ros = "inspect_robots_ros:ros_embodiment"`.
 - Docs: plugin README (robot-side rosbridge bringup for ROS 1/ROS 2,
   eval-side quickstart, full config table, ros2_control controller notes —
-  which `command_type` pairs with which controller family — plus a leading
+  which `command_type`/`gripper_command_type` pairs with which controller
+  family, including the explicit exclusion that ROS 2's stock
+  `gripper_action_controller` is action-only and needs a
+  `forward_command_controller` on the gripper joint instead, and the
+  `joint_pos` unit caveat that the folded gripper dim is in the gripper's
+  native unit, not rad — plus a leading
   safety section: e-stop, verified bounds from URDF/datasheet, low
   `max_speed_frac`, supervised first runs; troubleshooting: base64 image
   bandwidth, throttle rates, the 6-DoF+gripper+`eef_pose` conformance

--- a/plans/0016-ros-embodiment-plugin.md
+++ b/plans/0016-ros-embodiment-plugin.md
@@ -113,8 +113,10 @@ Message-type facts (standard ROS msgs):
   `"rgb8; jpeg compressed bgr8"`) + `data` (base64 in JSON) — decoded via
   Pillow, converted to `(H, W, 3)` RGB uint8.
 - `geometry_msgs/PoseStamped`: `pose.position` xyz + `pose.orientation`
-  **xyzw** quaternion — the adapter reorders to the core's canonical
-  `eef_pose` form `[x, y, z, qw, qx, qy, qz]` (quat wxyz).
+  **xyzw** quaternion — the adapter reorders to `[x, y, z, qw, qx, qy, qz]`
+  (quat wxyz). Core pins no quaternion order for `eef_pose` (the unit is
+  just `"m+quat"`); wxyz is the ecosystem precedent (plan 0007 /
+  xpolicylab's ee-pose convention) and the plugin README documents it.
 - `trajectory_msgs/JointTrajectory`: `joint_names` + `points[]` with
   `positions` and `time_from_start`. **Not identical across ROS versions**:
   the duration is `{secs, nsecs}` in ROS 1 but `{sec, nanosec}` in ROS 2
@@ -165,10 +167,23 @@ exactly the degenerate loop R1's escape hatch exists for. So:
 - The embodiment declares the `SELF_PACED` capability.
 - `step()` publishes the command, then sleeps until one control period
   (`1/control_hz`, monotonic clock, measured from the previous step's
-  publish) has elapsed, then assembles the post-action observation from the
-  topic cache. The sleep doubles as the freshness window: state topics are
-  subscribed at the control rate, so the cache has a post-command message by
-  the time the observation is read.
+  publish) has elapsed — this is the pacing half, and it composes with
+  open-loop `ActionChunk` playout (mid-chunk, buffered pops are fast and
+  the sleep absorbs the overhead; at a chunk boundary after slow inference
+  the period has already elapsed and the sleep is ~zero, which is correct:
+  pacing bounds the command rate, it never adds latency on top of
+  inference).
+- Freshness is a **separate** guarantee, not a side effect of the sleep
+  (at a chunk boundary there is no sleep, and a state stream throttled at
+  exactly the control rate would only race the deadline): after the
+  pacing sleep, `step()` waits for a joint-states message whose receive
+  stamp postdates this step's publish, bounded by `fresh_obs_timeout_s`
+  (default `2/control_hz`; timeout ⇒ staleness fault). To keep that wait
+  short, state topics subscribe at **2× the control rate**
+  (`throttle_rate = 500/control_hz` ms), so a post-command message
+  arrives within ~half a period. The observation a policy plans from is
+  therefore always post-command, including the one the LLM agent sees
+  after seconds of inference.
 - Core stays untouched; if/when core pacing lands, `self_paced` remains
   correct (the framework defers to it).
 
@@ -209,7 +224,7 @@ string→string maps.
 | Arg | Default | Meaning |
 | --- | --- | --- |
 | `url` | `"ws://localhost:9090"` | rosbridge websocket URL (9090 is the rosbridge default) |
-| `ros_version` | `2` | `1` or `2`; selects `JointTrajectory` duration field names and type strings (§2) |
+| `ros_version` | `2` | `1` or `2`; selects `JointTrajectory` duration field names and type strings (§2). ROS 1 is kept despite Noetic's 2025 EOL because industrial fleets still run it and the cost is two builder branches plus golden tests — the protocol layer is identical |
 | `joints` | **required** | ordered arm joint names; defines `joint_pos` order |
 | `joint_states_topic` | `"/joint_states"` | `sensor_msgs/JointState` source |
 | `command_topic` | **required** | where arm actions go |
@@ -220,7 +235,8 @@ string→string maps.
 | `gripper_low` / `gripper_high` | `None` | **required iff `gripper_topic`**: the gripper's native command range (rad or m — robot-specific; no default, same honesty rule as arm bounds). Appended to the action `Box` bounds and used to normalize the canonical `gripper` observation to 0..1 |
 | `eef_pose_topic` | `None` | optional `geometry_msgs/PoseStamped` → observation `eef_pose` (7-D, wxyz) |
 | `cameras` | `{}` | camera name → `(topic, height, width)`; compact form `name:topic:WxH`. Resolution is required — `CameraSpec.height/width` are mandatory ints, and an embodiment that declares no `CameraSpec` fails compat against every camera-requiring policy (`missing_camera`) |
-| `control_hz` | `10.0` | control rate; `step()` paces to it (§3) and state subscriptions throttle to it |
+| `control_hz` | `10.0` | control rate; `step()` paces to it (§3); state subscriptions throttle at 2× it |
+| `fresh_obs_timeout_s` | `2/control_hz` | max wait for a post-publish joint-states message in `step()` (§3); timeout ⇒ staleness fault |
 | `camera_throttle_ms` | `1000/control_hz` | camera subscribe `throttle_rate`; `0` = unthrottled. Default ties camera bandwidth to the control rate — base64 JSON frames on a thin link otherwise queue in the socket and trip the staleness fault |
 | `reset_service` | `None` | optional service called on `reset()` (e.g. a bringup-provided home routine); empty args, must return `result: true` |
 | `operator_reset_confirm` | `False` | when true, `reset()` prints the scene instruction and blocks on Enter (TTY prompt via `input()`) — the "human arranges the scene" path |
@@ -247,7 +263,11 @@ the one-line rosbridge launch command for ROS 1 and ROS 2.
   value; the field is irrelevant to `joint_pos` mode). `dim_labels` are
   mandatory in practice: conformance errors without them and the agent
   policy's tool surface is built from them; they also pin the gripper to
-  the last dim.
+  the last dim. Factory validations: an arm joint literally named
+  `"gripper"` alongside `gripper_topic` would duplicate `dim_labels`
+  (conformance error) ⇒ rejected at construction; `gripper_low >=
+  gripper_high` is rejected too (conformance only warns on zero width,
+  but the 0..1 normalization divides by the range).
 - `observation_space.state` (`StateSpec`):
   - `joint_pos`, shape `(d,)` — arm joints in `joints` order, plus the raw
     `gripper_joint` position as the last element when a gripper is
@@ -261,11 +281,19 @@ the one-line rosbridge launch command for ROS 1 and ROS 2.
     `(raw - gripper_low) / (gripper_high - gripper_low)`. Declared only
     when a gripper is configured.
   - `eef_pose`, shape `(7,)` — declared only when `eef_pose_topic` set.
-    **Known corner**: a 6-DoF arm + gripper (d = 7) + `eef_pose` gives two
-    `(7,)` fields, which fails the shape-based `state_alignment`
-    conformance check (eval itself is unaffected — compat doesn't use
-    alignment). Documented in the README; follow-up core issue: match the
-    reference field by key priority (`joint_pos` first), not shape alone.
+    **Hard constraint, enforced in the factory**: when `d == 7` (any
+    shape — 6-DoF + gripper *or* a gripperless 7-DoF arm, i.e. Franka /
+    iiwa / Kinova Gen3), setting `eef_pose_topic` creates two `(7,)`
+    state fields. That is not a cosmetic conformance blemish: the agent
+    policy replicates the same shape-match at `bind()` time
+    (`inspect_robots_agent/_tools.py` raises `ToolsetError` on ambiguous
+    reference fields, and `eval()` binds before any rollout), so
+    agent-on-ROS would hard-fail at eval start. The factory therefore
+    raises an actionable `ValueError` at construction ("omit
+    `eef_pose_topic` on a 7-dim action space until core supports
+    key-priority reference matching"). Follow-up core issue: match the
+    proprioceptive reference by key priority (`joint_pos` first), not
+    shape alone; lift the restriction when it lands.
 - `observation_space.cameras`: `CameraSpec(name, height, width)` per
   configured camera; the first received frame is validated against the
   declared resolution at reset (mismatch ⇒ error naming both).
@@ -281,7 +309,8 @@ the one-line rosbridge launch command for ROS 1 and ROS 2.
 
 1. First call: connect, `advertise` the command (and gripper) topics,
    `subscribe` (always `queue_length=1` — latest-value semantics) to joint
-   states / eef pose (`throttle_rate` = `1000/control_hz` ms) and cameras
+   states / eef pose (`throttle_rate` = `500/control_hz` ms — 2× the
+   control rate, see §3 freshness) and cameras
    (`camera_throttle_ms`), then wait up to `obs_timeout_s` for one message
    per subscribed topic — a missing topic fails *here*, at reset, with the
    topic name, not mid-rollout. First camera frames validate declared
@@ -292,16 +321,22 @@ the one-line rosbridge launch command for ROS 1 and ROS 2.
 4. If `operator_reset_confirm`: print `scene.instruction` and block on
    Enter.
 5. Assemble and return the initial `Observation` (fresh-message wait, not
-   cache: reset must observe the *post-reset* world).
+   cache: reset must observe the *post-reset* world). Every observation —
+   here and in `step()` — carries `scene.instruction` on
+   `Observation.instruction`, matching the cubepick/isaacsim precedent
+   (policies keep a reset-time fallback, but the embodiment threads it).
 
 **`step(action)`**: split the vector into arm command (+ gripper command),
 build the §2 message shapes per `ros_version`, `publish` (two publishes when
-gripper is configured), sleep out the control period (§3), assemble the
-current observation from the topic cache (staleness-checked), return
-`StepResult(observation=..., reward=None, terminated=False,
-truncated=False)`. Per-topic message ages ride on the observation's own
-`state_time` / `image_times` fields (that is what they exist for — no
-duplicate `info` payload). No success oracle ⇒ `terminated` is always
+gripper is configured), sleep out the control period, wait for a
+post-publish joint-states message (§3), assemble the observation
+(staleness-checked), return `StepResult(observation=..., reward=None,
+terminated=False, truncated=False)`. Timing rides on the observation's own
+fields — no duplicate `info` payload — with the convention stated here
+because no core producer has pinned one yet: `state_time` is the monotonic
+receive stamp of the **oldest** state message contributing to the
+observation (joint states or eef pose), and `image_times[name]` is each
+camera frame's receive stamp. No success oracle ⇒ `terminated` is always
 False; horizons and policy `request_stop` end trials, scorers decide
 success.
 
@@ -326,7 +361,11 @@ axis.
   the stub-server test pattern carries over) and relies on the websockets
   sync client's documented one-thread-receiving / one-thread-sending
   safety — pin the claim to the installed version's docs during
-  implementation and cover it with a threaded test.
+  implementation and cover it with a threaded test. Both the client
+  (cache receive stamps) and the embodiment (pacing sleep, fresh-obs
+  wait, staleness checks) take an injectable monotonic clock + sleep
+  (default `time.monotonic`/`time.sleep`), so timing tests control one
+  clock domain instead of racing real stamps against a fake clock.
 - **Error latching**: the receive thread can't raise into the rollout
   thread, and rosbridge reports publish-side type errors asynchronously as
   `status: error` ops. The thread latches the first error (and any socket
@@ -354,15 +393,18 @@ Coverage targets (plugin CI, full-line aim on `embodiment.py`):
   string-form `-E` args (joints, cameras incl. `WxH`, bounds) normalizes
   correctly; scalar-coerced 1-DoF bounds (float, not str) normalize too;
   required-arg omissions (incl. `gripper_low/high` when `gripper_topic`)
-  raise actionable errors.
+  raise actionable errors; factory rejections: `d == 7` +
+  `eef_pose_topic`, arm joint named `"gripper"` with a gripper, and
+  `gripper_low >= gripper_high`.
 - `.info`: correct spaces/semantics/`dim_labels`/capabilities for all config
   shapes (gripper folds into `joint_pos (d,)` and bounds; normalized
   `gripper` field declared; `self_paced` always on); no network before
   first `reset()` (construct with an unroutable URL).
 - conformance: `assert_embodiment_conformant(RosEmbodiment(...).info)`
-  passes for gripperless and gripper configs (no `eef_pose` collision);
-  the documented 6-DoF+gripper+`eef_pose` corner is asserted to fail with
-  `state_alignment` (pinning the known limitation).
+  passes for gripperless and gripper configs both with and without
+  `eef_pose` at `d != 7`; the `d == 7` + `eef_pose_topic` combinations
+  (6-DoF+gripper *and* 7-DoF gripperless) are asserted to raise the
+  factory's actionable error (pinning the enforced limitation).
 - reset: subscribes with `queue_length=1` and the right `throttle_rate`s;
   missing topic ⇒ error naming it within `obs_timeout_s`; camera resolution
   mismatch ⇒ error; `reset_service` called and `result: false` raises;
@@ -371,9 +413,12 @@ Coverage targets (plugin CI, full-line aim on `embodiment.py`):
   (`{secs,nsecs}` vs `{sec,nanosec}`, type strings) and Float64MultiArray;
   joint order = config order; `time_from_start` = period; gripper split
   publishes two messages with the raw (un-normalized) command; pacing
-  sleeps to `control_hz` (monotonic-clock based, tested with a fake
-  clock); staleness beyond `staleness_s` raises; `terminated` always
-  False; observation `gripper` normalized 0..1.
+  sleeps to `control_hz` and is ~zero after slow inference (injected
+  fake clock, §6); the fresh-obs wait returns only a post-publish
+  joint-states message and faults on `fresh_obs_timeout_s`; staleness
+  beyond `staleness_s` raises; `terminated` always False; observation
+  `gripper` normalized 0..1; `instruction` threaded onto every
+  observation; `state_time`/`image_times` follow the §5 convention.
 - messages: JointState reorder (shuffled names), missing-joint error,
   CompressedImage jpeg + png decode to `(H, W, 3)` uint8 RGB, exotic ROS 1
   `format` strings, PoseStamped xyzw→wxyz reorder.
@@ -395,7 +440,10 @@ Coverage targets (plugin CI, full-line aim on `embodiment.py`):
   inspect-robots = { workspace = true }`, mypy strict, ruff line-length 100.
   `uv lock` after adding; workspace glob picks it up.
 - CI: `plugin-ros` job cloned from `plugin-xpolicylab` (ruff, mypy strict,
-  pytest, ubuntu) and **added to `ci-ok.needs`**.
+  pytest, ubuntu) and **added to both `ci-ok.needs` and
+  `alert-red-main.needs`** (plugin jobs appear in both lists; omitting the
+  second would exempt `plugin-ros` failures from red-main stop-the-line
+  alerts).
 - Release: `publish-ros` job in `release.yml` (environment `pypi-ros`;
   maintainer must create the PyPI trusted-publisher environment before first
   release — settings action, called out in the PR).
@@ -421,7 +469,7 @@ Coverage targets (plugin CI, full-line aim on `embodiment.py`):
 | Base64 JSON images too slow at control rate | `CompressedImage` (jpeg) keeps frames tens-of-KB; camera subscriptions throttle to the control rate by default (`camera_throttle_ms`); documented follow-up: `cbor` subscription mode |
 | JointState arrives without all configured joints (some drivers split arm/gripper across publishers) | Reorder-by-name errors list missing vs available; v1 requires `gripper_joint` on the same topic and says so; split-topic support is a follow-up |
 | Wrong `command_type` / `ros_version` for the robot's stack | README maps types to controller families; rosbridge `status: error` (type mismatch) latches and surfaces on the next step as `EmbodimentFault` |
-| Stale cache read as live state (robot died, cache survives) | `staleness_s` check on every observation assembly ⇒ fault, not silent stale data; socket death latches the client dead |
+| Stale cache read as live state (robot died, cache survives) | `staleness_s` check on every observation assembly ⇒ fault, not silent stale data; socket death latches the client dead; `step()` additionally requires a post-publish joint-states message (§3), so a pre-command observation can't masquerade as post-command |
 | Guardrail bounds wrong because user guessed | Arm **and gripper** bounds are required, never defaulted; README tells users to copy them from URDF/datasheet and start with low agent speed caps |
 | Unpaced rollout loop on real hardware | `self_paced` + in-`step()` pacing (§3) — the loop cannot outrun `control_hz` regardless of policy inference speed |
 | websockets sync client thread-safety assumptions | One-reader (receive thread) / one-writer (rollout thread) split; claim pinned to installed-version docs; threaded test in CI |

--- a/plans/0016-ros-embodiment-plugin.md
+++ b/plans/0016-ros-embodiment-plugin.md
@@ -1,0 +1,343 @@
+# 0016 — `inspect-robots-ros`: first-class ROS embodiment plugin (rosbridge protocol)
+
+Issue: robocurve/inspect-robots#104.
+
+## 1. Goal
+
+Give Inspect Robots a first-class `Embodiment` adapter for **any ROS 1 / ROS 2
+robot running `rosbridge_server`**, shipped as the fourth in-repo plugin:
+
+```bash
+# robot side — any ROS distro, one extra node
+ros2 launch rosbridge_server rosbridge_websocket_launch.xml
+
+# eval side — no ROS installed at all
+inspect-robots run --task my-task --policy agent --embodiment ros \
+    -P url=ws://robot:9090 \
+    -P joints=joint1,joint2,joint3,joint4,joint5,joint6 \
+    -P command_topic=/joint_trajectory_controller/joint_trajectory \
+    -P cameras=wrist:/camera/wrist/image_raw/compressed \
+    -P action_low=-3.1,-2.2,-2.9,-3.1,-2.9,-3.1 \
+    -P action_high=3.1,2.2,2.9,3.1,2.9,3.1
+```
+
+One adapter ⇒ every registered policy becomes runnable on ROS hardware (and on
+ROS-connected simulators like Gazebo): XPolicyLab-served VLAs and, notably, the
+`agent` LLM policy — which then covers the "LLM drives a ROS robot" use case
+that interactive tools like [ros-mcp-server](https://github.com/robotmcp/ros-mcp-server)
+target, but scored, logged, guardrailed, and reproducible.
+
+### Why rosbridge and not MCP (the ROS-MCP evaluation)
+
+Recorded here because the feature request started as "should we integrate with
+ROS-MCP?" (issue #104 has the long form):
+
+- ROS-MCP is an MCP **tool surface** for interactive assistants (Claude
+  Desktop, Cursor) over a robot. Inspect Robots already has an eval-grade LLM
+  tool surface (`inspect-robots-agent`: tools generated from
+  `ActionSemantics`, speed-limited playout, approver chain, transcripts in the
+  `EvalLog`). Integrating MCP into the closed-loop control path would add a
+  request/response tool-calling hop with no action-space contract and no
+  scoring hooks.
+- ROS-MCP itself reaches the robot over **rosbridge**. Integrating "through"
+  ROS-MCP would tunnel rosbridge → MCP → our own tool layer → rosbridge.
+- rosbridge v2 is the portable surface of the ROS ecosystem (ROS-MCP,
+  Foxglove, roslibjs all target it): JSON over websocket, covers ROS 1 and
+  ROS 2, and needs zero ROS packages on the client. That is exactly the
+  workspace doctrine — *speak the protocol, don't import the package* (cf.
+  plan 0007 §3).
+
+### Non-goals (YAGNI)
+
+- **No mobile-base / Twist control** (`cmd_vel`) — v1 is arm-shaped
+  (`joint_pos` control mode). A Twist mode is a small follow-up once the
+  transport is proven.
+- **No ROS actions** (rosbridge `send_action_goal` ops) and no parameter
+  get/set — `step()` publishes to a topic; actions' goal/feedback/result
+  lifecycle doesn't fit a control-rate loop.
+- **No TF** — `eef_pose` comes from a pose topic if the user has one
+  (ros2_control publishes one for most arms; otherwise omit it).
+- **No URDF introspection** — action bounds are explicit config (see §5;
+  guardrails need honest bounds, and a wrong guess is worse than a required
+  arg).
+- **No raw `sensor_msgs/Image`** in v1 — cameras use `CompressedImage`
+  (standard `image_transport` output, tiny on the wire). A `cbor`-compression
+  raw-image mode is a documented follow-up.
+- **No rosbridge server launching** — the server belongs to the robot bringup;
+  we connect to a URL (same stance as plan 0007's no-server-launching).
+
+## 2. Grounding: the rosbridge v2 protocol (verified against spec)
+
+Facts from `RobotWebTools/rosbridge_suite` `ROSBRIDGE_PROTOCOL.md` (v2.1.0,
+fetched 2026-07-15):
+
+- Envelope: every message is a JSON object with an `op` field; optional `id`
+  correlates request/response pairs.
+- `subscribe`: `topic`, optional `type`, `throttle_rate` (ms between
+  messages), `queue_length`, `compression` ∈ {`none`, `png`, `cbor`,
+  `cbor-raw`}. Incoming traffic arrives as `{"op": "publish", "topic": ...,
+  "msg": {...}}`.
+- `publish`: `topic` + `msg`; servers auto-advertise, but explicit
+  `advertise` (`topic` + `type`) is required to *create* a not-yet-existing
+  topic with the right type — we always advertise the command topic.
+- `call_service`: `service`, optional `args`, reply is `service_response`
+  with `values` and boolean `result`.
+- With `compression: "none"`, binary fields (e.g. `CompressedImage.data`)
+  arrive base64-encoded inside JSON.
+- `status` ops carry server-side errors (e.g. type mismatch on publish) at
+  configurable verbosity.
+- Transport-agnostic spec; websocket is the default and the one we target.
+
+Message-type facts (standard ROS msgs, stable across ROS 1/2):
+
+- `sensor_msgs/JointState`: parallel arrays `name`, `position`, `velocity`,
+  `effort` — name-indexed, order not guaranteed ⇒ the adapter reorders by the
+  user's `joints` list every message.
+- `sensor_msgs/CompressedImage`: `format` (`"jpeg"`/`"png"`, ROS 1 sometimes
+  `"rgb8; jpeg compressed bgr8"`) + `data` (base64 in JSON) — decoded via
+  Pillow, converted to `(H, W, 3)` RGB uint8.
+- `geometry_msgs/PoseStamped`: `pose.position` xyz + `pose.orientation`
+  xyzw quaternion — reordered to the core's `[x, y, z, qw, qx, qy, qz]`
+  (`eef_pose` canonical form, quat wxyz; same reorder xpolicylab does).
+- `trajectory_msgs/JointTrajectory`: `joint_names` + `points[]` with
+  `positions` and `time_from_start` — the standard ros2_control position
+  interface.
+- `std_msgs/Float64MultiArray`: `data` — the forward-controller interface.
+
+## 3. The one big decision: an embodiment, not a policy or a tool layer
+
+The ROS integration is an **`Embodiment`** (entry-point group
+`inspect_robots.embodiments`, name `ros`), mirroring `inspect-robots-isaacsim`
+on the embodiment axis exactly as `inspect-robots-xpolicylab` mirrors it on
+the policy axis. Everything else falls out of existing machinery:
+
+- The `agent` policy is embodiment-adaptive (`bind()` builds its tool surface
+  from our `ActionSemantics`) ⇒ LLM-on-ROS-robot works with zero agent
+  changes.
+- CLI guardrails (Clamp + DeltaLimit) apply to every run by default —
+  which is why §5 makes action bounds required config.
+- `RerunSink` gives live visualization of a real-robot eval for free.
+- Real-hardware honesty is already designed into the core contract
+  (`embodiment.py` docstring): reset may block on an operator, there is no
+  privileged success oracle — scorers (operator / VLM) own success.
+
+Dependency policy: `inspect-robots>=0.4`, `numpy`, `websockets>=12`
+(sync client, same floor as xpolicylab), `pillow>=10` (CompressedImage
+decode; already the floor core uses for its `rerun` extra). **No `rclpy`, no
+`roslibpy`, no ROS message packages** — messages are plain JSON dicts and the
+five shapes we touch are enumerated in §2.
+
+## 4. Deliverable layout
+
+```text
+plugins/inspect-robots-ros/
+├── pyproject.toml                    # hatchling; entry point inspect_robots.embodiments:ros
+├── README.md                         # robot-side bringup, eval-side quickstart, config reference
+├── src/inspect_robots_ros/
+│   ├── __init__.py                   # RosEmbodiment, ros_embodiment factory, __version__
+│   ├── _protocol.py                  # op-envelope builders/parsers (subscribe/advertise/publish/call_service/status)
+│   ├── _client.py                    # RosbridgeClient: sync ws + receive thread + per-topic latest cache
+│   ├── _msgs.py                      # JointState/CompressedImage/PoseStamped/JointTrajectory ↔ numpy
+│   └── embodiment.py                 # RosEmbodiment: the inspect_robots.Embodiment adapter
+└── tests/
+    ├── conftest.py                   # in-process stub rosbridge server (websockets, thread, port 0)
+    └── test_ros_embodiment.py
+plans/0016-ros-embodiment-plugin.md   # this file
+.github/workflows/ci.yml              # + plugin-ros job, wired into ci-ok.needs
+.github/workflows/release.yml         # + publish-ros job (environment: pypi-ros)
+README.md                             # + "Real robots via ROS" section
+CLAUDE.md                             # plugins list mentions the new package
+```
+
+## 5. The adapter: `RosEmbodiment`
+
+`RosEmbodiment(EmbodimentBase)`, constructor all-keyword, every arg reachable
+from `-P k=v` (mapping/list args accept the compact string forms plan 0007
+established: `name:topic,name:topic` and comma-separated lists — topic names
+never contain `,` or the pre-colon camera names we require to be simple
+identifiers):
+
+| Arg | Default | Meaning |
+| --- | --- | --- |
+| `url` | `"ws://localhost:9090"` | rosbridge websocket URL (9090 is the rosbridge default) |
+| `joints` | **required** | ordered joint names; defines `joint_pos` order and action dim |
+| `joint_states_topic` | `"/joint_states"` | `sensor_msgs/JointState` source |
+| `command_topic` | **required** | where actions go |
+| `command_type` | `"joint_trajectory"` | `"joint_trajectory"` (`trajectory_msgs/JointTrajectory`, one point, `time_from_start` = 1/`control_hz`) or `"float64_multi_array"` (`std_msgs/Float64MultiArray`) |
+| `action_low` / `action_high` | **required** | per-joint bounds (comma-separated floats); gripper bound appended when `gripper_topic` set |
+| `gripper_topic` | `None` | optional command topic for a 1-DoF gripper (`std_msgs/Float64` position); when set, action dim grows by 1 and observation `gripper` is read from `gripper_joint` in joint states |
+| `gripper_joint` | `None` | joint-states name holding gripper position (required iff `gripper_topic`) |
+| `eef_pose_topic` | `None` | optional `geometry_msgs/PoseStamped` → observation `eef_pose` (7-D, wxyz) |
+| `cameras` | `{}` | camera name → `sensor_msgs/CompressedImage` topic |
+| `control_hz` | `10.0` | declared control rate; also the subscribe `throttle_rate` for state topics |
+| `reset_service` | `None` | optional service called on `reset()` (e.g. a bringup-provided home routine); empty args, must return `result: true` |
+| `operator_reset_confirm` | `False` | when true, `reset()` prints the scene instruction and blocks on Enter (TTY prompt via `input()`) — the "human arranges the scene" path |
+| `obs_timeout_s` | `5.0` | max wait for the first message on every subscribed topic (reset-time) |
+| `staleness_s` | `2.0` | max age of cached state messages when an observation is assembled; older ⇒ raise (embodiment fault — the robot stopped publishing) |
+| `simulated` | `False` | sets `EmbodimentInfo.is_simulated` (Gazebo-behind-rosbridge runs) |
+| `name` | `"ros"` | `EmbodimentInfo.name` (users can tag e.g. `"ros:ur5e"`) |
+| `connect_timeout_s` / `request_timeout_s` | `10` / `30` | client timeouts |
+
+**Lazy connection** (the xpolicylab/isaacsim invariant): construction and
+`.info` never touch the network, so `inspect-robots list embodiments` and
+fail-fast compat checks work with no robot. The client connects on first
+`reset()`; connection failure raises an actionable error naming the URL and
+the one-line rosbridge launch command for ROS 1 and ROS 2.
+
+**`EmbodimentInfo`**:
+
+- `action_space`: `Box(low=action_low, high=action_high)` with
+  `ActionSemantics(control_mode="joint_pos", gripper="continuous" iff
+  gripper_topic, frame="joint", bounds=explicit)` — sized `len(joints)`
+  (+1 with gripper).
+- `observation_space`: `StateSpec` with `joint_pos` (dim `len(joints)`),
+  plus `gripper` (1) and `eef_pose` (7) when configured; `CameraSpec` per
+  camera **without** resolution (unknown until frames arrive; compat stays
+  meaningful, same stance as plan 0007).
+- `control_hz` passthrough; `is_simulated` from config.
+- `capabilities`: `{"resettable"}` iff `reset_service` set. **Never**
+  `seedable`, `auto_reset`, or `privileged_success` (real hardware; nothing
+  to seed, no oracle). Not `self_paced`: `step()` returns immediately after
+  the publish and the framework paces the loop — R1's default is exactly
+  what a stream-commanded robot wants.
+- `supported_setups` / `supported_target_kinds`: empty (unconstrained) —
+  scene realization on hardware is operator- or bringup-owned; the tracer
+  has nothing to check.
+
+**`reset(scene, *, seed=None)`**:
+
+1. First call: connect, `advertise` the command (and gripper) topics,
+   `subscribe` to joint states / eef pose / cameras (`throttle_rate` =
+   `1000/control_hz` ms for state, cameras unthrottled), then wait up to
+   `obs_timeout_s` for one message per subscribed topic — a missing topic
+   fails *here*, at reset, with the topic name, not mid-rollout.
+2. `seed` is accepted and ignored (contract allows it; `seedable` is not
+   declared).
+3. If `reset_service`: `call_service`, require `result: true`.
+4. If `operator_reset_confirm`: print `scene.instruction` and block on
+   Enter.
+5. Assemble and return the initial `Observation` (fresh-message wait, not
+   cache: reset must observe the *post-reset* world).
+
+**`step(action)`**: split the vector into arm command (+ gripper command),
+build the §2 message shapes, `publish` (two publishes when gripper is
+configured), assemble the current observation from the topic cache
+(staleness-checked), return
+`StepResult(observation=..., reward=None, terminated=False, truncated=False,
+info={"staleness_s": per-topic ages})`. No success oracle ⇒ `terminated`
+is always False; horizons and policy `request_stop` end trials, scorers
+decide success.
+
+**`close()`**: unsubscribe/unadvertise best-effort, close the socket,
+idempotent. `eval()` auto-closes registry-resolved embodiments ("close what
+we open"), so no atexit dance is needed on this axis.
+
+## 6. The client: `_protocol.py` + `_client.py`
+
+- `_protocol.py`: builders/parsers for the six ops we use (`subscribe`,
+  `unsubscribe`, `advertise`, `unadvertise`, `publish`, `call_service` /
+  `service_response`, plus `status` parsing). Pure dict↔dataclass, JSON via
+  stdlib. `RosbridgeError(code, message)` for `status` errors and failed
+  service calls.
+- `_client.py`: `RosbridgeClient` on `websockets.sync.client.connect`
+  (`max_size=None`; multi-camera JSON frames are large). One background
+  **receive thread** owns `recv()`: it demuxes `publish` ops into a
+  per-topic `(msg, monotonic_stamp)` latest-slot under a lock, resolves
+  pending `call_service` futures by `id`, and surfaces `status: error`
+  ops. Sends happen from the rollout thread — the websockets sync client
+  documents one-reader/one-writer thread safety, which is exactly this
+  split. A dead socket marks the client disconnected; the *next* `reset()`
+  reconnects and replays advertises/subscribes (mid-trial death raises —
+  a dead robot link mid-motion must fault the trial, mirroring
+  `EmbodimentFault` semantics, not silently reconnect).
+- `_msgs.py`: the five message shapes ↔ numpy. JointState reorder-by-name
+  (missing joint ⇒ error listing available names), CompressedImage
+  base64→Pillow→RGB (lazy `PIL` import at first frame, matching the core's
+  lazy-import posture), PoseStamped xyzw→wxyz reorder, JointTrajectory /
+  Float64MultiArray builders.
+
+## 7. Tests (no ROS, no hardware, no external processes)
+
+`conftest.py` runs a **stub rosbridge server** in-process (same pattern as
+xpolicylab's stub policy server): a `websockets` server on a thread, port 0,
+implementing subscribe/advertise/publish/call_service per §2, publishing
+canned JointState/CompressedImage/PoseStamped streams on subscription, and
+recording every client op for assertions.
+
+Coverage targets (plugin CI, full-line aim on `embodiment.py`):
+
+- registry: entry point resolves; `resolve("embodiment", "ros", ...)` with
+  string-form `-P` args (joints, cameras, bounds) normalizes correctly;
+  required-arg omissions raise actionable `TypeError`s.
+- `.info`: correct spaces/semantics/capabilities for all config shapes; no
+  network before first `reset()` (construct with an unroutable URL).
+- reset: subscribes with the right `throttle_rate`; missing topic ⇒ error
+  naming it within `obs_timeout_s`; `reset_service` called and `result:
+  false` raises; fresh-observation wait (a stale pre-reset message is not
+  returned); reconnect-after-drop replays advertise/subscribe.
+- step: JointTrajectory and Float64MultiArray messages have the §2 golden
+  shapes (joint order = config order, `time_from_start` = period); gripper
+  split publishes two messages; staleness beyond `staleness_s` raises;
+  `terminated` always False.
+- messages: JointState reorder (shuffled names), gripper extraction,
+  CompressedImage jpeg + png decode to `(H, W, 3)` uint8 RGB, exotic ROS 1
+  `format` strings, PoseStamped wxyz reorder.
+- protocol golden test: our op dicts match the spec's documented JSON
+  shapes verbatim (guards codec drift, mirrors plan 0007's golden wire
+  test).
+- lifecycle: close is idempotent, unsubscribes; mid-trial socket death ⇒
+  raise (not silent reconnect); `status: error` from server surfaces as
+  `RosbridgeError`.
+- compat: `check_compatibility(agent_policy-shaped stub / xpolicylab-shaped
+  stub, RosEmbodiment(...))` passes for a matching profile; conformance kit
+  (`assert_embodiment_conformant`) passes against the stub server.
+- operator confirm: `input()` path exercised via monkeypatched stdin.
+
+## 8. CI, workspace, docs
+
+- `pyproject.toml` mirrors xpolicylab's: hatchling, static
+  `version = "0.1.0"`, `inspect-robots>=0.4`, `[tool.uv.sources]
+  inspect-robots = { workspace = true }`, mypy strict, ruff line-length 100.
+  `uv lock` after adding; workspace glob picks it up.
+- CI: `plugin-ros` job cloned from `plugin-xpolicylab` (ruff, mypy strict,
+  pytest, ubuntu) and **added to `ci-ok.needs`**.
+- Release: `publish-ros` job in `release.yml` (environment `pypi-ros`;
+  maintainer must create the PyPI trusted-publisher environment before first
+  release — settings action, called out in the PR).
+- Entry point: `[project.entry-points."inspect_robots.embodiments"]
+  ros = "inspect_robots_ros:ros_embodiment"`.
+- Docs: plugin README (robot-side rosbridge bringup for ROS 1/ROS 2,
+  eval-side quickstart, full config table, ros2_control controller notes,
+  troubleshooting: base64 image bandwidth, throttle_rate, firewalls) —
+  public-facing, so it follows the CLAUDE.md writing-style rules (no em
+  dashes, etc.). Root README gets a "Real robots via ROS" section beside the
+  Isaac/XPolicyLab mentions; root CLAUDE.md plugin list gains the package.
+- **Core is untouched**: no new core deps, no `__all__`/api-snapshot churn.
+
+## 9. Risks & mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Base64 JSON images too slow at control rate | `CompressedImage` (jpeg) keeps frames tens-of-KB; cameras unthrottled but latest-slot semantics drop backlog; documented follow-up: `cbor` subscription mode |
+| JointState arrives without all configured joints (some drivers split arm/gripper across publishers) | Reorder-by-name errors list missing vs available; `gripper_joint` may come from the same or another topic later — v1 requires same-topic and says so |
+| Wrong `command_type` for the robot's controller stack | README maps the two types to ros2_control controller families; `status: error` from rosbridge (type mismatch) surfaces as `RosbridgeError` at first step |
+| Stale cache read as live state (robot died, cache survives) | `staleness_s` check on every observation assembly ⇒ fault, not silent stale data |
+| Guardrail bounds wrong because user guessed | Bounds are required, never defaulted; README tells users to copy them from their URDF/datasheet and start with `--policy agent -P max_speed_frac=0.05` style caution |
+| websockets sync client thread-safety assumptions | One-reader (receive thread) / one-writer (rollout thread) split is the documented safe pattern; service futures resolved via the receive thread only |
+| Protocol drift (rosbridge adds/changes ops) | We use six stable ops documented since protocol v2.0 (2013); golden shape tests; spec version + fetch date recorded in §2 |
+| Real-robot safety | Every CLI run wires Clamp + DeltaLimit by default; bounds required; `terminated` never fakes success; README leads with a safety section (e-stop, speed fractions, supervised first runs) |
+
+## 10. Execution steps (each a commit)
+
+1. Plugin skeleton: pyproject, `__init__`, empty modules, README stub;
+   `uv lock`; `uv sync --all-packages --extra dev` green.
+2. `_protocol.py` + golden shape tests.
+3. `_client.py` + stub-server conftest + client tests (threading, cache,
+   service correlation, death/reconnect).
+4. `_msgs.py` + tests (reorder, decode, builders).
+5. `embodiment.py` adapter + tests (info, reset, step, lifecycle, compat,
+   conformance).
+6. CI job + `ci-ok.needs`; `publish-ros` release job; root README + plugin
+   README + CLAUDE.md touches.
+7. Gates: `ruff check`, `ruff format --check`, plugin mypy strict, plugin
+   pytest, core suite untouched and green (`uv run pytest --cov`).

--- a/plans/0016-ros-embodiment-plugin.md
+++ b/plans/0016-ros-embodiment-plugin.md
@@ -165,25 +165,37 @@ unpaced stream of `JointTrajectory` points at LLM/VLA inference cadence is
 exactly the degenerate loop R1's escape hatch exists for. So:
 
 - The embodiment declares the `SELF_PACED` capability.
-- `step()` publishes the command, then sleeps until one control period
-  (`1/control_hz`, monotonic clock, measured from the previous step's
-  publish) has elapsed — this is the pacing half, and it composes with
-  open-loop `ActionChunk` playout (mid-chunk, buffered pops are fast and
-  the sleep absorbs the overhead; at a chunk boundary after slow inference
-  the period has already elapsed and the sleep is ~zero, which is correct:
-  pacing bounds the command rate, it never adds latency on top of
-  inference).
+- **The publish is gated, not followed, by the pacing sleep**: at the top
+  of `step()`, sleep until one control period (`1/control_hz`, monotonic
+  clock) has elapsed since the *previous* publish, **then** publish this
+  step's command. This enforces the real invariant — every inter-publish
+  interval ≥ the period — rather than a constraint on publishes two
+  apart (publish-then-sleep would let steady-state intervals average
+  `T/2`, streaming commands at ~2× the configured rate on real
+  hardware). It composes with open-loop `ActionChunk` playout: mid-chunk,
+  buffered pops are fast and the sleep absorbs the overhead; at a chunk
+  boundary after slow inference the period has already elapsed, the
+  sleep is ~zero, and pacing never adds latency on top of inference.
 - Freshness is a **separate** guarantee, not a side effect of the sleep
   (at a chunk boundary there is no sleep, and a state stream throttled at
-  exactly the control rate would only race the deadline): after the
-  pacing sleep, `step()` waits for a joint-states message whose receive
+  exactly the control rate would only race the deadline): after
+  publishing, `step()` waits for a joint-states message whose receive
   stamp postdates this step's publish, bounded by `fresh_obs_timeout_s`
-  (default `2/control_hz`; timeout ⇒ staleness fault). To keep that wait
+  (default `2/control_hz`; timeout ⇒ staleness fault naming both
+  `fresh_obs_timeout_s` and `control_hz` as the knobs). To keep that wait
   short, state topics subscribe at **2× the control rate**
-  (`throttle_rate = 500/control_hz` ms), so a post-command message
-  arrives within ~half a period. The observation a policy plans from is
-  therefore always post-command, including the one the LLM agent sees
-  after seconds of inference.
+  (`throttle_rate = 500/control_hz` ms, rounded to an integer ≥ 1 — the
+  field is integer milliseconds). Post-command here means *received*
+  after the publish; a message sampled just before but delivered just
+  after passes the check — a milliseconds-scale approximation on a LAN,
+  documented rather than hidden.
+- The design assumes the robot's native `joint_states` rate is at least
+  ~2× `control_hz` (real arms publish at 25-500 Hz; `throttle_rate` can
+  only thin a stream, never speed one up). `reset()` measures the
+  inter-arrival rate during its first-message wait and warns when the
+  native rate is below 2× `control_hz` ("lower `control_hz` or raise
+  `fresh_obs_timeout_s`"), so a slow publisher is diagnosed up front
+  instead of as a mid-rollout staleness fault on a healthy robot.
 - Core stays untouched; if/when core pacing lands, `self_paced` remains
   correct (the framework defers to it).
 
@@ -233,6 +245,7 @@ string→string maps.
 | `gripper_topic` | `None` | optional command topic for a 1-DoF gripper (`std_msgs/Float64` position); when set, action dim grows by 1 |
 | `gripper_joint` | `None` | joint-states name holding the gripper position (required iff `gripper_topic`) |
 | `gripper_low` / `gripper_high` | `None` | **required iff `gripper_topic`**: the gripper's native command range (rad or m — robot-specific; no default, same honesty rule as arm bounds). Appended to the action `Box` bounds and used to normalize the canonical `gripper` observation to 0..1 |
+| `gripper_closed_at` | `"low"` | `"low"` or `"high"`: which end of the command range is *closed*. The canonical `gripper` observation pins 0 = closed, 1 = open, and `Box` requires low < high, so polarity must be a flag, not a bound swap |
 | `eef_pose_topic` | `None` | optional `geometry_msgs/PoseStamped` → observation `eef_pose` (7-D, wxyz) |
 | `cameras` | `{}` | camera name → `(topic, height, width)`; compact form `name:topic:WxH`. Resolution is required — `CameraSpec.height/width` are mandatory ints, and an embodiment that declares no `CameraSpec` fails compat against every camera-requiring policy (`missing_camera`) |
 | `control_hz` | `10.0` | control rate; `step()` paces to it (§3); state subscriptions throttle at 2× it |
@@ -241,7 +254,7 @@ string→string maps.
 | `reset_service` | `None` | optional service called on `reset()` (e.g. a bringup-provided home routine); empty args, must return `result: true` |
 | `operator_reset_confirm` | `False` | when true, `reset()` prints the scene instruction and blocks on Enter (TTY prompt via `input()`) — the "human arranges the scene" path |
 | `obs_timeout_s` | `5.0` | max wait for the first message on every subscribed topic (reset-time) |
-| `staleness_s` | `2.0` | max age of cached state messages when an observation is assembled; older ⇒ raise (the robot stopped publishing; wrapped into `EmbodimentFault` by the rollout) |
+| `staleness_s` | `2.0` | max age of cached state messages when an observation is assembled; older ⇒ raise (the robot stopped publishing; wrapped into `EmbodimentFault` by the rollout). This is also the **cross-modal skew bound**: a fresh `joint_pos` may pair with an `eef_pose`/camera frame up to `staleness_s` old (up to 20 control periods at the defaults) — `state_time`/`image_times` expose the actual ages, and the README states the bound |
 | `simulated` | `False` | sets `EmbodimentInfo.is_simulated` (Gazebo-behind-rosbridge runs) |
 | `name` | `"ros"` | `EmbodimentInfo.name` (users can tag e.g. `"ros:ur5e"`) |
 | `connect_timeout_s` / `request_timeout_s` | `10` / `30` | client timeouts |
@@ -278,8 +291,9 @@ the one-line rosbridge launch command for ROS 1 and ROS 2.
     gripper dim is in its native command unit — documented).
   - `gripper`, shape `(1,)` — canonical normalized 0..1 (0 closed, 1 open
     per `CANONICAL_STATE_UNITS`), computed from
-    `(raw - gripper_low) / (gripper_high - gripper_low)`. Declared only
-    when a gripper is configured.
+    `(raw - gripper_low) / (gripper_high - gripper_low)` and flipped to
+    `1 - that` when `gripper_closed_at="high"`. Declared only when a
+    gripper is configured.
   - `eef_pose`, shape `(7,)` — declared only when `eef_pose_topic` set.
     **Hard constraint, enforced in the factory**: when `d == 7` (any
     shape — 6-DoF + gripper *or* a gripperless 7-DoF arm, i.e. Franka /
@@ -320,16 +334,24 @@ the one-line rosbridge launch command for ROS 1 and ROS 2.
 3. If `reset_service`: `call_service`, require `result: true`.
 4. If `operator_reset_confirm`: print `scene.instruction` and block on
    Enter.
-5. Assemble and return the initial `Observation` (fresh-message wait, not
-   cache: reset must observe the *post-reset* world). Every observation —
+5. If *neither* `reset_service` nor `operator_reset_confirm` is
+   configured, the second and every later `reset()` warns once on stderr:
+   between-trial resets are then no-ops on the physical world, and trial
+   N+1 silently starting from trial N's end state is an eval-validity
+   trap, not an ops detail.
+6. Assemble and return the initial `Observation` (fresh-message wait
+   bounded by `obs_timeout_s` — the reset-time bound; arbitrary time may
+   have passed during an operator confirm, so the post-confirm wait must
+   not reuse the tight `fresh_obs_timeout_s`). Not cache: reset must
+   observe the *post-reset* world. Every observation —
    here and in `step()` — carries `scene.instruction` on
    `Observation.instruction`, matching the cubepick/isaacsim precedent
    (policies keep a reset-time fallback, but the embodiment threads it).
 
-**`step(action)`**: split the vector into arm command (+ gripper command),
-build the §2 message shapes per `ros_version`, `publish` (two publishes when
-gripper is configured), sleep out the control period, wait for a
-post-publish joint-states message (§3), assemble the observation
+**`step(action)`**: sleep-gate on the previous publish (§3), split the
+vector into arm command (+ gripper command), build the §2 message shapes
+per `ros_version`, `publish` (two publishes when gripper is configured),
+wait for a post-publish joint-states message (§3), assemble the observation
 (staleness-checked), return `StepResult(observation=..., reward=None,
 terminated=False, truncated=False)`. Timing rides on the observation's own
 fields — no duplicate `info` payload — with the convention stated here
@@ -412,13 +434,22 @@ Coverage targets (plugin CI, full-line aim on `embodiment.py`):
 - step: JointTrajectory golden shapes for **both** `ros_version`s
   (`{secs,nsecs}` vs `{sec,nanosec}`, type strings) and Float64MultiArray;
   joint order = config order; `time_from_start` = period; gripper split
-  publishes two messages with the raw (un-normalized) command; pacing
-  sleeps to `control_hz` and is ~zero after slow inference (injected
+  publishes two messages with the raw (un-normalized) command; pacing:
+  **every inter-publish interval ≥ the control period under fast
+  back-to-back steps** (the assertion that catches a publish-then-sleep
+  implementation, which passes weaker "slept once" checks while
+  streaming at 2×), and the gate is ~zero after slow inference (injected
   fake clock, §6); the fresh-obs wait returns only a post-publish
-  joint-states message and faults on `fresh_obs_timeout_s`; staleness
-  beyond `staleness_s` raises; `terminated` always False; observation
-  `gripper` normalized 0..1; `instruction` threaded onto every
+  joint-states message and faults on `fresh_obs_timeout_s` naming both
+  knobs; staleness beyond `staleness_s` raises; `terminated` always
+  False; observation `gripper` normalized 0..1 and flipped under
+  `gripper_closed_at="high"`; `instruction` threaded onto every
   observation; `state_time`/`image_times` follow the §5 convention.
+- reset warnings: slow native `joint_states` rate (< 2× `control_hz`)
+  warns at first reset; the second reset with neither `reset_service`
+  nor `operator_reset_confirm` warns once about physical-reset absence;
+  post-confirm fresh wait is bounded by `obs_timeout_s`, not
+  `fresh_obs_timeout_s`.
 - messages: JointState reorder (shuffled names), missing-joint error,
   CompressedImage jpeg + png decode to `(H, W, 3)` uint8 RGB, exotic ROS 1
   `format` strings, PoseStamped xyzw→wxyz reorder.

--- a/plugins/inspect-robots-ros/README.md
+++ b/plugins/inspect-robots-ros/README.md
@@ -1,0 +1,11 @@
+# inspect-robots-ros
+
+## Safety:
+
+> [!WARNING]
+> Use a tested emergency stop, verify every configured action bound against the
+> robot specification, and supervise initial runs at reduced speed.
+
+This package provides an Inspect Robots embodiment for ROS 1 and ROS 2 robots
+through rosbridge. Full setup and configuration documentation will accompany
+the adapter implementation.

--- a/plugins/inspect-robots-ros/README.md
+++ b/plugins/inspect-robots-ros/README.md
@@ -1,6 +1,6 @@
 # inspect-robots-ros
 
-## Safety:
+## Safety
 
 > [!WARNING]
 > This adapter sends commands to physical hardware. Keep a tested emergency
@@ -20,7 +20,7 @@ The package registers the `ros` Inspect Robots embodiment. It connects directly
 to `rosbridge_server`, so the evaluation machine needs no ROS installation,
 ROS message packages, or robot-vendor SDK.
 
-## Install:
+## Install
 
 ```bash
 pip install inspect-robots-ros
@@ -28,7 +28,7 @@ pip install inspect-robots-ros
 
 The embodiment then appears in `inspect-robots list embodiments`.
 
-## Robot-side bringup:
+## Robot-side bringup
 
 Install `rosbridge_server` in the robot's ROS environment and start its
 websocket endpoint. Port 9090 is the rosbridge default.
@@ -49,7 +49,7 @@ The evaluation host must be able to reach the websocket URL. Restrict network
 access to trusted hosts because rosbridge exposes ROS topics and services.
 The plugin does not launch rosbridge or install anything on the robot.
 
-## Quickstart:
+## Quickstart
 
 This six-joint example publishes `JointTrajectory` commands, reads a wrist
 camera, and uses explicit joint limits:
@@ -68,7 +68,7 @@ Construction and `.info` are network-free. The websocket connects on the first
 `reset()`, after compatibility and guardrail checks have inspected the declared
 spaces.
 
-## Configuration:
+## Configuration
 
 Pass values as `-E key=value` arguments or as keyword arguments to
 `RosEmbodiment`. Compact lists use commas. Camera entries use
@@ -108,7 +108,7 @@ Arm bounds and gripper bounds form the action `Box`, so the default Inspect
 Robots clamp and delta-limit guardrails can reject unsafe policy output before
 it reaches rosbridge.
 
-## Controller mapping:
+## Controller mapping
 
 Choose settings that match the controller's subscribed ROS message type.
 
@@ -125,7 +125,7 @@ The stock ROS 2 `gripper_action_controller` is action-only and is not supported
 by this publish-based adapter. Configure a `forward_command_controller` on the
 gripper joint instead. The plugin does not send ROS action goals.
 
-## Observation and timing contract:
+## Observation and timing contract
 
 - `joint_pos` follows the configured arm joint order. With a gripper, its raw
   measured position is folded into the last element so proprioception matches
@@ -150,7 +150,7 @@ before the arm publish and waits for a greater sequence afterward. A message
 sampled just before the command but received just after it can satisfy this
 check; this is a receive-time approximation intended for low-latency links.
 
-## Reset behavior:
+## Reset behavior
 
 The first reset advertises command topics, performs the native-rate preflight,
 subscribes with queue length 1, and verifies every configured topic and camera
@@ -161,7 +161,7 @@ If neither reset path is configured, the adapter warns once on the second
 reset because it cannot change the physical scene between trials. An operator
 confirmation on non-interactive stdin raises `EOFError` and halts the run.
 
-## Troubleshooting:
+## Troubleshooting
 
 - Connection failures name the URL and both rosbridge launch commands. Confirm
   the server is listening, port 9090 is reachable, and no proxy intercepts the

--- a/plugins/inspect-robots-ros/README.md
+++ b/plugins/inspect-robots-ros/README.md
@@ -3,9 +3,184 @@
 ## Safety:
 
 > [!WARNING]
-> Use a tested emergency stop, verify every configured action bound against the
-> robot specification, and supervise initial runs at reduced speed.
+> This adapter sends commands to physical hardware. Keep a tested emergency
+> stop within reach, and do not run an unsupervised evaluation until the full
+> command path has been checked on your robot.
 
-This package provides an Inspect Robots embodiment for ROS 1 and ROS 2 robots
-through rosbridge. Full setup and configuration documentation will accompany
-the adapter implementation.
+- Verify every arm and gripper bound against the robot URDF, manufacturer
+  datasheet, and controller configuration.
+- Start with a low policy speed limit such as a low `max_speed_frac`, then
+  increase it only after reviewing commanded and measured motion.
+- Supervise first runs with the workspace clear and the robot at reduced
+  hardware speed.
+- Confirm that loss of rosbridge communication stops motion safely at the
+  controller or robot level.
+
+The package registers the `ros` Inspect Robots embodiment. It connects directly
+to `rosbridge_server`, so the evaluation machine needs no ROS installation,
+ROS message packages, or robot-vendor SDK.
+
+## Install:
+
+```bash
+pip install inspect-robots-ros
+```
+
+The embodiment then appears in `inspect-robots list embodiments`.
+
+## Robot-side bringup:
+
+Install `rosbridge_server` in the robot's ROS environment and start its
+websocket endpoint. Port 9090 is the rosbridge default.
+
+ROS 1:
+
+```bash
+roslaunch rosbridge_server rosbridge_websocket.launch
+```
+
+ROS 2:
+
+```bash
+ros2 launch rosbridge_server rosbridge_websocket_launch.xml
+```
+
+The evaluation host must be able to reach the websocket URL. Restrict network
+access to trusted hosts because rosbridge exposes ROS topics and services.
+The plugin does not launch rosbridge or install anything on the robot.
+
+## Quickstart:
+
+This six-joint example publishes `JointTrajectory` commands, reads a wrist
+camera, and uses explicit joint limits:
+
+```bash
+inspect-robots run --task my-task --policy agent --embodiment ros \
+    -E url=ws://robot:9090 \
+    -E joints=joint1,joint2,joint3,joint4,joint5,joint6 \
+    -E command_topic=/joint_trajectory_controller/joint_trajectory \
+    -E cameras=wrist:/camera/wrist/image_raw/compressed:640x480 \
+    -E action_low=-3.1,-2.2,-2.9,-3.1,-2.9,-3.1 \
+    -E action_high=3.1,2.2,2.9,3.1,2.9,3.1
+```
+
+Construction and `.info` are network-free. The websocket connects on the first
+`reset()`, after compatibility and guardrail checks have inspected the declared
+spaces.
+
+## Configuration:
+
+Pass values as `-E key=value` arguments or as keyword arguments to
+`RosEmbodiment`. Compact lists use commas. Camera entries use
+`name:topic:WxH`; `640x480` means width 640 and height 480.
+
+| Argument | Default | Meaning |
+| --- | --- | --- |
+| `url` | `ws://localhost:9090` | rosbridge websocket URL. |
+| `ros_version` | `2` | `1` or `2`. Selects message type strings and `JointTrajectory` duration keys. |
+| `joints` | required | Ordered arm joint names. This order defines arm actions and `joint_pos`. |
+| `joint_states_topic` | `/joint_states` | `sensor_msgs/JointState` source. Arm and configured gripper names must appear in this topic. |
+| `command_topic` | required | Arm controller command topic. |
+| `command_type` | `joint_trajectory` | `joint_trajectory` or `float64_multi_array`. |
+| `action_low` | required | One lower command bound per arm joint. |
+| `action_high` | required | One upper command bound per arm joint. |
+| `gripper_topic` | `None` | Optional gripper command topic. Adds one final action dimension. |
+| `gripper_command_type` | ROS 1: `float64`; ROS 2: `float64_multi_array` | Gripper wire message type. |
+| `gripper_joint` | `None` | JointState name for measured gripper position. Required exactly when `gripper_topic` is set. |
+| `gripper_low` | `None` | Native lower gripper command bound. Required with `gripper_topic`. |
+| `gripper_high` | `None` | Native upper gripper command bound. Required with `gripper_topic` and must exceed `gripper_low`. |
+| `gripper_closed_at` | `low` | `low` or `high`, identifying which native bound means closed. |
+| `eef_pose_topic` | `None` | Optional `geometry_msgs/PoseStamped` source for `eef_pose`. |
+| `cameras` | none | Camera name to compressed topic and resolution. Compact form: `wrist:/camera/compressed:640x480`. |
+| `control_hz` | `10.0` | Command rate. The adapter sleep-gates each arm publish to this rate. |
+| `fresh_obs_timeout_s` | `2/control_hz` | Maximum step-time wait for a sequence-newer joint-state message. |
+| `camera_throttle_ms` | `1000/control_hz` | Camera subscription throttle in milliseconds. Set `0` for unthrottled. |
+| `reset_service` | `None` | Optional empty-argument service called on every reset. It must return `result: true`. |
+| `operator_reset_confirm` | `False` | Print the scene instruction and require Enter on every reset. EOF stops the run. |
+| `obs_timeout_s` | `5.0` | Reset-time wait for initial and post-reset messages on every configured topic. |
+| `staleness_s` | `2.0` | Maximum cached sample age and cross-modal skew bound during observation assembly. |
+| `simulated` | `False` | Set true for a simulator such as Gazebo behind rosbridge. |
+| `name` | `ros` | Embodiment name recorded in logs, for example `ros:ur5e`. |
+| `connect_timeout_s` | `10` | Websocket connection timeout. |
+| `request_timeout_s` | `30` | Service response timeout. |
+
+Arm bounds and gripper bounds form the action `Box`, so the default Inspect
+Robots clamp and delta-limit guardrails can reject unsafe policy output before
+it reaches rosbridge.
+
+## Controller mapping:
+
+Choose settings that match the controller's subscribed ROS message type.
+
+| ROS controller family | Plugin setting | Typical topic and message |
+| --- | --- | --- |
+| ROS 1 `joint_trajectory_controller/JointTrajectoryController` | `command_type=joint_trajectory` | `<controller>/command`, `trajectory_msgs/JointTrajectory` |
+| ROS 1 `position_controllers/JointGroupPositionController` | `command_type=float64_multi_array` | `<controller>/command`, `std_msgs/Float64MultiArray` |
+| ROS 2 `joint_trajectory_controller/JointTrajectoryController` | `command_type=joint_trajectory` | `<controller>/joint_trajectory`, `trajectory_msgs/msg/JointTrajectory` |
+| ROS 2 `forward_command_controller/ForwardCommandController` | `command_type=float64_multi_array` | `<controller>/commands`, `std_msgs/msg/Float64MultiArray` |
+| ROS 1 single-joint position controller for a gripper | `gripper_command_type=float64` | `<controller>/command`, `std_msgs/Float64` |
+| ROS 2 forward command controller for a gripper joint | `gripper_command_type=float64_multi_array` | `<controller>/commands`, one-element `std_msgs/msg/Float64MultiArray` |
+
+The stock ROS 2 `gripper_action_controller` is action-only and is not supported
+by this publish-based adapter. Configure a `forward_command_controller` on the
+gripper joint instead. The plugin does not send ROS action goals.
+
+## Observation and timing contract:
+
+- `joint_pos` follows the configured arm joint order. With a gripper, its raw
+  measured position is folded into the last element so proprioception matches
+  the action dimension.
+- Arm joint positions are normally radians. The folded gripper element remains
+  in its controller's native unit, commonly radians or metres. Do not assume
+  every element of a gripper-equipped `joint_pos` vector has the same unit.
+- `gripper` is a separate normalized field with shape `(1,)`: 0 means closed
+  and 1 means open. `gripper_closed_at=high` flips the native range.
+- `eef_pose` is `[x, y, z, qw, qx, qy, qz]`. ROS supplies quaternion fields as
+  xyzw, and the adapter reorders them to wxyz.
+- `state_time` is the monotonic receive time of the oldest state message used
+  for an observation. `image_times[name]` records each camera frame's receive
+  time.
+- A fresh joint state may be combined with an end-effector pose or camera frame
+  up to `staleness_s` old. This is the explicit cross-modal skew bound.
+
+The adapter subscribes to joint state at twice `control_hz`. On the first
+reset, it measures the unthrottled native rate and warns when the publisher is
+slower than that target. Each step captures the joint-state sequence just
+before the arm publish and waits for a greater sequence afterward. A message
+sampled just before the command but received just after it can satisfy this
+check; this is a receive-time approximation intended for low-latency links.
+
+## Reset behavior:
+
+The first reset advertises command topics, performs the native-rate preflight,
+subscribes with queue length 1, and verifies every configured topic and camera
+resolution. Every reset then calls `reset_service` when configured, prompts the
+operator when requested, and waits for newer messages with `obs_timeout_s`.
+
+If neither reset path is configured, the adapter warns once on the second
+reset because it cannot change the physical scene between trials. An operator
+confirmation on non-interactive stdin raises `EOFError` and halts the run.
+
+## Troubleshooting:
+
+- Connection failures name the URL and both rosbridge launch commands. Confirm
+  the server is listening, port 9090 is reachable, and no proxy intercepts the
+  websocket.
+- A missing-joint error lists all names present in `JointState`. Version 0.1
+  requires arm and gripper state on the same topic.
+- Fresh-observation timeouts usually mean the native joint-state publisher is
+  slower than twice `control_hz`. Lower `control_hz` or raise
+  `fresh_obs_timeout_s`.
+- Staleness errors mean a configured state or camera topic stopped arriving.
+  Check the publisher and consider a larger `staleness_s` only after confirming
+  that older cross-modal pairing is acceptable.
+- Compressed images are base64-encoded inside rosbridge JSON. Reduce JPEG size
+  or increase `camera_throttle_ms` when image traffic queues behind state.
+- Camera resolution is written as width by height, but images are represented
+  as `(height, width, 3)` RGB arrays.
+- A rosbridge `status:error` after publishing usually indicates a mismatched
+  `ros_version`, `command_type`, or controller message type. The first error is
+  latched and all later client calls fail.
+- A 7-dimensional action space cannot also declare `eef_pose` in this release.
+  This includes a seven-joint arm and a six-joint arm with a gripper. Omit
+  `eef_pose_topic` until core supports key-priority reference matching.

--- a/plugins/inspect-robots-ros/pyproject.toml
+++ b/plugins/inspect-robots-ros/pyproject.toml
@@ -1,0 +1,84 @@
+[build-system]
+requires = ["hatchling>=1.18", "hatch-fancy-pypi-readme>=24.1"]
+build-backend = "hatchling.build"
+
+[project]
+name = "inspect-robots-ros"
+version = "0.1.0"
+description = "ROS embodiment adapter for Inspect Robots over the rosbridge websocket protocol."
+dynamic = ["readme"]
+requires-python = ">=3.10"
+license = "MIT"
+authors = [{ name = "Inspect Robots contributors" }]
+keywords = ["robotics", "ros", "rosbridge", "inspect_robots", "vla", "evaluation"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Typing :: Typed",
+]
+dependencies = [
+    "inspect-robots>=0.6",
+    "numpy>=1.24",
+    "websockets>=12",
+    "pillow>=10",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "mypy>=1.11", "ruff>=0.6"]
+
+[project.entry-points."inspect_robots.embodiments"]
+ros = "inspect_robots_ros:ros_embodiment"
+
+[project.urls]
+Homepage = "https://github.com/robocurve/inspect-robots/tree/main/plugins/inspect-robots-ros"
+Repository = "https://github.com/robocurve/inspect-robots"
+
+[tool.uv.sources]
+inspect-robots = { workspace = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/inspect_robots_ros"]
+
+[tool.hatch.build.targets.sdist]
+include = ["src/inspect_robots_ros", "tests", "README.md"]
+
+[tool.ruff]
+extend = "../../pyproject.toml"
+
+[tool.ruff.lint.isort]
+known-first-party = ["inspect_robots", "inspect_robots_ros"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["D1"]
+
+[tool.mypy]
+strict = true
+
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!NOTE\][ \t]*$'
+replacement = '> **Note:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!TIP\][ \t]*$'
+replacement = '> **Tip:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!IMPORTANT\][ \t]*$'
+replacement = '> **Important:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!WARNING\][ \t]*$'
+replacement = '> **Warning:**'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '(?m)^> \[!CAUTION\][ \t]*$'
+replacement = '> **Caution:**'

--- a/plugins/inspect-robots-ros/src/inspect_robots_ros/__init__.py
+++ b/plugins/inspect-robots-ros/src/inspect_robots_ros/__init__.py
@@ -1,0 +1,14 @@
+"""Run Inspect Robots evaluations on ROS robots through rosbridge.
+
+The ``ros`` embodiment is discovered through the
+``inspect_robots.embodiments`` entry-point group. Its implementation is added
+in the subsequent focused commits described by plan 0016.
+"""
+
+from __future__ import annotations
+
+from inspect_robots_ros.embodiment import RosEmbodiment, ros_embodiment
+
+__all__ = ["RosEmbodiment", "ros_embodiment"]
+
+__version__ = "0.1.0"

--- a/plugins/inspect-robots-ros/src/inspect_robots_ros/__init__.py
+++ b/plugins/inspect-robots-ros/src/inspect_robots_ros/__init__.py
@@ -1,8 +1,8 @@
-"""Run Inspect Robots evaluations on ROS robots through rosbridge.
+"""Run Inspect Robots evaluations on ROS 1 and ROS 2 robots through rosbridge.
 
 The ``ros`` embodiment is discovered through the
-``inspect_robots.embodiments`` entry-point group. Its implementation is added
-in the subsequent focused commits described by plan 0016.
+``inspect_robots.embodiments`` entry-point group. Construction and ``.info``
+remain network-free; the websocket connects on the first reset.
 """
 
 from __future__ import annotations

--- a/plugins/inspect-robots-ros/src/inspect_robots_ros/_client.py
+++ b/plugins/inspect-robots-ros/src/inspect_robots_ros/_client.py
@@ -1,1 +1,334 @@
-"""Own the rosbridge websocket connection and its receive-thread state."""
+"""Threaded synchronous client for the rosbridge v2 websocket protocol.
+
+One receive thread owns ``ClientConnection.recv``. Rollout-facing calls only
+send, which matches websockets 16's documented concurrency contract: concurrent
+send and receive are supported, while concurrent receives raise
+``ConcurrencyError``. Topic traffic is reduced to a latest-value slot carrying
+the monotonic receive stamp and a per-topic sequence number.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable, Mapping
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from websockets.sync.client import connect as ws_connect
+
+from inspect_robots_ros._protocol import (
+    PublishedMessage,
+    RosbridgeError,
+    ServiceResponse,
+    StatusMessage,
+    advertise,
+    call_service,
+    decode_message,
+    encode_message,
+    parse_incoming,
+    publish,
+    subscribe,
+    unadvertise,
+    unsubscribe,
+)
+
+if TYPE_CHECKING:
+    from websockets.sync.client import ClientConnection
+
+
+@dataclass(frozen=True)
+class TopicSample:
+    """The latest message for a topic with receive time and monotonic sequence."""
+
+    msg: dict[str, Any]
+    stamp: float
+    seq: int
+
+
+@dataclass
+class _PendingService:
+    response: ServiceResponse | None = None
+
+
+class RosbridgeClient:
+    """Own one rosbridge socket, one receiver, and latest-value topic caches."""
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        connect_timeout_s: float = 10.0,
+        request_timeout_s: float = 30.0,
+        clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self.url = url
+        self.connect_timeout_s = connect_timeout_s
+        self.request_timeout_s = request_timeout_s
+        self._clock = clock
+        self._sleep = sleep
+        self._lock = threading.RLock()
+        self._ws: ClientConnection | None = None
+        self._receiver_thread: threading.Thread | None = None
+        self._topics: dict[str, TopicSample] = {}
+        self._pending_services: dict[str, _PendingService] = {}
+        self._subscriptions: dict[str, str] = {}
+        self._advertisements: set[str] = set()
+        self._request_counter = 0
+        self._latched_error: Exception | None = None
+        self._closing = False
+        self._closed = False
+
+    @property
+    def connected(self) -> bool:
+        """Whether a socket has been established and not explicitly closed."""
+        with self._lock:
+            return self._ws is not None and not self._closed
+
+    @property
+    def receiver_alive(self) -> bool:
+        """Whether the sole receive thread is still running."""
+        with self._lock:
+            thread = self._receiver_thread
+        return thread is not None and thread.is_alive()
+
+    @property
+    def latched_error(self) -> Exception | None:
+        """The first asynchronous protocol or connection failure, if any."""
+        with self._lock:
+            return self._latched_error
+
+    def connect(self) -> None:
+        """Connect once and start the sole receive thread; never reconnect a dead client."""
+        with self._lock:
+            self._raise_latched_locked()
+            if self._closed:
+                raise RuntimeError("RosbridgeClient is closed")
+            if self._ws is not None:
+                return
+        try:
+            ws = ws_connect(self.url, max_size=None, open_timeout=self.connect_timeout_s)
+        except Exception as exc:
+            raise ConnectionError(f"could not connect to rosbridge at {self.url}: {exc}") from exc
+        with self._lock:
+            self._ws = ws
+            thread = threading.Thread(
+                target=self._receive_loop,
+                name="inspect-robots-ros-receiver",
+                daemon=True,
+            )
+            self._receiver_thread = thread
+        thread.start()
+
+    def advertise(self, topic: str, *, message_type: str) -> None:
+        """Advertise a command topic and remember it for best-effort close cleanup."""
+        self._send(advertise(topic, message_type=message_type))
+        with self._lock:
+            self._advertisements.add(topic)
+
+    def unadvertise(self, topic: str) -> None:
+        """Remove one advertisement and its close-cleanup record."""
+        self._send(unadvertise(topic))
+        with self._lock:
+            self._advertisements.discard(topic)
+
+    def subscribe(
+        self,
+        topic: str,
+        *,
+        subscription_id: str,
+        message_type: str,
+        throttle_rate: int,
+        queue_length: int = 1,
+        compression: str = "none",
+    ) -> None:
+        """Create one explicit-id subscription and track it for exact removal."""
+        operation = subscribe(
+            topic,
+            subscription_id=subscription_id,
+            message_type=message_type,
+            throttle_rate=throttle_rate,
+            queue_length=queue_length,
+            compression=compression,
+        )
+        self._send(operation)
+        with self._lock:
+            self._subscriptions[subscription_id] = topic
+
+    def unsubscribe(self, topic: str, *, subscription_id: str) -> None:
+        """Remove exactly one id-keyed subscription and its cleanup record."""
+        self._send(unsubscribe(topic, subscription_id=subscription_id))
+        with self._lock:
+            self._subscriptions.pop(subscription_id, None)
+
+    def publish(self, topic: str, msg: Mapping[str, Any]) -> None:
+        """Publish one ROS message, surfacing any previously latched async error first."""
+        self._send(publish(topic, msg))
+
+    def call_service(self, service: str, args: Mapping[str, Any] | None = None) -> ServiceResponse:
+        """Call a service and wait for the response carrying the matching request ID."""
+        with self._lock:
+            self._check_ready_locked()
+            self._request_counter += 1
+            request_id = f"inspect-robots-service-{self._request_counter}"
+            pending = _PendingService()
+            self._pending_services[request_id] = pending
+        try:
+            self._send(call_service(service, request_id=request_id, args=args))
+            deadline = self._clock() + self.request_timeout_s
+            while True:
+                with self._lock:
+                    self._raise_latched_locked()
+                    if self._closed:
+                        raise ConnectionError(f"rosbridge client for {self.url} closed")
+                    response = pending.response
+                if response is not None:
+                    if not response.result:
+                        raise RosbridgeError(
+                            "service_failed",
+                            f"service {service!r} returned result=false; "
+                            f"values={response.values!r}",
+                        )
+                    return response
+                remaining = deadline - self._clock()
+                if remaining <= 0:
+                    raise RosbridgeError(
+                        "timeout",
+                        f"timed out after {self.request_timeout_s:g}s waiting for "
+                        f"service {service!r} from {self.url}",
+                    )
+                self._sleep(min(0.01, remaining))
+        finally:
+            with self._lock:
+                self._pending_services.pop(request_id, None)
+
+    def latest(self, topic: str) -> TopicSample | None:
+        """Read a topic's latest slot after surfacing any latched failure."""
+        with self._lock:
+            self._check_ready_locked()
+            return self._topics.get(topic)
+
+    def sequence(self, topic: str) -> int:
+        """Read the current per-topic receive sequence, or zero before the first message."""
+        sample = self.latest(topic)
+        return sample.seq if sample is not None else 0
+
+    def wait_for_sample(self, topic: str, *, after_seq: int = 0, timeout_s: float) -> TopicSample:
+        """Wait until a topic slot has a sequence strictly newer than ``after_seq``."""
+        deadline = self._clock() + timeout_s
+        while True:
+            sample = self.latest(topic)
+            if sample is not None and sample.seq > after_seq:
+                return sample
+            remaining = deadline - self._clock()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"timed out after {timeout_s:g}s waiting for a new message on {topic!r}"
+                )
+            self._sleep(min(0.01, remaining))
+
+    def close(self) -> None:
+        """Best-effort unsubscribe/unadvertise, close, and join; idempotent."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closing = True
+            ws = self._ws
+            subscriptions = tuple(self._subscriptions.items())
+            advertisements = tuple(self._advertisements)
+            thread = self._receiver_thread
+        if ws is not None:
+            for subscription_id, topic in subscriptions:
+                self._send_best_effort(ws, unsubscribe(topic, subscription_id=subscription_id))
+            for topic in advertisements:
+                self._send_best_effort(ws, unadvertise(topic))
+            with suppress(Exception):
+                ws.close()
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=min(max(self.connect_timeout_s, 1.0), 5.0))
+        with self._lock:
+            self._ws = None
+            self._subscriptions.clear()
+            self._advertisements.clear()
+            self._closed = True
+
+    def _send(self, operation: Mapping[str, Any]) -> None:
+        with self._lock:
+            self._check_ready_locked()
+            ws = self._ws
+            assert ws is not None
+        try:
+            ws.send(encode_message(operation))
+        except Exception as exc:
+            error = ConnectionError(
+                f"connection to rosbridge at {self.url} lost while sending: {exc}"
+            )
+            self._latch(error)
+            raise error from exc
+
+    @staticmethod
+    def _send_best_effort(ws: ClientConnection, operation: Mapping[str, Any]) -> None:
+        with suppress(Exception):
+            ws.send(encode_message(operation))
+
+    def _receive_loop(self) -> None:
+        with self._lock:
+            ws = self._ws
+        assert ws is not None
+        try:
+            while True:
+                raw = ws.recv()
+                if not isinstance(raw, (str, bytes)):
+                    raise RosbridgeError(
+                        "invalid_frame",
+                        f"rosbridge sent unsupported frame type {type(raw).__name__}",
+                    )
+                incoming = parse_incoming(decode_message(raw))
+                if isinstance(incoming, PublishedMessage):
+                    with self._lock:
+                        previous = self._topics.get(incoming.topic)
+                        seq = previous.seq + 1 if previous is not None else 1
+                        self._topics[incoming.topic] = TopicSample(
+                            msg=incoming.msg,
+                            stamp=self._clock(),
+                            seq=seq,
+                        )
+                elif isinstance(incoming, ServiceResponse):
+                    with self._lock:
+                        pending = self._pending_services.get(incoming.request_id)
+                        if pending is not None:
+                            pending.response = incoming
+                elif isinstance(incoming, StatusMessage):
+                    status_error = incoming.as_error()
+                    if status_error is not None:
+                        self._latch(status_error)
+                        return
+        except Exception as exc:
+            with self._lock:
+                closing = self._closing
+            if not closing:
+                if isinstance(exc, RosbridgeError):
+                    receive_error: Exception = exc
+                else:
+                    receive_error = ConnectionError(
+                        f"connection to rosbridge at {self.url} lost while receiving: {exc}"
+                    )
+                self._latch(receive_error)
+
+    def _latch(self, error: Exception) -> None:
+        with self._lock:
+            if self._latched_error is None:
+                self._latched_error = error
+
+    def _check_ready_locked(self) -> None:
+        self._raise_latched_locked()
+        if self._closed:
+            raise RuntimeError("RosbridgeClient is closed")
+        if self._ws is None:
+            raise ConnectionError(f"not connected to rosbridge at {self.url}; call connect() first")
+
+    def _raise_latched_locked(self) -> None:
+        if self._latched_error is not None:
+            raise self._latched_error

--- a/plugins/inspect-robots-ros/src/inspect_robots_ros/_client.py
+++ b/plugins/inspect-robots-ros/src/inspect_robots_ros/_client.py
@@ -1,10 +1,12 @@
 """Threaded synchronous client for the rosbridge v2 websocket protocol.
 
 One receive thread owns ``ClientConnection.recv``. Rollout-facing calls only
-send, which matches websockets 16's documented concurrency contract: concurrent
-send and receive are supported, while concurrent receives raise
-``ConcurrencyError``. Topic traffic is reduced to a latest-value slot carrying
-the monotonic receive stamp and a per-topic sequence number.
+send, which matches the sync client's documented concurrency contract since
+its introduction (verified against the websockets 16.0 docs, the locked
+version; the declared ``>=12`` floor ships the same one-reader/one-writer
+guarantee): concurrent send and receive are supported, while concurrent
+receives raise an error. Topic traffic is reduced to a latest-value slot
+carrying the monotonic receive stamp and a per-topic sequence number.
 """
 
 from __future__ import annotations

--- a/plugins/inspect-robots-ros/src/inspect_robots_ros/_client.py
+++ b/plugins/inspect-robots-ros/src/inspect_robots_ros/_client.py
@@ -1,0 +1,1 @@
+"""Own the rosbridge websocket connection and its receive-thread state."""

--- a/plugins/inspect-robots-ros/src/inspect_robots_ros/_msgs.py
+++ b/plugins/inspect-robots-ros/src/inspect_robots_ros/_msgs.py
@@ -1,1 +1,179 @@
-"""Translate the supported ROS message dictionaries to and from NumPy values."""
+"""Translate the supported ROS message dictionaries to and from NumPy values.
+
+rosbridge performs ROS message conversion server-side. The adapter therefore
+needs only the six standard message shapes used for state, images, poses, arm
+commands, and gripper commands. ROS 1 and ROS 2 differ in type strings and in
+the duration keys inside ``JointTrajectory``.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from collections.abc import Mapping, Sequence
+from io import BytesIO
+from typing import Any, Literal
+
+import numpy as np
+import numpy.typing as npt
+from PIL import Image, UnidentifiedImageError
+
+MessageKind = Literal[
+    "joint_state",
+    "compressed_image",
+    "pose_stamped",
+    "joint_trajectory",
+    "float64_multi_array",
+    "float64",
+]
+
+_ROS1_TYPES: dict[MessageKind, str] = {
+    "joint_state": "sensor_msgs/JointState",
+    "compressed_image": "sensor_msgs/CompressedImage",
+    "pose_stamped": "geometry_msgs/PoseStamped",
+    "joint_trajectory": "trajectory_msgs/JointTrajectory",
+    "float64_multi_array": "std_msgs/Float64MultiArray",
+    "float64": "std_msgs/Float64",
+}
+_ROS2_TYPES: dict[MessageKind, str] = {
+    "joint_state": "sensor_msgs/msg/JointState",
+    "compressed_image": "sensor_msgs/msg/CompressedImage",
+    "pose_stamped": "geometry_msgs/msg/PoseStamped",
+    "joint_trajectory": "trajectory_msgs/msg/JointTrajectory",
+    "float64_multi_array": "std_msgs/msg/Float64MultiArray",
+    "float64": "std_msgs/msg/Float64",
+}
+
+
+def message_type(kind: MessageKind, ros_version: int) -> str:
+    """Return the rosbridge type string for one supported message and ROS version."""
+    if ros_version == 1:
+        return _ROS1_TYPES[kind]
+    if ros_version == 2:
+        return _ROS2_TYPES[kind]
+    raise ValueError(f"ros_version must be 1 or 2, got {ros_version!r}")
+
+
+def parse_joint_state(
+    msg: Mapping[str, Any], joint_names: Sequence[str]
+) -> npt.NDArray[np.float64]:
+    """Return positions reordered into configured joint order.
+
+    A configured joint absent from the message is an error that lists every
+    available name, because many ROS drivers split arm and gripper state across
+    publishers and that configuration must not fail silently.
+    """
+    raw_names = msg.get("name")
+    raw_positions = msg.get("position")
+    if not isinstance(raw_names, list) or not all(isinstance(name, str) for name in raw_names):
+        raise ValueError("JointState field 'name' must be an array of strings")
+    if not isinstance(raw_positions, list):
+        raise ValueError("JointState field 'position' must be an array")
+    if len(raw_names) != len(raw_positions):
+        raise ValueError(
+            "JointState name and position arrays must have equal length; "
+            f"got {len(raw_names)} names and {len(raw_positions)} positions"
+        )
+    try:
+        positions = np.asarray(raw_positions, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("JointState field 'position' must contain numeric values") from exc
+    by_name = dict(zip(raw_names, positions, strict=True))
+    missing = [name for name in joint_names if name not in by_name]
+    if missing:
+        raise ValueError(
+            f"JointState is missing configured joints {missing}; available names: {sorted(by_name)}"
+        )
+    return np.asarray([by_name[name] for name in joint_names], dtype=np.float64)
+
+
+def parse_compressed_image(msg: Mapping[str, Any]) -> npt.NDArray[np.uint8]:
+    """Decode base64 JPEG or PNG bytes into a copied ``(H, W, 3)`` RGB uint8 array."""
+    data = msg.get("data")
+    if not isinstance(data, str):
+        raise ValueError("CompressedImage field 'data' must be a base64 string")
+    try:
+        encoded = base64.b64decode(data, validate=True)
+        with Image.open(BytesIO(encoded)) as image:
+            return np.asarray(image.convert("RGB"), dtype=np.uint8).copy()
+    except (binascii.Error, UnidentifiedImageError, OSError) as exc:
+        image_format = msg.get("format", "unknown")
+        raise ValueError(
+            f"could not decode CompressedImage format {image_format!r} as JPEG or PNG: {exc}"
+        ) from exc
+
+
+def parse_pose_stamped(msg: Mapping[str, Any]) -> npt.NDArray[np.float64]:
+    """Convert PoseStamped xyz plus xyzw orientation to ``[x, y, z, qw, qx, qy, qz]``."""
+    try:
+        pose = msg["pose"]
+        position = pose["position"]
+        orientation = pose["orientation"]
+        values = (
+            position["x"],
+            position["y"],
+            position["z"],
+            orientation["w"],
+            orientation["x"],
+            orientation["y"],
+            orientation["z"],
+        )
+        return np.asarray(values, dtype=np.float64)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(
+            "PoseStamped must contain numeric pose.position.{x,y,z} and "
+            "pose.orientation.{x,y,z,w} fields"
+        ) from exc
+
+
+def build_joint_trajectory(
+    joint_names: Sequence[str],
+    positions: npt.ArrayLike,
+    *,
+    period_s: float,
+    ros_version: int,
+) -> dict[str, Any]:
+    """Build a one-point joint trajectory whose duration equals the control period."""
+    if not np.isfinite(period_s) or period_s < 0:
+        raise ValueError(f"period_s must be finite and non-negative, got {period_s!r}")
+    position_array = np.asarray(positions, dtype=np.float64).reshape(-1)
+    if len(joint_names) != position_array.size:
+        raise ValueError(
+            f"joint trajectory has {len(joint_names)} names but {position_array.size} positions"
+        )
+    whole_seconds = int(period_s)
+    nanoseconds = round((period_s - whole_seconds) * 1_000_000_000)
+    if nanoseconds == 1_000_000_000:
+        whole_seconds += 1
+        nanoseconds = 0
+    if ros_version == 1:
+        duration = {"secs": whole_seconds, "nsecs": nanoseconds}
+    elif ros_version == 2:
+        duration = {"sec": whole_seconds, "nanosec": nanoseconds}
+    else:
+        raise ValueError(f"ros_version must be 1 or 2, got {ros_version!r}")
+    return {
+        "joint_names": list(joint_names),
+        "points": [
+            {
+                "positions": position_array.tolist(),
+                "time_from_start": duration,
+            }
+        ],
+    }
+
+
+def build_float64_multi_array(values: npt.ArrayLike) -> dict[str, Any]:
+    """Build ``Float64MultiArray`` with a flat numeric ``data`` field."""
+    return {"data": np.asarray(values, dtype=np.float64).reshape(-1).tolist()}
+
+
+def build_gripper_command(value: float, command_type: str) -> dict[str, Any]:
+    """Build a raw scalar or one-element array gripper command without normalization."""
+    if command_type == "float64":
+        return {"data": float(value)}
+    if command_type == "float64_multi_array":
+        return build_float64_multi_array([value])
+    raise ValueError(
+        f"gripper command_type must be 'float64' or 'float64_multi_array', got {command_type!r}"
+    )

--- a/plugins/inspect-robots-ros/src/inspect_robots_ros/_msgs.py
+++ b/plugins/inspect-robots-ros/src/inspect_robots_ros/_msgs.py
@@ -1,0 +1,1 @@
+"""Translate the supported ROS message dictionaries to and from NumPy values."""

--- a/plugins/inspect-robots-ros/src/inspect_robots_ros/_protocol.py
+++ b/plugins/inspect-robots-ros/src/inspect_robots_ros/_protocol.py
@@ -1,0 +1,1 @@
+"""Build and parse the rosbridge v2 JSON operations used by the adapter."""

--- a/plugins/inspect-robots-ros/src/inspect_robots_ros/_protocol.py
+++ b/plugins/inspect-robots-ros/src/inspect_robots_ros/_protocol.py
@@ -1,1 +1,180 @@
-"""Build and parse the rosbridge v2 JSON operations used by the adapter."""
+"""Build and parse the rosbridge v2 JSON operations used by the adapter.
+
+The transport carries one JSON object per websocket text frame. Outbound
+builders return ordinary dictionaries so their exact wire shapes stay visible
+and testable. Incoming operations are parsed into frozen dataclasses before the
+threaded client handles them.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+JsonObject = dict[str, Any]
+
+
+class RosbridgeError(Exception):
+    """A rosbridge protocol failure with a stable machine-readable code."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class PublishedMessage:
+    """One topic message delivered by a rosbridge ``publish`` operation."""
+
+    topic: str
+    msg: JsonObject
+
+
+@dataclass(frozen=True)
+class ServiceResponse:
+    """A service reply correlated to a prior ``call_service`` operation."""
+
+    request_id: str
+    values: JsonObject
+    result: bool
+
+
+@dataclass(frozen=True)
+class StatusMessage:
+    """A rosbridge status notification, including asynchronous publish errors."""
+
+    level: str
+    message: str
+    request_id: str | None = None
+
+    def as_error(self) -> RosbridgeError | None:
+        """Return a latchable error only when rosbridge marks this status as an error."""
+        if self.level != "error":
+            return None
+        return RosbridgeError("status_error", self.message)
+
+
+IncomingMessage = PublishedMessage | ServiceResponse | StatusMessage
+
+
+def subscribe(
+    topic: str,
+    *,
+    subscription_id: str,
+    message_type: str,
+    throttle_rate: int,
+    queue_length: int = 1,
+    compression: str = "none",
+) -> JsonObject:
+    """Build an explicit-id subscription with latest-value queue semantics."""
+    return {
+        "op": "subscribe",
+        "id": subscription_id,
+        "topic": topic,
+        "type": message_type,
+        "throttle_rate": throttle_rate,
+        "queue_length": queue_length,
+        "compression": compression,
+    }
+
+
+def unsubscribe(topic: str, *, subscription_id: str) -> JsonObject:
+    """Build removal of exactly one id-keyed subscription."""
+    return {"op": "unsubscribe", "id": subscription_id, "topic": topic}
+
+
+def advertise(topic: str, *, message_type: str) -> JsonObject:
+    """Build an explicit topic advertisement with its ROS message type."""
+    return {"op": "advertise", "topic": topic, "type": message_type}
+
+
+def unadvertise(topic: str) -> JsonObject:
+    """Build removal of a topic advertisement owned by this client."""
+    return {"op": "unadvertise", "topic": topic}
+
+
+def publish(topic: str, msg: Mapping[str, Any]) -> JsonObject:
+    """Build one topic publication without altering the ROS message dictionary."""
+    return {"op": "publish", "topic": topic, "msg": dict(msg)}
+
+
+def call_service(
+    service: str, *, request_id: str, args: Mapping[str, Any] | None = None
+) -> JsonObject:
+    """Build an id-correlated service call, using an empty argument object by default."""
+    return {
+        "op": "call_service",
+        "id": request_id,
+        "service": service,
+        "args": dict(args or {}),
+    }
+
+
+def encode_message(message: Mapping[str, Any]) -> str:
+    """Encode one operation as a compact websocket JSON text frame."""
+    try:
+        return json.dumps(dict(message), separators=(",", ":"), allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise RosbridgeError("invalid_frame", f"could not encode JSON operation: {exc}") from exc
+
+
+def decode_message(raw: str | bytes) -> JsonObject:
+    """Decode and validate one websocket JSON object."""
+    try:
+        decoded = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise RosbridgeError("invalid_frame", f"could not decode JSON operation: {exc}") from exc
+    if not isinstance(decoded, dict):
+        raise RosbridgeError("invalid_frame", "rosbridge frame must be a JSON object")
+    if not isinstance(decoded.get("op"), str):
+        raise RosbridgeError("invalid_frame", "rosbridge frame is missing string field 'op'")
+    return decoded
+
+
+def parse_incoming(message: Mapping[str, Any]) -> IncomingMessage | None:
+    """Parse the incoming operation kinds consumed by the client.
+
+    Operations outside ``publish``, ``service_response``, and ``status`` are
+    ignored so additions to rosbridge do not break the receive loop.
+    """
+    op = message.get("op")
+    if op == "publish":
+        topic = _required_str(message, "topic")
+        msg = _required_object(message, "msg")
+        return PublishedMessage(topic=topic, msg=msg)
+    if op == "service_response":
+        request_id = _required_str(message, "id")
+        values = _required_object(message, "values")
+        result = message.get("result")
+        if not isinstance(result, bool):
+            raise RosbridgeError(
+                "invalid_frame", "service_response field 'result' must be a boolean"
+            )
+        return ServiceResponse(request_id=request_id, values=values, result=result)
+    if op == "status":
+        level = _required_str(message, "level")
+        status_text = _required_str(message, "msg")
+        status_request_id = message.get("id")
+        if status_request_id is not None and not isinstance(status_request_id, str):
+            raise RosbridgeError("invalid_frame", "status field 'id' must be a string")
+        return StatusMessage(level=level, message=status_text, request_id=status_request_id)
+    return None
+
+
+def _required_str(message: Mapping[str, Any], key: str) -> str:
+    value = message.get(key)
+    if not isinstance(value, str):
+        raise RosbridgeError("invalid_frame", f"rosbridge frame field {key!r} must be a string")
+    return value
+
+
+def _required_object(message: Mapping[str, Any], key: str) -> JsonObject:
+    value = message.get(key)
+    if not isinstance(value, Mapping):
+        raise RosbridgeError(
+            "invalid_frame", f"rosbridge frame field {key!r} must be a JSON object"
+        )
+    return dict(value)

--- a/plugins/inspect-robots-ros/src/inspect_robots_ros/embodiment.py
+++ b/plugins/inspect-robots-ros/src/inspect_robots_ros/embodiment.py
@@ -182,7 +182,7 @@ class RosEmbodiment(EmbodimentBase):
         cameras: CameraMap | str | None = None,
         control_hz: float = 10.0,
         fresh_obs_timeout_s: float | None = None,
-        camera_throttle_ms: int | None = None,
+        camera_throttle_ms: int | float | None = None,
         reset_service: str | None = None,
         operator_reset_confirm: bool = False,
         obs_timeout_s: float = 5.0,
@@ -274,9 +274,14 @@ class RosEmbodiment(EmbodimentBase):
         resolved_fresh_timeout = (
             2.0 / control_hz if fresh_obs_timeout_s is None else float(fresh_obs_timeout_s)
         )
-        resolved_camera_throttle = (
-            max(1, int(1000.0 / control_hz)) if camera_throttle_ms is None else camera_throttle_ms
-        )
+        if camera_throttle_ms is None:
+            resolved_camera_throttle = max(1, round(1000.0 / control_hz))
+        else:
+            if camera_throttle_ms != int(camera_throttle_ms):
+                raise ValueError(
+                    f"camera_throttle_ms must be integer milliseconds, got {camera_throttle_ms!r}"
+                )
+            resolved_camera_throttle = int(camera_throttle_ms)
         if resolved_fresh_timeout <= 0 or not math.isfinite(resolved_fresh_timeout):
             raise ValueError(
                 f"fresh_obs_timeout_s must be positive and finite, got {resolved_fresh_timeout!r}"
@@ -526,7 +531,7 @@ class RosEmbodiment(EmbodimentBase):
 
     @property
     def _state_throttle_ms(self) -> int:
-        return max(1, int(500.0 / self.control_hz))
+        return max(1, round(500.0 / self.control_hz))
 
     def _joint_state_preflight(self) -> None:
         self._client.subscribe(
@@ -575,8 +580,13 @@ class RosEmbodiment(EmbodimentBase):
                 stacklevel=2,
             )
         elif len(samples) >= 2:
+            # Count messages by sequence delta, not by collected samples: the
+            # client's poll loop coalesces fast publishers into its latest-value
+            # slot, so sample count alone caps the measurable rate at the poll
+            # frequency and would falsely warn on healthy high-rate rigs.
             elapsed = samples[-1].stamp - samples[0].stamp
-            native_hz = math.inf if elapsed <= 0 else (len(samples) - 1) / elapsed
+            message_count = samples[-1].seq - samples[0].seq
+            native_hz = math.inf if elapsed <= 0 else message_count / elapsed
             if native_hz < 2.0 * self.control_hz:
                 warnings.warn(
                     f"joint_states native rate is about {native_hz:g} Hz, below 2x "

--- a/plugins/inspect-robots-ros/src/inspect_robots_ros/embodiment.py
+++ b/plugins/inspect-robots-ros/src/inspect_robots_ros/embodiment.py
@@ -1,17 +1,686 @@
-"""Expose the ROS robot and its rosbridge streams through the embodiment contract."""
+"""Expose ROS robots and rosbridge streams through the embodiment contract.
+
+The adapter is configuration-driven and ROS-free on the evaluation machine.
+Construction builds only static spaces; the websocket connects lazily on the
+first reset. Commands are sleep-gated before the arm publish, then paired with
+a sequence-newer joint-state message before an observation is returned.
+"""
 
 from __future__ import annotations
 
-from typing import Any
+import math
+import sys
+import time
+import warnings
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+
+import numpy as np
+
+from inspect_robots import (
+    Action,
+    ActionSemantics,
+    Box,
+    CameraSpec,
+    EmbodimentBase,
+    EmbodimentInfo,
+    Observation,
+    ObservationSpace,
+    Scene,
+    StateField,
+    StateSpec,
+    StepResult,
+)
+from inspect_robots.embodiment import RESETTABLE, SELF_PACED
+from inspect_robots.spaces import CANONICAL_STATE_UNITS
+from inspect_robots_ros._client import RosbridgeClient, TopicSample
+from inspect_robots_ros._msgs import (
+    MessageKind,
+    build_float64_multi_array,
+    build_gripper_command,
+    build_joint_trajectory,
+    message_type,
+    parse_compressed_image,
+    parse_joint_state,
+    parse_pose_stamped,
+)
+
+_PREFLIGHT_SUBSCRIPTION_ID = "inspect-robots-preflight-joint-states"
+_JOINT_SUBSCRIPTION_ID = "inspect-robots-joint-states"
+_EEF_SUBSCRIPTION_ID = "inspect-robots-eef-pose"
 
 
-class RosEmbodiment:
-    """Placeholder for the ROS embodiment implemented by plan 0016."""
+@dataclass(frozen=True)
+class _CameraConfig:
+    topic: str
+    height: int
+    width: int
 
-    def __init__(self, **kwargs: Any) -> None:
-        raise NotImplementedError("RosEmbodiment is added in plan 0016 implementation step 5")
+
+NumericList = str | int | float | Sequence[float]
+JointList = str | Sequence[str]
+CameraMap = Mapping[str, tuple[str, int, int]]
+
+
+def _parse_joints(value: JointList | None) -> tuple[str, ...]:
+    if value is None:
+        raise ValueError("joints is required; pass -E joints=joint1,joint2,...")
+    if isinstance(value, str):
+        joints = tuple(item.strip() for item in value.split(",") if item.strip())
+    else:
+        joints = tuple(str(item).strip() for item in value if str(item).strip())
+    if not joints:
+        raise ValueError("joints must contain at least one joint name")
+    duplicates = sorted({name for name in joints if joints.count(name) > 1})
+    if duplicates:
+        raise ValueError(
+            f"joints contains duplicate names {duplicates}; each arm joint must be unique"
+        )
+    return joints
+
+
+def _parse_numeric_list(value: NumericList | None, arg: str) -> tuple[float, ...]:
+    if value is None:
+        raise ValueError(f"{arg} is required; pass one numeric bound per configured arm joint")
+    raw: Sequence[Any]
+    if isinstance(value, str):
+        raw = tuple(item.strip() for item in value.split(",") if item.strip())
+    elif isinstance(value, (int, float)):
+        raw = (value,)
+    else:
+        raw = value
+    try:
+        parsed = tuple(float(item) for item in raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{arg} must be a comma-separated list of numbers") from exc
+    if not parsed:
+        raise ValueError(f"{arg} must contain at least one numeric bound")
+    return parsed
+
+
+def _parse_cameras(value: CameraMap | str | None) -> dict[str, _CameraConfig]:
+    if value is None:
+        return {}
+    if isinstance(value, str):
+        cameras: dict[str, _CameraConfig] = {}
+        for raw_entry in value.split(","):
+            entry = raw_entry.strip()
+            if not entry:
+                continue
+            parts = entry.split(":")
+            if len(parts) != 3:
+                raise ValueError(
+                    f"cameras entry {entry!r} must be name:topic:WxH, "
+                    "for example wrist:/camera/image_raw/compressed:640x480"
+                )
+            name, topic, resolution = (part.strip() for part in parts)
+            if name in cameras:
+                raise ValueError(
+                    f"cameras contains duplicate name {name!r}; camera names must be unique"
+                )
+            width_text, separator, height_text = resolution.lower().partition("x")
+            if not separator:
+                raise ValueError(
+                    f"camera {name!r} resolution {resolution!r} must be WxH, for example 640x480"
+                )
+            try:
+                width, height = int(width_text), int(height_text)
+            except ValueError as exc:
+                raise ValueError(
+                    f"camera {name!r} resolution {resolution!r} must contain "
+                    "integer width and height"
+                ) from exc
+            cameras[name] = _validate_camera(name, topic, height, width)
+        if value.strip() and not cameras:
+            raise ValueError(f"cameras string form parsed to no cameras: {value!r}")
+        return cameras
+
+    cameras = {}
+    for name, config in value.items():
+        if not isinstance(config, Sequence) or isinstance(config, str) or len(config) != 3:
+            raise ValueError(f"camera {name!r} must map to (topic, height, width), got {config!r}")
+        topic, height, width = config
+        cameras[name] = _validate_camera(name, topic, height, width)
+    return cameras
+
+
+def _validate_camera(name: str, topic: Any, height: Any, width: Any) -> _CameraConfig:
+    if not name.isidentifier():
+        raise ValueError(f"camera name {name!r} must be a valid identifier")
+    if not isinstance(topic, str) or not topic:
+        raise ValueError(f"camera {name!r} topic must be a non-empty string")
+    if not isinstance(height, int) or not isinstance(width, int) or height < 1 or width < 1:
+        raise ValueError(
+            f"camera {name!r} height and width must be positive integers, "
+            f"got height={height!r}, width={width!r}"
+        )
+    return _CameraConfig(topic=topic, height=height, width=width)
+
+
+class RosEmbodiment(EmbodimentBase):
+    """Drive a joint-position ROS arm through a rosbridge websocket connection."""
+
+    def __init__(
+        self,
+        *,
+        url: str = "ws://localhost:9090",
+        ros_version: int = 2,
+        joints: JointList | None = None,
+        joint_states_topic: str = "/joint_states",
+        command_topic: str | None = None,
+        command_type: str = "joint_trajectory",
+        action_low: NumericList | None = None,
+        action_high: NumericList | None = None,
+        gripper_topic: str | None = None,
+        gripper_command_type: str | None = None,
+        gripper_joint: str | None = None,
+        gripper_low: float | None = None,
+        gripper_high: float | None = None,
+        gripper_closed_at: str = "low",
+        eef_pose_topic: str | None = None,
+        cameras: CameraMap | str | None = None,
+        control_hz: float = 10.0,
+        fresh_obs_timeout_s: float | None = None,
+        camera_throttle_ms: int | None = None,
+        reset_service: str | None = None,
+        operator_reset_confirm: bool = False,
+        obs_timeout_s: float = 5.0,
+        staleness_s: float = 2.0,
+        simulated: bool = False,
+        name: str = "ros",
+        connect_timeout_s: float = 10.0,
+        request_timeout_s: float = 30.0,
+        clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        if ros_version not in (1, 2):
+            raise ValueError(f"ros_version must be 1 or 2, got {ros_version!r}")
+        if command_type not in ("joint_trajectory", "float64_multi_array"):
+            raise ValueError(
+                "command_type must be 'joint_trajectory' or 'float64_multi_array', "
+                f"got {command_type!r}"
+            )
+        if gripper_closed_at not in ("low", "high"):
+            raise ValueError(
+                f"gripper_closed_at must be 'low' or 'high', got {gripper_closed_at!r}"
+            )
+        if not math.isfinite(control_hz) or control_hz <= 0:
+            raise ValueError(f"control_hz must be positive and finite, got {control_hz!r}")
+        if command_topic is None or not command_topic:
+            raise ValueError(
+                "command_topic is required; pass the arm controller command topic with "
+                "-E command_topic=/controller/command"
+            )
+
+        parsed_joints = _parse_joints(joints)
+        parsed_low = _parse_numeric_list(action_low, "action_low")
+        parsed_high = _parse_numeric_list(action_high, "action_high")
+        for arg, bounds in (("action_low", parsed_low), ("action_high", parsed_high)):
+            if len(bounds) != len(parsed_joints):
+                raise ValueError(
+                    f"{arg} has {len(bounds)} bounds for {len(parsed_joints)} joints; "
+                    "provide exactly one bound per configured joint"
+                )
+            if not all(math.isfinite(bound) for bound in bounds):
+                raise ValueError(f"{arg} bounds must all be finite, got {bounds!r}")
+        if any(low > high for low, high in zip(parsed_low, parsed_high, strict=True)):
+            raise ValueError("action_low must be elementwise <= action_high")
+
+        gripper_values = (gripper_joint, gripper_low, gripper_high)
+        if gripper_topic is not None:
+            if any(value is None for value in gripper_values):
+                raise ValueError(
+                    "gripper_joint, gripper_low, and gripper_high are required when "
+                    "gripper_topic is configured"
+                )
+            assert gripper_joint is not None
+            assert gripper_low is not None
+            assert gripper_high is not None
+            if "gripper" in parsed_joints:
+                raise ValueError(
+                    "an arm joint named 'gripper' conflicts with the appended gripper action "
+                    "label; rename or omit that arm joint"
+                )
+            if not math.isfinite(gripper_low) or not math.isfinite(gripper_high):
+                raise ValueError("gripper_low and gripper_high must be finite")
+            if gripper_low >= gripper_high:
+                raise ValueError(
+                    f"gripper_low must be less than gripper_high for 0..1 normalization; "
+                    f"got {gripper_low!r} >= {gripper_high!r}"
+                )
+        elif any(value is not None for value in gripper_values):
+            raise ValueError(
+                "gripper_joint, gripper_low, and gripper_high may be set only when "
+                "gripper_topic is configured"
+            )
+
+        default_gripper_type = "float64" if ros_version == 1 else "float64_multi_array"
+        resolved_gripper_type = gripper_command_type or default_gripper_type
+        if resolved_gripper_type not in ("float64", "float64_multi_array"):
+            raise ValueError(
+                "gripper_command_type must be 'float64' or 'float64_multi_array', "
+                f"got {resolved_gripper_type!r}"
+            )
+
+        parsed_cameras = _parse_cameras(cameras)
+        action_dim = len(parsed_joints) + (1 if gripper_topic is not None else 0)
+        if action_dim == 7 and eef_pose_topic is not None:
+            raise ValueError(
+                "omit eef_pose_topic on a 7-dim action space until core supports "
+                "key-priority reference matching"
+            )
+
+        resolved_fresh_timeout = (
+            2.0 / control_hz if fresh_obs_timeout_s is None else float(fresh_obs_timeout_s)
+        )
+        resolved_camera_throttle = (
+            max(1, int(1000.0 / control_hz)) if camera_throttle_ms is None else camera_throttle_ms
+        )
+        if resolved_fresh_timeout <= 0 or not math.isfinite(resolved_fresh_timeout):
+            raise ValueError(
+                f"fresh_obs_timeout_s must be positive and finite, got {resolved_fresh_timeout!r}"
+            )
+        if resolved_camera_throttle < 0:
+            raise ValueError(f"camera_throttle_ms must be >= 0, got {resolved_camera_throttle!r}")
+        for arg, timeout in (
+            ("obs_timeout_s", obs_timeout_s),
+            ("connect_timeout_s", connect_timeout_s),
+            ("request_timeout_s", request_timeout_s),
+        ):
+            if timeout <= 0 or not math.isfinite(timeout):
+                raise ValueError(f"{arg} must be positive and finite, got {timeout!r}")
+        if staleness_s < 0 or not math.isfinite(staleness_s):
+            raise ValueError(f"staleness_s must be finite and >= 0, got {staleness_s!r}")
+
+        low_array = np.asarray(parsed_low, dtype=np.float64)
+        high_array = np.asarray(parsed_high, dtype=np.float64)
+        labels = parsed_joints
+        state_fields = [
+            StateField(
+                key="joint_pos",
+                shape=(action_dim,),
+                unit=CANONICAL_STATE_UNITS["joint_pos"],
+            )
+        ]
+        if gripper_topic is not None:
+            assert gripper_low is not None and gripper_high is not None
+            low_array = np.concatenate((low_array, np.asarray([gripper_low])))
+            high_array = np.concatenate((high_array, np.asarray([gripper_high])))
+            labels = (*parsed_joints, "gripper")
+            state_fields.append(StateField("gripper", (1,), CANONICAL_STATE_UNITS["gripper"]))
+        if eef_pose_topic is not None:
+            state_fields.append(StateField("eef_pose", (7,), CANONICAL_STATE_UNITS["eef_pose"]))
+
+        capabilities = {SELF_PACED}
+        if reset_service is not None:
+            capabilities.add(RESETTABLE)
+        self.info = EmbodimentInfo(
+            name=name,
+            action_space=Box(
+                shape=(action_dim,),
+                low=low_array,
+                high=high_array,
+                semantics=ActionSemantics(
+                    control_mode="joint_pos",
+                    rotation_repr="none",
+                    gripper="continuous" if gripper_topic is not None else "none",
+                    frame="base",
+                    dim_labels=labels,
+                ),
+            ),
+            observation_space=ObservationSpace(
+                cameras=tuple(
+                    CameraSpec(camera_name, config.height, config.width)
+                    for camera_name, config in parsed_cameras.items()
+                ),
+                state=StateSpec(fields=tuple(state_fields)),
+            ),
+            control_hz=control_hz,
+            is_simulated=simulated,
+            capabilities=frozenset(capabilities),
+            supported_setups=frozenset(),
+            supported_target_kinds=frozenset(),
+        )
+
+        self.url = url
+        self.ros_version = ros_version
+        self.joints = parsed_joints
+        self.joint_states_topic = joint_states_topic
+        self.command_topic = command_topic
+        self.command_type = command_type
+        self.gripper_topic = gripper_topic
+        self.gripper_command_type = resolved_gripper_type
+        self.gripper_joint = gripper_joint
+        self.gripper_low = gripper_low
+        self.gripper_high = gripper_high
+        self.gripper_closed_at = gripper_closed_at
+        self.eef_pose_topic = eef_pose_topic
+        self.cameras = parsed_cameras
+        self.control_hz = control_hz
+        self.fresh_obs_timeout_s = resolved_fresh_timeout
+        self.camera_throttle_ms = resolved_camera_throttle
+        self.reset_service = reset_service
+        self.operator_reset_confirm = operator_reset_confirm
+        self.obs_timeout_s = obs_timeout_s
+        self.staleness_s = staleness_s
+        self._clock = clock
+        self._sleep = sleep
+        self._client = RosbridgeClient(
+            url,
+            connect_timeout_s=connect_timeout_s,
+            request_timeout_s=request_timeout_s,
+            clock=clock,
+            sleep=sleep,
+        )
+        self._initialized = False
+        self._instruction: str | None = None
+        self._last_publish_time: float | None = None
+        self._reset_count = 0
+        self._warned_no_physical_reset = False
+        self._validated_cameras: set[str] = set()
+
+    def reset(self, scene: Scene, *, seed: int | None = None) -> Observation:
+        """Connect lazily, perform the configured reset path, and return fresh state."""
+        del seed
+        self._instruction = scene.instruction
+        self._ensure_initialized()
+
+        if self.reset_service is not None:
+            self._client.call_service(self.reset_service)
+        if self.operator_reset_confirm:
+            print(f"Operator reset required for instruction: {scene.instruction}")
+            input("Arrange the scene, then press Enter to continue: ")
+        if (
+            self._reset_count >= 1
+            and self.reset_service is None
+            and not self.operator_reset_confirm
+            and not self._warned_no_physical_reset
+        ):
+            print(
+                "warning: ROS embodiment has no reset_service or operator_reset_confirm; "
+                "between-trial reset does not change the physical world",
+                file=sys.stderr,
+            )
+            self._warned_no_physical_reset = True
+
+        sequences = self._capture_sequences(self._all_topics())
+        self._wait_for_sequences(sequences, self.obs_timeout_s, "obs_timeout_s")
+        observation = self._assemble_observation()
+        self._last_publish_time = None
+        self._reset_count += 1
+        return observation
+
+    def step(self, action: Action) -> StepResult:
+        """Sleep-gate the arm publish, require fresher joint state, and assemble a step."""
+        data = np.asarray(action.data, dtype=np.float64)
+        if data.shape != self.info.action_space.shape:
+            raise ValueError(
+                f"action has shape {data.shape}, expected {self.info.action_space.shape}"
+            )
+        now = self._clock()
+        if self._last_publish_time is not None:
+            remaining = self._last_publish_time + (1.0 / self.control_hz) - now
+            if remaining > 0:
+                self._sleep(remaining)
+
+        arm = data[: len(self.joints)]
+        seq_at_publish = self._client.sequence(self.joint_states_topic)
+        publish_time = self._clock()
+        if self.command_type == "joint_trajectory":
+            arm_message = build_joint_trajectory(
+                self.joints,
+                arm,
+                period_s=1.0 / self.control_hz,
+                ros_version=self.ros_version,
+            )
+        else:
+            arm_message = build_float64_multi_array(arm)
+        self._client.publish(self.command_topic, arm_message)
+        self._last_publish_time = publish_time
+
+        if self.gripper_topic is not None:
+            self._client.publish(
+                self.gripper_topic,
+                build_gripper_command(data[-1], self.gripper_command_type),
+            )
+        try:
+            self._client.wait_for_sample(
+                self.joint_states_topic,
+                after_seq=seq_at_publish,
+                timeout_s=self.fresh_obs_timeout_s,
+            )
+        except TimeoutError as exc:
+            raise TimeoutError(
+                f"no post-publish joint state within fresh_obs_timeout_s="
+                f"{self.fresh_obs_timeout_s:g}s at control_hz={self.control_hz:g}; "
+                "lower control_hz or raise fresh_obs_timeout_s"
+            ) from exc
+        return StepResult(
+            observation=self._assemble_observation(),
+            reward=None,
+            terminated=False,
+            truncated=False,
+        )
+
+    def close(self) -> None:
+        """Release rosbridge subscriptions, advertisements, socket, and receiver thread."""
+        self._client.close()
+
+    def __enter__(self) -> RosEmbodiment:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def _ensure_initialized(self) -> None:
+        if self._initialized:
+            return
+        try:
+            self._client.connect()
+        except Exception as exc:
+            raise ConnectionError(
+                f"could not connect to rosbridge at {self.url}. Start it on the robot with "
+                "ROS 1: roslaunch rosbridge_server rosbridge_websocket.launch; "
+                "ROS 2: ros2 launch rosbridge_server rosbridge_websocket_launch.xml"
+            ) from exc
+
+        self._client.advertise(
+            self.command_topic,
+            message_type=message_type(
+                "joint_trajectory"
+                if self.command_type == "joint_trajectory"
+                else "float64_multi_array",
+                self.ros_version,
+            ),
+        )
+        if self.gripper_topic is not None:
+            self._client.advertise(
+                self.gripper_topic,
+                message_type=message_type(
+                    cast(MessageKind, self.gripper_command_type), self.ros_version
+                ),
+            )
+        if self.eef_pose_topic is not None:
+            self._client.subscribe(
+                self.eef_pose_topic,
+                subscription_id=_EEF_SUBSCRIPTION_ID,
+                message_type=message_type("pose_stamped", self.ros_version),
+                throttle_rate=self._state_throttle_ms,
+                queue_length=1,
+            )
+        for camera_name, camera in self.cameras.items():
+            self._client.subscribe(
+                camera.topic,
+                subscription_id=f"inspect-robots-camera-{camera_name}",
+                message_type=message_type("compressed_image", self.ros_version),
+                throttle_rate=self.camera_throttle_ms,
+                queue_length=1,
+            )
+        self._joint_state_preflight()
+        self._wait_for_sequences(
+            dict.fromkeys(self._all_topics(), 0), self.obs_timeout_s, "obs_timeout_s"
+        )
+        self._validate_camera_resolutions()
+        self._initialized = True
+
+    @property
+    def _state_throttle_ms(self) -> int:
+        return max(1, int(500.0 / self.control_hz))
+
+    def _joint_state_preflight(self) -> None:
+        self._client.subscribe(
+            self.joint_states_topic,
+            subscription_id=_PREFLIGHT_SUBSCRIPTION_ID,
+            message_type=message_type("joint_state", self.ros_version),
+            throttle_rate=0,
+            queue_length=1,
+        )
+        samples: list[TopicSample] = []
+        sequence = self._client.sequence(self.joint_states_topic)
+        start = self._clock()
+        try:
+            while len(samples) < 5:
+                remaining = 1.0 - (self._clock() - start)
+                if remaining <= 0:
+                    break
+                try:
+                    sample = self._client.wait_for_sample(
+                        self.joint_states_topic,
+                        after_seq=sequence,
+                        timeout_s=remaining,
+                    )
+                except TimeoutError:
+                    break
+                samples.append(sample)
+                sequence = sample.seq
+        finally:
+            self._client.unsubscribe(
+                self.joint_states_topic,
+                subscription_id=_PREFLIGHT_SUBSCRIPTION_ID,
+            )
+        self._client.subscribe(
+            self.joint_states_topic,
+            subscription_id=_JOINT_SUBSCRIPTION_ID,
+            message_type=message_type("joint_state", self.ros_version),
+            throttle_rate=self._state_throttle_ms,
+            queue_length=1,
+        )
+
+        if len(samples) == 1:
+            warnings.warn(
+                "joint_states preflight received exactly one message in 1s, too few to "
+                "measure native rate; lower control_hz or raise fresh_obs_timeout_s",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        elif len(samples) >= 2:
+            elapsed = samples[-1].stamp - samples[0].stamp
+            native_hz = math.inf if elapsed <= 0 else (len(samples) - 1) / elapsed
+            if native_hz < 2.0 * self.control_hz:
+                warnings.warn(
+                    f"joint_states native rate is about {native_hz:g} Hz, below 2x "
+                    f"control_hz={self.control_hz:g}; lower control_hz or raise "
+                    "fresh_obs_timeout_s",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+
+    def _all_topics(self) -> tuple[str, ...]:
+        topics = [self.joint_states_topic]
+        if self.eef_pose_topic is not None:
+            topics.append(self.eef_pose_topic)
+        topics.extend(camera.topic for camera in self.cameras.values())
+        return tuple(dict.fromkeys(topics))
+
+    def _capture_sequences(self, topics: Sequence[str]) -> dict[str, int]:
+        return {topic: self._client.sequence(topic) for topic in topics}
+
+    def _wait_for_sequences(
+        self, sequences: Mapping[str, int], timeout_s: float, timeout_name: str
+    ) -> None:
+        deadline = self._clock() + timeout_s
+        for topic, sequence in sequences.items():
+            remaining = deadline - self._clock()
+            if remaining <= 0:
+                raise TimeoutError(f"missing topic {topic!r} within {timeout_name}={timeout_s:g}s")
+            try:
+                self._client.wait_for_sample(topic, after_seq=sequence, timeout_s=remaining)
+            except TimeoutError as exc:
+                raise TimeoutError(
+                    f"missing topic {topic!r} within {timeout_name}={timeout_s:g}s"
+                ) from exc
+
+    def _validate_camera_resolutions(self) -> None:
+        for camera_name, camera in self.cameras.items():
+            if camera_name in self._validated_cameras:
+                continue
+            sample = self._required_sample(camera.topic)
+            image = parse_compressed_image(sample.msg)
+            actual = image.shape[:2]
+            declared = (camera.height, camera.width)
+            if actual != declared:
+                raise ValueError(
+                    f"camera {camera_name!r} declared resolution "
+                    f"{camera.width}x{camera.height} but first frame is "
+                    f"{actual[1]}x{actual[0]}"
+                )
+            self._validated_cameras.add(camera_name)
+
+    def _assemble_observation(self) -> Observation:
+        now = self._clock()
+        joint_sample = self._required_sample(self.joint_states_topic)
+        self._check_staleness(self.joint_states_topic, joint_sample, now)
+        requested_joints = self.joints
+        if self.gripper_joint is not None:
+            requested_joints = (*requested_joints, self.gripper_joint)
+        joint_position = parse_joint_state(joint_sample.msg, requested_joints)
+        state: dict[str, np.ndarray[Any, np.dtype[np.float64]]] = {"joint_pos": joint_position}
+        state_stamps = [joint_sample.stamp]
+        if self.gripper_topic is not None:
+            assert self.gripper_low is not None and self.gripper_high is not None
+            normalized = (joint_position[-1] - self.gripper_low) / (
+                self.gripper_high - self.gripper_low
+            )
+            if self.gripper_closed_at == "high":
+                normalized = 1.0 - normalized
+            state["gripper"] = np.asarray([normalized], dtype=np.float64)
+        if self.eef_pose_topic is not None:
+            eef_sample = self._required_sample(self.eef_pose_topic)
+            self._check_staleness(self.eef_pose_topic, eef_sample, now)
+            state["eef_pose"] = parse_pose_stamped(eef_sample.msg)
+            state_stamps.append(eef_sample.stamp)
+
+        images: dict[str, np.ndarray[Any, np.dtype[np.uint8]]] = {}
+        image_times: dict[str, float] = {}
+        for camera_name, camera in self.cameras.items():
+            sample = self._required_sample(camera.topic)
+            self._check_staleness(camera.topic, sample, now)
+            images[camera_name] = parse_compressed_image(sample.msg)
+            image_times[camera_name] = sample.stamp
+        return Observation(
+            images=images,
+            state=state,
+            instruction=self._instruction,
+            image_times=image_times,
+            state_time=min(state_stamps),
+        )
+
+    def _required_sample(self, topic: str) -> TopicSample:
+        sample = self._client.latest(topic)
+        if sample is None:
+            raise RuntimeError(f"no cached message for subscribed topic {topic!r}")
+        return sample
+
+    def _check_staleness(self, topic: str, sample: TopicSample, now: float) -> None:
+        age = now - sample.stamp
+        if age > self.staleness_s:
+            raise TimeoutError(
+                f"cached message on {topic!r} is stale by {age:g}s, exceeding "
+                f"staleness_s={self.staleness_s:g}"
+            )
 
 
 def ros_embodiment(**kwargs: Any) -> RosEmbodiment:
-    """Construct the registry-facing ROS embodiment placeholder."""
+    """Construct the registry-facing ROS embodiment from CLI or programmatic arguments."""
     return RosEmbodiment(**kwargs)

--- a/plugins/inspect-robots-ros/src/inspect_robots_ros/embodiment.py
+++ b/plugins/inspect-robots-ros/src/inspect_robots_ros/embodiment.py
@@ -1,0 +1,17 @@
+"""Expose the ROS robot and its rosbridge streams through the embodiment contract."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class RosEmbodiment:
+    """Placeholder for the ROS embodiment implemented by plan 0016."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        raise NotImplementedError("RosEmbodiment is added in plan 0016 implementation step 5")
+
+
+def ros_embodiment(**kwargs: Any) -> RosEmbodiment:
+    """Construct the registry-facing ROS embodiment placeholder."""
+    return RosEmbodiment(**kwargs)

--- a/plugins/inspect-robots-ros/tests/_stub_server.py
+++ b/plugins/inspect-robots-ros/tests/_stub_server.py
@@ -22,6 +22,7 @@ class StubRosbridgeServer:
         self._lock = threading.RLock()
         self._connections: set[ServerConnection] = set()
         self._subscriptions: dict[ServerConnection, dict[str, dict[str, Any]]] = {}
+        self._last_subscription_send: dict[tuple[ServerConnection, str], float] = {}
         self._server: Server = serve(self._handler, "127.0.0.1", 0, max_size=None)
         self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
         self._thread.start()
@@ -63,12 +64,22 @@ class StubRosbridgeServer:
     def publish(self, topic: str, msg: Mapping[str, Any]) -> None:
         """Send a topic message only to connections subscribed to that topic."""
         frame = {"op": "publish", "topic": topic, "msg": dict(msg)}
+        now = time.monotonic()
         with self._lock:
-            targets = [
-                connection
-                for connection, by_id in self._subscriptions.items()
-                if any(operation.get("topic") == topic for operation in by_id.values())
-            ]
+            targets: list[ServerConnection] = []
+            for connection, by_id in self._subscriptions.items():
+                due_ids: list[str] = []
+                for subscription_id, operation in by_id.items():
+                    if operation.get("topic") != topic:
+                        continue
+                    throttle_s = float(operation.get("throttle_rate", 0)) / 1000.0
+                    last = self._last_subscription_send.get((connection, subscription_id))
+                    if last is None or throttle_s == 0 or now - last >= throttle_s:
+                        due_ids.append(subscription_id)
+                if due_ids:
+                    targets.append(connection)
+                    for subscription_id in due_ids:
+                        self._last_subscription_send[(connection, subscription_id)] = now
         self._send(targets, frame)
 
     def send_status(self, level: str, message: str, *, request_id: str | None = None) -> None:
@@ -109,6 +120,8 @@ class StubRosbridgeServer:
                 connection.close()
         self._server.shutdown()
         self._thread.join(timeout=5)
+        if self._thread.is_alive():
+            raise TimeoutError("stub rosbridge serving thread did not stop")
 
     def _handler(self, ws: ServerConnection) -> None:
         with self._lock:
@@ -129,17 +142,24 @@ class StubRosbridgeServer:
                     if isinstance(subscription_id, str):
                         with self._lock:
                             self._subscriptions[ws][subscription_id] = operation
+                            self._last_subscription_send.pop((ws, subscription_id), None)
                 elif op == "unsubscribe":
                     subscription_id = operation.get("id")
                     if isinstance(subscription_id, str):
                         with self._lock:
                             self._subscriptions[ws].pop(subscription_id, None)
+                            self._last_subscription_send.pop((ws, subscription_id), None)
                 elif op == "call_service":
                     self._handle_service(ws, operation)
         finally:
             with self._lock:
                 self._connections.discard(ws)
                 self._subscriptions.pop(ws, None)
+                self._last_subscription_send = {
+                    key: stamp
+                    for key, stamp in self._last_subscription_send.items()
+                    if key[0] is not ws
+                }
 
     def _handle_service(self, ws: ServerConnection, operation: dict[str, Any]) -> None:
         service = operation.get("service")

--- a/plugins/inspect-robots-ros/tests/_stub_server.py
+++ b/plugins/inspect-robots-ros/tests/_stub_server.py
@@ -1,0 +1,177 @@
+"""In-process rosbridge-shaped websocket server for adapter tests."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections.abc import Callable, Mapping
+from contextlib import suppress
+from typing import Any
+
+from websockets.sync.server import Server, ServerConnection, serve
+
+
+class StubRosbridgeServer:
+    """Serve the rosbridge operations used by the plugin on a free local port."""
+
+    def __init__(self) -> None:
+        self.ops: list[dict[str, Any]] = []
+        self.deferred_services: set[str] = set()
+        self.service_results: dict[str, tuple[bool, dict[str, Any]]] = {}
+        self._lock = threading.RLock()
+        self._connections: set[ServerConnection] = set()
+        self._subscriptions: dict[ServerConnection, dict[str, dict[str, Any]]] = {}
+        self._server: Server = serve(self._handler, "127.0.0.1", 0, max_size=None)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def url(self) -> str:
+        """The websocket URL bound to the server's ephemeral port."""
+        port = self._server.socket.getsockname()[1]
+        return f"ws://127.0.0.1:{port}"
+
+    @property
+    def subscriptions(self) -> dict[str, dict[str, Any]]:
+        """Current subscriptions keyed by rosbridge subscription ID."""
+        with self._lock:
+            return {
+                subscription_id: dict(operation)
+                for by_id in self._subscriptions.values()
+                for subscription_id, operation in by_id.items()
+            }
+
+    def ops_of(self, op: str) -> list[dict[str, Any]]:
+        """Return a snapshot of received operations matching ``op``."""
+        with self._lock:
+            return [dict(operation) for operation in self.ops if operation.get("op") == op]
+
+    def wait_for(
+        self, predicate: Callable[[list[dict[str, Any]]], bool], *, timeout_s: float = 2.0
+    ) -> None:
+        """Wait until a predicate over the recorded operations becomes true."""
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            with self._lock:
+                snapshot = [dict(operation) for operation in self.ops]
+            if predicate(snapshot):
+                return
+            time.sleep(0.005)
+        raise TimeoutError("stub rosbridge did not receive the expected operation")
+
+    def publish(self, topic: str, msg: Mapping[str, Any]) -> None:
+        """Send a topic message only to connections subscribed to that topic."""
+        frame = {"op": "publish", "topic": topic, "msg": dict(msg)}
+        with self._lock:
+            targets = [
+                connection
+                for connection, by_id in self._subscriptions.items()
+                if any(operation.get("topic") == topic for operation in by_id.values())
+            ]
+        self._send(targets, frame)
+
+    def send_status(self, level: str, message: str, *, request_id: str | None = None) -> None:
+        """Send a rosbridge status notification to every live client."""
+        frame: dict[str, Any] = {"op": "status", "level": level, "msg": message}
+        if request_id is not None:
+            frame["id"] = request_id
+        self._send(self._connected_targets(), frame)
+
+    def send_service_response(
+        self,
+        request_id: str,
+        *,
+        result: bool = True,
+        values: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Send an explicitly correlated service response to every live client."""
+        frame = {
+            "op": "service_response",
+            "id": request_id,
+            "values": dict(values or {}),
+            "result": result,
+        }
+        self._send(self._connected_targets(), frame)
+
+    def drop_connections(self) -> None:
+        """Close every client socket to exercise receive-thread death latching."""
+        for connection in self._connected_targets():
+            with suppress(Exception):
+                connection.close()
+
+    def stop(self) -> None:
+        """Shut down the websocket server and join its serving thread."""
+        with self._lock:
+            targets = list(self._connections)
+        for connection in targets:
+            with suppress(Exception):
+                connection.close()
+        self._server.shutdown()
+        self._thread.join(timeout=5)
+
+    def _handler(self, ws: ServerConnection) -> None:
+        with self._lock:
+            self._connections.add(ws)
+            self._subscriptions[ws] = {}
+        try:
+            for raw in ws:
+                if not isinstance(raw, (str, bytes)):
+                    continue
+                operation = json.loads(raw)
+                if not isinstance(operation, dict):
+                    continue
+                with self._lock:
+                    self.ops.append(operation)
+                op = operation.get("op")
+                if op == "subscribe":
+                    subscription_id = operation.get("id")
+                    if isinstance(subscription_id, str):
+                        with self._lock:
+                            self._subscriptions[ws][subscription_id] = operation
+                elif op == "unsubscribe":
+                    subscription_id = operation.get("id")
+                    if isinstance(subscription_id, str):
+                        with self._lock:
+                            self._subscriptions[ws].pop(subscription_id, None)
+                elif op == "call_service":
+                    self._handle_service(ws, operation)
+        finally:
+            with self._lock:
+                self._connections.discard(ws)
+                self._subscriptions.pop(ws, None)
+
+    def _handle_service(self, ws: ServerConnection, operation: dict[str, Any]) -> None:
+        service = operation.get("service")
+        request_id = operation.get("id")
+        if not isinstance(service, str) or not isinstance(request_id, str):
+            return
+        if service in self.deferred_services:
+            return
+        result, values = self.service_results.get(service, (True, {"ok": True}))
+        self._send(
+            [ws],
+            {
+                "op": "service_response",
+                "id": request_id,
+                "values": values,
+                "result": result,
+            },
+        )
+
+    def _connected_targets(self) -> list[ServerConnection]:
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            with self._lock:
+                targets = list(self._connections)
+            if targets:
+                return targets
+            time.sleep(0.005)
+        raise TimeoutError("stub rosbridge has no connected client")
+
+    @staticmethod
+    def _send(targets: list[ServerConnection], frame: Mapping[str, Any]) -> None:
+        encoded = json.dumps(dict(frame), separators=(",", ":"))
+        for connection in targets:
+            with suppress(Exception):
+                connection.send(encoded)

--- a/plugins/inspect-robots-ros/tests/conftest.py
+++ b/plugins/inspect-robots-ros/tests/conftest.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from _stub_server import StubRosbridgeServer
+
+
+@pytest.fixture()
+def stub_server() -> Iterator[StubRosbridgeServer]:
+    server = StubRosbridgeServer()
+    yield server
+    server.stop()

--- a/plugins/inspect-robots-ros/tests/test_ros_embodiment.py
+++ b/plugins/inspect-robots-ros/tests/test_ros_embodiment.py
@@ -3,17 +3,36 @@
 from __future__ import annotations
 
 import base64
+import math
 import threading
 import time
+import warnings
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
 from io import BytesIO
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pytest
 from _stub_server import StubRosbridgeServer
 from PIL import Image
 
-from inspect_robots_ros._client import RosbridgeClient
+from inspect_robots import (
+    Action,
+    ActionChunk,
+    ActionSemantics,
+    Box,
+    Observation,
+    ObservationSpace,
+    PolicyConfig,
+    PolicyInfo,
+    Scene,
+)
+from inspect_robots.compat import check_compatibility
+from inspect_robots.conformance import assert_embodiment_conformant
+from inspect_robots.registry import registered, resolve
+from inspect_robots_ros import RosEmbodiment, ros_embodiment
+from inspect_robots_ros._client import RosbridgeClient, TopicSample
 from inspect_robots_ros._msgs import (
     build_float64_multi_array,
     build_gripper_command,
@@ -171,6 +190,18 @@ def _wait_for_latched_error(client: RosbridgeClient) -> Exception:
     raise TimeoutError("client did not latch an error")
 
 
+def _wait_for_topic_sequence(
+    client: RosbridgeClient, topic: str, *, after_seq: int, timeout_s: float = 2.0
+) -> TopicSample:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        sample = client.latest(topic)
+        if sample is not None and sample.seq > after_seq:
+            return sample
+        time.sleep(0.005)
+    raise TimeoutError(f"client did not receive sequence newer than {after_seq} on {topic}")
+
+
 def test_client_sends_while_receive_thread_updates_topic_cache(
     stub_server: StubRosbridgeServer,
 ) -> None:
@@ -189,11 +220,12 @@ def test_client_sends_while_receive_thread_updates_topic_cache(
             stub_server.publish("/joint_states", {"position": [float(index)]})
             time.sleep(0.002)
 
-    publisher = threading.Thread(target=stream)
+    publisher = threading.Thread(target=stream, daemon=True)
     publisher.start()
     for index in range(20):
         client.publish("/arm/command", {"data": [float(index)]})
     publisher.join(timeout=2)
+    assert not publisher.is_alive()
 
     sample = client.wait_for_sample("/joint_states", timeout_s=1.0)
     stub_server.wait_for(lambda ops: len([op for op in ops if op.get("op") == "publish"]) == 20)
@@ -212,13 +244,13 @@ def test_client_topic_sequence_increments_even_when_receive_stamps_tie(
         "/joint_states",
         subscription_id="joints",
         message_type="sensor_msgs/msg/JointState",
-        throttle_rate=50,
+        throttle_rate=0,
     )
     stub_server.wait_for(lambda ops: any(op.get("op") == "subscribe" for op in ops))
     stub_server.publish("/joint_states", {"position": [1.0]})
-    first = client.wait_for_sample("/joint_states", timeout_s=1.0)
+    first = _wait_for_topic_sequence(client, "/joint_states", after_seq=0)
     stub_server.publish("/joint_states", {"position": [2.0]})
-    second = client.wait_for_sample("/joint_states", after_seq=first.seq, timeout_s=1.0)
+    second = _wait_for_topic_sequence(client, "/joint_states", after_seq=first.seq)
     assert first.stamp == second.stamp == 7.0
     assert second.seq == first.seq + 1
     client.close()
@@ -269,7 +301,7 @@ def test_client_service_response_is_correlated_by_id(stub_server: StubRosbridgeS
         except BaseException as exc:  # pragma: no cover - assertion reports unexpected failure
             failures.append(exc)
 
-    caller = threading.Thread(target=call)
+    caller = threading.Thread(target=call, daemon=True)
     caller.start()
     stub_server.wait_for(lambda ops: any(op.get("op") == "call_service" for op in ops))
     request_id = stub_server.ops_of("call_service")[0]["id"]
@@ -278,6 +310,7 @@ def test_client_service_response_is_correlated_by_id(stub_server: StubRosbridgeS
     assert caller.is_alive()
     stub_server.send_service_response(request_id, values={"homed": True})
     caller.join(timeout=2)
+    assert not caller.is_alive()
     assert not failures
     assert replies == [ServiceResponse(request_id, {"homed": True}, True)]
     client.close()
@@ -517,3 +550,921 @@ def test_supported_message_type_strings_are_versioned() -> None:
     assert message_type("float64", 1) == "std_msgs/Float64"
     with pytest.raises(ValueError, match="ros_version"):
         message_type("joint_state", 3)
+
+
+_SCENE = Scene(id="scene-1", instruction="place the red block in the tray")
+
+
+def _embodiment(**kwargs: Any) -> RosEmbodiment:
+    kwargs.setdefault("joints", ("joint_1", "joint_2"))
+    kwargs.setdefault("command_topic", "/arm/command")
+    kwargs.setdefault("action_low", (-2.0, -3.0))
+    kwargs.setdefault("action_high", (2.0, 3.0))
+    kwargs.setdefault("obs_timeout_s", 1.0)
+    return RosEmbodiment(**kwargs)
+
+
+class _FakeClock:
+    def __init__(self, now: float = 0.0) -> None:
+        self.now = now
+        self.sleep_calls: list[float] = []
+
+    def __call__(self) -> float:
+        return self.now
+
+    def sleep(self, duration: float) -> None:
+        self.sleep_calls.append(duration)
+        self.now += duration
+
+    def advance(self, duration: float) -> None:
+        self.now += duration
+
+
+class _FakeClient:
+    def __init__(self, clock: _FakeClock) -> None:
+        self.clock = clock
+        self.samples: dict[str, TopicSample] = {}
+        self.operations: list[tuple[str, str, Any, float]] = []
+        self.wait_timeouts: list[float] = []
+        self.on_publish: Callable[[str, Mapping[str, Any]], None] | None = None
+        self.on_wait: Callable[[str, int], None] | None = None
+        self.service_response = ServiceResponse("fake-service", {}, True)
+        self.closed = False
+
+    def put(self, topic: str, msg: Mapping[str, Any], *, stamp: float | None = None) -> None:
+        previous = self.samples.get(topic)
+        self.samples[topic] = TopicSample(
+            msg=dict(msg),
+            stamp=self.clock() if stamp is None else stamp,
+            seq=1 if previous is None else previous.seq + 1,
+        )
+
+    def connect(self) -> None:
+        self.operations.append(("connect", "", None, self.clock()))
+
+    def advertise(self, topic: str, *, message_type: str) -> None:
+        self.operations.append(("advertise", topic, message_type, self.clock()))
+
+    def subscribe(self, topic: str, **kwargs: Any) -> None:
+        self.operations.append(("subscribe", topic, kwargs, self.clock()))
+
+    def unsubscribe(self, topic: str, **kwargs: Any) -> None:
+        self.operations.append(("unsubscribe", topic, kwargs, self.clock()))
+
+    def publish(self, topic: str, msg: Mapping[str, Any]) -> None:
+        self.operations.append(("publish", topic, dict(msg), self.clock()))
+        if self.on_publish is not None:
+            self.on_publish(topic, msg)
+
+    def call_service(self, service: str) -> ServiceResponse:
+        self.operations.append(("call_service", service, None, self.clock()))
+        return self.service_response
+
+    def latest(self, topic: str) -> TopicSample | None:
+        return self.samples.get(topic)
+
+    def sequence(self, topic: str) -> int:
+        sample = self.samples.get(topic)
+        return 0 if sample is None else sample.seq
+
+    def wait_for_sample(self, topic: str, *, after_seq: int = 0, timeout_s: float) -> TopicSample:
+        self.wait_timeouts.append(timeout_s)
+        if self.on_wait is not None:
+            self.on_wait(topic, after_seq)
+        sample = self.samples.get(topic)
+        if sample is not None and sample.seq > after_seq:
+            return sample
+        self.clock.sleep(timeout_s)
+        raise TimeoutError(topic)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _joint_message(positions: list[float] | None = None) -> dict[str, Any]:
+    return {
+        "name": ["joint_2", "finger", "joint_1"],
+        "position": positions or [0.2, 0.03, 0.1],
+    }
+
+
+def _pose_message() -> dict[str, Any]:
+    return {
+        "pose": {
+            "position": {"x": 1.0, "y": 2.0, "z": 3.0},
+            "orientation": {"x": 0.1, "y": 0.2, "z": 0.3, "w": 0.9},
+        }
+    }
+
+
+def _ready_embodiment(
+    *,
+    clock: _FakeClock | None = None,
+    joint_message: Mapping[str, Any] | None = None,
+    **kwargs: Any,
+) -> tuple[RosEmbodiment, _FakeClient, _FakeClock]:
+    fake_clock = clock or _FakeClock()
+    kwargs.setdefault("clock", fake_clock)
+    kwargs.setdefault("sleep", fake_clock.sleep)
+    embodiment = _embodiment(**kwargs)
+    client = _FakeClient(fake_clock)
+    client.put(embodiment.joint_states_topic, joint_message or _joint_message())
+    if embodiment.eef_pose_topic is not None:
+        client.put(embodiment.eef_pose_topic, _pose_message())
+    for camera in embodiment.cameras.values():
+        image = np.zeros((camera.height, camera.width, 3), dtype=np.uint8)
+        client.put(camera.topic, _compressed_image_message(image, "PNG", "png"))
+
+    def fresh_joint_state(topic: str, _msg: Mapping[str, Any]) -> None:
+        if topic == embodiment.command_topic:
+            current = client.samples[embodiment.joint_states_topic]
+            client.put(embodiment.joint_states_topic, current.msg)
+
+    client.on_publish = fresh_joint_state
+    embodiment._client = cast(Any, client)
+    embodiment._initialized = True
+    embodiment._instruction = _SCENE.instruction
+    return embodiment, client, fake_clock
+
+
+class _TopicStreams:
+    def __init__(
+        self,
+        server: StubRosbridgeServer,
+        messages: Mapping[str, Mapping[str, Any] | Callable[[], Mapping[str, Any]]],
+        *,
+        interval_s: float,
+    ) -> None:
+        self.server = server
+        self.messages = messages
+        self.interval_s = interval_s
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=2)
+        if self._thread.is_alive():
+            raise TimeoutError("topic publisher thread did not stop")
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            for topic, source in self.messages.items():
+                message = source() if callable(source) else source
+                self.server.publish(topic, message)
+            time.sleep(self.interval_s)
+
+
+@contextmanager
+def _topic_streams(
+    server: StubRosbridgeServer,
+    messages: Mapping[str, Mapping[str, Any] | Callable[[], Mapping[str, Any]]],
+    *,
+    interval_s: float = 0.005,
+) -> Iterator[None]:
+    streams = _TopicStreams(server, messages, interval_s=interval_s)
+    streams.start()
+    try:
+        yield
+    finally:
+        streams.stop()
+
+
+def test_registry_entry_point_and_cli_string_forms_include_non_square_camera() -> None:
+    assert "ros" in registered("embodiment")
+    embodiment = resolve(
+        "embodiment",
+        "ros",
+        joints="joint_1,joint_2",
+        command_topic="/arm/command",
+        action_low="-2,-3",
+        action_high="2,3",
+        cameras="wrist:/camera/wrist/compressed:640x480",
+    )
+    assert isinstance(embodiment, RosEmbodiment)
+    assert embodiment.joints == ("joint_1", "joint_2")
+    camera = embodiment.info.observation_space.cameras[0]
+    assert (camera.name, camera.height, camera.width) == ("wrist", 480, 640)
+    embodiment.close()
+
+
+def test_scalar_coerced_one_dof_bounds_are_accepted() -> None:
+    embodiment = ros_embodiment(
+        joints="joint_1",
+        command_topic="/arm/command",
+        action_low=-3.1,
+        action_high=3.1,
+    )
+    assert embodiment.info.action_space.shape == (1,)
+    np.testing.assert_array_equal(embodiment.info.action_space.low, [-3.1])
+    embodiment.close()
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"joints": None}, "joints is required"),
+        ({"command_topic": None}, "command_topic is required"),
+        ({"action_low": None}, "action_low is required"),
+        ({"action_high": None}, "action_high is required"),
+        ({"action_low": (-1.0,)}, "1 bounds for 2 joints"),
+        ({"action_high": (1.0,)}, "1 bounds for 2 joints"),
+        ({"joints": ("joint_1", "joint_1")}, "duplicate"),
+        (
+            {
+                "joints": ("joint_1", "gripper"),
+                "gripper_topic": "/gripper/command",
+                "gripper_joint": "finger",
+                "gripper_low": 0.0,
+                "gripper_high": 1.0,
+            },
+            "named 'gripper'",
+        ),
+        (
+            {
+                "gripper_topic": "/gripper/command",
+                "gripper_joint": "finger",
+                "gripper_low": 1.0,
+                "gripper_high": 1.0,
+            },
+            "less than",
+        ),
+        ({"gripper_topic": "/gripper/command"}, "required when gripper_topic"),
+        ({"gripper_joint": "finger"}, "only when gripper_topic"),
+        ({"control_hz": 0.0}, "positive and finite"),
+        ({"control_hz": math.inf}, "positive and finite"),
+        ({"ros_version": 3}, "ros_version"),
+        ({"command_type": "effort"}, "command_type"),
+        ({"gripper_command_type": "action"}, "gripper_command_type"),
+        ({"gripper_closed_at": "left"}, "gripper_closed_at"),
+        (
+            {"cameras": "wrist:/a:640x480,wrist:/b:320x240"},
+            "duplicate name",
+        ),
+    ],
+)
+def test_factory_validation_errors_are_actionable(kwargs: dict[str, Any], match: str) -> None:
+    defaults: dict[str, Any] = {
+        "joints": ("joint_1", "joint_2"),
+        "command_topic": "/arm/command",
+        "action_low": (-2.0, -3.0),
+        "action_high": (2.0, 3.0),
+    }
+    defaults.update(kwargs)
+    with pytest.raises(ValueError, match=match):
+        RosEmbodiment(**defaults)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "joints": tuple(f"joint_{index}" for index in range(7)),
+            "action_low": (-1.0,) * 7,
+            "action_high": (1.0,) * 7,
+            "eef_pose_topic": "/eef_pose",
+        },
+        {
+            "joints": tuple(f"joint_{index}" for index in range(6)),
+            "action_low": (-1.0,) * 6,
+            "action_high": (1.0,) * 6,
+            "gripper_topic": "/gripper/command",
+            "gripper_joint": "finger",
+            "gripper_low": 0.0,
+            "gripper_high": 0.08,
+            "eef_pose_topic": "/eef_pose",
+        },
+    ],
+)
+def test_seven_dimensional_action_with_eef_pose_is_rejected(kwargs: dict[str, Any]) -> None:
+    with pytest.raises(
+        ValueError,
+        match="omit eef_pose_topic on a 7-dim action space until core supports "
+        "key-priority reference matching",
+    ):
+        RosEmbodiment(command_topic="/arm/command", **kwargs)
+
+
+def test_info_declares_spaces_semantics_capabilities_and_lazy_network() -> None:
+    embodiment = _embodiment(
+        url="ws://192.0.2.1:9090",
+        gripper_topic="/gripper/command",
+        gripper_joint="finger",
+        gripper_low=0.0,
+        gripper_high=0.08,
+        eef_pose_topic="/eef_pose",
+        cameras={"wrist": ("/camera/compressed", 480, 640)},
+        reset_service="/home",
+        simulated=True,
+        control_hz=20.0,
+        name="ros:test-arm",
+    )
+    info = embodiment.info
+    assert info.name == "ros:test-arm"
+    assert info.action_space.shape == (3,)
+    np.testing.assert_array_equal(info.action_space.low, [-2.0, -3.0, 0.0])
+    np.testing.assert_array_equal(info.action_space.high, [2.0, 3.0, 0.08])
+    assert info.action_space.semantics == ActionSemantics(
+        control_mode="joint_pos",
+        rotation_repr="none",
+        gripper="continuous",
+        frame="base",
+        dim_labels=("joint_1", "joint_2", "gripper"),
+    )
+    state_spec = info.observation_space.state
+    assert state_spec is not None
+    fields = {field.key: field for field in state_spec.fields}
+    assert fields["joint_pos"].shape == (3,)
+    assert fields["gripper"].shape == (1,)
+    assert fields["eef_pose"].shape == (7,)
+    assert info.capabilities == frozenset({"self_paced", "resettable"})
+    assert info.control_hz == 20.0
+    assert info.is_simulated
+    assert info.supported_setups == info.supported_target_kinds == frozenset()
+    assert not embodiment._client.connected
+    embodiment.close()
+
+
+@pytest.mark.parametrize("with_gripper", [False, True])
+@pytest.mark.parametrize("with_eef_pose", [False, True])
+def test_conformance_matrix_passes_away_from_seven_dimensions(
+    with_gripper: bool, with_eef_pose: bool
+) -> None:
+    kwargs: dict[str, Any] = {}
+    if with_gripper:
+        kwargs.update(
+            gripper_topic="/gripper/command",
+            gripper_joint="finger",
+            gripper_low=0.0,
+            gripper_high=0.08,
+        )
+    if with_eef_pose:
+        kwargs["eef_pose_topic"] = "/eef_pose"
+    embodiment = _embodiment(**kwargs)
+    assert_embodiment_conformant(embodiment.info)
+    embodiment.close()
+
+
+def test_gripperless_info_never_claims_real_hardware_oracle_capabilities() -> None:
+    embodiment = _embodiment()
+    assert embodiment.info.capabilities == frozenset({"self_paced"})
+    semantics = embodiment.info.action_space.semantics
+    assert semantics is not None
+    assert semantics.dim_labels == ("joint_1", "joint_2")
+    assert embodiment.info.observation_space.state_keys == frozenset({"joint_pos"})
+    for capability in ("seedable", "auto_reset", "privileged_success"):
+        assert capability not in embodiment.info.capabilities
+    embodiment.close()
+
+
+@pytest.mark.parametrize(
+    "ros_version,command_type,expected",
+    [
+        (
+            1,
+            "joint_trajectory",
+            {
+                "joint_names": ["joint_1", "joint_2"],
+                "points": [
+                    {
+                        "positions": [1.0, 2.0],
+                        "time_from_start": {"secs": 0, "nsecs": 100_000_000},
+                    }
+                ],
+            },
+        ),
+        (
+            2,
+            "joint_trajectory",
+            {
+                "joint_names": ["joint_1", "joint_2"],
+                "points": [
+                    {
+                        "positions": [1.0, 2.0],
+                        "time_from_start": {"sec": 0, "nanosec": 100_000_000},
+                    }
+                ],
+            },
+        ),
+        (2, "float64_multi_array", {"data": [1.0, 2.0]}),
+    ],
+)
+def test_step_publishes_versioned_arm_command_and_returns_nonterminal_result(
+    ros_version: int, command_type: str, expected: dict[str, Any]
+) -> None:
+    embodiment, client, _clock = _ready_embodiment(
+        ros_version=ros_version, command_type=command_type
+    )
+    result = embodiment.step(Action(data=np.asarray([1.0, 2.0])))
+    arm_publish = next(op for op in client.operations if op[:2] == ("publish", "/arm/command"))
+    assert arm_publish[2] == expected
+    assert result.reward is None
+    assert not result.terminated
+    assert not result.truncated
+    assert result.observation.instruction == _SCENE.instruction
+
+
+@pytest.mark.parametrize(
+    "ros_version,override,expected_message",
+    [
+        (1, None, {"data": 0.037}),
+        (2, None, {"data": [0.037]}),
+        (2, "float64", {"data": 0.037}),
+        (1, "float64_multi_array", {"data": [0.037]}),
+    ],
+)
+def test_step_splits_raw_gripper_command_with_version_default_and_override(
+    ros_version: int, override: str | None, expected_message: dict[str, Any]
+) -> None:
+    embodiment, client, _clock = _ready_embodiment(
+        ros_version=ros_version,
+        gripper_topic="/gripper/command",
+        gripper_command_type=override,
+        gripper_joint="finger",
+        gripper_low=0.0,
+        gripper_high=0.08,
+    )
+    embodiment.step(Action(data=np.asarray([1.0, 2.0, 0.037])))
+    publishes = [operation for operation in client.operations if operation[0] == "publish"]
+    assert [operation[1] for operation in publishes] == [
+        "/arm/command",
+        "/gripper/command",
+    ]
+    assert publishes[1][2] == expected_message
+
+
+def test_every_fast_back_to_back_arm_publish_interval_is_at_least_period() -> None:
+    embodiment, client, _clock = _ready_embodiment(control_hz=10.0)
+    for _ in range(5):
+        embodiment.step(Action(data=np.asarray([0.1, 0.2])))
+    publish_times = [
+        operation[3]
+        for operation in client.operations
+        if operation[:2] == ("publish", "/arm/command")
+    ]
+    intervals = np.diff(publish_times)
+    assert len(intervals) == 4
+    assert bool(np.all(intervals >= 0.1 - 1e-12)), intervals
+
+
+def test_pacing_adds_no_sleep_after_slow_inference_gap() -> None:
+    embodiment, _client, clock = _ready_embodiment(control_hz=10.0)
+    embodiment.step(Action(data=np.asarray([0.1, 0.2])))
+    clock.advance(0.25)
+    sleeps_before = len(clock.sleep_calls)
+    embodiment.step(Action(data=np.asarray([0.2, 0.3])))
+    assert len(clock.sleep_calls) == sleeps_before
+
+
+def test_step_freshness_uses_sequence_when_receive_stamps_are_equal() -> None:
+    clock = _FakeClock(now=5.0)
+    embodiment, client, _clock = _ready_embodiment(clock=clock)
+    before = client.samples[embodiment.joint_states_topic]
+    result = embodiment.step(Action(data=np.asarray([0.1, 0.2])))
+    after = client.samples[embodiment.joint_states_topic]
+    assert before.stamp == after.stamp == 5.0
+    assert after.seq == before.seq + 1
+    assert result.observation.state_time == 5.0
+
+
+def test_step_freshness_timeout_names_both_configuration_knobs() -> None:
+    embodiment, client, _clock = _ready_embodiment(control_hz=20.0, fresh_obs_timeout_s=0.15)
+    client.on_publish = None
+    with pytest.raises(TimeoutError, match=r"fresh_obs_timeout_s=0.15s.*control_hz=20"):
+        embodiment.step(Action(data=np.asarray([0.1, 0.2])))
+
+
+def test_step_rejects_stale_cross_modal_sample() -> None:
+    clock = _FakeClock(now=10.0)
+    embodiment, client, _clock = _ready_embodiment(
+        clock=clock,
+        cameras={"wrist": ("/camera/compressed", 2, 3)},
+        staleness_s=1.0,
+    )
+    camera_sample = client.samples["/camera/compressed"]
+    client.samples["/camera/compressed"] = TopicSample(
+        camera_sample.msg, stamp=8.0, seq=camera_sample.seq
+    )
+    with pytest.raises(TimeoutError, match=r"camera/compressed.*staleness_s=1"):
+        embodiment.step(Action(data=np.asarray([0.1, 0.2])))
+
+
+@pytest.mark.parametrize(
+    "closed_at,raw,expected",
+    [("low", 0.02, 0.25), ("high", 0.02, 0.75)],
+)
+def test_observation_gripper_normalization_and_polarity(
+    closed_at: str, raw: float, expected: float
+) -> None:
+    embodiment, _client, _clock = _ready_embodiment(
+        joint_message=_joint_message([0.2, raw, 0.1]),
+        gripper_topic="/gripper/command",
+        gripper_joint="finger",
+        gripper_low=0.0,
+        gripper_high=0.08,
+        gripper_closed_at=closed_at,
+    )
+    observation = embodiment.step(Action(data=np.asarray([0.1, 0.2, raw]))).observation
+    np.testing.assert_allclose(observation.state["joint_pos"], [0.1, 0.2, raw])
+    np.testing.assert_allclose(observation.state["gripper"], [expected])
+
+
+def test_observation_state_and_image_times_follow_oldest_state_convention() -> None:
+    clock = _FakeClock(now=10.0)
+    embodiment, client, _clock = _ready_embodiment(
+        clock=clock,
+        eef_pose_topic="/eef_pose",
+        cameras={"wrist": ("/camera/compressed", 2, 3)},
+        staleness_s=3.0,
+    )
+    eef = client.samples["/eef_pose"]
+    camera = client.samples["/camera/compressed"]
+    client.samples["/eef_pose"] = TopicSample(eef.msg, 8.5, eef.seq)
+    client.samples["/camera/compressed"] = TopicSample(camera.msg, 9.0, camera.seq)
+    observation = embodiment.step(Action(data=np.asarray([0.1, 0.2]))).observation
+    assert observation.state_time == 8.5
+    assert observation.image_times == {"wrist": 9.0}
+    np.testing.assert_array_equal(
+        observation.state["eef_pose"], [1.0, 2.0, 3.0, 0.9, 0.1, 0.2, 0.3]
+    )
+
+
+def test_step_rejects_wrong_action_shape() -> None:
+    embodiment, _client, _clock = _ready_embodiment()
+    with pytest.raises(ValueError, match=r"shape.*expected"):
+        embodiment.step(Action(data=np.zeros((1, 2))))
+
+
+def test_second_reset_without_physical_reset_path_warns_once(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    embodiment, client, _clock = _ready_embodiment()
+
+    def fresh(topic: str, _after: int) -> None:
+        client.put(topic, client.samples[topic].msg)
+
+    client.on_wait = fresh
+    embodiment.reset(_SCENE)
+    embodiment.reset(_SCENE)
+    embodiment.reset(_SCENE)
+    stderr = capsys.readouterr().err
+    assert stderr.count("no reset_service or operator_reset_confirm") == 1
+
+
+def test_operator_confirm_post_wait_uses_obs_timeout_not_fresh_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    embodiment, client, _clock = _ready_embodiment(
+        operator_reset_confirm=True,
+        obs_timeout_s=3.0,
+        fresh_obs_timeout_s=0.01,
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "")
+
+    def fresh(topic: str, _after: int) -> None:
+        client.put(topic, client.samples[topic].msg)
+
+    client.on_wait = fresh
+    observation = embodiment.reset(_SCENE)
+    assert client.wait_timeouts[-1] == 3.0
+    assert observation.instruction == _SCENE.instruction
+    assert _SCENE.instruction in capsys.readouterr().out
+
+
+def test_reset_accepts_and_ignores_seed_without_claiming_seedable() -> None:
+    embodiment, client, _clock = _ready_embodiment()
+
+    def fresh(topic: str, _after: int) -> None:
+        client.put(topic, client.samples[topic].msg)
+
+    client.on_wait = fresh
+    observation = embodiment.reset(_SCENE, seed=123)
+    assert observation.instruction == _SCENE.instruction
+    assert "seedable" not in embodiment.info.capabilities
+
+
+def test_operator_confirm_eof_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    embodiment, _client, _clock = _ready_embodiment(operator_reset_confirm=True)
+
+    def eof(_prompt: str) -> str:
+        raise EOFError("stdin is not interactive")
+
+    monkeypatch.setattr("builtins.input", eof)
+    with pytest.raises(EOFError, match="not interactive"):
+        embodiment.reset(_SCENE)
+
+
+def test_close_delegates_idempotently_to_client() -> None:
+    embodiment, client, _clock = _ready_embodiment()
+    embodiment.close()
+    embodiment.close()
+    assert client.closed
+
+
+def test_connection_failure_names_url_and_both_rosbridge_launch_commands() -> None:
+    embodiment = _embodiment(url="ws://127.0.0.1:9", connect_timeout_s=0.05)
+    with pytest.raises(ConnectionError) as exc_info:
+        embodiment.reset(_SCENE)
+    message = str(exc_info.value)
+    assert "ws://127.0.0.1:9" in message
+    assert "roslaunch rosbridge_server rosbridge_websocket.launch" in message
+    assert "ros2 launch rosbridge_server rosbridge_websocket_launch.xml" in message
+    embodiment.close()
+
+
+class _PolicyInfoStub:
+    config = PolicyConfig()
+
+    def __init__(self, info: PolicyInfo) -> None:
+        self.info = info
+
+    def reset(self, scene: Scene) -> None:
+        del scene
+
+    def act(self, observation: Observation) -> ActionChunk:
+        del observation
+        return ActionChunk(actions=(Action(data=np.zeros(self.info.action_space.shape)),))
+
+    def close(self) -> None:
+        pass
+
+
+def test_compatibility_with_agent_and_xpolicylab_shaped_policy_info_stubs() -> None:
+    embodiment = _embodiment(
+        gripper_topic="/gripper/command",
+        gripper_joint="finger",
+        gripper_low=0.0,
+        gripper_high=0.08,
+        cameras={"wrist": ("/camera/compressed", 480, 640)},
+    )
+    agent = _PolicyInfoStub(
+        PolicyInfo(
+            name="agent-shaped",
+            action_space=embodiment.info.action_space,
+            observation_space=ObservationSpace(
+                cameras=embodiment.info.observation_space.cameras,
+                state_keys=frozenset({"joint_pos"}),
+            ),
+            control_hz=10.0,
+        )
+    )
+    xpolicylab = _PolicyInfoStub(
+        PolicyInfo(
+            name="xpolicylab-shaped",
+            action_space=Box(
+                shape=(3,),
+                semantics=ActionSemantics(
+                    control_mode="joint_pos",
+                    rotation_repr="none",
+                    gripper="continuous",
+                    frame="base",
+                ),
+            ),
+            observation_space=ObservationSpace(
+                cameras=embodiment.info.observation_space.cameras,
+                state_keys=frozenset({"joint_pos", "gripper"}),
+            ),
+            control_hz=10.0,
+        )
+    )
+    assert check_compatibility(agent, embodiment).ok
+    assert check_compatibility(xpolicylab, embodiment).ok
+
+    camera_free = _embodiment(
+        gripper_topic="/gripper/command",
+        gripper_joint="finger",
+        gripper_low=0.0,
+        gripper_high=0.08,
+    )
+    report = check_compatibility(xpolicylab, camera_free)
+    assert {issue.code for issue in report.errors} == {"missing_camera"}
+    embodiment.close()
+    camera_free.close()
+
+
+def test_rosbridge_reset_subscriptions_preflight_handoff_and_fast_rate_no_warning(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    embodiment = _embodiment(url=stub_server.url, control_hz=10.0)
+    with (
+        _topic_streams(stub_server, {"/joint_states": _joint_message()}),
+        warnings.catch_warnings(record=True) as caught,
+    ):
+        warnings.simplefilter("always")
+        observation = embodiment.reset(_SCENE)
+    assert observation.instruction == _SCENE.instruction
+    rate_warnings = [
+        warning
+        for warning in caught
+        if "native rate" in str(warning.message) or "too few" in str(warning.message)
+    ]
+    assert not rate_warnings
+    joint_ops = [
+        operation
+        for operation in stub_server.ops
+        if operation.get("topic") == "/joint_states"
+        and operation.get("op") in {"subscribe", "unsubscribe"}
+    ]
+    assert [(operation["op"], operation["id"]) for operation in joint_ops] == [
+        ("subscribe", "inspect-robots-preflight-joint-states"),
+        ("unsubscribe", "inspect-robots-preflight-joint-states"),
+        ("subscribe", "inspect-robots-joint-states"),
+    ]
+    assert joint_ops[0]["throttle_rate"] == 0
+    assert joint_ops[0]["queue_length"] == 1
+    assert joint_ops[2]["throttle_rate"] == 50
+    assert joint_ops[2]["queue_length"] == 1
+    assert set(stub_server.subscriptions) == {"inspect-robots-joint-states"}
+    embodiment.close()
+
+
+def test_rosbridge_preflight_warns_for_slow_native_joint_state_rate(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    embodiment = _embodiment(url=stub_server.url, control_hz=50.0)
+    with (
+        _topic_streams(stub_server, {"/joint_states": _joint_message()}, interval_s=0.03),
+        pytest.warns(RuntimeWarning, match=r"native rate.*below 2x control_hz"),
+    ):
+        embodiment.reset(_SCENE)
+    embodiment.close()
+
+
+def test_rosbridge_preflight_single_message_warns_then_hands_off(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    stop = threading.Event()
+
+    def publish_once_then_rollout() -> None:
+        stub_server.wait_for(
+            lambda ops: any(
+                operation.get("op") == "subscribe"
+                and operation.get("id") == "inspect-robots-preflight-joint-states"
+                for operation in ops
+            )
+        )
+        stub_server.publish("/joint_states", _joint_message())
+        stub_server.wait_for(
+            lambda ops: any(
+                operation.get("op") == "subscribe"
+                and operation.get("id") == "inspect-robots-joint-states"
+                for operation in ops
+            ),
+            timeout_s=2.0,
+        )
+        while not stop.is_set():
+            stub_server.publish("/joint_states", _joint_message())
+            time.sleep(0.005)
+
+    publisher = threading.Thread(target=publish_once_then_rollout, daemon=True)
+    publisher.start()
+    embodiment = _embodiment(url=stub_server.url, obs_timeout_s=1.0)
+    try:
+        with pytest.warns(RuntimeWarning, match="exactly one message"):
+            embodiment.reset(_SCENE)
+    finally:
+        stop.set()
+        publisher.join(timeout=2)
+        assert not publisher.is_alive()
+        embodiment.close()
+
+
+def test_rosbridge_zero_joint_messages_fall_through_to_missing_topic_error(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    embodiment = _embodiment(url=stub_server.url, obs_timeout_s=0.03)
+    with pytest.raises(TimeoutError, match=r"/joint_states.*obs_timeout_s=0.03"):
+        embodiment.reset(_SCENE)
+    embodiment.close()
+
+
+def test_rosbridge_missing_optional_topic_names_that_topic(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    embodiment = _embodiment(
+        url=stub_server.url,
+        eef_pose_topic="/eef_pose",
+        obs_timeout_s=0.05,
+    )
+    with (
+        _topic_streams(stub_server, {"/joint_states": _joint_message()}),
+        pytest.raises(TimeoutError, match=r"/eef_pose.*obs_timeout_s=0.05"),
+    ):
+        embodiment.reset(_SCENE)
+    embodiment.close()
+
+
+def test_rosbridge_camera_resolution_mismatch_names_declared_and_actual(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    image = np.zeros((2, 3, 3), dtype=np.uint8)
+    embodiment = _embodiment(
+        url=stub_server.url,
+        cameras={"wrist": ("/camera/compressed", 3, 4)},
+    )
+    with (
+        _topic_streams(
+            stub_server,
+            {
+                "/joint_states": _joint_message(),
+                "/camera/compressed": _compressed_image_message(image, "PNG", "png"),
+            },
+        ),
+        pytest.raises(ValueError, match=r"declared resolution 4x3.*first frame is 3x2"),
+    ):
+        embodiment.reset(_SCENE)
+    embodiment.close()
+
+
+def test_rosbridge_subscribes_every_modality_with_declared_throttles_and_types(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    image = np.zeros((2, 3, 3), dtype=np.uint8)
+    embodiment = _embodiment(
+        url=stub_server.url,
+        control_hz=20.0,
+        eef_pose_topic="/eef_pose",
+        cameras={"wrist": ("/camera/compressed", 2, 3)},
+        reset_service="/home",
+    )
+    with _topic_streams(
+        stub_server,
+        {
+            "/joint_states": _joint_message(),
+            "/eef_pose": _pose_message(),
+            "/camera/compressed": _compressed_image_message(image, "PNG", "png"),
+        },
+    ):
+        observation = embodiment.reset(_SCENE)
+    assert observation.images["wrist"].shape == (2, 3, 3)
+    subscriptions = {operation["id"]: operation for operation in stub_server.ops_of("subscribe")}
+    assert subscriptions["inspect-robots-preflight-joint-states"]["throttle_rate"] == 0
+    assert subscriptions["inspect-robots-joint-states"]["throttle_rate"] == 25
+    assert subscriptions["inspect-robots-eef-pose"]["throttle_rate"] == 25
+    assert subscriptions["inspect-robots-camera-wrist"]["throttle_rate"] == 50
+    assert subscriptions["inspect-robots-eef-pose"]["type"] == ("geometry_msgs/msg/PoseStamped")
+    assert subscriptions["inspect-robots-camera-wrist"]["type"] == (
+        "sensor_msgs/msg/CompressedImage"
+    )
+    assert all(operation["queue_length"] == 1 for operation in subscriptions.values())
+    assert stub_server.ops_of("call_service")[0]["service"] == "/home"
+    assert stub_server.ops_of("advertise")[0]["type"] == ("trajectory_msgs/msg/JointTrajectory")
+    embodiment.close()
+
+
+def test_rosbridge_reset_service_is_called_and_false_result_raises(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    stub_server.service_results["/home"] = (False, {"reason": "blocked"})
+    embodiment = _embodiment(
+        url=stub_server.url,
+        reset_service="/home",
+    )
+    with (
+        _topic_streams(stub_server, {"/joint_states": _joint_message()}),
+        pytest.raises(RosbridgeError, match=r"/home.*result=false.*blocked"),
+    ):
+        embodiment.reset(_SCENE)
+    assert stub_server.ops_of("call_service")[0]["args"] == {}
+    embodiment.close()
+
+
+def test_rosbridge_reset_returns_message_newer_than_initial_cache(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    counter = 0
+
+    def changing_joint_state() -> Mapping[str, Any]:
+        nonlocal counter
+        counter += 1
+        return _joint_message([float(counter), 0.03, float(counter) + 0.5])
+
+    embodiment = _embodiment(url=stub_server.url)
+    with _topic_streams(stub_server, {"/joint_states": changing_joint_state}):
+        observation = embodiment.reset(_SCENE)
+    assert counter > 5
+    assert observation.state["joint_pos"][0] > 1.0
+    embodiment.close()
+
+
+def test_rosbridge_end_to_end_step_publishes_and_threads_instruction(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    embodiment = _embodiment(url=stub_server.url, fresh_obs_timeout_s=0.3)
+    with _topic_streams(stub_server, {"/joint_states": _joint_message()}):
+        reset_observation = embodiment.reset(_SCENE)
+        step_result = embodiment.step(Action(data=np.asarray([0.4, 0.5])))
+    assert (
+        reset_observation.instruction == step_result.observation.instruction == _SCENE.instruction
+    )
+    command = [
+        operation
+        for operation in stub_server.ops_of("publish")
+        if operation.get("topic") == "/arm/command"
+    ][-1]
+    assert command["msg"]["points"][0]["positions"] == [0.4, 0.5]
+    embodiment.close()

--- a/plugins/inspect-robots-ros/tests/test_ros_embodiment.py
+++ b/plugins/inspect-robots-ros/tests/test_ros_embodiment.py
@@ -1460,6 +1460,33 @@ def test_rosbridge_reset_subscriptions_preflight_handoff_and_fast_rate_no_warnin
     embodiment.close()
 
 
+def test_rosbridge_preflight_high_rate_publisher_above_poll_frequency_no_warning(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    """A 500 Hz publisher at control_hz=60 must not warn.
+
+    The client poll loop coalesces messages faster than its 10 ms poll into the
+    latest-value slot, so a sample-count rate estimate caps at ~100 Hz and
+    falsely flags any rig whose 2x-control_hz threshold exceeds that cap; the
+    sequence-delta estimate sees the coalesced messages.
+    """
+    embodiment = _embodiment(url=stub_server.url, control_hz=60.0)
+    with (
+        _topic_streams(stub_server, {"/joint_states": _joint_message()}, interval_s=0.002),
+        warnings.catch_warnings(record=True) as caught,
+    ):
+        warnings.simplefilter("always")
+        observation = embodiment.reset(_SCENE)
+    assert observation.instruction == _SCENE.instruction
+    rate_warnings = [
+        warning
+        for warning in caught
+        if "native rate" in str(warning.message) or "too few" in str(warning.message)
+    ]
+    assert not rate_warnings
+    embodiment.close()
+
+
 def test_rosbridge_preflight_warns_for_slow_native_joint_state_rate(
     stub_server: StubRosbridgeServer,
 ) -> None:

--- a/plugins/inspect-robots-ros/tests/test_ros_embodiment.py
+++ b/plugins/inspect-robots-ros/tests/test_ros_embodiment.py
@@ -886,6 +886,7 @@ def test_scalar_coerced_one_dof_bounds_are_accepted() -> None:
         ({"gripper_closed_at": "left"}, "gripper_closed_at"),
         ({"fresh_obs_timeout_s": 0.0}, "fresh_obs_timeout_s must be positive and finite"),
         ({"camera_throttle_ms": -1}, "camera_throttle_ms must be >= 0"),
+        ({"camera_throttle_ms": 50.5}, "camera_throttle_ms must be integer milliseconds"),
         ({"obs_timeout_s": 0.0}, "obs_timeout_s must be positive and finite"),
         ({"connect_timeout_s": math.inf}, "connect_timeout_s must be positive and finite"),
         ({"request_timeout_s": 0.0}, "request_timeout_s must be positive and finite"),

--- a/plugins/inspect-robots-ros/tests/test_ros_embodiment.py
+++ b/plugins/inspect-robots-ros/tests/test_ros_embodiment.py
@@ -2,14 +2,27 @@
 
 from __future__ import annotations
 
+import base64
 import threading
 import time
+from io import BytesIO
 from typing import Any
 
+import numpy as np
 import pytest
 from _stub_server import StubRosbridgeServer
+from PIL import Image
 
 from inspect_robots_ros._client import RosbridgeClient
+from inspect_robots_ros._msgs import (
+    build_float64_multi_array,
+    build_gripper_command,
+    build_joint_trajectory,
+    message_type,
+    parse_compressed_image,
+    parse_joint_state,
+    parse_pose_stamped,
+)
 from inspect_robots_ros._protocol import (
     PublishedMessage,
     RosbridgeError,
@@ -334,3 +347,173 @@ def test_client_requires_connect_and_connect_failure_names_url(
     with pytest.raises(ConnectionError, match=r"ws://127\.0\.0\.1:9"):
         unreachable.connect()
     unreachable.close()
+
+
+def test_joint_state_reorders_shuffled_names() -> None:
+    parsed = parse_joint_state(
+        {
+            "name": ["finger", "joint_2", "unused", "joint_1"],
+            "position": [0.04, 2.0, 99.0, 1.0],
+        },
+        ("joint_1", "joint_2", "finger"),
+    )
+    assert parsed.dtype == np.float64
+    np.testing.assert_array_equal(parsed, [1.0, 2.0, 0.04])
+
+
+def test_joint_state_missing_joint_error_lists_available_names() -> None:
+    with pytest.raises(ValueError, match=r"missing.*joint_2.*available.*joint_1.*spare"):
+        parse_joint_state(
+            {"name": ["spare", "joint_1"], "position": [9.0, 1.0]},
+            ("joint_1", "joint_2"),
+        )
+
+
+@pytest.mark.parametrize(
+    "msg,match",
+    [
+        ({"name": "joint_1", "position": [1.0]}, "name"),
+        ({"name": ["joint_1"], "position": "1.0"}, "position"),
+        ({"name": ["joint_1"], "position": [1.0, 2.0]}, "equal length"),
+        ({"name": ["joint_1"], "position": [object()]}, "numeric"),
+    ],
+)
+def test_joint_state_rejects_malformed_parallel_arrays(msg: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        parse_joint_state(msg, ("joint_1",))
+
+
+def _compressed_image_message(
+    image: np.ndarray[Any, np.dtype[np.uint8]], image_format: str, ros_format: str
+) -> dict[str, str]:
+    buffer = BytesIO()
+    Image.fromarray(image, mode="RGB").save(buffer, format=image_format)
+    return {
+        "format": ros_format,
+        "data": base64.b64encode(buffer.getvalue()).decode("ascii"),
+    }
+
+
+@pytest.mark.parametrize(
+    "image_format,ros_format",
+    [
+        ("PNG", "png"),
+        ("JPEG", "jpeg"),
+        ("JPEG", "rgb8; jpeg compressed bgr8"),
+    ],
+)
+def test_compressed_image_decodes_rgb_uint8(image_format: str, ros_format: str) -> None:
+    image = np.zeros((2, 3, 3), dtype=np.uint8)
+    image[..., 0] = 240
+    image[..., 1] = 10
+    parsed = parse_compressed_image(_compressed_image_message(image, image_format, ros_format))
+    assert parsed.shape == (2, 3, 3)
+    assert parsed.dtype == np.uint8
+    if image_format == "PNG":
+        np.testing.assert_array_equal(parsed, image)
+    else:
+        np.testing.assert_allclose(parsed, image, atol=4)
+
+
+@pytest.mark.parametrize(
+    "msg",
+    [
+        {"format": "jpeg", "data": [1, 2, 3]},
+        {"format": "jpeg", "data": "not base64!"},
+        {"format": "jpeg", "data": base64.b64encode(b"not an image").decode()},
+    ],
+)
+def test_compressed_image_rejects_bad_data(msg: dict[str, Any]) -> None:
+    with pytest.raises(ValueError, match=r"CompressedImage|decode"):
+        parse_compressed_image(msg)
+
+
+def test_pose_stamped_reorders_xyzw_to_wxyz() -> None:
+    parsed = parse_pose_stamped(
+        {
+            "pose": {
+                "position": {"x": 1.0, "y": 2.0, "z": 3.0},
+                "orientation": {"x": 0.1, "y": 0.2, "z": 0.3, "w": 0.9},
+            }
+        }
+    )
+    np.testing.assert_array_equal(parsed, [1.0, 2.0, 3.0, 0.9, 0.1, 0.2, 0.3])
+
+
+def test_pose_stamped_rejects_missing_fields() -> None:
+    with pytest.raises(ValueError, match="orientation"):
+        parse_pose_stamped({"pose": {"position": {"x": 1.0}}})
+
+
+@pytest.mark.parametrize(
+    "ros_version,expected_type,expected_duration",
+    [
+        (
+            1,
+            "trajectory_msgs/JointTrajectory",
+            {"secs": 0, "nsecs": 100_000_000},
+        ),
+        (
+            2,
+            "trajectory_msgs/msg/JointTrajectory",
+            {"sec": 0, "nanosec": 100_000_000},
+        ),
+    ],
+)
+def test_joint_trajectory_golden_shapes_for_both_ros_versions(
+    ros_version: int, expected_type: str, expected_duration: dict[str, int]
+) -> None:
+    assert message_type("joint_trajectory", ros_version) == expected_type
+    assert build_joint_trajectory(
+        ("joint_2", "joint_1"), [2.0, 1.0], period_s=0.1, ros_version=ros_version
+    ) == {
+        "joint_names": ["joint_2", "joint_1"],
+        "points": [
+            {
+                "positions": [2.0, 1.0],
+                "time_from_start": expected_duration,
+            }
+        ],
+    }
+
+
+def test_joint_trajectory_duration_rounding_carries_to_next_second() -> None:
+    message = build_joint_trajectory(("joint_1",), [1.0], period_s=1.9999999996, ros_version=2)
+    assert message["points"][0]["time_from_start"] == {"sec": 2, "nanosec": 0}
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        (
+            {"joint_names": ("j1",), "positions": [1.0, 2.0], "period_s": 0.1},
+            "names",
+        ),
+        (
+            {"joint_names": ("j1",), "positions": [1.0], "period_s": -0.1},
+            "period_s",
+        ),
+    ],
+)
+def test_joint_trajectory_rejects_invalid_inputs(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        build_joint_trajectory(**kwargs, ros_version=2)
+
+
+def test_float64_and_gripper_command_builders_preserve_raw_values() -> None:
+    assert build_float64_multi_array(np.array([1.0, 2.0])) == {"data": [1.0, 2.0]}
+    assert build_gripper_command(0.037, "float64") == {"data": 0.037}
+    assert build_gripper_command(0.037, "float64_multi_array") == {"data": [0.037]}
+    with pytest.raises(ValueError, match="command_type"):
+        build_gripper_command(0.0, "action")
+
+
+def test_supported_message_type_strings_are_versioned() -> None:
+    assert message_type("joint_state", 1) == "sensor_msgs/JointState"
+    assert message_type("joint_state", 2) == "sensor_msgs/msg/JointState"
+    assert message_type("compressed_image", 2) == "sensor_msgs/msg/CompressedImage"
+    assert message_type("pose_stamped", 2) == "geometry_msgs/msg/PoseStamped"
+    assert message_type("float64_multi_array", 2) == "std_msgs/msg/Float64MultiArray"
+    assert message_type("float64", 1) == "std_msgs/Float64"
+    with pytest.raises(ValueError, match="ros_version"):
+        message_type("joint_state", 3)

--- a/plugins/inspect-robots-ros/tests/test_ros_embodiment.py
+++ b/plugins/inspect-robots-ros/tests/test_ros_embodiment.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
-import pytest
+import threading
+import time
+from typing import Any
 
+import pytest
+from _stub_server import StubRosbridgeServer
+
+from inspect_robots_ros._client import RosbridgeClient
 from inspect_robots_ros._protocol import (
     PublishedMessage,
     RosbridgeError,
@@ -131,3 +137,200 @@ def test_protocol_rejects_non_json_values_on_encode() -> None:
 
 def test_non_error_status_does_not_create_an_error() -> None:
     assert StatusMessage("warning", "slow publisher").as_error() is None
+
+
+def _client(server: StubRosbridgeServer, **kwargs: Any) -> RosbridgeClient:
+    return RosbridgeClient(
+        server.url,
+        connect_timeout_s=2.0,
+        request_timeout_s=1.0,
+        **kwargs,
+    )
+
+
+def _wait_for_latched_error(client: RosbridgeClient) -> Exception:
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        error = client.latched_error
+        if error is not None:
+            return error
+        time.sleep(0.005)
+    raise TimeoutError("client did not latch an error")
+
+
+def test_client_sends_while_receive_thread_updates_topic_cache(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    client = _client(stub_server)
+    client.connect()
+    client.subscribe(
+        "/joint_states",
+        subscription_id="joints",
+        message_type="sensor_msgs/msg/JointState",
+        throttle_rate=50,
+    )
+    stub_server.wait_for(lambda ops: any(op.get("op") == "subscribe" for op in ops))
+
+    def stream() -> None:
+        for index in range(20):
+            stub_server.publish("/joint_states", {"position": [float(index)]})
+            time.sleep(0.002)
+
+    publisher = threading.Thread(target=stream)
+    publisher.start()
+    for index in range(20):
+        client.publish("/arm/command", {"data": [float(index)]})
+    publisher.join(timeout=2)
+
+    sample = client.wait_for_sample("/joint_states", timeout_s=1.0)
+    stub_server.wait_for(lambda ops: len([op for op in ops if op.get("op") == "publish"]) == 20)
+    assert sample.seq >= 1
+    assert sample.msg["position"][0] >= 0.0
+    assert len(stub_server.ops_of("publish")) == 20
+    client.close()
+
+
+def test_client_topic_sequence_increments_even_when_receive_stamps_tie(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    client = _client(stub_server, clock=lambda: 7.0)
+    client.connect()
+    client.subscribe(
+        "/joint_states",
+        subscription_id="joints",
+        message_type="sensor_msgs/msg/JointState",
+        throttle_rate=50,
+    )
+    stub_server.wait_for(lambda ops: any(op.get("op") == "subscribe" for op in ops))
+    stub_server.publish("/joint_states", {"position": [1.0]})
+    first = client.wait_for_sample("/joint_states", timeout_s=1.0)
+    stub_server.publish("/joint_states", {"position": [2.0]})
+    second = client.wait_for_sample("/joint_states", after_seq=first.seq, timeout_s=1.0)
+    assert first.stamp == second.stamp == 7.0
+    assert second.seq == first.seq + 1
+    client.close()
+
+
+def test_client_status_error_latches_and_surfaces_on_every_later_call(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    client = _client(stub_server)
+    client.connect()
+    stub_server.send_status("error", "message type mismatch")
+    error = _wait_for_latched_error(client)
+    assert isinstance(error, RosbridgeError)
+    assert "message type mismatch" in str(error)
+    with pytest.raises(RosbridgeError, match="message type mismatch"):
+        client.publish("/arm/command", {"data": []})
+    with pytest.raises(RosbridgeError, match="message type mismatch"):
+        client.latest("/joint_states")
+    with pytest.raises(RosbridgeError, match="message type mismatch"):
+        client.call_service("/home")
+    client.close()
+
+
+def test_client_socket_death_latches_connection_error(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    client = _client(stub_server)
+    client.connect()
+    stub_server.drop_connections()
+    error = _wait_for_latched_error(client)
+    assert isinstance(error, ConnectionError)
+    assert stub_server.url in str(error)
+    with pytest.raises(ConnectionError, match="lost"):
+        client.sequence("/joint_states")
+    client.close()
+
+
+def test_client_service_response_is_correlated_by_id(stub_server: StubRosbridgeServer) -> None:
+    stub_server.deferred_services.add("/home")
+    client = _client(stub_server)
+    client.connect()
+    replies: list[ServiceResponse] = []
+    failures: list[BaseException] = []
+
+    def call() -> None:
+        try:
+            replies.append(client.call_service("/home"))
+        except BaseException as exc:  # pragma: no cover - assertion reports unexpected failure
+            failures.append(exc)
+
+    caller = threading.Thread(target=call)
+    caller.start()
+    stub_server.wait_for(lambda ops: any(op.get("op") == "call_service" for op in ops))
+    request_id = stub_server.ops_of("call_service")[0]["id"]
+    stub_server.send_service_response("wrong-id", values={"wrong": True})
+    time.sleep(0.02)
+    assert caller.is_alive()
+    stub_server.send_service_response(request_id, values={"homed": True})
+    caller.join(timeout=2)
+    assert not failures
+    assert replies == [ServiceResponse(request_id, {"homed": True}, True)]
+    client.close()
+
+
+def test_client_failed_service_result_raises_protocol_error(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    stub_server.service_results["/home"] = (False, {"reason": "blocked"})
+    client = _client(stub_server)
+    client.connect()
+    with pytest.raises(RosbridgeError, match=r"/home.*result=false.*blocked"):
+        client.call_service("/home")
+    client.close()
+
+
+def test_client_service_timeout_names_service_and_url(stub_server: StubRosbridgeServer) -> None:
+    stub_server.deferred_services.add("/home")
+    client = RosbridgeClient(
+        stub_server.url,
+        connect_timeout_s=2.0,
+        request_timeout_s=0.03,
+    )
+    client.connect()
+    with pytest.raises(RosbridgeError, match=rf"/home.*{stub_server.url}"):
+        client.call_service("/home")
+    client.close()
+
+
+def test_client_close_cleans_resources_joins_thread_and_is_idempotent(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    client = _client(stub_server)
+    client.connect()
+    client.advertise("/arm/command", message_type="std_msgs/msg/Float64MultiArray")
+    client.subscribe(
+        "/joint_states",
+        subscription_id="joints",
+        message_type="sensor_msgs/msg/JointState",
+        throttle_rate=50,
+    )
+    stub_server.wait_for(lambda ops: len(ops) >= 2)
+    client.close()
+    client.close()
+    stub_server.wait_for(
+        lambda ops: (
+            any(op.get("op") == "unsubscribe" for op in ops)
+            and any(op.get("op") == "unadvertise" for op in ops)
+        )
+    )
+    assert not client.connected
+    assert not client.receiver_alive
+    assert set(stub_server.subscriptions) == set()
+    with pytest.raises(RuntimeError, match="closed"):
+        client.publish("/arm/command", {"data": []})
+
+
+def test_client_requires_connect_and_connect_failure_names_url(
+    stub_server: StubRosbridgeServer,
+) -> None:
+    client = _client(stub_server)
+    with pytest.raises(ConnectionError, match="call connect"):
+        client.latest("/joint_states")
+    client.close()
+
+    unreachable = RosbridgeClient("ws://127.0.0.1:9", connect_timeout_s=0.05)
+    with pytest.raises(ConnectionError, match=r"ws://127\.0\.0\.1:9"):
+        unreachable.connect()
+    unreachable.close()

--- a/plugins/inspect-robots-ros/tests/test_ros_embodiment.py
+++ b/plugins/inspect-robots-ros/tests/test_ros_embodiment.py
@@ -207,6 +207,9 @@ def test_client_sends_while_receive_thread_updates_topic_cache(
 ) -> None:
     client = _client(stub_server)
     client.connect()
+    client.connect()
+    client.advertise("/temporary", message_type="std_msgs/msg/Float64MultiArray")
+    client.unadvertise("/temporary")
     client.subscribe(
         "/joint_states",
         subscription_id="joints",
@@ -261,6 +264,7 @@ def test_client_status_error_latches_and_surfaces_on_every_later_call(
 ) -> None:
     client = _client(stub_server)
     client.connect()
+    stub_server.send_status("warning", "slow publisher")
     stub_server.send_status("error", "message type mismatch")
     error = _wait_for_latched_error(client)
     assert isinstance(error, RosbridgeError)
@@ -375,11 +379,72 @@ def test_client_requires_connect_and_connect_failure_names_url(
     with pytest.raises(ConnectionError, match="call connect"):
         client.latest("/joint_states")
     client.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        client.connect()
 
     unreachable = RosbridgeClient("ws://127.0.0.1:9", connect_timeout_s=0.05)
     with pytest.raises(ConnectionError, match=r"ws://127\.0\.0\.1:9"):
         unreachable.connect()
     unreachable.close()
+
+
+def test_client_send_failure_latches_first_connection_error() -> None:
+    class FailingSocket:
+        def send(self, _message: str) -> None:
+            raise OSError("broken pipe")
+
+        def close(self) -> None:
+            pass
+
+    client = RosbridgeClient("ws://robot.example:9090")
+    client._ws = cast(Any, FailingSocket())
+    with pytest.raises(ConnectionError, match=r"robot\.example.*broken pipe") as exc_info:
+        client.publish("/arm/command", {"data": []})
+    assert client.latched_error is exc_info.value
+    with pytest.raises(ConnectionError) as repeated:
+        client.latest("/joint_states")
+    assert repeated.value is exc_info.value
+    client._latch(RuntimeError("later failure"))
+    assert client.latched_error is exc_info.value
+    client.close()
+
+
+def test_client_rejects_unsupported_incoming_frame_type() -> None:
+    class InvalidFrameSocket:
+        def recv(self) -> object:
+            return object()
+
+        def close(self) -> None:
+            pass
+
+    client = RosbridgeClient("ws://robot.example:9090")
+    client._ws = cast(Any, InvalidFrameSocket())
+    client._receive_loop()
+    error = client.latched_error
+    assert isinstance(error, RosbridgeError)
+    assert "unsupported frame type object" in str(error)
+    client.close()
+
+
+def test_client_service_wait_detects_concurrent_close() -> None:
+    class NoopSocket:
+        def send(self, _message: str) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    client = RosbridgeClient("ws://robot.example:9090")
+
+    def close_during_wait(_duration: float) -> None:
+        client._closed = True
+
+    client._sleep = close_during_wait
+    client._ws = cast(Any, NoopSocket())
+    with pytest.raises(ConnectionError, match=r"robot\.example.*closed"):
+        client.call_service("/home")
+    client._closed = False
+    client.close()
 
 
 def test_joint_state_reorders_shuffled_names() -> None:
@@ -531,6 +596,11 @@ def test_joint_trajectory_duration_rounding_carries_to_next_second() -> None:
 def test_joint_trajectory_rejects_invalid_inputs(kwargs: dict[str, Any], match: str) -> None:
     with pytest.raises(ValueError, match=match):
         build_joint_trajectory(**kwargs, ros_version=2)
+
+
+def test_joint_trajectory_rejects_unknown_ros_version() -> None:
+    with pytest.raises(ValueError, match="ros_version must be 1 or 2"):
+        build_joint_trajectory(("joint_1",), [1.0], period_s=0.1, ros_version=3)
 
 
 def test_float64_and_gripper_command_builders_preserve_raw_values() -> None:
@@ -767,11 +837,16 @@ def test_scalar_coerced_one_dof_bounds_are_accepted() -> None:
     "kwargs,match",
     [
         ({"joints": None}, "joints is required"),
+        ({"joints": ""}, "at least one joint name"),
         ({"command_topic": None}, "command_topic is required"),
         ({"action_low": None}, "action_low is required"),
         ({"action_high": None}, "action_high is required"),
+        ({"action_low": "bad,1"}, "comma-separated list of numbers"),
+        ({"action_low": ""}, "at least one numeric bound"),
         ({"action_low": (-1.0,)}, "1 bounds for 2 joints"),
         ({"action_high": (1.0,)}, "1 bounds for 2 joints"),
+        ({"action_low": (-math.inf, -3.0)}, "bounds must all be finite"),
+        ({"action_low": (3.0, -3.0)}, "elementwise <="),
         ({"joints": ("joint_1", "joint_1")}, "duplicate"),
         (
             {
@@ -792,6 +867,15 @@ def test_scalar_coerced_one_dof_bounds_are_accepted() -> None:
             },
             "less than",
         ),
+        (
+            {
+                "gripper_topic": "/gripper/command",
+                "gripper_joint": "finger",
+                "gripper_low": 0.0,
+                "gripper_high": math.inf,
+            },
+            "gripper_low and gripper_high must be finite",
+        ),
         ({"gripper_topic": "/gripper/command"}, "required when gripper_topic"),
         ({"gripper_joint": "finger"}, "only when gripper_topic"),
         ({"control_hz": 0.0}, "positive and finite"),
@@ -800,6 +884,20 @@ def test_scalar_coerced_one_dof_bounds_are_accepted() -> None:
         ({"command_type": "effort"}, "command_type"),
         ({"gripper_command_type": "action"}, "gripper_command_type"),
         ({"gripper_closed_at": "left"}, "gripper_closed_at"),
+        ({"fresh_obs_timeout_s": 0.0}, "fresh_obs_timeout_s must be positive and finite"),
+        ({"camera_throttle_ms": -1}, "camera_throttle_ms must be >= 0"),
+        ({"obs_timeout_s": 0.0}, "obs_timeout_s must be positive and finite"),
+        ({"connect_timeout_s": math.inf}, "connect_timeout_s must be positive and finite"),
+        ({"request_timeout_s": 0.0}, "request_timeout_s must be positive and finite"),
+        ({"staleness_s": -1.0}, "staleness_s must be finite and >= 0"),
+        ({"cameras": ","}, "parsed to no cameras"),
+        ({"cameras": "wrist=/cam=640x480"}, "name:topic:WxH"),
+        ({"cameras": "wrist:/cam:640by480"}, "must be WxH"),
+        ({"cameras": "wrist:/cam:widex480"}, "integer width and height"),
+        ({"cameras": {"wrist": ("/cam", 480)}}, "must map to"),
+        ({"cameras": {"wrist-cam": ("/cam", 480, 640)}}, "valid identifier"),
+        ({"cameras": {"wrist": ("", 480, 640)}}, "non-empty string"),
+        ({"cameras": {"wrist": ("/cam", 0, 640)}}, "positive integers"),
         (
             {"cameras": "wrist:/a:640x480,wrist:/b:320x240"},
             "duplicate name",
@@ -1163,6 +1261,86 @@ def test_close_delegates_idempotently_to_client() -> None:
     embodiment.close()
     embodiment.close()
     assert client.closed
+
+
+def test_context_manager_returns_embodiment_and_closes_client() -> None:
+    embodiment, client, _clock = _ready_embodiment()
+    with embodiment as entered:
+        assert entered is embodiment
+    assert client.closed
+
+
+def test_initialization_advertises_configured_gripper() -> None:
+    clock = _FakeClock()
+    embodiment = _embodiment(
+        clock=clock,
+        sleep=clock.sleep,
+        gripper_topic="/gripper/command",
+        gripper_joint="finger",
+        gripper_low=0.0,
+        gripper_high=0.08,
+    )
+    client = _FakeClient(clock)
+
+    def provide_joint_state(topic: str, _after: int) -> None:
+        client.put(topic, _joint_message())
+
+    client.on_wait = provide_joint_state
+    embodiment._client = cast(Any, client)
+    embodiment._ensure_initialized()
+    advertisements = [operation for operation in client.operations if operation[0] == "advertise"]
+    assert [(operation[1], operation[2]) for operation in advertisements] == [
+        ("/arm/command", "trajectory_msgs/msg/JointTrajectory"),
+        ("/gripper/command", "std_msgs/msg/Float64MultiArray"),
+    ]
+
+
+def test_preflight_stops_when_one_second_deadline_is_reached() -> None:
+    clock = _FakeClock()
+    embodiment = _embodiment(clock=clock, sleep=clock.sleep)
+    client = _FakeClient(clock)
+
+    def delayed_joint_state(topic: str, _after: int) -> None:
+        clock.advance(1.0)
+        client.put(topic, _joint_message())
+
+    client.on_wait = delayed_joint_state
+    embodiment._client = cast(Any, client)
+    with pytest.warns(RuntimeWarning, match="exactly one message"):
+        embodiment._joint_state_preflight()
+    assert len(client.wait_timeouts) == 1
+
+
+def test_shared_observation_deadline_names_later_missing_topic() -> None:
+    clock = _FakeClock()
+    embodiment = _embodiment(clock=clock, sleep=clock.sleep)
+    client = _FakeClient(clock)
+
+    def consume_deadline(topic: str, _after: int) -> None:
+        clock.advance(1.0)
+        client.put(topic, {})
+
+    client.on_wait = consume_deadline
+    embodiment._client = cast(Any, client)
+    with pytest.raises(TimeoutError, match=r"missing topic '/camera'.*obs_timeout_s=1s"):
+        embodiment._wait_for_sequences({"/joint_states": 0, "/camera": 0}, 1.0, "obs_timeout_s")
+
+
+def test_camera_resolution_validation_is_only_applied_to_first_frame() -> None:
+    embodiment, client, _clock = _ready_embodiment(cameras={"wrist": ("/camera/compressed", 2, 3)})
+    embodiment._validate_camera_resolutions()
+    client.put(
+        "/camera/compressed",
+        _compressed_image_message(np.zeros((4, 5, 3), dtype=np.uint8), "PNG", "png"),
+    )
+    embodiment._validate_camera_resolutions()
+
+
+def test_observation_assembly_rejects_missing_cached_sample() -> None:
+    embodiment, client, _clock = _ready_embodiment()
+    client.samples.pop(embodiment.joint_states_topic)
+    with pytest.raises(RuntimeError, match=r"no cached message.*joint_states"):
+        embodiment._assemble_observation()
 
 
 def test_connection_failure_names_url_and_both_rosbridge_launch_commands() -> None:

--- a/plugins/inspect-robots-ros/tests/test_ros_embodiment.py
+++ b/plugins/inspect-robots-ros/tests/test_ros_embodiment.py
@@ -1,0 +1,133 @@
+"""Tests for the rosbridge embodiment adapter and its wire protocol."""
+
+from __future__ import annotations
+
+import pytest
+
+from inspect_robots_ros._protocol import (
+    PublishedMessage,
+    RosbridgeError,
+    ServiceResponse,
+    StatusMessage,
+    advertise,
+    call_service,
+    decode_message,
+    encode_message,
+    parse_incoming,
+    publish,
+    subscribe,
+    unadvertise,
+    unsubscribe,
+)
+
+
+def test_protocol_outbound_operations_match_rosbridge_v2_shapes() -> None:
+    assert subscribe(
+        "/joint_states",
+        subscription_id="inspect-robots-joints",
+        message_type="sensor_msgs/msg/JointState",
+        throttle_rate=50,
+    ) == {
+        "op": "subscribe",
+        "id": "inspect-robots-joints",
+        "topic": "/joint_states",
+        "type": "sensor_msgs/msg/JointState",
+        "throttle_rate": 50,
+        "queue_length": 1,
+        "compression": "none",
+    }
+    assert unsubscribe("/joint_states", subscription_id="inspect-robots-joints") == {
+        "op": "unsubscribe",
+        "id": "inspect-robots-joints",
+        "topic": "/joint_states",
+    }
+    assert advertise("/arm/command", message_type="trajectory_msgs/msg/JointTrajectory") == {
+        "op": "advertise",
+        "topic": "/arm/command",
+        "type": "trajectory_msgs/msg/JointTrajectory",
+    }
+    assert unadvertise("/arm/command") == {
+        "op": "unadvertise",
+        "topic": "/arm/command",
+    }
+    assert publish("/arm/command", {"joint_names": ["j1"]}) == {
+        "op": "publish",
+        "topic": "/arm/command",
+        "msg": {"joint_names": ["j1"]},
+    }
+    assert call_service("/home", request_id="service-1") == {
+        "op": "call_service",
+        "id": "service-1",
+        "service": "/home",
+        "args": {},
+    }
+
+
+def test_protocol_json_codec_is_compact_and_round_trips() -> None:
+    operation = publish("/gripper/command", {"data": [0.25]})
+    encoded = encode_message(operation)
+    assert encoded == '{"op":"publish","topic":"/gripper/command","msg":{"data":[0.25]}}'
+    assert decode_message(encoded) == operation
+    assert decode_message(encoded.encode()) == operation
+
+
+def test_protocol_parses_incoming_operations() -> None:
+    assert parse_incoming(
+        {"op": "publish", "topic": "/joint_states", "msg": {"position": [1.0]}}
+    ) == PublishedMessage("/joint_states", {"position": [1.0]})
+    assert parse_incoming(
+        {
+            "op": "service_response",
+            "id": "service-1",
+            "values": {"message": "homed"},
+            "result": True,
+        }
+    ) == ServiceResponse("service-1", {"message": "homed"}, True)
+    status = parse_incoming(
+        {"op": "status", "id": "publish-1", "level": "error", "msg": "bad type"}
+    )
+    assert status == StatusMessage("error", "bad type", "publish-1")
+    assert isinstance(status, StatusMessage)
+    assert str(status.as_error()) == "status_error: bad type"
+    assert parse_incoming({"op": "pong"}) is None
+
+
+@pytest.mark.parametrize(
+    "raw,match",
+    [
+        ("not json", "decode"),
+        ("[]", "JSON object"),
+        ('{"topic":"/joint_states"}', "missing string field 'op'"),
+    ],
+)
+def test_protocol_rejects_invalid_json_frames(raw: str, match: str) -> None:
+    with pytest.raises(RosbridgeError, match=match):
+        decode_message(raw)
+
+
+@pytest.mark.parametrize(
+    "operation,match",
+    [
+        ({"op": "publish", "topic": 1, "msg": {}}, "topic"),
+        ({"op": "publish", "topic": "/x", "msg": []}, "msg"),
+        (
+            {"op": "service_response", "id": "s", "values": {}, "result": "yes"},
+            "result",
+        ),
+        ({"op": "status", "level": "error", "msg": "bad", "id": 1}, "id"),
+    ],
+)
+def test_protocol_rejects_malformed_known_operations(
+    operation: dict[str, object], match: str
+) -> None:
+    with pytest.raises(RosbridgeError, match=match):
+        parse_incoming(operation)
+
+
+def test_protocol_rejects_non_json_values_on_encode() -> None:
+    with pytest.raises(RosbridgeError, match="encode"):
+        encode_message({"op": "publish", "value": object()})
+
+
+def test_non_error_status_does_not_create_an_error() -> None:
+    assert StatusMessage("warning", "slow publisher").as_error() is None

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ members = [
     "inspect-robots",
     "inspect-robots-agent",
     "inspect-robots-isaacsim",
+    "inspect-robots-ros",
     "inspect-robots-xpolicylab",
 ]
 
@@ -574,6 +575,39 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "inspect-robots-ros"
+version = "0.1.0"
+source = { editable = "plugins/inspect-robots-ros" }
+dependencies = [
+    { name = "inspect-robots" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+    { name = "websockets" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "inspect-robots", editable = "." },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
+    { name = "numpy", specifier = ">=1.24" },
+    { name = "pillow", specifier = ">=10" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
+    { name = "websockets", specifier = ">=12" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
Closes #104.

Adds `plugins/inspect-robots-ros`: an `Embodiment` plugin (registered as `ros`) that speaks the rosbridge v2 websocket protocol directly, so any ROS 1 / ROS 2 robot running `rosbridge_server` becomes an eval target with zero ROS dependencies on the eval side.

Origin: an evaluation of first-class integration with [ros-mcp-server](https://github.com/robotmcp/ros-mcp-server). Conclusion (details in #104 and plan §1): MCP is the wrong layer for closed-loop evaluation; the right integration is the rosbridge protocol ROS-MCP itself sits on. With this embodiment, the existing `agent` policy covers the LLM-drives-ROS-robot use case with scoring, guardrails, and transcripts.

Plan: `plans/0016-ros-embodiment-plugin.md` (critique loop in progress; implementation follows on this branch).

Note for maintainers: first release of the plugin needs a `pypi-ros` trusted-publisher environment created on PyPI/GitHub before the `publish-ros` job can succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
