### PR TITLE
feat: Ctrl-C writes a cancelled eval log before re-raising

### DIFF
--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -18,6 +18,9 @@ again = read_eval_log("logs/cubepick-reach_xxxx.json")   # always re-readable
 Logs are written atomically (temp file + rename), schema-versioned, and carry
 a read-back guarantee: a newer Inspect Robots always reads an older log.
 
+Pressing Ctrl-C during a rollout writes a log with `status: "cancelled"` and
+everything gathered so far, including the partial trial record and transcript.
+
 ## Sinks
 
 A [`LogSink`][inspect_robots.logging.LogSink] observes the run lifecycle

--- a/plans/0017-cancelled-run-log.md
+++ b/plans/0017-cancelled-run-log.md
@@ -13,20 +13,25 @@ by that point, but nothing can join to them (`inspect-robots video` takes a log
 path). Observed on a real robot run 2026-07-15: a ~1,000-step agent-policy
 episode was stopped mid-run and left 3,075 orphaned `.npy` files and no record.
 
-Note `rollout()`'s `finally` block already collects `inference_latencies` and
-`policy_transcript` while *any* exception unwinds — the data survives to the
-`TrialRecord`; only the record itself is dropped, because `KeyboardInterrupt`
-carries no `.record` and `eval()` never catches it.
+Note `rollout()`'s `finally` block already collects `inference_latencies`
+while any exception unwinds, and `policy_transcript` too *provided
+`policy.reset` completed* (the `policy_reset_ok` gate at rollout.py:307, whose
+`# pragma: no branch` stays valid after this change — do not "fix" it). The
+data survives to the `TrialRecord`; only the record itself is dropped, because
+`KeyboardInterrupt` carries no `.record` and `eval()` never catches it.
 
 ## Design
 
-### New exception: `CancelledTrial(KeyboardInterrupt)`
+### New exception: `_CancelledTrial(KeyboardInterrupt)`
 
-In `src/inspect_robots/errors.py`, private to the framework (NOT added to
-`inspect_robots.__all__` or the errors module's public docs):
+In `src/inspect_robots/errors.py`, private to the framework. The leading
+underscore is load-bearing: `docs/api/index.md` renders
+`::: inspect_robots.errors` and mkdocs filters only `"!^_"`, so a public name
+would auto-appear in the published API docs. `_CancelledTrial` stays out of
+the docs, out of `inspect_robots.__all__`, and is exempt from ruff D101.
 
 ```python
-class CancelledTrial(KeyboardInterrupt):
+class _CancelledTrial(KeyboardInterrupt):
     """Ctrl-C during a trial, carrying the partial record (mirrors exc.record)."""
     def __init__(self, message: str, record: TrialRecord) -> None: ...
 ```
@@ -37,8 +42,11 @@ handlers (user scripts, pytest, asyncio) working unchanged, while giving
 existing `InspectRobotsError.record` pattern, without `setattr` on a stdlib
 exception instance (which mypy strict rejects).
 
-`TrialRecord` is imported under `TYPE_CHECKING` in errors.py if needed to
-avoid an import cycle (errors is imported by rollout).
+The `TYPE_CHECKING` import of `TrialRecord` already exists in errors.py
+(lines 21-22, used by `InspectRobotsError.record`) — do not add a duplicate.
+`__init__` MUST call `super().__init__(message)` so `str(exc)` carries the
+message — `eval()`'s `error = str(exc)` depends on it, and a test pins the
+resulting `log.error` text.
 
 ### `rollout()`: catch, mark, re-raise typed
 
@@ -50,12 +58,14 @@ except KeyboardInterrupt as exc:
     record.status = "cancelled"
     record.error = "cancelled by user (KeyboardInterrupt)"
     record.events.append(error_event(t, "KeyboardInterrupt", "cancelled by user"))
-    raise CancelledTrial(record.error, record) from exc
+    raise _CancelledTrial(record.error, record) from exc
 ```
 
-- `t` must be defined on every path: initialize `t = -1` before
-  `policy.reset(scene)` (matching the `-1` convention `_record_failure`
-  already uses for pre-loop failures) and let the loop rebind it.
+- `t` must be defined on every path: ADD `t = -1` before `policy.reset(scene)`
+  (matching the `-1` convention `_record_failure` already uses for pre-loop
+  failures). The existing `t = 0` before the `while` (rollout.py:215) STAYS —
+  removing it in favor of the `-1` initializer would shift step indices and
+  run `max_steps + 1` iterations.
 - The `finally` block runs after this handler, so `policy_transcript` and
   `inference_latencies` land on the record exactly as they do today for
   typed errors.
@@ -66,9 +76,9 @@ except KeyboardInterrupt as exc:
 At the rollout call site, alongside the existing handlers:
 
 ```python
-except CancelledTrial as exc:
+except _CancelledTrial as exc:
     status = "cancelled"
-    error = exc.args[0] if exc.args else "cancelled by user (KeyboardInterrupt)"
+    error = str(exc)
     scene_status = "cancelled"
     scene_error = error
     halted = True
@@ -76,19 +86,26 @@ except CancelledTrial as exc:
     record = exc.record
 ```
 
-- `cancelled_exc: KeyboardInterrupt | None = None` is initialized with the
+- `error = str(exc)` — no `exc.args` conditional or fallback: rollout always
+  passes a non-empty message, so a fallback arm would be dead code guarding a
+  value that cannot occur (simplicity, not the coverage gate, is the reason —
+  short-circuit forms would not register as branch arcs anyway).
+- `cancelled_exc: _CancelledTrial | None = None` is initialized with the
   other loop state.
-- The existing record-preservation block runs unchanged *except* the scoring
-  gate: `if record.status == "error":` becomes `if record.status != "success":`
-  so a cancelled partial trial is preserved (termination reason, transcript,
-  `on_trial_end`) but never scored — identical treatment to errored trials,
-  same rationale (a half-trial must not masquerade as data).
+- The existing record-preservation block runs with the scoring gate widened:
+  `if record.status == "error":` becomes `if record.status != "success":`,
+  BUT `errored_trials += 1` moves under a nested `if record.status ==
+  "error":` so a cancelled trial is preserved (termination reason,
+  transcript, `on_trial_end`) and never scored, yet does NOT count as
+  errored — otherwise `EvalResults.errored_trials` and the `inspect` view's
+  "trials: N (1 errored)" line would mislabel a cancellation as an error in
+  the very forensic view this feature exists to enable. A test pins
+  `errored_trials == 0` for a cancelled-only run.
 - `halted = True` reuses the existing halt path to break both loops and skip
   remaining scenes/epochs.
-- The "all trials errored" guard (issue #73) must not overwrite the cancelled
-  status: change its condition from `status == "success"` — it already only
-  fires then, and `status` is `"cancelled"` here, so no change is actually
-  needed; a test pins this.
+- The "all trials errored" guard (issue #73) needs NO change: it fires only
+  when `status == "success"`, and status is `"cancelled"` on this path, so it
+  cannot overwrite. Do not touch the guard; a test pins the behavior.
 - After `bus.on_eval_end(log)` (log written by the JSON sink at this point):
 
 ```python
@@ -101,7 +118,26 @@ if cancelled_exc is not None:
   abort, pytest aborts, `eval_set` propagates.
 - A Ctrl-C that lands *outside* the rollout call (during scoring, reducers,
   or log assembly — microseconds vs. minutes of rollout wall-clock) keeps
-  today's behavior (no log). Explicitly out of scope; noted in the docstring.
+  today's behavior (no log). A *second* Ctrl-C landing inside the new
+  handlers before the log write completes also loses the log, but still
+  exits 130 cleanly from the CLI (the nested `except KeyboardInterrupt`
+  catches it and the `.exists()` guard routes to "no log written"). Both are
+  explicitly out of scope; the `eval()` docstring notes them so neither gets
+  reported as a bug.
+- The cancel handler's unconditional `status = "cancelled"` overwrites an
+  earlier top-level `"error"` (e.g. a scene-0 reducer failure followed by
+  Ctrl-C in scene 1); the reducer note survives in that scene's
+  `scene_error`. Accepted deliberately: it mirrors the existing
+  EmbodimentFault handler's unconditional overwrite, and "cancelled" is the
+  fact the operator needs first.
+- Accepted quirk: if an earlier epoch of the scene scored before the
+  cancellation, the reducer can legitimately fail on the partial score set
+  (e.g. `pass_at_k` over fewer epochs than k); the existing reducer-failure
+  handler then overwrites the *scene* status to `"error"` with its note. The
+  top-level `"cancelled"` status survives (that handler only overwrites
+  top-level status when it is `"success"`). Acceptable: the reducer note is
+  real information, and the top-level status is the source of truth for
+  cancellation.
 
 ### Log schema
 
@@ -113,30 +149,53 @@ structural change).
 
 ### CLI
 
