### PR TITLE
feat: embodiment-authored docs channel for LLM agent policies

### DIFF
--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -9,7 +9,9 @@ those declarations load-bearing:
 - The LLM agent policy (`inspect-robots-agent`) builds its whole tool surface
   from the spaces at bind time: tool schemas from the bounds and labels, the
   motion strategy from the control mode, the proprioceptive reference from
-  the `StateSpec`.
+  the `StateSpec`. It also injects `EmbodimentInfo.docs` (free-form operating
+  notes: joint layout, positive directions, gripper polarity) into its system
+  prompt, so an adapter that ships good notes measurably helps LLM policies.
 
 An adapter with missing or dishonest declarations silently degrades both.
 This page is the contract; the conformance kit makes most of it mechanical.

--- a/plans/0016-embodiment-agent-docs.md
+++ b/plans/0016-embodiment-agent-docs.md
@@ -69,10 +69,14 @@ object. No new hook is needed.
 
 Ripple effects inside core:
 
-- `__all__` / `tests/test_api_snapshot.py`: `EmbodimentInfo` is already
-  exported; the snapshot records field names, so it must be regenerated or
-  updated to include `docs`.
+- `tests/test_api_snapshot.py` needs **no change**: it fences the symbol
+  names in `inspect_robots.__all__`, not dataclass fields, and
+  `EmbodimentInfo` is already exported. Do not add `"docs"` to `EXPECTED`.
 - `conformance.py` does not gate on the new field (advisory).
+- `EvalSpec.embodiment_info` (the hand-picked dict projection in `eval.py`)
+  deliberately does **not** gain `docs`: the rendered system prompt is
+  already captured verbatim in the per-trial policy transcript, which is the
+  audit surface that matters. Leave the projection unchanged.
 - Mock embodiments: `CubePick` gains a one-paragraph docs string, which
   doubles as the in-tree usage example and exercises the field end to end in
   the existing agent-plugin-against-mock tests (if any) and core tests.
@@ -82,34 +86,56 @@ Ripple effects inside core:
 
 `plugins/inspect-robots-agent`:
 
-- `LLMAgentPolicy.bind()` captures `getattr(embodiment_info, "docs", None)`
-  (getattr so the plugin keeps working against older cores; the pyproject
-  lower bound is still raised — see §5 — but the plugin should not crash if
-  someone pins an old core with a new plugin).
+- `LLMAgentPolicy.bind()` captures `getattr(embodiment_info, "docs", None)`.
+  The getattr fallback means the plugin degrades gracefully against older
+  cores (docs simply absent), so the `inspect-robots>=0.4` lower bound in
+  the plugin's pyproject stays as-is — no bump.
+- The docs attribute is initialized to `None` in `__init__` (not only in
+  `bind()`): `reset()` must keep working on an unbound policy.
 - `reset()` appends a section to the system prompt when docs are non-empty
-  after `str.strip()`:
+  after `str.strip()`. Order of operations is normative: run
+  `_SYSTEM_TEMPLATE.format(...)` **first**, then concatenate the docs text
+  verbatim (`formatted + "\n\nEmbodiment notes:\n" + docs`). Embodiment
+  markdown may legally contain `{`/`}` (JSON snippets, code examples);
+  passing it through `str.format` would let third-party content crash every
+  trial at reset.
 
-  ```text
-  {existing _SYSTEM_TEMPLATE text}
-
-  Embodiment notes:
-  {docs}
-  ```
-
-  No truncation, no reformatting. Whitespace-only docs are treated as absent.
+  No truncation, no reformatting. Whitespace-only docs are treated as absent
+  (no dangling header).
 - Tool descriptions are unchanged: bounds and labels already live there, and
   duplicating prose into every tool schema wastes tokens on every call.
 
 ### 3.3 Agent plugin: labeled proprio state in observations
 
-In `_observation_content` (policy.py), when rendering the state field that
-the toolset selected as the proprio reference (`state_key`) *and* its length
-equals the number of action dims, render label/value pairs instead of a bare
+Goal: render the proprio state field as label/value pairs instead of a bare
 list:
 
 ```text
 state[joint_pos]: left_j0=0.01 left_j1=-0.02 … right_gripper=0.98
 ```
+
+Which field gets labeled — normative selection rule, applying in **all**
+modes (absolute and displacement; today's `state_key` is only computed for
+absolute modes, which would silently skip YAM `joint_delta` runs):
+
+1. If the toolset's existing `state_key` is set (absolute modes), label that
+   field.
+2. Otherwise (displacement modes), label the state field whose shape equals
+   `(action_dim,)` **iff exactly one field matches**; ambiguity (e.g.
+   CubePick's two 2-D fields `eef_pos`/`cube_pos` against a 2-D action)
+   means no labeling — a mislabeled line is worse than an unlabeled one.
+3. Labeling additionally requires real `dim_labels` on the action semantics.
+   When `build_toolset` synthesized fallback labels (`"0"`, `"1"`, …),
+   render the old unlabeled list — `0=0.01 1=-0.02` is pure noise.
+4. At render time, if the runtime vector's length mismatches the labels,
+   fall back to the unlabeled rendering (sanity check, never crash).
+
+Plumbing — normative, because `_observation_content` is a module-level
+function with no toolset access: `Toolset` gains one public method,
+`state_labels() -> tuple[str, tuple[str, ...]] | None`, returning
+`(state_key_to_label, labels)` per rules 1–3 or `None`. The policy calls it
+once after bind and passes the result into `_observation_content` as an
+optional parameter (default `None` keeps the current rendering).
 
 All other state fields keep the existing unlabeled rendering. Rounding stays
 as-is. This is a pure prompt-format change; update the plugin tests that
@@ -125,9 +151,12 @@ assert on observation text.
   identical sign conventions, so the notes are written once and prefixed
   "each arm".
 - `eef_pos` mode: frame identity (+X forward out of the arm base, +Y left,
-  +Z up, per-arm base frame), yaw-relative-to-start restated briefly, and
-  the validated workspace box from plan 0006 (yam repo) as a reachability
-  hint.
+  +Z up, per-arm base frame), yaw-relative-to-start restated briefly, arm
+  geometry (link lengths, reach), and gripper polarity. **No numeric
+  workspace bounds**: in eef mode the action box *is* the workspace box and
+  `build_toolset` already renders those numbers into the move tool's
+  bounds text; restating them here would violate the no-restated-bounds
+  rule and drift whenever an operator overrides `eef_low`/`eef_high`.
 - New optional config key `docs_extra: str = ""` (embodiment arg, so
   `-E docs_extra="…"` and config.ini both work): operator-supplied
   rig-specific notes (e.g. how the two arms are mounted relative to the
@@ -156,35 +185,47 @@ Two identical 6-DoF arms ("left_", "right_") with parallel-jaw grippers …
 Core (100% gate):
 
 - `EmbodimentInfo` default `docs is None`; frozen dataclass still hashes/eqs.
-- API snapshot updated.
+- No API-snapshot change (see §3.1).
 - CubePick publishes non-empty docs.
 
 Agent plugin:
 
-- bind→reset with docs set: system prompt contains the section verbatim.
+- bind→reset with docs set: system prompt contains the section verbatim,
+  **including docs containing `{`/`}` characters** (the format-first rule).
 - docs None / empty / whitespace-only: prompt identical to today's (no
   dangling header).
