### PR TITLE
feat: camera frames in agent transcripts carry the environment step

### DIFF
--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -104,13 +104,15 @@ hint whenever a log has stored frames.
 
 ## Policy transcripts
 
-Policies can persist a per-trial audit record in the eval log. The agent policy
-stores its conversation, with streamed image bytes replaced by
+Policies can persist a per-trial audit record in the eval log; read it with
+`inspect-robots inspect LOG.json --transcript`. The agent policy stores its
+conversation, with streamed image bytes replaced by
 `[image omitted: streamed camera frame]`. The preceding label, such as
-`camera 'top_cam' (step 480):`, provides the step join key from a transcript
-observation to the stored frame.
+`camera 'top_cam' (step 480):`, is emitted whether or not frames are stored,
+and when they are (`store_frames=True`) it provides the step join key from a
+transcript observation to the stored frame.
 
-`FrameStore` sanitizes trial and camera names with `_safe()` before building
+`FrameStore` sanitizes trial and camera names before building
 `{trial}_{camera}_{t:06d}.npy`. When the sanitizer rewrites a name, use
 `StepRecord.image_refs` and `FrameRef.path` as the authoritative mapping instead
 of assembling the path from the transcript label.

--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -101,3 +101,16 @@ inspect-robots video logs/adhoc_xxxx.json
 
 `inspect-robots inspect` prints the frames directory and this command as a
 hint whenever a log has stored frames.
+
+## Policy transcripts
+
+Policies can persist a per-trial audit record in the eval log. The agent policy
+stores its conversation, with streamed image bytes replaced by
+`[image omitted: streamed camera frame]`. The preceding label, such as
+`camera 'top_cam' (step 480):`, provides the step join key from a transcript
+observation to the stored frame.
+
+`FrameStore` sanitizes trial and camera names with `_safe()` before building
+`{trial}_{camera}_{t:06d}.npy`. When the sanitizer rewrites a name, use
+`StepRecord.image_refs` and `FrameRef.path` as the authoritative mapping instead
+of assembling the path from the transcript label.

