### PR TITLE
feat(cli): inspect shows the scene instruction

### DIFF
--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -744,6 +744,12 @@ def _cmd_inspect(path: str, *, transcript: bool = False) -> int:
     log = read_eval_log(path)
     _print_step_limit_notice(log, log.eval.task == "adhoc")
     print(f"task:        {log.eval.task}")
+    # One shared instruction (the adhoc case) reads as run-level identity;
+    # differing instructions print per scene below instead.
+    instructions = {scene.instruction for scene in log.samples}
+    shared = next(iter(instructions)) if len(instructions) == 1 else None
+    if shared is not None:
+        print(f"instruction: {shared}")
     print(f"policy:      {log.eval.policy}")
     print(f"embodiment:  {log.eval.embodiment}")
     print(f"status:      {log.status}")
@@ -764,6 +770,8 @@ def _cmd_inspect(path: str, *, transcript: bool = False) -> int:
         if step_limit_count:
             details.append(f"({step_limit_count}/{len(scene.epochs)} trials hit max_steps)")
         print(f"  [{scene.status}] {scene.scene_id}: {'  '.join(details)}")
+        if shared is None and scene.instruction is not None:
+            print(f"      instruction: {scene.instruction}")
     if log.error:
         print(f"error: {log.error}")
     if transcript:

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -745,11 +745,12 @@ def _cmd_inspect(path: str, *, transcript: bool = False) -> int:
     _print_step_limit_notice(log, log.eval.task == "adhoc")
     print(f"task:        {log.eval.task}")
     # One shared instruction (the adhoc case) reads as run-level identity;
-    # differing instructions print per scene below instead.
+    # differing instructions print per scene below instead. Instructions are
+    # foreign text (dataset/operator-supplied), so printing degrades.
     instructions = {scene.instruction for scene in log.samples}
     shared = next(iter(instructions)) if len(instructions) == 1 else None
-    if shared is not None:
-        print(f"instruction: {shared}")
+    if shared:
+        _print_degraded(f"instruction: {shared}")
     print(f"policy:      {log.eval.policy}")
     print(f"embodiment:  {log.eval.embodiment}")
     print(f"status:      {log.status}")
@@ -770,8 +771,8 @@ def _cmd_inspect(path: str, *, transcript: bool = False) -> int:
         if step_limit_count:
             details.append(f"({step_limit_count}/{len(scene.epochs)} trials hit max_steps)")
         print(f"  [{scene.status}] {scene.scene_id}: {'  '.join(details)}")