-- getattr fallback: bind against a stub info object without a `docs`
-  attribute does not raise.
-- labeled proprio line: exact-format test for label=value rendering; a state
-  field whose length mismatches action dims keeps the old rendering.
+- reset before bind still works (docs attr initialized in `__init__`).
+- getattr fallback: bind against a stub info object lacking a `docs`
+  attribute does not raise (test will need a `cast`, since `bind()` is
+  typed against `EmbodimentInfo`).
+- `state_labels()`: absolute mode returns the proprio field labels;
+  displacement mode with a unique shape match returns it; ambiguous shapes
+  (CubePick-style) return None; synthesized fallback labels return None;
+  runtime length mismatch falls back to unlabeled rendering.
+- labeled proprio line: exact-format test for label=value rendering.
 
 YAM plugin (companion PR):
 
 - joints-mode docs mention every label `left_j0`…`right_gripper` exactly
-  once in the bullet list; gripper polarity string matches the normalization
-  in `packing.py` (test derives expected polarity from the code, not a
-  literal).
-- eef-mode docs mention every eef label and the workspace box bounds equal
-  to the constants in `config.py`.
-- `docs_extra` appended verbatim; empty default adds nothing.
+  once in the bullet list; the gripper polarity sentence is asserted as a
+  literal matching the wire convention hardcoded in the yam
+  `embodiment.py` gripper normalization (cmd 1 → open). The convention is
+  structural there, not a derivable constant — a literal is the honest test.
+- eef-mode docs mention every eef label; assert **no** numeric workspace
+  bounds appear (guards the no-restated-bounds rule).
+- `docs_extra` appended verbatim (including braces); empty default adds
+  nothing.
 
 ## 5. Rollout
 
 1. Core PR (this plan): core field + agent plugin consumption. Agent plugin
-   version → 0.5.0 (feature); core minor release after merge.
-2. Yam PR: raise `inspect-robots` lower bound to the new core version, add
-   the cheat-sheet + `docs_extra`. Yam minor release after merge.
+   version → 0.5.0 (feature); its `inspect-robots>=0.4` bound is unchanged
+   (getattr fallback, §3.2). Core minor release after merge.
+2. Yam PR: raise the yam plugin's `inspect-robots` lower bound to the new
+   core minor (it constructs `EmbodimentInfo(docs=…)`, which raises
+   TypeError on older cores — unlike the agent plugin, yam genuinely needs
+   the new field), add the cheat-sheet + `docs_extra`. Yam minor release
+   after merge.
 3. No config migration: absent field defaults preserve today's behavior
    everywhere.
 
@@ -210,10 +251,15 @@ all-zero joints), +Y left, +Z up.
 
 Geometry: upper arm 0.264 m, forearm 0.252 m, wrist-to-grasp-point 0.247 m
 when straight; max reach shoulder→grasp ≈ 0.76 m. At all-zero joints the arm