--- a/plans/0018-transcript-step-labels.md
+++ b/plans/0018-transcript-step-labels.md
@@ -1,0 +1,120 @@
+# 0018 — Camera frames in agent transcripts carry the environment step
+
+Issue: #117. Status: draft.
+
+## Problem
+
+Persisted policy transcripts (plan 0015) elide image bytes: each frame becomes
+a text part `[image omitted: streamed camera frame]`. The camera name is
+recoverable from the preceding label part (`camera 'top_cam':`), but the
+environment step is recorded nowhere, so there is no exact join from a
+transcript observation back to the `.npy` frames the policy actually saw
+(`{trial}_{camera}_{t:06d}.npy` in the FrameStore). Chunk lengths quoted in
+tool-result strings allow only a fragile textual reconstruction.
+
+Root cause: the policy never learns the step. `Observation` has no step field
+and `Policy.act(observation)` receives nothing else; only `rollout()` and the
+`Controller` know `t`.
+
+## Design
+
+Two small changes: core exposes the step to the policy through the existing
+`Observation.extra` channel; the agent plugin embeds it in the camera label
+text at message-build time. The label serves both audiences at once — the LLM
+gains explicit temporal context, and the persisted transcript becomes
+self-describing with zero elision-time logic.
+
+### Core: rollout injects a reserved `extra` key
+
+In `rollout()`, the observation handed to the controller (and thus to
+`policy.act`) gains the current step under a reserved key:
+
+```python
+action = controller.next_action(
+    policy, replace(obs, extra={**obs.extra, "env_step": t}), t, store
+)
+```
+
+- `dataclasses.replace` on the frozen `Observation` is a shallow copy; images
+  and state arrays are shared, not copied.
+- Only the policy-facing observation is modified. `sink.log_step(t, obs, ...)`
+  and the `StepRecord` keep the embodiment's original observation, so logs,
+  Rerun streams, and stored records are byte-identical to today (`log_step`
+  already receives `t` separately).
+- Key name `env_step` (not `step`) to reduce collision odds with embodiment
+  extras. If an embodiment emits its own `env_step`, the rollout's value wins;
+  the `Observation.extra` docstring documents the reservation. No embodiment
+  in this repo or the first-party plugins emits `env_step` today (verified by
+  grep).
+- The initial `policy.reset(scene)` carries no observation and is unaffected;
+  the first `act` sees `env_step == 0`.
+
+This is additive for every policy: dict consumers that ignore unknown keys see
+no change. Not a `Policy` protocol change; no API-snapshot impact
+(`Observation`'s field set is unchanged).
+
+### Agent plugin: step-labeled camera parts
+
+`_observation_content` in `plugins/inspect-robots-agent/.../policy.py`:
+
+```python
+step = observation.extra.get("env_step")
+suffix = f" (step {step})" if isinstance(step, int) else ""
+...
+parts.append({"type": "text", "text": f"camera {name!r}{suffix}:"})
+```
+
+- `isinstance(step, int)` guards the fallback: under an older core (no
+  injection) or a non-int value, the label is exactly today's, so the plugin
+  keeps its "no minimum core version bump" property. `bool` is an `int`
+  subclass but the rollout only ever injects real ints; guarding `bool` out
+  adds an untestable branch for a value that cannot occur — keep plain
+  `isinstance(step, int)`.
+- The elision placeholder in `transcript()` stays
+  `[image omitted: streamed camera frame]` — the join key lives in the
+  adjacent label part, which the persisted transcript keeps verbatim.
+- The system prompt is not changed; the label is self-explanatory in context.
+
+### Versioning
+
+The agent plugin's static version is already `0.6.0`, unreleased (bumped by
+PR #115 which is not yet on PyPI). This feature rides `0.6.0`; no further
+bump. Core needs no version action (hatch-vcs, next tag).
+
+### Docs
+
+- `Observation.extra` docstring in `types.py`: document the `env_step`
+  reservation ("the rollout injects the current step for the policy-facing
+  observation; embodiments should not set this key").
+- Agent plugin README: one line in the observation-format section showing the
+  labeled form `camera 'top_cam' (step 480):` and the join to
+  `{trial}_{camera}_{t:06d}.npy`.
+- `docs/guide/logging-and-rerun.md`: extend the transcript paragraph — the
+  step label is the join key from transcript observations to stored frames.
+
+## Testing (100% branch coverage for core; agent plugin's own suite)
+
+Core (`tests/`):
+1. Rollout injection: a probe policy records the observations it receives;
+   assert `extra["env_step"] == t` for each call and that the observations in
+   `record.steps` / `sink.log_step` do NOT contain `env_step` (original obs).
+2. Collision: a mock embodiment that sets `extra={"env_step": "theirs"}`;
+   the policy sees the rollout's int.
+3. Sharing, not copying: the policy-facing observation's `images` mapping is
+   the same object as the embodiment's (identity assert), pinning the
+   shallow-copy claim.
+
+Agent plugin (`plugins/inspect-robots-agent/tests/`):
+4. `_observation_content` with `extra={"env_step": 480}` → label text
+   `camera 'top_cam' (step 480):` precedes the image part.
+5. Without `env_step` (and with a non-int value) → today's unlabeled text.
+6. Transcript round-trip: build a conversation via the policy, call
+   `transcript()`, assert the label text survives elision next to the
+   `[image omitted: ...]` placeholder.
+
+## Out of scope
+
+- Storing `FrameRef` paths in the transcript (duplicates the join the step
+  label already provides, couples the plugin to FrameStore layout).
+- A `transcript` CLI viewer (possible follow-up once labels exist).
+- Changing the `Policy` protocol signature.

--- a/plans/0018-transcript-step-labels.md
+++ b/plans/0018-transcript-step-labels.md
@@ -60,16 +60,24 @@ no change. Not a `Policy` protocol change; no API-snapshot impact
 ```python
 step = observation.extra.get("env_step")
 suffix = f" (step {step})" if isinstance(step, int) else ""
-...
+# suffix is computed ONCE, before the camera loop (env_step is
+# per-observation, not per-camera), then reused for every label:
 parts.append({"type": "text", "text": f"camera {name!r}{suffix}:"})
 ```
 
 - `isinstance(step, int)` guards the fallback: under an older core (no
   injection) or a non-int value, the label is exactly today's, so the plugin
-  keeps its "no minimum core version bump" property. `bool` is an `int`
-  subclass but the rollout only ever injects real ints; guarding `bool` out
-  adds an untestable branch for a value that cannot occur — keep plain
-  `isinstance(step, int)`.
+  keeps its "no minimum core version bump" property. `bool` passes this guard
+  (`bool` subclasses `int`): on a new core the rollout's overwrite makes that
+  unreachable, and under an older core an embodiment that sets
+  `env_step=True` produces a cosmetic `(step True)` label — no worse than an
+  embodiment injecting a wrong-but-real int, which no guard can detect. Keep
+  plain `isinstance(step, int)` and pin the `True` behavior with a plugin
+  unit test so the choice is deliberate, not accidental. Same deliberateness
+  for numpy ints: an older-core embodiment emitting `env_step` as `np.int64`
+  fails `isinstance(step, int)` (numpy scalars don't subclass `int`) and
+  silently gets no label — consistent with the fallback framing, unreachable
+  on a new core (rollout injects a Python `int`), pinned in test 5.
 - The elision placeholder in `transcript()` stays
   `[image omitted: streamed camera frame]` — the join key lives in the
   adjacent label part, which the persisted transcript keeps verbatim.
@@ -77,37 +85,63 @@ parts.append({"type": "text", "text": f"camera {name!r}{suffix}:"})
 
 ### Versioning
 
-The agent plugin's static version is already `0.6.0`, unreleased (bumped by
-PR #115 which is not yet on PyPI). This feature rides `0.6.0`; no further
-bump. Core needs no version action (hatch-vcs, next tag).
+The agent plugin's `0.6.0` is already on PyPI (released as part of v0.13.1,
+2026-07-15). Because `skip-existing` makes an unchanged plugin version a
+silent no-op at release time, this PR MUST bump the plugin's static version —
+to `0.7.0` (new feature) — or the feature never publishes. Core needs no
+version action (hatch-vcs, next tag).
 
 ### Docs
 
-- `Observation.extra` docstring in `types.py`: document the `env_step`
-  reservation ("the rollout injects the current step for the policy-facing
-  observation; embodiments should not set this key").
-- Agent plugin README: one line in the observation-format section showing the
-  labeled form `camera 'top_cam' (step 480):` and the join to
-  `{trial}_{camera}_{t:06d}.npy`.
-- `docs/guide/logging-and-rerun.md`: extend the transcript paragraph — the
-  step label is the join key from transcript observations to stored frames.
+- `Observation` class docstring in `types.py` (there is no per-field
+  docstring for `extra` today, and the class docstring does not mention it):
+  add the `env_step` reservation ("the rollout injects the current step into
+  the policy-facing observation's `extra`; embodiments should not set this
+  key").
+- Agent plugin README: the README has no observation-format heading (its
+  headings are Install / Quickstart / How it works); anchor the new line to
+  the existing `transcript()` sentence (~line 95, inside "How it works"),
+  showing the labeled form `camera 'top_cam' (step 480):` as the join key to
+  stored frames.
+- `docs/guide/logging-and-rerun.md`: write a short "Policy transcripts"
+  paragraph from scratch — plan 0015's transcript persistence was never
+  documented here (the file currently has no mention of transcripts). Cover:
+  what is persisted, image elision, and the step label as the join key from
+  transcript observations to stored frames. Precision caveat to include:
+  FrameStore sanitizes trial and camera names (`_safe()` in frames.py) before
+  building `{trial}_{camera}_{t:06d}.npy`, so for camera names containing
+  characters the sanitizer rewrites, the authoritative mapping is
+  `StepRecord.image_refs` / `FrameRef.path`, not string assembly.
 
 ## Testing (100% branch coverage for core; agent plugin's own suite)
 
 Core (`tests/`):
-1. Rollout injection: a probe policy records the observations it receives;
-   assert `extra["env_step"] == t` for each call and that the observations in
+1. Rollout injection: a probe policy that emits single-action chunks (so
+   `act()` fires at every step and each call maps to a known `t`) records the
+   observations it receives; assert the recorded `extra["env_step"]` sequence
+   equals `[0, 1, ..., n-1]` exactly, and that the observations in
    `record.steps` / `sink.log_step` do NOT contain `env_step` (original obs).
-2. Collision: a mock embodiment that sets `extra={"env_step": "theirs"}`;
-   the policy sees the rollout's int.
+2. Merge, not replace: a mock embodiment that sets
+   `extra={"env_step": "theirs", "unrelated": 1}` on EVERY observation it
+   returns (`reset()`'s and each `StepResult.observation` — `obs` is
+   reassigned per iteration, so reset-only extras would vacuously pass past
+   t=0); the policy-facing observation has `env_step == t` (rollout's int
+   wins) AND `extra["unrelated"] == 1` (embodiment extras survive the merge —
+   kills the `replace(obs, extra={"env_step": t})` mutant that drops
+   `**obs.extra`).
 3. Sharing, not copying: the policy-facing observation's `images` mapping is
    the same object as the embodiment's (identity assert), pinning the
    shallow-copy claim.
 
 Agent plugin (`plugins/inspect-robots-agent/tests/`):
-4. `_observation_content` with `extra={"env_step": 480}` → label text
-   `camera 'top_cam' (step 480):` precedes the image part.
-5. Without `env_step` (and with a non-int value) → today's unlabeled text.
+4. `_observation_content` with `extra={"env_step": 480}` and TWO OR MORE
+   cameras → every camera label carries the suffix (`camera 'top_cam'
+   (step 480):`, `camera 'left_cam' (step 480):`), each preceding its image
+   part — a single-camera test would pass a "label only the first camera"
+   mutant.
+5. Without `env_step` (and with a non-int value, e.g. a string) → today's
+   unlabeled text; with `env_step=True` → `(step True)` (pins the deliberate
+   bool behavior from the design section).
 6. Transcript round-trip: build a conversation via the policy, call
    `transcript()`, assert the label text survives elision next to the
    `[image omitted: ...]` placeholder.

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -93,6 +93,7 @@ Configuration knobs (all `-P key=value`): `model`, `base_url`, `api_key_env`,
 The speed fraction defaults to `0.1` and applies only to absolute modes.
 
 `LLMAgentPolicy.transcript()` returns the current conversation as a deep copy with streamed camera frames replaced by omission markers, ready for core eval-log persistence.
+Camera labels such as `camera 'top_cam' (step 480):` provide the join key from a transcript observation to its stored frame.
 
 Reasoning effort defaults to `low`: robot control is latency-sensitive (the
 arm stands still while the model thinks), safety guardrails sit below the

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.6.0"
+version = "0.7.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -265,8 +265,10 @@ def _observation_content(
                 continue
         lines.append(f"state[{key}]: {rounded}")
     parts: list[dict[str, Any]] = [{"type": "text", "text": "\n".join(lines)}]
+    step = observation.extra.get("env_step")
+    suffix = f" (step {step})" if isinstance(step, int) else ""
     for name, image in observation.images.items():
-        parts.append({"type": "text", "text": f"camera {name!r}:"})
+        parts.append({"type": "text", "text": f"camera {name!r}{suffix}:"})
         parts.append({"type": "image_url", "image_url": {"url": png_data_url(image)}})
     return parts
 

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,5 +6,5 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.6.0"
+    assert inspect_robots_agent.__version__ == "0.7.0"
     assert callable(inspect_robots_agent.agent_policy)

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -270,6 +270,60 @@ def test_observation_content_uses_unlabeled_fallback_for_length_mismatch() -> No
     assert content[0]["text"] == "Current observation.\nstate[joint_pos]: [0.01, -0.02]"
 
 
+def test_observation_content_labels_every_camera_with_the_environment_step() -> None:
+    image = np.zeros((1, 1, 3), dtype=np.uint8)
+
+    content = _observation_content(
+        Observation(
+            images={"top_cam": image, "left_cam": image},
+            extra={"env_step": 480},
+        )
+    )
+
+    assert content[1]["text"] == "camera 'top_cam' (step 480):"
+    assert content[2]["type"] == "image_url"
+    assert content[3]["text"] == "camera 'left_cam' (step 480):"
+    assert content[4]["type"] == "image_url"
+
+
+def test_observation_content_step_label_fallbacks() -> None:
+    image = np.zeros((1, 1, 3), dtype=np.uint8)
+
+    without_step = _observation_content(Observation(images={"top": image}))
+    string_step = _observation_content(
+        Observation(images={"top": image}, extra={"env_step": "480"})
+    )
+    bool_step = _observation_content(Observation(images={"top": image}, extra={"env_step": True}))
+    numpy_step = _observation_content(
+        Observation(images={"top": image}, extra={"env_step": np.int64(480)})
+    )
+
+    assert without_step[1]["text"] == "camera 'top':"
+    assert string_step[1]["text"] == "camera 'top':"
+    assert bool_step[1]["text"] == "camera 'top' (step True):"
+    assert numpy_step[1]["text"] == "camera 'top':"
+
+
+def test_transcript_preserves_step_label_next_to_elided_image() -> None:
+    policy = _policy(_Script([_tool_response("done", {"summary": "observed"})]))
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="observe"))
+    policy.act(
+        Observation(
+            images={"top_cam": np.zeros((1, 1, 3), dtype=np.uint8)},
+            extra={"env_step": 480},
+        )
+    )
+
+    transcript = policy.transcript()
+
+    assert transcript is not None
+    assert transcript[-3]["content"][-2:] == [
+        {"type": "text", "text": "camera 'top_cam' (step 480):"},
+        {"type": "text", "text": "[image omitted: streamed camera frame]"},
+    ]
+
+
 def test_transcript_strips_images_and_preserves_text_and_tools() -> None:
     policy = _policy(_Script([_text_response("unused")]))
     policy.reset(Scene(id="s0", instruction="reach"))

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -216,7 +216,9 @@ def rollout(
         while t < max_steps:
             prev_inferences = len(store.get(_INFER_KEY, []))
             try:
-                action = controller.next_action(policy, obs, t, store)
+                action = controller.next_action(
+                    policy, replace(obs, extra={**obs.extra, "env_step": t}), t, store
+                )
             except InspectRobotsError as exc:
                 _record_failure(record, exc, t)
                 raise

--- a/src/inspect_robots/types.py
+++ b/src/inspect_robots/types.py
@@ -29,7 +29,9 @@ class Observation:
     ``images`` are keyed by camera name; ``state`` holds proprioception keyed by a
     controlled vocabulary (e.g. ``"eef_pos"``, ``"gripper"``). ``instruction`` is
     the language goal for this step (usually constant across an episode, but may
-    change for long-horizon tasks).
+    change for long-horizon tasks). The rollout injects the current step into the
+    policy-facing observation's ``extra["env_step"]`` and reserves that key;
+    embodiments should not set it.
     """
 
     images: Mapping[str, ImageArray] = field(default_factory=dict)

--- a/tests/test_rollout_observation_step.py
+++ b/tests/test_rollout_observation_step.py
@@ -1,0 +1,137 @@
+"""Policy-facing rollout observations carry a reserved environment step."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+
+from inspect_robots.approver import AutoApprover
+from inspect_robots.controller import DefaultController
+from inspect_robots.logging.sink import LogSink, NullSink
+from inspect_robots.mock import CubePickEmbodiment
+from inspect_robots.policy import PolicyConfig, PolicyInfo
+from inspect_robots.rollout import TrialRecord, rollout
+from inspect_robots.scene import Scene
+from inspect_robots.spaces import ActionSemantics, Box
+from inspect_robots.types import Action, ActionChunk, Observation, StepResult
+
+_SCENE = Scene(id="step-probe", instruction="hold still")
+_ACTION_SPACE = Box(
+    shape=(2,), semantics=ActionSemantics(control_mode="eef_delta_pos", frame="world")
+)
+
+
+class _ProbePolicy:
+    """Record every policy-facing observation and emit one action per call."""
+
+    def __init__(self) -> None:
+        self.info = PolicyInfo(name="step-probe", action_space=_ACTION_SPACE)
+        self.config = PolicyConfig(action_horizon=1)
+        self.observations: list[Observation] = []
+
+    def reset(self, scene: Scene) -> None:
+        """Clear observations before the trial."""
+        self.observations.clear()
+
+    def act(self, observation: Observation) -> ActionChunk:
+        """Capture the observation and return a single hold-still action."""
+        self.observations.append(observation)
+        return ActionChunk(actions=[Action(data=np.zeros(2))])
+
+
+class _ObservationSink(NullSink):
+    """Capture observations delivered to ``log_step``."""
+
+    def __init__(self) -> None:
+        self.observations: list[Observation] = []
+
+    def log_step(
+        self, t: int, observation: Observation, action: Action, result: StepResult
+    ) -> None:
+        """Record the logged observation."""
+        self.observations.append(observation)
+
+
+class _ExtraEmbodiment(CubePickEmbodiment):
+    """Attach colliding and unrelated extras to every produced observation."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.observations: list[Observation] = []
+
+    def reset(self, scene: Scene, *, seed: int | None = None) -> Observation:
+        """Return and record a reset observation carrying embodiment extras."""
+        self.observations.clear()
+        observation = replace(
+            super().reset(scene, seed=seed),
+            extra={"env_step": "theirs", "unrelated": 1},
+        )
+        self.observations.append(observation)
+        return observation
+
+    def step(self, action: Action) -> StepResult:
+        """Return and record a step observation carrying embodiment extras."""
+        result = super().step(action)
+        observation = replace(
+            result.observation,
+            extra={"env_step": "theirs", "unrelated": 1},
+        )
+        self.observations.append(observation)
+        return replace(result, observation=observation)
+
+
+def _run(
+    policy: _ProbePolicy,
+    embodiment: CubePickEmbodiment,
+    *,
+    max_steps: int,
+    sink: LogSink | None = None,
+) -> TrialRecord:
+    return rollout(
+        policy,
+        embodiment,
+        _SCENE,
+        max_steps=max_steps,
+        seed=0,
+        epoch=0,
+        controller=DefaultController(),
+        approver=AutoApprover(),
+        sink=sink or NullSink(),
+    )
+
+
+def test_rollout_injects_step_only_into_policy_observations() -> None:
+    policy = _ProbePolicy()
+    sink = _ObservationSink()
+
+    record = _run(policy, CubePickEmbodiment(), max_steps=4, sink=sink)
+
+    assert [observation.extra["env_step"] for observation in policy.observations] == [0, 1, 2, 3]
+    assert len(record.steps) == len(sink.observations) == 4
+    assert all("env_step" not in step.observation.extra for step in record.steps)
+    assert all("env_step" not in observation.extra for observation in sink.observations)
+
+
+def test_rollout_step_merge_preserves_extras_and_overwrites_collision() -> None:
+    policy = _ProbePolicy()
+
+    _run(policy, _ExtraEmbodiment(), max_steps=3)
+
+    assert [observation.extra["env_step"] for observation in policy.observations] == [0, 1, 2]
+    assert all(observation.extra["unrelated"] == 1 for observation in policy.observations)
+
+
+def test_rollout_step_injection_shares_the_images_mapping() -> None:
+    policy = _ProbePolicy()
+    embodiment = _ExtraEmbodiment()
+
+    _run(policy, embodiment, max_steps=3)
+
+    assert len(policy.observations) == 3
+    assert all(
+        policy_observation.images is embodiment_observation.images
+        for policy_observation, embodiment_observation in zip(
+            policy.observations, embodiment.observations[:3], strict=True
+        )
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -520,7 +520,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #117.

Design: plans/0018-transcript-step-labels.md (critique loop in progress). Implementation to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)