-        if shared is None and scene.instruction is not None:
-            print(f"      instruction: {scene.instruction}")
+        if not shared and scene.instruction:
+            _print_degraded(f"      instruction: {scene.instruction}")
     if log.error:
         print(f"error: {log.error}")
     if transcript:

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -536,11 +536,15 @@ def test_transcript_rendering_degrades_lone_surrogates_instead_of_crashing(
 def test_inspect_shows_shared_instruction_in_header(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    # Two scenes with the same instruction collapse to ONE header line: the
+    # collapse is by value equality across scenes, not by scene count.
     log = _step_limit_log(reasons=("success",))
-    scene = dataclasses.replace(log.samples[0], instruction="wipe the table")
+    first = dataclasses.replace(log.samples[0], instruction="wipe the table")
+    second = dataclasses.replace(first, scene_id="s1")
     path = tmp_path / "shared.json"
     path.write_text(
-        json.dumps(dataclasses.replace(log, samples=(scene,)).to_dict()), encoding="utf-8"
+        json.dumps(dataclasses.replace(log, samples=(first, second)).to_dict()),
+        encoding="utf-8",
     )
 
     assert main(["inspect", str(path)]) == 0
@@ -550,6 +554,7 @@ def test_inspect_shows_shared_instruction_in_header(
     # Run-level identity: directly under the task line, not repeated per scene.
     assert out.index("task:") < out.index("instruction:") < out.index("policy:")
     assert "      instruction:" not in out
+    assert out.count("instruction:") == 1
 
 
 def test_inspect_shows_differing_instructions_per_scene(
@@ -557,10 +562,11 @@ def test_inspect_shows_differing_instructions_per_scene(
 ) -> None:
     log = _step_limit_log(reasons=("success",))
     first = dataclasses.replace(log.samples[0], instruction="fold the towel")
-    second = dataclasses.replace(log.samples[0], scene_id="s1")
+    second = dataclasses.replace(log.samples[0], scene_id="s1", instruction="stack the cups")
+    third = dataclasses.replace(log.samples[0], scene_id="s2")
     path = tmp_path / "differing.json"
     path.write_text(
-        json.dumps(dataclasses.replace(log, samples=(first, second)).to_dict()),
+        json.dumps(dataclasses.replace(log, samples=(first, second, third)).to_dict()),
         encoding="utf-8",
     )
 
@@ -568,20 +574,46 @@ def test_inspect_shows_differing_instructions_per_scene(
 
     out = capsys.readouterr().out
     assert "      instruction: fold the towel\n" in out
+    assert "      instruction: stack the cups\n" in out
     assert out.index("[success] s0") < out.index("      instruction:") < out.index("[success] s1")
     # No shared header line, and the instruction-less scene prints no sub-line.
     assert out.index("instruction:") > out.index("scenes:")
-    assert out.count("instruction:") == 1
+    assert out.count("instruction:") == 2
 
 
-def test_inspect_stays_silent_when_no_scene_has_an_instruction(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+@pytest.mark.parametrize("instruction", [None, ""])
+def test_inspect_stays_silent_without_a_real_instruction(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], instruction: str | None
 ) -> None:
-    # Logs written before SceneResult.instruction existed must render as today.
+    # Logs written before SceneResult.instruction existed (None) and empty
+    # strings must render exactly as today: no blank-value header line.
+    log = _step_limit_log(reasons=("success",))
+    scene = dataclasses.replace(log.samples[0], instruction=instruction)
     path = tmp_path / "legacy.json"
-    path.write_text(json.dumps(_step_limit_log(reasons=("success",)).to_dict()), encoding="utf-8")
+    path.write_text(
+        json.dumps(dataclasses.replace(log, samples=(scene,)).to_dict()), encoding="utf-8"
+    )
     assert main(["inspect", str(path)]) == 0
     assert "instruction:" not in capsys.readouterr().out
+
+
+def test_inspect_degrades_lone_surrogates_in_instructions(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Instructions are foreign text and survive the JSON round-trip; a lone
+    # UTF-16 surrogate must degrade at print time, not crash the reader.
+    log = _step_limit_log(reasons=("success",))
+    scene = dataclasses.replace(log.samples[0], instruction="wipe \ud800 the table")
+    path = tmp_path / "hostile.json"
+    path.write_text(
+        json.dumps(dataclasses.replace(log, samples=(scene,)).to_dict()), encoding="utf-8"
+    )
+
+    assert main(["inspect", str(path)]) == 0
+
+    out = capsys.readouterr().out
+    assert "\ud800" not in out
+    assert "wipe � the table" in out or "wipe ? the table" in out
 
 
 def test_transcript_empty_list_falls_back_to_json_rendering(

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -533,6 +533,57 @@ def test_transcript_rendering_degrades_lone_surrogates_instead_of_crashing(
     assert "bad � data" in out or "bad ? data" in out
 
 
+def test_inspect_shows_shared_instruction_in_header(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    log = _step_limit_log(reasons=("success",))
+    scene = dataclasses.replace(log.samples[0], instruction="wipe the table")
+    path = tmp_path / "shared.json"
+    path.write_text(
+        json.dumps(dataclasses.replace(log, samples=(scene,)).to_dict()), encoding="utf-8"
+    )
+
+    assert main(["inspect", str(path)]) == 0
+
+    out = capsys.readouterr().out
+    assert "instruction: wipe the table\n" in out
+    # Run-level identity: directly under the task line, not repeated per scene.
+    assert out.index("task:") < out.index("instruction:") < out.index("policy:")
+    assert "      instruction:" not in out
+
+
+def test_inspect_shows_differing_instructions_per_scene(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    log = _step_limit_log(reasons=("success",))
+    first = dataclasses.replace(log.samples[0], instruction="fold the towel")
+    second = dataclasses.replace(log.samples[0], scene_id="s1")
+    path = tmp_path / "differing.json"
+    path.write_text(
+        json.dumps(dataclasses.replace(log, samples=(first, second)).to_dict()),
+        encoding="utf-8",
+    )
+
+    assert main(["inspect", str(path)]) == 0
+
+    out = capsys.readouterr().out
+    assert "      instruction: fold the towel\n" in out
+    assert out.index("[success] s0") < out.index("      instruction:") < out.index("[success] s1")
+    # No shared header line, and the instruction-less scene prints no sub-line.
+    assert out.index("instruction:") > out.index("scenes:")
+    assert out.count("instruction:") == 1
+
+
+def test_inspect_stays_silent_when_no_scene_has_an_instruction(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Logs written before SceneResult.instruction existed must render as today.
+    path = tmp_path / "legacy.json"
+    path.write_text(json.dumps(_step_limit_log(reasons=("success",)).to_dict()), encoding="utf-8")
+    assert main(["inspect", str(path)]) == 0
+    assert "instruction:" not in capsys.readouterr().out
+
+
 def test_transcript_empty_list_falls_back_to_json_rendering(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
Closes #106

`SceneResult.instruction` is persisted in every log ("makes a log self-describing") but `inspect-robots inspect` never displayed it, so the one thing an ad-hoc log is about — the natural-language command — was invisible in the viewer.

- When every scene carries the same instruction (the adhoc case, single-instruction tasks): one `instruction:` line in the header, directly under `task:`, value column aligned with the other header fields.
- When instructions differ across scenes: an indented `instruction:` sub-line under each scene entry that has one.
- Legacy logs (instruction `None` everywhere) render byte-identical to today: the shared-instruction set is `{None}` so both branches stay silent.

Verified against a real adhoc log:

```
task:        adhoc
instruction: place the fork and spoon on the plate
policy:      molmoact2
```

Gates: ruff, ruff format, mypy strict, pytest 525 passed at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)