-rests folded with the gripper pointing forward (+X). Runtime software widens
-the XML ranges by ±0.15 rad; the plugin's declared bounds already reflect
-what the embodiment accepts, so the notes must not restate numeric ranges
-(the tool description owns bounds).
+rests folded with the gripper pointing forward (+X).
+
+The notes must not restate numeric ranges: the tool description owns bounds.
+This matters doubly because the yam plugin's default joint bounds are
+conservative ±π placeholders that do not match the XML ranges above (e.g.
+j1 XML [0, 3.65] vs declared [-π, π]) — restated numbers would contradict
+the tool text on a default rig. The XML ranges in the table exist to inform
+the *prose* (e.g. "j1 and j2 only move one way from zero"), never to be
+copied into the docs string.
 
 Caution for the author of the prose: with the arm folded (near zero), the
 *end-effector* motion produced by a joint can be counterintuitive (e.g. +j1

--- a/plans/0016-embodiment-agent-docs.md
+++ b/plans/0016-embodiment-agent-docs.md
@@ -1,0 +1,222 @@
+# 0016 — Embodiment-authored docs for LLM agent policies
+
+Status: draft
+Issue: robocurve/inspect-robots#109
+Companion: inspect-robots-yam (cheat-sheet content, separate PR after core release)
+
+## 1. Problem
+
+An LLM agent controlling a physical arm through `inspect-robots-agent` sees
+only generic dimension labels (`left_j0` … `right_gripper`) and numeric
+bounds. It does not know which joint is the shoulder, which direction is
+positive, what the zero pose looks like, or that `gripper=1` means open. On
+YAM fork-task runs the agent must infer all of this by trial and error inside
+a 100-call budget.
+
+Root cause (verified against source): there is no free-text field anywhere in
+the embodiment → policy chain. `EmbodimentInfo` carries `name`, spaces,
+`control_hz`, `is_simulated`, capability flags, and nothing else;
+`ActionSemantics` carries `dim_labels` only; `StateField` carries a short
+`unit` string. The agent plugin's `bind()` consumes `action_space`,
+`observation_space`, `control_hz`, `name` — there is nothing else to consume.
+
+A second, smaller gap: the per-step observation text renders the proprio
+state as an unlabeled rounded list (`state[joint_pos]: [0.01, -0.02, …]`),
+forcing the model to count elements to map values to joints.
+
+## 2. Goals / non-goals
+
+Goals:
+
+- G1: an embodiment can publish concise, policy-facing operating notes
+  (kinematic layout, sign conventions, units, gripper polarity) that LLM
+  agent policies include in their system prompt.
+- G2: the proprio state line in each observation is labeled per element using
+  the action-space `dim_labels` when shapes line up.
+- G3: the channel is generic core API, usable by any embodiment; VLA policies
+  ignore it entirely (no compat implications).
+
+Non-goals:
+
+- Structured per-dimension doc objects (a single markdown string is enough;
+  the consumer flattens to prose anyway).
+- Task- or scene-level docs (that is the instruction's job).
+- Any change to compat checking, scoring, or logging schemas. The docs field
+  is advisory metadata.
+
+## 3. Design
+
+### 3.1 Core: `EmbodimentInfo.docs`
+
+Add one optional field to the frozen `EmbodimentInfo` dataclass
+(`src/inspect_robots/embodiment.py`):
+
+```python
+docs: str | None = None
+```
+
+Contract (docstring): free-form markdown operating notes for policies that
+can read text (LLM agents). Should describe what the spaces cannot: joint
+layout and positive directions, zero-pose geometry, gripper polarity, frame
+conventions, workspace hints. Concise — this text is injected into a system
+prompt verbatim. `None` (default) means the embodiment offers no notes;
+consumers must treat absence and empty/whitespace-only strings identically.
+
+Placement rationale: `EmbodimentInfo` rather than the spaces, because the
+notes describe the embodiment as a whole (geometry, conventions spanning
+action *and* observation) and `bind()` already receives the whole info
+object. No new hook is needed.
+
+Ripple effects inside core:
+
+- `__all__` / `tests/test_api_snapshot.py`: `EmbodimentInfo` is already
+  exported; the snapshot records field names, so it must be regenerated or
+  updated to include `docs`.
+- `conformance.py` does not gate on the new field (advisory).
+- Mock embodiments: `CubePick` gains a one-paragraph docs string, which
+  doubles as the in-tree usage example and exercises the field end to end in
+  the existing agent-plugin-against-mock tests (if any) and core tests.
+- Nothing in `log.py` persists `EmbodimentInfo`, so no schema bump.
+
+### 3.2 Agent plugin: render docs into the system prompt
+
+`plugins/inspect-robots-agent`:
+
+- `LLMAgentPolicy.bind()` captures `getattr(embodiment_info, "docs", None)`
+  (getattr so the plugin keeps working against older cores; the pyproject
+  lower bound is still raised — see §5 — but the plugin should not crash if
+  someone pins an old core with a new plugin).
+- `reset()` appends a section to the system prompt when docs are non-empty
+  after `str.strip()`:
+
+  ```text
+  {existing _SYSTEM_TEMPLATE text}
+
+  Embodiment notes:
+  {docs}
+  ```
+
+  No truncation, no reformatting. Whitespace-only docs are treated as absent.
+- Tool descriptions are unchanged: bounds and labels already live there, and
+  duplicating prose into every tool schema wastes tokens on every call.
+
+### 3.3 Agent plugin: labeled proprio state in observations
+
+In `_observation_content` (policy.py), when rendering the state field that
+the toolset selected as the proprio reference (`state_key`) *and* its length
+equals the number of action dims, render label/value pairs instead of a bare
+list:
+
+```text
+state[joint_pos]: left_j0=0.01 left_j1=-0.02 … right_gripper=0.98
+```
+
+All other state fields keep the existing unlabeled rendering. Rounding stays
+as-is. This is a pure prompt-format change; update the plugin tests that
+assert on observation text.
+
+### 3.4 YAM plugin: authored cheat-sheet (companion PR, separate repo)
+
+`inspect_robots_yam` sets `EmbodimentInfo.docs` according to
+`control_interface`:
+
+- `joints` mode: the joint cheat-sheet in Appendix A, with labels rewritten
+  to the plugin's `{side}_j{i}` naming. Both arms are identical hardware with
+  identical sign conventions, so the notes are written once and prefixed
+  "each arm".
+- `eef_pos` mode: frame identity (+X forward out of the arm base, +Y left,
+  +Z up, per-arm base frame), yaw-relative-to-start restated briefly, and
+  the validated workspace box from plan 0006 (yam repo) as a reachability
+  hint.
+- New optional config key `docs_extra: str = ""` (embodiment arg, so
+  `-E docs_extra="…"` and config.ini both work): operator-supplied
+  rig-specific notes (e.g. how the two arms are mounted relative to the
+  table) appended after the built-in text with a blank line. The built-in
+  text must stay rig-agnostic because mounting varies.
+
+Implementation must verify against `packing.py`/`config.py` (yam repo), not
+this plan, for: label order, gripper normalization direction, and eef dim
+labels. Appendix A values were verified numerically against the combined
+i2rt MuJoCo model (FK sign probes) on 2026-07-15 and are normative for the
+*content*; the label mapping is normative from the code.
+
+### 3.5 What Fable sees afterwards (joints mode, abridged)
+
+```text
+You are controlling a real robot embodiment named 'yam_arms' … budget of 100 LLM calls …
+
+Embodiment notes:
+Two identical 6-DoF arms ("left_", "right_") with parallel-jaw grippers …
+- j0: base yaw, positive swings the arm counterclockwise seen from above …
+…
+```
+
+## 4. Testing
+
+Core (100% gate):
+
+- `EmbodimentInfo` default `docs is None`; frozen dataclass still hashes/eqs.
+- API snapshot updated.
+- CubePick publishes non-empty docs.
+
+Agent plugin:
+
+- bind→reset with docs set: system prompt contains the section verbatim.
+- docs None / empty / whitespace-only: prompt identical to today's (no
+  dangling header).
+- getattr fallback: bind against a stub info object without a `docs`
+  attribute does not raise.
+- labeled proprio line: exact-format test for label=value rendering; a state
+  field whose length mismatches action dims keeps the old rendering.
+
+YAM plugin (companion PR):
+
+- joints-mode docs mention every label `left_j0`…`right_gripper` exactly
+  once in the bullet list; gripper polarity string matches the normalization
+  in `packing.py` (test derives expected polarity from the code, not a
+  literal).
+- eef-mode docs mention every eef label and the workspace box bounds equal
+  to the constants in `config.py`.
+- `docs_extra` appended verbatim; empty default adds nothing.
+
+## 5. Rollout
+
+1. Core PR (this plan): core field + agent plugin consumption. Agent plugin
+   version → 0.5.0 (feature); core minor release after merge.
+2. Yam PR: raise `inspect-robots` lower bound to the new core version, add
+   the cheat-sheet + `docs_extra`. Yam minor release after merge.
+3. No config migration: absent field defaults preserve today's behavior
+   everywhere.
+
+## Appendix A — verified YAM kinematic facts (content source)
+
+Source: combined arm+gripper MuJoCo model from the i2rt repo
+(`i2rt/robot_models/arm/yam/yam.xml` + `linear_4310` gripper via
+`combine_arm_and_gripper_xml`), signs verified by FK probes; hardware motor
+`directions: [1,1,1,1,1,1]` so model signs match hardware.
+
+Per-arm base frame: +X forward (the direction the folded gripper points at
+all-zero joints), +Y left, +Z up.
+
+| API label (per side) | physical joint | positive direction | range (rad, XML) |
+|---|---|---|---|
+| j0 | base yaw (vertical axis) | counterclockwise viewed from above; a forward-pointing gripper swings toward +Y (left) | [-2.618, 3.054] |
+| j1 | shoulder pitch | raises the upper arm; 0 = folded horizontally backward, π/2 = straight up, π = horizontal forward | [0, 3.65] |
+| j2 | elbow | opens/extends the elbow; 0 = forearm fully folded back against the upper arm | [0, 3.665] |
+| j3 | wrist pitch (axis parallel to elbow) | tilts the gripper up | [-1.571, 1.571] |
+| j4 | wrist yaw | swings the gripper toward the arm's right viewed from above (opposite sign sense of j0) | [-1.571, 1.571] |
+| j5 | wrist roll about the gripper's pointing axis | right-hand rule about the outward axis | [-2.094, 2.094] |
+| gripper | parallel jaws, normalized | 0 = fully closed, 1 = fully open (~9.5 cm opening) | [0, 1] |
+
+Geometry: upper arm 0.264 m, forearm 0.252 m, wrist-to-grasp-point 0.247 m
+when straight; max reach shoulder→grasp ≈ 0.76 m. At all-zero joints the arm
+rests folded with the gripper pointing forward (+X). Runtime software widens
+the XML ranges by ±0.15 rad; the plugin's declared bounds already reflect
+what the embodiment accepts, so the notes must not restate numeric ranges
+(the tool description owns bounds).
+
+Caution for the author of the prose: with the arm folded (near zero), the
+*end-effector* motion produced by a joint can be counterintuitive (e.g. +j1
+raises the upper arm but initially lowers the grasp point because the
+forearm is doubled back). The notes therefore describe joint-level motion,
+not end-effector effect.

--- a/plans/0016-embodiment-agent-docs.md
+++ b/plans/0016-embodiment-agent-docs.md
@@ -15,9 +15,10 @@ a 100-call budget.
 
 Root cause (verified against source): there is no free-text field anywhere in
 the embodiment → policy chain. `EmbodimentInfo` carries `name`, spaces,
-`control_hz`, `is_simulated`, capability flags, and nothing else;
-`ActionSemantics` carries `dim_labels` only; `StateField` carries a short
-`unit` string. The agent plugin's `bind()` consumes `action_space`,
+`control_hz`, `is_simulated`, capability/setup metadata (`capabilities`,
+`supported_setups`, `supported_target_kinds`) — none of it free text;
+`dim_labels` is `ActionSemantics`' only textual member; `StateField` carries
+a short `unit` string. The agent plugin's `bind()` consumes `action_space`,
 `observation_space`, `control_hz`, `name` — there is nothing else to consume.
 
 A second, smaller gap: the per-step observation text renders the proprio
@@ -94,14 +95,15 @@ Ripple effects inside core:
   `bind()`): `reset()` must keep working on an unbound policy.
 - `reset()` appends a section to the system prompt when docs are non-empty
   after `str.strip()`. Order of operations is normative: run