-`_cmd_run` wraps the `eval(...)` call:
+`_cmd_run` wraps the `eval(...)` call with a NEW `try` nested *inside* the
+existing `try:` (cli.py ~line 700) and covering ONLY the `eval()` call
+(~line 753) — placement matters twice over: `sink` is constructed at ~line
+739, so attaching the handler to the outer try would hit an unbound `sink`
+for a Ctrl-C before that line; and `return 130` from the nested handler
+still runs the outer `finally: embodiment.close()`, which is required for
+real hardware.
 
 ```python
 try:
     logs = eval(...)
 except KeyboardInterrupt:
-    if sink.path is not None:
+    if sink.path is not None and sink.path.exists():
         _print_degraded(f"cancelled: partial log written to {sink.path}")
-        # then the existing inspect/video hints, reusing _print_run_summary's
-        # hint logic if cheaply factorable, else a one-line inspect hint
+        # then a one-line inspect hint (reuse _print_run_summary's hint
+        # logic only if cheaply factorable)
     else:
         _print_degraded("cancelled: no log written")
     return 130
 ```
 
-130 = conventional SIGINT exit code. `sink` is the `JsonLogSink` the CLI
-already constructs (`cli.py` ~line 739); its `.path` attribute is set by
-`on_eval_end` and stays `None` when the interrupt preceded the write.
+130 = conventional SIGINT exit code, propagated via the existing
+`SystemExit(main())`. The `.exists()` guard covers the window inside
+`JsonLogSink.on_eval_end` where `self.path` is assigned before the atomic
+rename lands — without it a Ctrl-C in that window prints a path that isn't
+there.
 
