### PR TITLE
docs: show VLA-on-ROS composition example

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,10 @@ inspect-robots run --task my-task --policy agent --embodiment ros \
     -E action_high=3.1,2.2,2.9,3.1,2.9,3.1
 ```
 
-Robot bringup, controller mappings, safety requirements, camera configuration,
-and reset behavior are documented in the
+Swap `--policy agent` for `--policy xpolicylab -P url=ws://gpu-box:19000` to
+evaluate any XPolicyLab-served VLA on the same arm; the `-E` robot arguments
+stay unchanged. Robot bringup, controller mappings, safety requirements,
+camera configuration, and reset behavior are documented in the
 [ROS plugin README](plugins/inspect-robots-ros/).
 
 Safety guardrails (a bounds clamp plus a per-step delta limit derived from

--- a/plugins/inspect-robots-ros/README.md
+++ b/plugins/inspect-robots-ros/README.md
@@ -64,6 +64,25 @@ inspect-robots run --task my-task --policy agent --embodiment ros \
     -E action_high=3.1,2.2,2.9,3.1,2.9,3.1
 ```
 
+The embodiment composes with any compatible policy. The same robot
+configuration evaluates an XPolicyLab-served VLA (any of the 40+ policies
+behind [inspect-robots-xpolicylab](../inspect-robots-xpolicylab/)) instead of
+an LLM:
+
+```bash
+inspect-robots run --task my-task --embodiment ros \
+    --policy xpolicylab -P url=ws://gpu-box:19000 -P cameras=cam_head:wrist \
+    -E url=ws://robot:9090 \
+    -E joints=joint1,joint2,joint3,joint4,joint5,joint6 \
+    -E command_topic=/joint_trajectory_controller/joint_trajectory \
+    -E cameras=wrist:/camera/wrist/image_raw/compressed:640x480 \
+    -E action_low=-3.1,-2.2,-2.9,-3.1,-2.9,-3.1 \
+    -E action_high=3.1,2.2,2.9,3.1,2.9,3.1
+```
+
+`-P` arguments go to the policy and `-E` arguments go to the embodiment, so
+the robot half of the command never changes when you swap policies.
+
 Construction and `.info` are network-free. The websocket connects on the first
 `reset()`, after compatibility and guardrail checks have inspected the declared
 spaces.


### PR DESCRIPTION
Follow-up to #105: the docs stated the ROS embodiment "works with every compatible policy" but never showed the marquee composition. Adds the `--policy xpolicylab --embodiment ros` example to the plugin README quickstart (same `-E` robot arguments, only the policy half changes) and an explicit policy-swap sentence to the root README ROS section. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
