### PR TITLE
docs: show -P effort=low explicitly in the Fable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ uv pip install inspect-robots-agent
 Run the LLM on the robot:
 
 ```bash
-inspect-robots "place the fork on the plate" --policy agent -P model=anthropic/claude-fable-5
+inspect-robots "place the fork on the plate" --policy agent \
+    -P model=anthropic/claude-fable-5 -P effort=low
 ```
 
 Read the recorded agent conversation with `inspect-robots inspect LOG.json --transcript`.
@@ -249,7 +250,7 @@ inspect-robots run --task my-task --embodiment isaacsim \
 # Claude driving the mock world, no hardware or GPU required:
 export ANTHROPIC_API_KEY=sk-ant-...
 inspect-robots "pick up the cube" --policy agent \
-    -P model=anthropic/claude-fable-5 --embodiment cubepick
+    -P model=anthropic/claude-fable-5 -P effort=low --embodiment cubepick
 ```
 
 ### Real robots via ROS

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -18,7 +18,7 @@ pip install inspect-robots inspect-robots-agent
 export ANTHROPIC_API_KEY=sk-ant-...
 
 inspect-robots "pick up the cube" --policy agent \
-    -P model=anthropic/claude-fable-5 --embodiment cubepick
+    -P model=anthropic/claude-fable-5 -P effort=low --embodiment cubepick
 ```
 
 Model strings are OpenRouter-style `provider/model`, resolved from


### PR DESCRIPTION
Adds `-P effort=low` to the three `anthropic/claude-fable-5` example commands (main README x2, agent plugin README x1). The agent policy already defaults to low effort, so this is documentation only: it surfaces the latency knob in the commands readers copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)