-  `_SYSTEM_TEMPLATE.format(...)` **first**, then concatenate the docs text
-  verbatim (`formatted + "\n\nEmbodiment notes:\n" + docs`). Embodiment
+  `_SYSTEM_TEMPLATE.format(...)` **first**, then concatenate the
+  **stripped** docs text with no further transformation
+  (`formatted + "\n\nEmbodiment notes:\n" + docs.strip()`). Embodiment
   markdown may legally contain `{`/`}` (JSON snippets, code examples);
   passing it through `str.format` would let third-party content crash every
   trial at reset.
 
-  No truncation, no reformatting. Whitespace-only docs are treated as absent
-  (no dangling header).
+  No truncation, no reformatting beyond the outer strip. Whitespace-only
+  docs are treated as absent (no dangling header).
 - Tool descriptions are unchanged: bounds and labels already live there, and
   duplicating prose into every tool schema wastes tokens on every call.
 
@@ -120,10 +122,18 @@ absolute modes, which would silently skip YAM `joint_delta` runs):
 
 1. If the toolset's existing `state_key` is set (absolute modes), label that
    field.
-2. Otherwise (displacement modes), label the state field whose shape equals
-   `(action_dim,)` **iff exactly one field matches**; ambiguity (e.g.
-   CubePick's two 2-D fields `eef_pos`/`cube_pos` against a 2-D action)
-   means no labeling — a mislabeled line is worse than an unlabeled one.
+2. Otherwise (displacement modes): if the observation space declares no
+   `StateSpec` at all (e.g. CubePick, which lists `state_keys` but no
+   spec'd fields), **no labeling**. If a spec exists, the candidates are
+   the declared fields whose shape equals `(action_dim,)` **and** whose key
+   appears in the canonical state vocabulary (`CANONICAL_STATE_UNITS` in
+   `spaces.py` — proprio keys, which is what action labels can honestly
+   describe; an object-pose field that happens to match the shape must not
+   get joint labels painted on it). Label iff exactly one candidate
+   remains; ambiguity means no labeling — a mislabeled line is worse than
+   an unlabeled one. Residual hazard accepted: a canonical-keyed,
+   shape-matching field could still in principle be mislabeled, but every
+   in-tree and yam case is correct under this rule.
 3. Labeling additionally requires real `dim_labels` on the action semantics.
    When `build_toolset` synthesized fallback labels (`"0"`, `"1"`, …),
    render the old unlabeled list — `0=0.01 1=-0.02` is pure noise.
@@ -131,11 +141,18 @@ absolute modes, which would silently skip YAM `joint_delta` runs):
    fall back to the unlabeled rendering (sanity check, never crash).
 
 Plumbing — normative, because `_observation_content` is a module-level
-function with no toolset access: `Toolset` gains one public method,
-`state_labels() -> tuple[str, tuple[str, ...]] | None`, returning
-`(state_key_to_label, labels)` per rules 1–3 or `None`. The policy calls it
-once after bind and passes the result into `_observation_content` as an
-optional parameter (default `None` keeps the current rendering).
+function with no toolset access and today's `Toolset` constructor receives
+neither the observation space nor the synthesized-labels fact: the rule 1–3
+decision is computed **inside `build_toolset`** (which has all three
+inputs: the semantics' real-or-absent `dim_labels`, the observation space,
+and the mode) and passed to the `Toolset` constructor as a precomputed
+`tuple[str, tuple[str, ...]] | None`; a public `Toolset.state_labels()`
+simply returns it. Do **not** detect synthesized labels by comparing the
+resolved labels against `("0", "1", …)` — an embodiment may legitimately
+name its dims that way; use the presence of `semantics.dim_labels` at the
+point of synthesis. The policy calls `state_labels()` once and passes the
+result into `_observation_content` as an optional parameter (default `None`
+keeps the current rendering).
 
 All other state fields keep the existing unlabeled rendering. Rounding stays
 as-is. This is a pure prompt-format change; update the plugin tests that
@@ -146,10 +163,12 @@ assert on observation text.
 `inspect_robots_yam` sets `EmbodimentInfo.docs` according to
 `control_interface`:
 
-- `joints` mode: the joint cheat-sheet in Appendix A, with labels rewritten
-  to the plugin's `{side}_j{i}` naming. Both arms are identical hardware with
-  identical sign conventions, so the notes are written once and prefixed
-  "each arm".
+- `joints` mode: the joint cheat-sheet in Appendix A. Both arms are
+  identical hardware with identical sign conventions, so the joint
+  descriptions are written once, but each bullet names both side labels
+  explicitly so the model can copy them into tool calls verbatim:
+  `- left_j0 / right_j0: base yaw, positive swings the arm …`. Every one of
+  the 14 action labels appears exactly once in the bullet list this way.
 - `eef_pos` mode: frame identity (+X forward out of the arm base, +Y left,
   +Z up, per-arm base frame), yaw-relative-to-start restated briefly, arm
   geometry (link lengths, reach), and gripper polarity. **No numeric
@@ -163,9 +182,11 @@ assert on observation text.
   table) appended after the built-in text with a blank line. The built-in
   text must stay rig-agnostic because mounting varies.
 
-Implementation must verify against `packing.py`/`config.py` (yam repo), not
-this plan, for: label order, gripper normalization direction, and eef dim
-labels. Appendix A values were verified numerically against the combined
+Implementation must verify against the yam repo code, not this plan, for:
+label order and eef dim labels (`packing.py`/`config.py`) and the gripper
+wire convention (`embodiment.py` `_denorm_grippers`/`_norm_grippers` —
+command 1 → open; that function is the single source of truth for
+polarity). Appendix A values were verified numerically against the combined
 i2rt MuJoCo model (FK sign probes) on 2026-07-15 and are normative for the
 *content*; the label mapping is normative from the code.
 
@@ -175,8 +196,8 @@ i2rt MuJoCo model (FK sign probes) on 2026-07-15 and are normative for the
 You are controlling a real robot embodiment named 'yam_arms' … budget of 100 LLM calls …
 
 Embodiment notes:
