### PR TITLE
feat(agent): native key resolution for google, x-ai, groq, mistralai, deepseek

### DIFF
--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -27,8 +27,11 @@ Model strings are OpenRouter-style `provider/model`, resolved from
 1. `-P base_url=...` (with `-P api_key_env=NAME`): any OpenAI-compatible endpoint
 2. A known provider prefix with that provider's key set: the provider's own
    endpoint, prefix stripped from the model id
-3. `OPENROUTER_API_KEY`: OpenRouter, any model string (including `:free` /
-   `:nitro` variant suffixes, which always route here)
+3. `OPENROUTER_API_KEY`: OpenRouter, any model string. Ids ending in a known
+   OpenRouter variant suffix (`:free`, `:nitro`, `:floor`, `:extended`,
+   `:online`, `:thinking`) always route here, since the variant means nothing
+   to a provider's own API; other colons (fine-tune ids like `openai/ft:...`)
+   still resolve directly.
 
 Providers resolved directly by prefix:
 

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -25,9 +25,22 @@ Model strings are OpenRouter-style `provider/model`, resolved from
 `-P model=...` or `$INSPECT_ROBOTS_MODEL`. API keys come from the environment:
 
 1. `-P base_url=...` (with `-P api_key_env=NAME`): any OpenAI-compatible endpoint
-2. `anthropic/*` model with `ANTHROPIC_API_KEY`: the Anthropic compat endpoint
-3. `openai/*` model with `OPENAI_API_KEY`: OpenAI
-4. `OPENROUTER_API_KEY`: OpenRouter, any model string
+2. A known provider prefix with that provider's key set: the provider's own
+   endpoint, prefix stripped from the model id
+3. `OPENROUTER_API_KEY`: OpenRouter, any model string (including `:free` /
+   `:nitro` variant suffixes, which always route here)
+
+Providers resolved directly by prefix:
+
+| Prefix | Key | Endpoint |
+|---|---|---|
+| `anthropic/*` | `ANTHROPIC_API_KEY` | Anthropic (OpenAI-compat) |
+| `openai/*` | `OPENAI_API_KEY` | OpenAI |
+| `google/*` | `GEMINI_API_KEY` | Google Gemini (OpenAI-compat) |
+| `x-ai/*` or `xai/*` | `XAI_API_KEY` | xAI |
+| `groq/*` | `GROQ_API_KEY` | Groq (rest of the id passed through, slashes and all) |
+| `mistralai/*` | `MISTRAL_API_KEY` | Mistral |
+| `deepseek/*` | `DEEPSEEK_API_KEY` | DeepSeek |
 
 ## How it works
 

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.5.0"
+version = "0.6.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
@@ -19,10 +19,40 @@ from inspect_robots.errors import ConfigError
 
 ENV_MODEL = "INSPECT_ROBOTS_MODEL"
 
-_ANTHROPIC_BASE = "https://api.anthropic.com/v1"
-_OPENAI_BASE = "https://api.openai.com/v1"
 _OPENROUTER_BASE = "https://openrouter.ai/api/v1"
 _OPENROUTER_KEY = "OPENROUTER_API_KEY"
+
+
+@dataclass(frozen=True)
+class _DirectProvider:
+    """A provider with a stable OpenAI-compatible endpoint and conventional key name."""
+
+    base_url: str
+    key_env: str
+
+
+# OpenRouter-style prefixes that resolve to the provider's own endpoint when its
+# key is present. The prefix is stripped: these endpoints want the bare model id.
+_DIRECT_PROVIDERS: dict[str, _DirectProvider] = {
+    "anthropic": _DirectProvider("https://api.anthropic.com/v1", "ANTHROPIC_API_KEY"),
+    "openai": _DirectProvider("https://api.openai.com/v1", "OPENAI_API_KEY"),
+    "google": _DirectProvider(
+        "https://generativelanguage.googleapis.com/v1beta/openai", "GEMINI_API_KEY"
+    ),
+    "x-ai": _DirectProvider("https://api.x.ai/v1", "XAI_API_KEY"),
+    "xai": _DirectProvider("https://api.x.ai/v1", "XAI_API_KEY"),
+    "groq": _DirectProvider("https://api.groq.com/openai/v1", "GROQ_API_KEY"),
+    "mistralai": _DirectProvider("https://api.mistral.ai/v1", "MISTRAL_API_KEY"),
+    "deepseek": _DirectProvider("https://api.deepseek.com/v1", "DEEPSEEK_API_KEY"),
+}
+
+
+def _provider_key_hints() -> str:
+    """One ``$KEY for prefix/*`` hint per distinct key, for the guided error."""
+    seen: dict[str, str] = {}
+    for prefix, direct in _DIRECT_PROVIDERS.items():
+        seen.setdefault(direct.key_env, prefix)
+    return ", ".join(f"${key} for {prefix}/*" for key, prefix in seen.items())
 
 
 @dataclass(frozen=True)