-### Docs
+### Display
+
+`inspect`'s per-scene failure listing (cli.py:581, `if scene.status ==
+"error":`) widens to `if scene.status != "success":` so a cancelled scene
+shows its detail line instead of silently disappearing from the very view
+this feature feeds; pinned by a test.
+
+### Docs and stale docstrings
 
 - `docs/guide/logging-and-rerun.md`: one short paragraph in "The eval log" —
   Ctrl-C writes a `status: "cancelled"` log with everything gathered so far.
 - `eval()` docstring: mention the cancelled path and its re-raise.
+- `EvalResults.errored_trials` docstring (log.py:87-89) currently reads
+  "Trials recorded but never scored" — after this change cancelled trials are
+  also recorded-but-never-scored yet excluded from the count; tighten the
+  wording to errored trials specifically.
+- `rerun_sink.py:431-432` comment ("``eval()`` does not guarantee
+  ``on_eval_end`` on every failure path (scorer/hook exceptions, Ctrl-C)"):
+  qualify the Ctrl-C parenthetical — it now reaches `on_eval_end` when the
+  interrupt lands inside the rollout window.
 - README: not needed (behavioral detail, not a feature surface).
 
 ## Testing (100% branch coverage, mypy strict incl. tests)
@@ -148,9 +207,12 @@ All tests use the existing `CubePick` mock world; a policy whose `act` raises
    the sink wrote a file; `read_eval_log` returns `status == "cancelled"`,
    scene status `"cancelled"`, non-empty transcript (policy provides one),
    `termination_reasons` preserved, no metrics for the cancelled trial,
+   `results.errored_trials == 0` (cancelled ≠ errored),
+   `log.error == "cancelled by user (KeyboardInterrupt)"` (pins the
+   `super().__init__(message)` contract behind `str(exc)`),
    `stats.frames_dir` set when `store_frames=True`.
 2. Re-raise identity: the caught exception is a `KeyboardInterrupt` (and a
-   `CancelledTrial`), `__cause__` is the original.
+   `_CancelledTrial`), `__cause__` is the original.
 3. Interrupt on the very first `policy.reset` (`t == -1` path): record has
    zero steps, log still written.
 4. Multi-scene task interrupted in scene 0: scene 1 never runs
@@ -158,11 +220,18 @@ All tests use the existing `CubePick` mock world; a policy whose `act` raises
 5. Cancelled trials are not scored: scorer call count pinned via a counting
    scorer.
 6. The all-errored guard does not rewrite `"cancelled"` to `"error"`.
-7. CLI: `_cmd_run` with a monkeypatched `eval` raising `KeyboardInterrupt`
-   after setting `sink.path` → exit code 130 + "partial log written" line;
-   with `sink.path` left `None` → "no log written" line, code 130.
-8. `rollout()` unit test: KI from `embodiment.step` mid-loop → `CancelledTrial`
-   raised, `record.status == "cancelled"`, transcript collected by `finally`.
+7. CLI: `_cmd_run` with a monkeypatched `eval` raising `KeyboardInterrupt` —
+   three cases: `sink.path` set to an existing file → exit 130 + "partial log
+   written" line; `sink.path` left `None` → "no log written", 130; `sink.path`
+   set but the file absent (the pre-rename window) → "no log written", 130.
+8. `rollout()` unit test: KI from `embodiment.step` mid-loop →
+   `_CancelledTrial` raised, `record.status == "cancelled"`, transcript
+   collected by `finally`.
+9. Mixed outcomes: one errored epoch then a cancelled epoch →
+   `errored_trials == 1`, status `"cancelled"`, both trials preserved
+   (pins the nested errored-counting branch both ways).
+10. `inspect` display: rendering a cancelled log shows the cancelled scene's
+    detail line (pins the widened `!= "success"` check in cli.py:581).
 
 ## Out of scope
 

--- a/plans/0017-cancelled-run-log.md
+++ b/plans/0017-cancelled-run-log.md
@@ -1,0 +1,173 @@
+# 0017 — Interrupted runs write a cancelled eval log
+
+Issue: #116. Status: draft.
+
+## Problem
+
+`KeyboardInterrupt` is a `BaseException`, and both `rollout()` and `eval()`
+guard only `Exception`-derived failures. Ctrl-C therefore propagates straight
+out of `eval()` before `bus.on_eval_end(log)` runs: no `EvalLog` is written,
+so the policy transcript, timing stats, step records, and the `stats.frames_dir`
+pointer are all lost. The FrameStore side-car has already persisted every frame
+by that point, but nothing can join to them (`inspect-robots video` takes a log
+path). Observed on a real robot run 2026-07-15: a ~1,000-step agent-policy
+episode was stopped mid-run and left 3,075 orphaned `.npy` files and no record.
+
+Note `rollout()`'s `finally` block already collects `inference_latencies` and
+`policy_transcript` while *any* exception unwinds — the data survives to the
+`TrialRecord`; only the record itself is dropped, because `KeyboardInterrupt`
+carries no `.record` and `eval()` never catches it.
+
+## Design
+
+### New exception: `CancelledTrial(KeyboardInterrupt)`
+
+In `src/inspect_robots/errors.py`, private to the framework (NOT added to
+`inspect_robots.__all__` or the errors module's public docs):
+
+```python
+class CancelledTrial(KeyboardInterrupt):
+    """Ctrl-C during a trial, carrying the partial record (mirrors exc.record)."""
+    def __init__(self, message: str, record: TrialRecord) -> None: ...
+```
+
+Subclassing `KeyboardInterrupt` keeps outer `except KeyboardInterrupt`
+handlers (user scripts, pytest, asyncio) working unchanged, while giving
+`eval()` a typed carrier for the partial record — the same shape as the
+existing `InspectRobotsError.record` pattern, without `setattr` on a stdlib
+exception instance (which mypy strict rejects).
+
+`TrialRecord` is imported under `TYPE_CHECKING` in errors.py if needed to
+avoid an import cycle (errors is imported by rollout).
+
+### `rollout()`: catch, mark, re-raise typed
+
+Add one handler to the existing outer `try` (the one whose `finally` collects
+the transcript):
+
+```python
+except KeyboardInterrupt as exc:
+    record.status = "cancelled"
+    record.error = "cancelled by user (KeyboardInterrupt)"
+    record.events.append(error_event(t, "KeyboardInterrupt", "cancelled by user"))
+    raise CancelledTrial(record.error, record) from exc
+```
+
+- `t` must be defined on every path: initialize `t = -1` before
+  `policy.reset(scene)` (matching the `-1` convention `_record_failure`
+  already uses for pre-loop failures) and let the loop rebind it.
+- The `finally` block runs after this handler, so `policy_transcript` and
+  `inference_latencies` land on the record exactly as they do today for
+  typed errors.
+- `TrialRecord.status` docstring/comment gains `"cancelled"` as a value.
+
+### `eval()`: preserve, write, re-raise
+
+At the rollout call site, alongside the existing handlers:
+
+```python
+except CancelledTrial as exc:
+    status = "cancelled"
+    error = exc.args[0] if exc.args else "cancelled by user (KeyboardInterrupt)"
+    scene_status = "cancelled"
+    scene_error = error
+    halted = True
+    cancelled_exc = exc
+    record = exc.record
+```
+
+- `cancelled_exc: KeyboardInterrupt | None = None` is initialized with the
+  other loop state.
+- The existing record-preservation block runs unchanged *except* the scoring
+  gate: `if record.status == "error":` becomes `if record.status != "success":`
+  so a cancelled partial trial is preserved (termination reason, transcript,
+  `on_trial_end`) but never scored — identical treatment to errored trials,
+  same rationale (a half-trial must not masquerade as data).
+- `halted = True` reuses the existing halt path to break both loops and skip
+  remaining scenes/epochs.
+- The "all trials errored" guard (issue #73) must not overwrite the cancelled
+  status: change its condition from `status == "success"` — it already only
+  fires then, and `status` is `"cancelled"` here, so no change is actually
+  needed; a test pins this.
+- After `bus.on_eval_end(log)` (log written by the JSON sink at this point):
+
+```python
+if cancelled_exc is not None:
+    raise cancelled_exc
+```
+
+  Re-raising the same instance preserves the chained traceback (`__cause__`
+  is the original `KeyboardInterrupt`). Callers see Ctrl-C semantics: scripts
+  abort, pytest aborts, `eval_set` propagates.
+- A Ctrl-C that lands *outside* the rollout call (during scoring, reducers,
+  or log assembly — microseconds vs. minutes of rollout wall-clock) keeps
+  today's behavior (no log). Explicitly out of scope; noted in the docstring.
+
+### Log schema
+
+`EvalLog.status` and `SceneResult.status` are plain documented strings; the
+comments in `log.py` gain `"cancelled"`. `read_eval_log` performs no status
+validation, so the read-back guarantee holds and older readers see a string
+they merely don't special-case. `EvalLog.SCHEMA_VERSION` is unchanged (no
+structural change).
+
+### CLI
+
+`_cmd_run` wraps the `eval(...)` call:
+
+```python
+try:
+    logs = eval(...)
+except KeyboardInterrupt:
+    if sink.path is not None:
+        _print_degraded(f"cancelled: partial log written to {sink.path}")
+        # then the existing inspect/video hints, reusing _print_run_summary's
+        # hint logic if cheaply factorable, else a one-line inspect hint
+    else:
+        _print_degraded("cancelled: no log written")
+    return 130
+```
+
+130 = conventional SIGINT exit code. `sink` is the `JsonLogSink` the CLI
+already constructs (`cli.py` ~line 739); its `.path` attribute is set by
+`on_eval_end` and stays `None` when the interrupt preceded the write.
+
+### Docs
+
+- `docs/guide/logging-and-rerun.md`: one short paragraph in "The eval log" —
+  Ctrl-C writes a `status: "cancelled"` log with everything gathered so far.
+- `eval()` docstring: mention the cancelled path and its re-raise.
+- README: not needed (behavioral detail, not a feature surface).
+
+## Testing (100% branch coverage, mypy strict incl. tests)
+
+All tests use the existing `CubePick` mock world; a policy whose `act` raises
+`KeyboardInterrupt` at step N simulates Ctrl-C deterministically.
+
+1. `eval()` with the interrupting policy inside `pytest.raises(KeyboardInterrupt)`:
+   the sink wrote a file; `read_eval_log` returns `status == "cancelled"`,
+   scene status `"cancelled"`, non-empty transcript (policy provides one),
+   `termination_reasons` preserved, no metrics for the cancelled trial,
+   `stats.frames_dir` set when `store_frames=True`.
+2. Re-raise identity: the caught exception is a `KeyboardInterrupt` (and a
+   `CancelledTrial`), `__cause__` is the original.
+3. Interrupt on the very first `policy.reset` (`t == -1` path): record has
+   zero steps, log still written.
+4. Multi-scene task interrupted in scene 0: scene 1 never runs
+   (`total_scenes == 1` in results), matching the halt semantics.
+5. Cancelled trials are not scored: scorer call count pinned via a counting
+   scorer.
+6. The all-errored guard does not rewrite `"cancelled"` to `"error"`.
+7. CLI: `_cmd_run` with a monkeypatched `eval` raising `KeyboardInterrupt`
+   after setting `sink.path` → exit code 130 + "partial log written" line;
+   with `sink.path` left `None` → "no log written" line, code 130.
+8. `rollout()` unit test: KI from `embodiment.step` mid-loop → `CancelledTrial`
+   raised, `record.status == "cancelled"`, transcript collected by `finally`.
+
+## Out of scope
+
+- Ctrl-C outside the rollout window (scoring/reducers/log assembly).
+- Signal handling beyond `KeyboardInterrupt` (SIGTERM etc.).
+- Resuming cancelled runs (`eval_set` retry_attempts is a separate thread).
+- A `video`/`inspect` affordance for logless frame dirs (this fix removes the
+  main way they arise).

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -768,6 +768,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         except KeyboardInterrupt:
             if sink.path is not None and sink.path.exists():
                 _print_degraded(f"cancelled: partial log written to {sink.path}")
+                print(_styled(f"hint: view it with: inspect-robots inspect {sink.path}", _DIM))
             else:
                 _print_degraded("cancelled: no log written")
             return 130

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -575,12 +575,12 @@ def _print_run_summary(log: EvalLog, log_path: str, is_adhoc: bool) -> None:
     if failed and log.error is not None:
         print(f"{_styled('error:', _CYAN)} {_styled(log.error, _RED)}")
     if failed or errored_count:
-        # Errored scenes are failure context even when the run as a whole
-        # succeeded (issue #73): a partially-errored "success" must be legible.
+        # Non-successful scenes are failure context. Errored scenes stay visible
+        # even when the run succeeded (issue #73).
         for scene in log.samples:
-            if scene.status == "error":
+            if scene.status != "success":
                 detail = "" if scene.error in (None, log.error) else f": {scene.error}"
-                print(f"  [{_styled('error', _RED)}] {scene.scene_id}{detail}")
+                print(f"  [{_styled(scene.status, _RED)}] {scene.scene_id}{detail}")
     _print_step_limit_notice(log, is_adhoc)
     trials = f"trials: {log.results.total_trials}"
     if errored_count:
@@ -750,20 +750,27 @@ def _cmd_run(args: argparse.Namespace) -> int:
             # warn-once no-op when rerun-sdk is not installed.
             sinks.append(RerunSink(spawn=True))
             print(f"{_styled('rerun:', _CYAN)} live viewer")
-        logs = eval(
-            task,
-            policy,
-            embodiment,
-            log_dir=args.log_dir,
-            seed=args.seed,
-            sinks=sinks,
-            fail_on_error=args.fail_on_error if args.fail_on_error is not None else False,
-            approver=approver,
-            store_frames=(
-                args.store_frames if args.store_frames is not None else defaults.store_frames
-            ),
-            before_scoring=before_scoring,
-        )
+        try:
+            logs = eval(
+                task,
+                policy,
+                embodiment,
+                log_dir=args.log_dir,
+                seed=args.seed,
+                sinks=sinks,
+                fail_on_error=args.fail_on_error if args.fail_on_error is not None else False,
+                approver=approver,
+                store_frames=(
+                    args.store_frames if args.store_frames is not None else defaults.store_frames
+                ),
+                before_scoring=before_scoring,
+            )
+        except KeyboardInterrupt:
+            if sink.path is not None and sink.path.exists():
+                _print_degraded(f"cancelled: partial log written to {sink.path}")
+            else:
+                _print_degraded("cancelled: no log written")
+            return 130
     finally:
         # The CLI resolved the embodiment itself, so eval() does not own it
         # ("close what we open"). Real-hardware embodiments release motor

--- a/src/inspect_robots/errors.py
+++ b/src/inspect_robots/errors.py
@@ -22,6 +22,14 @@ if TYPE_CHECKING:
     from inspect_robots.rollout import TrialRecord
 
 
+class _CancelledTrial(KeyboardInterrupt):
+    """Ctrl-C during a trial, carrying the partial record (mirrors exc.record)."""
+
+    def __init__(self, message: str, record: TrialRecord) -> None:
+        super().__init__(message)
+        self.record = record
+
+
 class InspectRobotsError(Exception):
     """Base class for all Inspect Robots errors.
 

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -148,8 +148,9 @@ def eval(
     with ``status == "error"``, regardless of ``fail_on_error``.
 
     Ctrl-C during a rollout records the partial trial and writes a log with
-    ``status == "cancelled"``, then re-raises the same ``KeyboardInterrupt``
-    instance after ``on_eval_end`` completes. An interrupt outside the rollout
+    ``status == "cancelled"``, then re-raises the interrupt (as a
+    ``KeyboardInterrupt`` subclass chaining the original) after
+    ``on_eval_end`` completes. An interrupt outside the rollout
     call (during scoring, reducers, or log assembly), or a second interrupt
     during the cancellation handlers, may still prevent the log from being
     written.

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -25,7 +25,13 @@ from inspect_robots.approver import Approver, AutoApprover
 from inspect_robots.compat import assert_compatible
 from inspect_robots.controller import Controller, DefaultController
 from inspect_robots.embodiment import Embodiment
-from inspect_robots.errors import ConfigError, EmbodimentFault, PolicyError, SafetyAbort
+from inspect_robots.errors import (
+    ConfigError,
+    EmbodimentFault,
+    PolicyError,
+    SafetyAbort,
+    _CancelledTrial,
+)
 from inspect_robots.frames import FrameStore
 from inspect_robots.log import EvalLog, EvalResults, EvalSpec, EvalStats, SceneResult
 from inspect_robots.policy import Policy
@@ -140,6 +146,13 @@ def eval(
 
     A run in which **every** trial errored (nothing was scored) always ends
     with ``status == "error"``, regardless of ``fail_on_error``.
+
+    Ctrl-C during a rollout records the partial trial and writes a log with
+    ``status == "cancelled"``, then re-raises the same ``KeyboardInterrupt``
+    instance after ``on_eval_end`` completes. An interrupt outside the rollout
+    call (during scoring, reducers, or log assembly), or a second interrupt
+    during the cancellation handlers, may still prevent the log from being
+    written.
 
     When ``store_frames`` is set, camera frames are streamed to
     ``<log_dir>/frames`` as binary side-cars (R5) rather than kept in memory.
@@ -284,6 +297,7 @@ def _run_eval(
 
     halted = False
     stopped = False
+    cancelled_exc: _CancelledTrial | None = None
     for scene in task.scenes:
         per_scorer_scores: dict[str, list[Score]] = {s.name: [] for s in scorers}
         epoch_dicts: list[dict[str, float]] = []
@@ -311,6 +325,14 @@ def _run_eval(
                     control_hz=task.control_hz,
                     frame_store=frame_store,
                 )
+            except _CancelledTrial as exc:
+                status = "cancelled"
+                error = str(exc)
+                scene_status = "cancelled"
+                scene_error = error
+                halted = True
+                cancelled_exc = exc
+                record = exc.record
             except (EmbodimentFault, SafetyAbort) as exc:
                 # Hardware/safety failures always halt the whole eval; the
                 # partial trial record (if any) is preserved below.
@@ -336,12 +358,13 @@ def _run_eval(
                 total_trials += 1
                 total_steps += len(record.steps)
                 all_latencies.extend(record.inference_latencies)
-                if record.status == "error":
-                    # Errored trials are not scored: a failed trial must not
-                    # masquerade as data (e.g. an inf min-distance poisoning
-                    # the metric mean). It stays visible via scene status.
+                if record.status != "success":
+                    # Non-successful trials are not scored: a partial trial
+                    # must not masquerade as data (e.g. an inf min-distance
+                    # poisoning the metric mean). It stays visible via status.
                     epoch_dicts.append({})
-                    errored_trials += 1
+                    if record.status == "error":
+                        errored_trials += 1
                     judgements.append(None)
                     termination_reasons.append(record.termination_reason)
                     policy_transcripts.append(record.policy_transcript)
@@ -444,6 +467,8 @@ def _run_eval(
         error=error,
     )
     bus.on_eval_end(log)
+    if cancelled_exc is not None:
+        raise cancelled_exc
     return [log]
 
 

--- a/src/inspect_robots/log.py
+++ b/src/inspect_robots/log.py
@@ -58,7 +58,7 @@ class SceneResult:
     """Per-scene result: the reduced score(s) plus the raw per-epoch scores."""
 
     scene_id: str
-    status: str  # "success" | "error"
+    status: str  # "success" | "error" | "cancelled"
     reduced: dict[str, float] = field(default_factory=dict)
     epochs: tuple[dict[str, float], ...] = ()
     error: str | None = None
@@ -83,9 +83,9 @@ class EvalResults:
     total_scenes: int
     total_trials: int
     metrics: dict[str, float] = field(default_factory=dict)
-    # Trials recorded but never scored (visible per-scene as empty entries in
-    # ``SceneResult.epochs``). The default keeps logs written before this
-    # field existed readable.
+    # Errored trials, which are recorded but never scored (visible per-scene
+    # as empty entries in ``SceneResult.epochs``). The default keeps logs
+    # written before this field existed readable.
     errored_trials: int = 0
 
 
@@ -94,7 +94,7 @@ class EvalLog:
     """The full record returned by [`eval`][inspect_robots.eval.eval] and persisted to disk."""
 
     version: int
-    status: str  # "started" | "success" | "error"
+    status: str  # "started" | "success" | "error" | "cancelled"
     eval: EvalSpec
     results: EvalResults
     stats: EvalStats

--- a/src/inspect_robots/logging/rerun_sink.py
+++ b/src/inspect_robots/logging/rerun_sink.py
@@ -429,13 +429,13 @@ class RerunSink:
         """Drain queued events between trials, bounding loss if the eval aborts mid-run.
 
         ``eval()`` does not guarantee ``on_eval_end`` on every failure path
-        (scorer/hook exceptions, Ctrl-C), so trial boundaries are the flush
-        points that cap tail loss at one trial. Blocking here is bounded by
-        ``flush_timeout`` and happens between trials, never inside the
-        control-rate loop. Once a flush times out, the connection is treated
-        as stalled for the rest of this worker generation and later trial
-        boundaries return immediately instead of re-paying the timeout; the
-        eval-end drop report still accounts for whatever never drained.
+        (scorer/hook exceptions, or Ctrl-C outside the rollout window), so
+        trial boundaries are the flush points that cap tail loss at one trial.
+        Blocking here is bounded by ``flush_timeout`` and happens between trials,
+        never inside the control-rate loop. Once a flush times out, the connection
+        is treated as stalled for the rest of this worker generation and later
+        trial boundaries return immediately instead of re-paying the timeout;
+        the eval-end drop report still accounts for whatever never drained.
         """
         state = self._state
         if state is not None and state.stalled:

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -20,7 +20,13 @@ import numpy as np
 from inspect_robots.approver import Approver
 from inspect_robots.controller import _INFER_KEY, Controller
 from inspect_robots.embodiment import Embodiment
-from inspect_robots.errors import EmbodimentFault, InspectRobotsError, PolicyError, SafetyAbort
+from inspect_robots.errors import (
+    EmbodimentFault,
+    InspectRobotsError,
+    PolicyError,
+    SafetyAbort,
+    _CancelledTrial,
+)
 from inspect_robots.frames import FrameRef, FrameStore
 from inspect_robots.policy import Policy
 from inspect_robots.scene import Scene
@@ -78,7 +84,7 @@ class TrialRecord:
     terminated: bool = False
     truncated: bool = False
     termination_reason: str | None = None
-    status: str = "success"  # "success" (ran to completion) | "error"
+    status: str = "success"  # "success" (ran to completion) | "error" | "cancelled"
     error: str | None = None
     inference_latencies: list[float] = field(default_factory=list)
     # Human operator's success verdict, captured once during rollout (R6). Read
@@ -196,6 +202,7 @@ def rollout(
     policy_reset_ok = False
 
     try:
+        t = -1
         try:
             policy.reset(scene)
             policy_reset_ok = True
@@ -301,6 +308,11 @@ def rollout(
         else:
             record.truncated = True
             record.termination_reason = "max_steps"
+    except KeyboardInterrupt as exc:
+        record.status = "cancelled"
+        record.error = "cancelled by user (KeyboardInterrupt)"
+        record.events.append(error_event(t, "KeyboardInterrupt", "cancelled by user"))
+        raise _CancelledTrial(record.error, record) from exc
     finally:
         # Preserve measured latencies even when the trial ends in an error.
         record.inference_latencies = [

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -8,17 +8,24 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from inspect_robots import eval, eval_set
-from inspect_robots.errors import ConfigError, EmbodimentFault, PolicyError, SafetyAbort
+from inspect_robots import eval, eval_set, read_eval_log
+from inspect_robots.errors import (
+    ConfigError,
+    EmbodimentFault,
+    PolicyError,
+    SafetyAbort,
+    _CancelledTrial,
+)
 from inspect_robots.eval import _git_commit
 from inspect_robots.log import EvalLog
+from inspect_robots.logging.json_log import JsonLogSink
 from inspect_robots.logging.sink import NullSink
 from inspect_robots.mock import CubePickEmbodiment, ScriptedPolicy
 from inspect_robots.policy import PolicyConfig, PolicyInfo
 from inspect_robots.registry import embodiment as embodiment_decorator
 from inspect_robots.rollout import TrialRecord
-from inspect_robots.scene import Scene
-from inspect_robots.scorer import min_distance_to_goal, operator_scorer, success_at_end
+from inspect_robots.scene import Scene, Target
+from inspect_robots.scorer import Score, min_distance_to_goal, operator_scorer, success_at_end
 from inspect_robots.spaces import ActionSemantics, Box
 from inspect_robots.task import Epochs, Task, TaskEnvelope
 from inspect_robots.types import Action, ActionChunk, Observation, StepResult
@@ -91,6 +98,217 @@ class _BoomPolicy:
 
     def act(self, observation: Observation) -> ActionChunk:
         raise RuntimeError("inference exploded")
+
+
+class _InterruptingPolicy(ScriptedPolicy):
+    """Raise one specific Ctrl-C during inference and expose an audit record."""
+
+    def __init__(self, interrupt: KeyboardInterrupt, *, interrupt_on_call: int = 2) -> None:
+        super().__init__(chunk_size=1)
+        self.interrupt = interrupt
+        self.interrupt_on_call = interrupt_on_call
+        self.act_calls = 0
+
+    def reset(self, scene: Scene) -> None:
+        self.act_calls = 0
+        super().reset(scene)
+
+    def act(self, observation: Observation) -> ActionChunk:
+        self.act_calls += 1
+        if self.act_calls == self.interrupt_on_call:
+            raise self.interrupt
+        return super().act(observation)
+
+    def transcript(self) -> object:
+        return {"act_calls": self.act_calls}
+
+
+class _CountingScorer:
+    """Count every trajectory presented for scoring."""
+
+    name = "counting"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, record: TrialRecord, target: Target | None) -> Score:
+        del record, target
+        self.calls += 1
+        return Score(value=1.0)
+
+
+# --------------------------------------------------------------------------- #
+# Ctrl-C during rollout writes a partial cancelled log before propagating.
+# --------------------------------------------------------------------------- #
+def test_cancelled_eval_writes_partial_log_with_forensic_data(tmp_path: Path) -> None:
+    policy = _InterruptingPolicy(KeyboardInterrupt())
+
+    with pytest.raises(KeyboardInterrupt):
+        eval(
+            _task(),
+            policy,
+            CubePickEmbodiment(),
+            log_dir=str(tmp_path),
+            store_frames=True,
+        )
+
+    (written,) = tmp_path.glob("*.json")
+    log = read_eval_log(str(written))
+    scene = log.samples[0]
+    assert log.status == "cancelled"
+    assert scene.status == "cancelled"
+    assert scene.policy_transcripts == ({"act_calls": 2},)
+    assert scene.termination_reasons == (None,)
+    assert scene.epochs == ({},)
+    assert scene.reduced == {}
+    assert log.results.metrics == {}
+    assert log.results.errored_trials == 0
+    assert log.error == "cancelled by user (KeyboardInterrupt)"
+    assert log.stats.frames_dir is not None
+    assert list(Path(log.stats.frames_dir).rglob("*.npy"))
+
+
+def test_cancelled_eval_reraises_typed_exception_with_original_cause(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import sys
+
+    from inspect_robots.rollout import rollout as actual_rollout
+
+    original = KeyboardInterrupt("operator interrupt")
+    raised: list[_CancelledTrial] = []
+
+    def capturing_rollout(*args: object, **kwargs: object) -> TrialRecord:
+        try:
+            return actual_rollout(*args, **kwargs)  # type: ignore[arg-type]
+        except _CancelledTrial as exc:
+            raised.append(exc)
+            raise
+
+    monkeypatch.setattr(sys.modules["inspect_robots.eval"], "rollout", capturing_rollout)
+
+    with pytest.raises(KeyboardInterrupt) as excinfo:
+        eval(
+            _task(),
+            _InterruptingPolicy(original),
+            CubePickEmbodiment(),
+            log_dir=str(tmp_path),
+        )
+
+    assert isinstance(excinfo.value, _CancelledTrial)
+    assert excinfo.value is raised[0]
+    assert excinfo.value.__cause__ is original
+
+
+def test_cancelled_policy_reset_records_t_minus_one_and_zero_steps(tmp_path: Path) -> None:
+    class _ResetInterruptPolicy(ScriptedPolicy):
+        def reset(self, scene: Scene) -> None:
+            raise KeyboardInterrupt
+
+    records = _RecordingSink()
+    json_sink = JsonLogSink(str(tmp_path))
+
+    with pytest.raises(KeyboardInterrupt):
+        eval(
+            _task(),
+            _ResetInterruptPolicy(),
+            CubePickEmbodiment(),
+            sinks=[records, json_sink],
+        )
+
+    (record,) = records.records
+    assert record.status == "cancelled"
+    assert record.steps == []
+    assert record.events[-1].kind == "error"
+    assert record.events[-1].t == -1
+    assert json_sink.path is not None and json_sink.path.exists()
+    assert read_eval_log(str(json_sink.path)).status == "cancelled"
+
+
+def test_cancelled_first_scene_halts_before_second_scene(tmp_path: Path) -> None:
+    task = Task(
+        name="two-scenes",
+        scenes=[
+            Scene(id="s0", instruction="reach", init_seed=0),
+            Scene(id="s1", instruction="reach", init_seed=1),
+        ],
+        scorer=success_at_end(),
+        max_steps=60,
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        eval(
+            task,
+            _InterruptingPolicy(KeyboardInterrupt(), interrupt_on_call=1),
+            CubePickEmbodiment(),
+            log_dir=str(tmp_path),
+        )
+
+    (written,) = tmp_path.glob("*.json")
+    log = read_eval_log(str(written))
+    assert log.results.total_scenes == 1
+    assert tuple(scene.scene_id for scene in log.samples) == ("s0",)
+
+
+def test_cancelled_trial_is_never_scored() -> None:
+    scorer = _CountingScorer()
+
+    with pytest.raises(KeyboardInterrupt):
+        eval(
+            _task(scorer=scorer),
+            _InterruptingPolicy(KeyboardInterrupt(), interrupt_on_call=1),
+            CubePickEmbodiment(),
+            sinks=[NullSink()],
+        )
+
+    assert scorer.calls == 0
+
+
+def test_all_errored_guard_does_not_rewrite_cancelled_status(tmp_path: Path) -> None:
+    with pytest.raises(KeyboardInterrupt):
+        eval(
+            _task(),
+            _InterruptingPolicy(KeyboardInterrupt(), interrupt_on_call=1),
+            CubePickEmbodiment(),
+            log_dir=str(tmp_path),
+        )
+
+    (written,) = tmp_path.glob("*.json")
+    log = read_eval_log(str(written))
+    assert log.status == "cancelled"
+    assert log.error == "cancelled by user (KeyboardInterrupt)"
+
+
+def test_errored_then_cancelled_epochs_preserve_both_records(tmp_path: Path) -> None:
+    class _ErrorThenCancelPolicy(_InterruptingPolicy):
+        def __init__(self) -> None:
+            super().__init__(KeyboardInterrupt(), interrupt_on_call=1)
+            self.resets = 0
+
+        def reset(self, scene: Scene) -> None:
+            self.resets += 1
+            if self.resets == 1:
+                raise RuntimeError("first epoch failed")
+            super().reset(scene)
+
+    records = _RecordingSink()
+    json_sink = JsonLogSink(str(tmp_path))
+
+    with pytest.raises(KeyboardInterrupt):
+        eval(
+            _task(epochs=2),
+            _ErrorThenCancelPolicy(),
+            CubePickEmbodiment(),
+            sinks=[records, json_sink],
+        )
+
+    assert json_sink.path is not None
+    log = read_eval_log(str(json_sink.path))
+    assert log.status == "cancelled"
+    assert log.results.errored_trials == 1
+    assert log.results.total_trials == 2
+    assert log.samples[0].epochs == ({}, {})
+    assert [record.status for record in records.records] == ["error", "cancelled"]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -112,6 +112,58 @@ def test_cli_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     assert out.count("hint:") == 1
 
 
+@pytest.mark.parametrize(
+    ("path_state", "expected"),
+    [
+        ("existing", "partial log written"),
+        ("none", "no log written"),
+        ("missing", "no log written"),
+    ],
+)
+def test_cli_cancelled_run_reports_partial_log_state(
+    path_state: str,
+    expected: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import inspect_robots
+    import inspect_robots.logging
+
+    path = tmp_path / f"{path_state}.json"
+    if path_state == "existing":
+        path.write_text("{}", encoding="utf-8")
+
+    class _CancelSink:
+        def __init__(self, log_dir: str) -> None:
+            del log_dir
+            self.path: Path | None = None if path_state == "none" else path
+
+    def interrupted_eval(*args: object, **kwargs: object) -> list[EvalLog]:
+        del args, kwargs
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(inspect_robots.logging, "JsonLogSink", _CancelSink)
+    monkeypatch.setattr(inspect_robots, "eval", interrupted_eval)
+
+    rc = main(
+        [
+            "run",
+            "--task",
+            "cubepick-reach",
+            "--policy",
+            "scripted",
+            "--embodiment",
+            "cubepick",
+            "--log-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert rc == 130
+    assert f"cancelled: {expected}" in capsys.readouterr().out
+
+
 def test_cli_run_embodiment_fault_prints_error_scene_and_inspect_hint(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -507,6 +559,20 @@ def test_run_summary_adds_agent_conversation_hint_when_recorded(
     out = capsys.readouterr().out
     assert "hint: view it with: inspect-robots inspect run.json" in out
     assert "hint: agent conversation: inspect-robots inspect run.json --transcript" in out
+
+
+def test_run_summary_shows_cancelled_scene_detail(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    log = _transcript_log(status="cancelled")
+    cancelled_scene = dataclasses.replace(
+        log.samples[0], status="cancelled", error="cancelled by user"
+    )
+    log = dataclasses.replace(log, samples=(cancelled_scene,))
+
+    cli._print_run_summary(log, "run.json", is_adhoc=False)
+
+    assert "[cancelled] s0: cancelled by user" in capsys.readouterr().out
 
 
 def test_transcript_rendering_degrades_lone_surrogates_instead_of_crashing(

--- a/tests/test_rollout_hardening.py
+++ b/tests/test_rollout_hardening.py
@@ -11,7 +11,7 @@ import pytest
 from inspect_robots import eval
 from inspect_robots.approver import Approver, AutoApprover, ClampApprover
 from inspect_robots.controller import DefaultController
-from inspect_robots.errors import EmbodimentFault, PolicyError, SafetyAbort
+from inspect_robots.errors import EmbodimentFault, PolicyError, SafetyAbort, _CancelledTrial
 from inspect_robots.frames import FrameStore
 from inspect_robots.logging.sink import NullSink
 from inspect_robots.mock import CubePickEmbodiment, ScriptedPolicy
@@ -78,6 +78,36 @@ def test_policy_exception_wrapped_as_policy_error() -> None:
 def test_embodiment_exception_wrapped_as_fault() -> None:
     with pytest.raises(EmbodimentFault, match="motor stalled"):
         _run(ScriptedPolicy(), _FaultyEmbodiment())
+
+
+def test_keyboard_interrupt_from_step_carries_partial_record_and_transcript() -> None:
+    original = KeyboardInterrupt("stop now")
+
+    class _InterruptingEmbodiment(CubePickEmbodiment):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls = 0
+
+        def step(self, action: Action):  # type: ignore[no-untyped-def]
+            self.calls += 1
+            if self.calls == 2:
+                raise original
+            return super().step(action)
+
+    class _AuditedPolicy(ScriptedPolicy):
+        def transcript(self) -> object:
+            return {"inferences": self.num_inferences}
+
+    with pytest.raises(_CancelledTrial) as excinfo:
+        _run(_AuditedPolicy(chunk_size=1), _InterruptingEmbodiment())
+
+    record = excinfo.value.record
+    assert record.status == "cancelled"
+    assert len(record.steps) == 1
+    assert record.policy_transcript == {"inferences": 2}
+    assert record.events[-1].kind == "error"
+    assert record.events[-1].t == 1
+    assert excinfo.value.__cause__ is original
 
 
 def test_safety_abort_propagates() -> None:


### PR DESCRIPTION
Closes #116.

Design: plans/0017-cancelled-run-log.md (critique loop in progress). Implementation to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)