-Two identical 6-DoF arms ("left_", "right_") with parallel-jaw grippers …
-- j0: base yaw, positive swings the arm counterclockwise seen from above …
+Two identical 6-DoF arms with parallel-jaw grippers …
+- left_j0 / right_j0: base yaw, positive swings the arm counterclockwise seen from above …
 …
 ```
 
@@ -198,10 +219,14 @@ Agent plugin:
 - getattr fallback: bind against a stub info object lacking a `docs`
   attribute does not raise (test will need a `cast`, since `bind()` is
   typed against `EmbodimentInfo`).
-- `state_labels()`: absolute mode returns the proprio field labels;
-  displacement mode with a unique shape match returns it; ambiguous shapes
-  (CubePick-style) return None; synthesized fallback labels return None;
-  runtime length mismatch falls back to unlabeled rendering.
+- `state_labels()`, one test per branch: absolute mode returns the proprio
+  field labels; displacement mode with a unique canonical-keyed shape match
+  returns it; **no StateSpec at all** returns None (use real
+  `CubePickEmbodiment().info` — CubePick declares `state_keys` but no
+  spec); **two canonical shape-matching fields** returns None (needs a
+  synthetic spec — no in-tree embodiment has this); non-canonical key
+  excluded from candidacy (synthetic); synthesized fallback labels return
+  None; runtime length mismatch falls back to unlabeled rendering.
 - labeled proprio line: exact-format test for label=value rendering.
 
 YAM plugin (companion PR):
@@ -211,8 +236,11 @@ YAM plugin (companion PR):
   literal matching the wire convention hardcoded in the yam
   `embodiment.py` gripper normalization (cmd 1 → open). The convention is
   structural there, not a derivable constant — a literal is the honest test.
-- eef-mode docs mention every eef label; assert **no** numeric workspace
-  bounds appear (guards the no-restated-bounds rule).
+- eef-mode docs mention every eef label; the no-restated-bounds rule is
+  guarded concretely: assert that none of the formatted default
+  `eef_low`/`eef_high` component values from `config.py` appear as
+  substrings of the docs (the docs legitimately contain other numbers —
+  link lengths, reach — so "no numbers" is not the test).
 - `docs_extra` appended verbatim (including braces); empty default adds
   nothing.
 

--- a/plans/0016-embodiment-agent-docs.md
+++ b/plans/0016-embodiment-agent-docs.md
@@ -1,6 +1,6 @@
 # 0016 — Embodiment-authored docs for LLM agent policies
 
-Status: draft
+Status: approved (4 critique rounds, 2026-07-15)
 Issue: robocurve/inspect-robots#109
 Companion: inspect-robots-yam (cheat-sheet content, separate PR after core release)
 
@@ -153,8 +153,9 @@ neither the observation space nor the synthesized-labels fact: the rule 1–3
 decision is computed **inside `build_toolset`** (which has all three
 inputs: the semantics' real-or-absent `dim_labels`, the observation space,
 and the mode) and passed to the `Toolset` constructor as a precomputed
-`tuple[str, tuple[str, ...]] | None`; a public `Toolset.state_labels()`
-simply returns it. Do **not** detect synthesized labels by comparing the
+`tuple[str, tuple[str, ...]] | None` (the `str` is the state field key to
+label; the inner tuple is the per-element labels); a public
+`Toolset.state_labels()` simply returns it. Do **not** detect synthesized labels by comparing the
 resolved labels against `("0", "1", …)` — an embodiment may legitimately
 name its dims that way; use the presence of `semantics.dim_labels` at the
 point of synthesis. The policy calls `state_labels()` once per `bind()`,
@@ -162,8 +163,10 @@ caches the result on itself, and passes it into `_observation_content` as
 an optional parameter (default `None` keeps the current rendering).
 
 All other state fields keep the existing unlabeled rendering. Rounding stays
-as-is. This is a pure prompt-format change; update the plugin tests that
-assert on observation text.
+as-is. This is a pure prompt-format change. Existing observation-text
+assertions survive as-is (the only one, `"state[eef_pos]" in …` in
+`test_policy_e2e.py`, hits CubePick's no-StateSpec branch → unlabeled); do
+not hunt for others.
 
 ### 3.4 YAM plugin: authored cheat-sheet (companion PR, separate repo)
 
@@ -251,8 +254,8 @@ YAM plugin (companion PR):
   guarded concretely but collision-safely: assert with word-boundary
   regexes that none of the tokens `0.48`, `0.15`, `0.03` (the default x
   bounds and z low, formatted `.4g`) appear in the docs. Deliberately
-  excluded from the check: `0.25` (y bound — substring-collides with the
-  required forearm length "0.252"), `0.4` (z high — too generic), the yaw
+  excluded from the check: `0.25` (y bound — the prose may legitimately
+  round the 0.252 m forearm to 0.25), `0.4` (z high — too generic), the yaw
   bounds (π), and the gripper 0/1 endpoints (the polarity sentence must
   state them). This is a drift tripwire, not an exhaustive guard.
 - `docs_extra` appended verbatim (including braces); empty default adds

--- a/plans/0016-embodiment-agent-docs.md
+++ b/plans/0016-embodiment-agent-docs.md
@@ -79,8 +79,10 @@ Ripple effects inside core:
   already captured verbatim in the per-trial policy transcript, which is the
   audit surface that matters. Leave the projection unchanged.
 - Mock embodiments: `CubePick` gains a one-paragraph docs string, which
-  doubles as the in-tree usage example and exercises the field end to end in
-  the existing agent-plugin-against-mock tests (if any) and core tests.
+  doubles as the in-tree usage example. The existing agent-plugin e2e test
+  (`tests/test_policy_e2e.py`) asserts on the system prompt via substring
+  (`"cubepick" in …`), so it survives CubePick gaining docs; extend it to
+  also assert the docs section is present.
 - Nothing in `log.py` persists `EmbodimentInfo`, so no schema bump.
 
 ### 3.2 Agent plugin: render docs into the system prompt
@@ -121,7 +123,12 @@ modes (absolute and displacement; today's `state_key` is only computed for
 absolute modes, which would silently skip YAM `joint_delta` runs):
 
 1. If the toolset's existing `state_key` is set (absolute modes), label that
-   field.
+   field. Rule 1 deliberately has **no** canonical-vocab check, unlike
+   rule 2: `build_toolset` already selected that field as the motion
+   reference, which is what makes the labels honest — and yam eef mode's
+   reference key `eef_state` is *not* in `CANONICAL_STATE_UNITS`, so
+   "harmonizing" rule 1 with rule 2's filter would silently disable
+   labeling for yam eef runs. Do not add the filter to rule 1.
 2. Otherwise (displacement modes): if the observation space declares no
    `StateSpec` at all (e.g. CubePick, which lists `state_keys` but no
    spec'd fields), **no labeling**. If a spec exists, the candidates are
@@ -150,9 +157,9 @@ and the mode) and passed to the `Toolset` constructor as a precomputed
 simply returns it. Do **not** detect synthesized labels by comparing the
 resolved labels against `("0", "1", …)` — an embodiment may legitimately
 name its dims that way; use the presence of `semantics.dim_labels` at the
-point of synthesis. The policy calls `state_labels()` once and passes the
-result into `_observation_content` as an optional parameter (default `None`
-keeps the current rendering).
+point of synthesis. The policy calls `state_labels()` once per `bind()`,
+caches the result on itself, and passes it into `_observation_content` as
+an optional parameter (default `None` keeps the current rendering).
 
 All other state fields keep the existing unlabeled rendering. Rounding stays
 as-is. This is a pure prompt-format change; update the plugin tests that
@@ -220,7 +227,9 @@ Agent plugin:
   attribute does not raise (test will need a `cast`, since `bind()` is
   typed against `EmbodimentInfo`).
 - `state_labels()`, one test per branch: absolute mode returns the proprio
-  field labels; displacement mode with a unique canonical-keyed shape match
+  field labels **including when the reference key is non-canonical**
+  (mirror yam's `eef_state` shape — guards the rule-1 asymmetry);
+  displacement mode with a unique canonical-keyed shape match
   returns it; **no StateSpec at all** returns None (use real
   `CubePickEmbodiment().info` — CubePick declares `state_keys` but no
   spec); **two canonical shape-matching fields** returns None (needs a
@@ -232,15 +241,20 @@ Agent plugin:
 YAM plugin (companion PR):
 
 - joints-mode docs mention every label `left_j0`…`right_gripper` exactly
-  once in the bullet list; the gripper polarity sentence is asserted as a
+  once in the bullet list, where "bullet list" means the lines starting
+  with `"- "` (labels may additionally appear in surrounding prose — only
+  the bulleted lines are counted); the gripper polarity sentence is asserted as a
   literal matching the wire convention hardcoded in the yam
   `embodiment.py` gripper normalization (cmd 1 → open). The convention is
   structural there, not a derivable constant — a literal is the honest test.
 - eef-mode docs mention every eef label; the no-restated-bounds rule is
-  guarded concretely: assert that none of the formatted default
-  `eef_low`/`eef_high` component values from `config.py` appear as
-  substrings of the docs (the docs legitimately contain other numbers —
-  link lengths, reach — so "no numbers" is not the test).
+  guarded concretely but collision-safely: assert with word-boundary
+  regexes that none of the tokens `0.48`, `0.15`, `0.03` (the default x
+  bounds and z low, formatted `.4g`) appear in the docs. Deliberately
+  excluded from the check: `0.25` (y bound — substring-collides with the
+  required forearm length "0.252"), `0.4` (z high — too generic), the yaw
+  bounds (π), and the gripper 0/1 endpoints (the polarity sentence must
+  state them). This is a drift tripwire, not an exhaustive guard.
 - `docs_extra` appended verbatim (including braces); empty default adds
   nothing.
 

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -55,6 +55,12 @@ The embodiment then plays the chunk at its native rate. In this case the speed
 and playout caps are step-count constructs, not wall-clock guarantees, and the
 tool result does not report seconds.
 
+When the embodiment publishes operating notes via `EmbodimentInfo.docs`
+(joint layout, sign conventions, gripper polarity), the policy appends them
+to the system prompt as an `Embodiment notes:` section. The per-step
+observation also labels the proprioceptive state vector with the action
+dimension names (`left_j0=0.01 ...`) whenever the mapping is unambiguous.
+
 Every action still passes the CLI's default safety approvers (bounds clamp plus
 per-step delta limit); the plugin contains no safety-critical code path of its
 own. An explicit `--max-action-delta` tighter than 5% of range can truncate

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.4.0"
+version = "0.5.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -21,7 +21,7 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 
-from inspect_robots.spaces import Box, ObservationSpace
+from inspect_robots.spaces import CANONICAL_STATE_UNITS, Box, ObservationSpace
 from inspect_robots.types import Action, ActionChunk, Observation
 
 _ABSOLUTE_MODES = frozenset({"joint_pos", "eef_abs_pose"})
@@ -61,6 +61,7 @@ class Toolset:
         absolute: bool,
         labels: tuple[str, ...],
         state_key: str | None,
+        state_labels: tuple[str, tuple[str, ...]] | None,
         control_hz: float | None,
         bounds_text: str,
         low: npt.NDArray[np.float64],
@@ -73,6 +74,7 @@ class Toolset:
         self._labels = labels
         self._index_by_label = {label: i for i, label in enumerate(labels)}
         self._state_key = state_key
+        self._state_labels = state_labels
         self._hz = control_hz
         self._resolved_hz = control_hz if control_hz is not None else _FALLBACK_HZ
         self._max_steps = math.ceil(_MAX_DURATION_S * self._resolved_hz)
@@ -92,6 +94,10 @@ class Toolset:
         else:
             self._positive_limits = high
             self._negative_limits = np.abs(low)
+
+    def state_labels(self) -> tuple[str, tuple[str, ...]] | None:
+        """Return the state field and per-element labels selected at build time."""
+        return self._state_labels
 
     def schemas(self) -> list[dict[str, Any]]:
         """Return OpenAI-format tool definitions for this embodiment."""
@@ -391,14 +397,14 @@ def build_toolset(
     absolute = mode in _ABSOLUTE_MODES
     dim = action_space.dim
     state_key: str | None = None
+    state_spec = observation_space.state
     if absolute:
-        spec = observation_space.state
-        if spec is None:
+        if state_spec is None:
             raise ToolsetError(
                 "absolute-target control needs a StateSpec on the embodiment's "
                 "observation space to locate the proprioceptive reference"
             )
-        matching = [field.key for field in spec.fields if field.shape == (dim,)]
+        matching = [field.key for field in state_spec.fields if field.shape == (dim,)]
         if len(matching) != 1:
             raise ToolsetError(
                 f"absolute-target control needs exactly one state field with shape "
@@ -454,7 +460,20 @@ def build_toolset(
                 "per-step limit for a movable dimension; increase it"
             )
 
-    labels = semantics.dim_labels or tuple(str(i) for i in range(dim))
+    authored_labels = semantics.dim_labels
+    labels = authored_labels or tuple(str(i) for i in range(dim))
+    state_labels: tuple[str, tuple[str, ...]] | None = None
+    if authored_labels is not None:
+        if state_key is not None:
+            state_labels = (state_key, authored_labels)
+        elif state_spec is not None:
+            candidates = [
+                field.key
+                for field in state_spec.fields
+                if field.shape == (dim,) and field.key in CANONICAL_STATE_UNITS
+            ]
+            if len(candidates) == 1:
+                state_labels = (candidates[0], authored_labels)
     pairs = ", ".join(
         f"{label}: [{lo:.4g}, {hi:.4g}]"
         for label, lo, hi in zip(labels, low64.tolist(), high64.tolist(), strict=False)
@@ -465,6 +484,7 @@ def build_toolset(
         absolute=absolute,
         labels=labels,
         state_key=state_key,
+        state_labels=state_labels,
         control_hz=control_hz,
         bounds_text=bounds_text,
         low=low64,

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -118,6 +118,8 @@ class LLMAgentPolicy(PolicyBase):
         self.info = PolicyInfo(name="agent", action_space=Box(shape=(1,)))
         self._toolset: Toolset | None = None
         self._embodiment_name = "(unbound)"
+        self._embodiment_docs: str | None = None
+        self._state_labels: tuple[str, tuple[str, ...]] | None = None
         self._messages: list[dict[str, Any]] = []
         self._calls_used = 0
 
@@ -125,13 +127,16 @@ class LLMAgentPolicy(PolicyBase):
 
     def bind(self, embodiment_info: EmbodimentInfo) -> None:
         """Adopt the embodiment's spaces and build the tool surface from them."""
-        self._toolset = build_toolset(
+        toolset = build_toolset(
             embodiment_info.action_space,
             embodiment_info.observation_space,
             embodiment_info.control_hz,
             self._max_speed_frac,
         )
+        self._toolset = toolset
+        self._state_labels = toolset.state_labels()
         self._embodiment_name = embodiment_info.name
+        self._embodiment_docs = getattr(embodiment_info, "docs", None)
         self.info = PolicyInfo(
             name="agent",
             action_space=embodiment_info.action_space,
@@ -141,12 +146,14 @@ class LLMAgentPolicy(PolicyBase):
 
     def reset(self, scene: Scene) -> None:
         """Start a fresh per-trial conversation with the scene goal and call budget."""
+        formatted = _SYSTEM_TEMPLATE.format(name=self._embodiment_name, budget=self._max_llm_calls)
+        docs = self._embodiment_docs
+        if docs is not None and docs.strip():
+            formatted = formatted + "\n\nEmbodiment notes:\n" + docs.strip()
         self._messages = [
             {
                 "role": "system",
-                "content": _SYSTEM_TEMPLATE.format(
-                    name=self._embodiment_name, budget=self._max_llm_calls
-                ),
+                "content": formatted,
             },
             {"role": "user", "content": f"Goal: {scene.instruction}"},
         ]
@@ -179,7 +186,12 @@ class LLMAgentPolicy(PolicyBase):
                 "LLMAgentPolicy.act() before bind(); run it through eval() or call "
                 "policy.bind(embodiment.info) first"
             )
-        self._messages.append({"role": "user", "content": _observation_content(observation)})
+        self._messages.append(
+            {
+                "role": "user",
+                "content": _observation_content(observation, self._state_labels),
+            }
+        )
         failures = 0
         while True:
             if self._calls_used >= self._max_llm_calls:
@@ -232,13 +244,25 @@ class LLMAgentPolicy(PolicyBase):
         return result.chunk
 
 
-def _observation_content(observation: Observation) -> list[dict[str, Any]]:
+def _observation_content(
+    observation: Observation,
+    state_labels: tuple[str, tuple[str, ...]] | None = None,
+) -> list[dict[str, Any]]:
     """State as readable text plus camera frames as inline PNG data URLs."""
     lines = ["Current observation."]
     if observation.instruction:
         lines.append(f"Instruction: {observation.instruction}")
     for key, value in observation.state.items():
-        rounded = np.round(np.asarray(value, dtype=np.float64), 4).tolist()
+        array = np.asarray(value, dtype=np.float64)
+        rounded = np.round(array, 4).tolist()
+        if state_labels is not None and key == state_labels[0]:
+            labels = state_labels[1]
+            if array.shape == (len(labels),):
+                labeled = " ".join(
+                    f"{label}={item}" for label, item in zip(labels, rounded, strict=True)
+                )
+                lines.append(f"state[{key}]: {labeled}")
+                continue
         lines.append(f"state[{key}]: {rounded}")
     parts: list[dict[str, Any]] = [{"type": "text", "text": "\n".join(lines)}]
     for name, image in observation.images.items():

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,5 +6,5 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.4.0"
+    assert inspect_robots_agent.__version__ == "0.5.0"
     assert callable(inspect_robots_agent.agent_policy)

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -8,8 +8,9 @@ guardrails, policy-stop, budgets, error taxonomy) runs for real.
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import numpy as np
@@ -29,6 +30,7 @@ from inspect_robots.types import Action, Observation, StepResult
 from inspect_robots_agent import LLMAgentPolicy
 from inspect_robots_agent._llm import ChatClient, resolve_provider
 from inspect_robots_agent._png import encode_png
+from inspect_robots_agent.policy import _SYSTEM_TEMPLATE, _observation_content
 
 # --- scripted-conversation harness ---------------------------------------------
 
@@ -183,6 +185,91 @@ def test_transcript_is_none_before_first_reset() -> None:
     assert policy.transcript() is None
 
 
+def test_reset_before_bind_uses_the_unchanged_unbound_prompt() -> None:
+    policy = _policy(_Script([_text_response("unused")]))
+    policy.reset(Scene(id="s0", instruction="reach"))
+
+    transcript = policy.transcript()
+
+    assert transcript is not None
+    assert transcript[0]["content"] == _SYSTEM_TEMPLATE.format(name="(unbound)", budget=100)
+
+
+def test_embodiment_docs_are_appended_verbatim_after_formatting() -> None:
+    docs = '  Keep {x/y} literal.\n```json\n{"open": 1}\n```  '
+    info = replace(CubePickEmbodiment().info, docs=docs)
+    policy = _policy(_Script([_text_response("unused")]))
+    policy.bind(info)
+    policy.reset(Scene(id="s0", instruction="reach"))
+
+    transcript = policy.transcript()
+
+    assert transcript is not None
+    assert transcript[0]["content"] == (
+        _SYSTEM_TEMPLATE.format(name="cubepick", budget=100)
+        + "\n\nEmbodiment notes:\n"
+        + docs.strip()
+    )
+
+
+@pytest.mark.parametrize("docs", [None, "", " \n\t "])
+def test_absent_embodiment_docs_leave_the_prompt_unchanged(docs: str | None) -> None:
+    info = replace(CubePickEmbodiment().info, docs=docs)
+    policy = _policy(_Script([_text_response("unused")]))
+    policy.bind(info)
+    policy.reset(Scene(id="s0", instruction="reach"))
+
+    transcript = policy.transcript()
+
+    assert transcript is not None
+    assert transcript[0]["content"] == _SYSTEM_TEMPLATE.format(name="cubepick", budget=100)
+
+
+def test_bind_accepts_legacy_embodiment_info_without_docs() -> None:
+    current = CubePickEmbodiment().info
+
+    class _LegacyInfo:
+        name = current.name
+        action_space = current.action_space
+        observation_space = current.observation_space
+        control_hz = current.control_hz
+
+    policy = _policy(_Script([_text_response("unused")]))
+    policy.bind(cast(EmbodimentInfo, _LegacyInfo()))
+    policy.reset(Scene(id="s0", instruction="reach"))
+
+    transcript = policy.transcript()
+
+    assert transcript is not None
+    assert "Embodiment notes:" not in transcript[0]["content"]
+
+
+def test_observation_content_labels_the_selected_state_field_exactly() -> None:
+    content = _observation_content(
+        Observation(state={"joint_pos": np.array([0.01, -0.02, 0.98])}),
+        ("joint_pos", ("left_j0", "left_j1", "right_gripper")),
+    )
+
+    assert content == [
+        {
+            "type": "text",
+            "text": (
+                "Current observation.\n"
+                "state[joint_pos]: left_j0=0.01 left_j1=-0.02 right_gripper=0.98"
+            ),
+        }
+    ]
+
+
+def test_observation_content_uses_unlabeled_fallback_for_length_mismatch() -> None:
+    content = _observation_content(
+        Observation(state={"joint_pos": np.array([0.01, -0.02])}),
+        ("joint_pos", ("left_j0", "left_j1", "right_gripper")),
+    )
+
+    assert content[0]["text"] == "Current observation.\nstate[joint_pos]: [0.01, -0.02]"
+
+
 def test_transcript_strips_images_and_preserves_text_and_tools() -> None:
     policy = _policy(_Script([_text_response("unused")]))
     policy.reset(Scene(id="s0", instruction="reach"))
@@ -244,6 +331,9 @@ def test_outbound_messages_carry_state_images_and_tools(tmp_path: Path) -> None:
     assert [t["function"]["name"] for t in first["tools"]] == ["move_by", "done", "give_up"]
     system, goal, observation = first["messages"]
     assert "cubepick" in system["content"]
+    assert "Embodiment notes:\n" in system["content"]
+    docs = CubePickEmbodiment().info.docs
+    assert docs is not None and docs in system["content"]
     assert goal["content"] == "Goal: reach the cube"
     text_parts = [p["text"] for p in observation["content"] if p["type"] == "text"]
     assert any("state[eef_pos]" in t for t in text_parts)

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from inspect_robots.approver import ChainApprover, ClampApprover, DeltaLimitApprover
+from inspect_robots.mock import CubePickEmbodiment
 from inspect_robots.spaces import ActionSemantics, Box, ObservationSpace, StateField, StateSpec
 from inspect_robots.types import Observation
 from inspect_robots_agent._llm import ToolCall
@@ -132,6 +133,85 @@ def test_absolute_mode_requires_exactly_one_aligned_state_field() -> None:
     )
     with pytest.raises(ToolsetError, match="exactly one"):
         build_toolset(space, two_match, control_hz=10.0)
+
+
+def test_absolute_mode_labels_its_reference_even_when_the_key_is_noncanonical() -> None:
+    canonical = build_toolset(_bimanual_space(), _bimanual_obs_space(), control_hz=10.0)
+    assert canonical.state_labels() == ("joint_pos", _ARM_LABELS)
+
+    labels = ("x", "y", "z", "yaw")
+    space = Box(
+        shape=(4,),
+        low=-np.ones(4),
+        high=np.ones(4),
+        semantics=ActionSemantics("eef_abs_pose", dim_labels=labels),
+    )
+    observation_space = ObservationSpace(
+        state=StateSpec(fields=(StateField(key="eef_state", shape=(4,)),))
+    )
+    noncanonical = build_toolset(space, observation_space, control_hz=10.0)
+    assert noncanonical.state_labels() == ("eef_state", labels)
+
+
+def test_displacement_mode_labels_one_canonical_shape_match() -> None:
+    labels = ("dx", "dy")
+    space = Box(
+        shape=(2,),
+        low=-np.ones(2),
+        high=np.ones(2),
+        semantics=ActionSemantics("eef_delta_pos", dim_labels=labels),
+    )
+    observation_space = ObservationSpace(
+        state=StateSpec(fields=(StateField(key="eef_pos", shape=(2,)),))
+    )
+    assert build_toolset(space, observation_space, 10.0).state_labels() == ("eef_pos", labels)
+
+
+def test_displacement_mode_without_state_spec_has_no_state_labels() -> None:
+    info = CubePickEmbodiment().info
+    assert (
+        build_toolset(info.action_space, info.observation_space, info.control_hz).state_labels()
+        is None
+    )
+
+
+def test_displacement_mode_rejects_ambiguous_canonical_shape_matches() -> None:
+    labels = ("a", "b")
+    space = Box(
+        shape=(2,),
+        low=-np.ones(2),
+        high=np.ones(2),
+        semantics=ActionSemantics("joint_delta", dim_labels=labels),
+    )
+    observation_space = ObservationSpace(
+        state=StateSpec(
+            fields=(
+                StateField(key="joint_pos", shape=(2,)),
+                StateField(key="eef_pos", shape=(2,)),
+            )
+        )
+    )
+    assert build_toolset(space, observation_space, 10.0).state_labels() is None
+
+
+def test_displacement_mode_excludes_noncanonical_shape_matches() -> None:
+    space = Box(
+        shape=(2,),
+        low=-np.ones(2),
+        high=np.ones(2),
+        semantics=ActionSemantics("joint_delta", dim_labels=("a", "b")),
+    )
+    observation_space = ObservationSpace(
+        state=StateSpec(fields=(StateField(key="object_pose", shape=(2,)),))
+    )
+    assert build_toolset(space, observation_space, 10.0).state_labels() is None
+
+
+def test_synthesized_action_labels_do_not_label_state() -> None:
+    observation_space = ObservationSpace(
+        state=StateSpec(fields=(StateField(key="eef_pos", shape=(2,)),))
+    )
+    assert build_toolset(_delta_space(), observation_space, 10.0).state_labels() is None
 
 
 @pytest.mark.parametrize(

--- a/src/inspect_robots/embodiment.py
+++ b/src/inspect_robots/embodiment.py
@@ -39,7 +39,15 @@ SELF_PACED: Capability = "self_paced"
 
 @dataclass(frozen=True)
 class EmbodimentInfo:
-    """Static description of an embodiment for compatibility checking + logging."""
+    """Static description of an embodiment for compatibility checking + logging.
+
+    ``docs`` contains free-form markdown operating notes for policies that can
+    read text, such as joint layout and positive directions, zero-pose
+    geometry, gripper polarity, frame conventions, and workspace hints. Keep
+    it concise because consumers inject it into system prompts verbatim.
+    ``None`` means no notes are offered; consumers must treat empty and
+    whitespace-only strings the same as absence.
+    """
 
     name: str
     action_space: Box
@@ -51,6 +59,7 @@ class EmbodimentInfo:
     # scene-realizability checks). Empty means "unconstrained" for the tracer.
     supported_setups: frozenset[str] = field(default_factory=frozenset)
     supported_target_kinds: frozenset[str] = field(default_factory=frozenset)
+    docs: str | None = None
 
 
 @runtime_checkable

--- a/src/inspect_robots/mock/cubepick.py
+++ b/src/inspect_robots/mock/cubepick.py
@@ -63,6 +63,11 @@ class CubePickEmbodiment:
             capabilities=frozenset(
                 {SEEDABLE, RESETTABLE, AUTO_RESET, PRIVILEGED_SUCCESS, RENDERABLE}
             ),
+            docs=(
+                "The red point is the end effector and the green point is the cube in the "
+                "top camera; world-frame +x points right and +y points down in the image, "
+                "and both positions stay within the unit square."
+            ),
         )
 
     def reset(self, scene: Scene, *, seed: int | None = None) -> Observation:

--- a/tests/test_types_spaces.py
+++ b/tests/test_types_spaces.py
@@ -7,6 +7,8 @@ import dataclasses
 import numpy as np
 import pytest
 
+from inspect_robots.embodiment import EmbodimentInfo
+from inspect_robots.mock import CubePickEmbodiment
 from inspect_robots.spaces import (
     ActionSemantics,
     Box,
@@ -16,6 +18,33 @@ from inspect_robots.spaces import (
     StateSpec,
 )
 from inspect_robots.types import Action, ActionChunk, Observation, StepResult
+
+
+def test_embodiment_info_docs_preserve_frozen_value_semantics() -> None:
+    action_space = Box(shape=(1,))
+    observation_space = ObservationSpace()
+    info = EmbodimentInfo(
+        name="test",
+        action_space=action_space,
+        observation_space=observation_space,
+    )
+    same = EmbodimentInfo(
+        name="test",
+        action_space=action_space,
+        observation_space=observation_space,
+    )
+
+    assert info.docs is None
+    assert info == same
+    assert hash(info) == hash(same)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        info.docs = "changed"  # type: ignore[misc]
+
+
+def test_cubepick_publishes_operating_notes() -> None:
+    docs = CubePickEmbodiment().info.docs
+    assert docs is not None
+    assert docs.strip()
 
 
 def test_core_types_are_frozen() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #109.

Implements plan 0016 (approved after 4 adversarial critique rounds):

- `EmbodimentInfo.docs`: optional free-form markdown operating notes an embodiment can publish for text-reading policies (joint layout, sign conventions, gripper polarity, frame conventions). Advisory only: no compat, conformance, snapshot, or log-schema impact. CubePick ships example docs.
- Agent plugin renders the notes into the system prompt (`Embodiment notes:` section), appended after `str.format` so third-party markdown containing braces cannot crash trial reset.
- Labeled proprio state in observations: `state[joint_pos]: left_j0=0.01 …` instead of an unlabeled list, with a conservative selection rule (absolute-mode reference field, or the unique canonical-keyed shape match in displacement modes; ambiguity or synthesized labels mean no labeling).
- Agent plugin 0.5.0; its `inspect-robots>=0.4` bound is unchanged (getattr fallback degrades gracefully on older cores).

Companion cheat-sheet content (YAM kinematics, FK-verified) lands in inspect-robots-yam after the core release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)