@@ -45,10 +75,12 @@ def resolve_provider(
     1. Explicit ``base_url`` — any OpenAI-compatible endpoint; the key comes
        from ``api_key_env`` (default ``OPENROUTER_API_KEY``), and a missing
        key is allowed (local vLLM/Ollama endpoints are typically keyless).
-    2. ``anthropic/*`` model + ``ANTHROPIC_API_KEY`` — the Anthropic compat
-       endpoint (provider prefix stripped from the model id).
-    3. ``openai/*`` model + ``OPENAI_API_KEY`` — OpenAI (prefix stripped).
-    4. ``OPENROUTER_API_KEY`` — OpenRouter, which takes the full
+    2. A known ``prefix/*`` model + that provider's key (``_DIRECT_PROVIDERS``:
+       anthropic, openai, google, x-ai, groq, mistralai, deepseek) — the
+       provider's own endpoint, prefix stripped from the model id. Ids with an
+       OpenRouter variant suffix (``:free``, ``:nitro``) are never claimed
+       here — the variant only means something to OpenRouter.
+    3. ``OPENROUTER_API_KEY`` — OpenRouter, which takes the full
        ``provider/model`` string.
 
     Anything else is a guided [`ConfigError`][inspect_robots.errors.ConfigError]
@@ -64,16 +96,20 @@ def resolve_provider(
         key_env = api_key_env or _OPENROUTER_KEY
         return Provider(base_url=base_url.rstrip("/"), api_key=env.get(key_env, ""), model=model)
     provider_prefix, _, bare_model = model.partition("/")
-    if provider_prefix == "anthropic" and (key := env.get("ANTHROPIC_API_KEY")):
-        return Provider(base_url=_ANTHROPIC_BASE, api_key=key, model=bare_model)
-    if provider_prefix == "openai" and (key := env.get("OPENAI_API_KEY")):
-        return Provider(base_url=_OPENAI_BASE, api_key=key, model=bare_model)
+    direct = _DIRECT_PROVIDERS.get(provider_prefix)
+    if (
+        direct is not None
+        and bare_model  # a bare "anthropic" must not resolve to an empty model id
+        and ":" not in bare_model  # OpenRouter variant syntax; not a direct-API id
+        and (key := env.get(direct.key_env))
+    ):
+        return Provider(base_url=direct.base_url, api_key=key, model=bare_model)
     if key := env.get(_OPENROUTER_KEY):
         return Provider(base_url=_OPENROUTER_BASE, api_key=key, model=model)
     raise ConfigError(
         f"no API key found for model {model!r}.\n"
         f"fix: set ${_OPENROUTER_KEY} (works for any model), or the provider's "
-        "key ($ANTHROPIC_API_KEY for anthropic/*, $OPENAI_API_KEY for openai/*), "
+        f"key ({_provider_key_hints()}), "
         "or pass -P base_url=... (+ -P api_key_env=NAME) for a custom endpoint"
     )
 

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
@@ -47,6 +47,19 @@ _DIRECT_PROVIDERS: dict[str, _DirectProvider] = {
 }
 
 
+# OpenRouter routing-variant suffixes. The variant only means something to
+# OpenRouter, so ids carrying one are never claimed by a direct provider. A
+# closed set, not "any colon": OpenAI/Mistral fine-tune ids legitimately
+# contain colons (ft:gpt-4o-mini:org:suffix:id) and must keep routing direct.
+_OPENROUTER_VARIANTS = frozenset({"free", "nitro", "floor", "extended", "online", "thinking"})
+
+
+def _has_openrouter_variant(model_id: str) -> bool:
+    """True when the id ends in a known OpenRouter ``:variant`` suffix."""
+    _, sep, suffix = model_id.rpartition(":")
+    return bool(sep) and suffix in _OPENROUTER_VARIANTS
+
+
 def _provider_key_hints() -> str:
     """One ``$KEY for prefix/*`` hint per distinct key, for the guided error."""
     seen: dict[str, str] = {}
@@ -76,10 +89,11 @@ def resolve_provider(
        from ``api_key_env`` (default ``OPENROUTER_API_KEY``), and a missing
        key is allowed (local vLLM/Ollama endpoints are typically keyless).
     2. A known ``prefix/*`` model + that provider's key (``_DIRECT_PROVIDERS``:
-       anthropic, openai, google, x-ai, groq, mistralai, deepseek) — the
-       provider's own endpoint, prefix stripped from the model id. Ids with an
-       OpenRouter variant suffix (``:free``, ``:nitro``) are never claimed
-       here — the variant only means something to OpenRouter.
+       anthropic, openai, google, x-ai/xai, groq, mistralai, deepseek) — the
+       provider's own endpoint, prefix stripped from the model id. Ids ending
+       in a known OpenRouter variant suffix (``_OPENROUTER_VARIANTS``, e.g.
+       ``:free``, ``:nitro``) are never claimed here — the variant only means
+       something to OpenRouter. Other colons (fine-tune ids) pass through.
     3. ``OPENROUTER_API_KEY`` — OpenRouter, which takes the full
        ``provider/model`` string.
 
@@ -100,7 +114,7 @@ def resolve_provider(
     if (
         direct is not None
         and bare_model  # a bare "anthropic" must not resolve to an empty model id
-        and ":" not in bare_model  # OpenRouter variant syntax; not a direct-API id
+        and not _has_openrouter_variant(bare_model)
         and (key := env.get(direct.key_env))
     ):
         return Provider(base_url=direct.base_url, api_key=key, model=bare_model)

--- a/plugins/inspect-robots-agent/tests/test_llm.py
+++ b/plugins/inspect-robots-agent/tests/test_llm.py
@@ -72,6 +72,84 @@ def test_openrouter_is_the_universal_fallback() -> None:
     assert p.model == "anthropic/claude-fable-5"  # OpenRouter takes the full string
 
 
+@pytest.mark.parametrize(
+    ("model", "key_env", "host", "bare"),
+    [
+        (
+            "google/gemini-3.1-flash-lite",
+            "GEMINI_API_KEY",
+            "googleapis.com",
+            "gemini-3.1-flash-lite",
+        ),
+        ("x-ai/grok-4.3", "XAI_API_KEY", "api.x.ai", "grok-4.3"),
+        ("xai/grok-4.3", "XAI_API_KEY", "api.x.ai", "grok-4.3"),
+        # Groq serves ids that themselves contain a slash; only the first
+        # segment is the routing prefix.
+        (
+            "groq/meta-llama/llama-4-scout-17b-16e-instruct",
+            "GROQ_API_KEY",
+            "api.groq.com",
+            "meta-llama/llama-4-scout-17b-16e-instruct",
+        ),
+        ("mistralai/mistral-medium-3", "MISTRAL_API_KEY", "api.mistral.ai", "mistral-medium-3"),
+        ("deepseek/deepseek-chat", "DEEPSEEK_API_KEY", "api.deepseek.com", "deepseek-chat"),
+    ],
+)
+def test_direct_provider_table(model: str, key_env: str, host: str, bare: str) -> None:
+    p = resolve_provider(
+        model=model,
+        base_url=None,
+        api_key_env=None,
+        env={key_env: "sk-provider", "OPENROUTER_API_KEY": "or-key"},
+    )
+    assert host in p.base_url
+    assert p.api_key == "sk-provider"  # provider key preferred over OpenRouter
+    assert p.model == bare
+
+
+def test_openrouter_variant_suffix_is_never_claimed_directly() -> None:
+    # ":nitro"/":free" mean something to OpenRouter only; the direct endpoint
+    # would 404 on them even with the provider key set.
+    p = resolve_provider(
+        model="google/gemini-3.5-flash:nitro",
+        base_url=None,
+        api_key_env=None,
+        env={"GEMINI_API_KEY": "gk", "OPENROUTER_API_KEY": "or-key"},
+    )
+    assert "openrouter.ai" in p.base_url
+    assert p.model == "google/gemini-3.5-flash:nitro"
+
+
+def test_variant_suffix_without_openrouter_key_is_a_guided_error() -> None:
+    with pytest.raises(ConfigError, match="OPENROUTER_API_KEY"):
+        resolve_provider(
+            model="google/gemini-3.5-flash:nitro",
+            base_url=None,
+            api_key_env=None,
+            env={"GEMINI_API_KEY": "gk"},
+        )
+
+
+def test_bare_prefix_without_model_id_is_not_claimed() -> None:
+    # "anthropic" alone must not resolve to an empty model id on the compat
+    # endpoint; it falls through the ladder like any unroutable string.
+    p = resolve_provider(
+        model="anthropic",
+        base_url=None,
+        api_key_env=None,
+        env={"ANTHROPIC_API_KEY": "ant-key", "OPENROUTER_API_KEY": "or-key"},
+    )
+    assert "openrouter.ai" in p.base_url
+
+
+def test_guided_error_names_the_new_provider_keys() -> None:
+    with pytest.raises(ConfigError) as excinfo:
+        resolve_provider(model="google/gemini-3.5-flash", base_url=None, api_key_env=None, env={})
+    message = str(excinfo.value)
+    assert "GEMINI_API_KEY" in message
+    assert "google/*" in message
+
+
 def test_missing_model_is_a_guided_error() -> None:
     with pytest.raises(ConfigError, match="INSPECT_ROBOTS_MODEL"):
         resolve_provider(model=None, base_url=None, api_key_env=None, env={})

--- a/plugins/inspect-robots-agent/tests/test_llm.py
+++ b/plugins/inspect-robots-agent/tests/test_llm.py
@@ -120,6 +120,30 @@ def test_openrouter_variant_suffix_is_never_claimed_directly() -> None:
     assert p.model == "google/gemini-3.5-flash:nitro"
 
 
+def test_fine_tune_colons_still_resolve_directly() -> None:
+    # Only the closed variant set defers to OpenRouter; fine-tune ids carry
+    # colons that the provider's own API understands.
+    p = resolve_provider(
+        model="openai/ft:gpt-4o-mini-2024-07-18:org:suffix:id",
+        base_url=None,
+        api_key_env=None,
+        env={"OPENAI_API_KEY": "oai", "OPENROUTER_API_KEY": "or-key"},
+    )
+    assert "api.openai.com" in p.base_url
+    assert p.model == "ft:gpt-4o-mini-2024-07-18:org:suffix:id"
+
+
+def test_table_provider_without_its_key_falls_back_to_openrouter() -> None:
+    p = resolve_provider(
+        model="google/gemini-3.5-flash",
+        base_url=None,
+        api_key_env=None,
+        env={"OPENROUTER_API_KEY": "or-key"},  # no GEMINI_API_KEY
+    )
+    assert "openrouter.ai" in p.base_url
+    assert p.model == "google/gemini-3.5-flash"
+
+
 def test_variant_suffix_without_openrouter_key_is_a_guided_error() -> None:
     with pytest.raises(ConfigError, match="OPENROUTER_API_KEY"):
         resolve_provider(
@@ -140,6 +164,17 @@ def test_bare_prefix_without_model_id_is_not_claimed() -> None:
         env={"ANTHROPIC_API_KEY": "ant-key", "OPENROUTER_API_KEY": "or-key"},
     )
     assert "openrouter.ai" in p.base_url
+    assert p.model == "anthropic"  # the full unmodified string reaches OpenRouter
+
+
+def test_bare_prefix_without_openrouter_key_is_a_guided_error() -> None:
+    with pytest.raises(ConfigError, match="OPENROUTER_API_KEY"):
+        resolve_provider(
+            model="anthropic",
+            base_url=None,
+            api_key_env=None,
+            env={"ANTHROPIC_API_KEY": "ant-key"},  # provider key alone can't route it
+        )
 
 
 def test_guided_error_names_the_new_provider_keys() -> None:

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,5 +6,5 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.5.0"
+    assert inspect_robots_agent.__version__ == "0.6.0"
     assert callable(inspect_robots_agent.agent_policy)

--- a/uv.lock
+++ b/uv.lock
@@ -520,7 +520,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #114.

The agent plugin's provider ladder only knew `anthropic/*` and `openai/*` natively; every other provider required `-P base_url=... -P api_key_env=NAME` even when the provider has a stable OpenAI-compatible endpoint and a conventional key name (hit in practice: `GEMINI_API_KEY` set, but `google/gemini-3.1-flash-lite` errored asking for OpenRouter).

- Table-driven `_DIRECT_PROVIDERS`: google → Gemini OpenAI-compat endpoint (`GEMINI_API_KEY`), x-ai/xai → xAI (`XAI_API_KEY`), groq (`GROQ_API_KEY`, nested-slash ids pass through), mistralai (`MISTRAL_API_KEY`), deepseek (`DEEPSEEK_API_KEY`). Same semantics as the existing rungs: claim the prefix only when the key is set; OpenRouter fallback unchanged.
- OpenRouter variant suffixes (`:free`, `:nitro`) always route to OpenRouter — the suffix means nothing to a provider's own API.
- A bare prefix with no model id (`-P model=anthropic`) no longer resolves to an empty model id on a direct endpoint.
- Guided error now enumerates the key table; plugin README documents it. Version 0.5.0 → 0.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)