### PR TITLE
feat(cli): run status label with completed display value and outcome line

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -194,7 +194,7 @@ run a single ad-hoc scene.
 
 The exit code is `0` on a successful eval, `1` otherwise. When trials errored,
 the summary shows the count (`trials: 4 (2 errored)`) and lists each errored
-scene; a run in which every trial errored reports `status: error` and exits `1`.
+scene; a run in which every trial errored reports `run status: error` and exits `1`.
 
 ## `inspect-robots doctor`
 
@@ -217,7 +217,8 @@ inspect-robots inspect logs/cubepick-reach_xxxx.json
 task:        cubepick-reach
 policy:      scripted
 embodiment:  cubepick
-status:      success
+run status:  completed
+outcome:     5 succeeded
 scenes:      5   trials: 5
 metrics:
   success_at_end: 1
@@ -225,6 +226,9 @@ scenes:
   [success] scene-0: success_at_end=1
   ...
 ```
+
+`completed` is the display form of the log's `success` status value; the
+on-disk field and Python API keep `success`.
 
 ## `inspect-robots video`
 

--- a/plans/0017-run-status-outcome-line.md
+++ b/plans/0017-run-status-outcome-line.md
@@ -1,0 +1,241 @@
+# 0017: `run status:` label and `outcome:` line in the CLI
+
+Issue: [#122](https://github.com/robocurve/inspect-robots/issues/122)
+Status: approved (critique rounds 1-3 applied; round 3 found no substantive design issues)
+
+## 1. Problem
+
+`_print_run_summary` and `_cmd_inspect` print `status: {log.status}`. The
+value `success` means "the eval ran to completion without a halting error,
+and at least one trial survived" (under the default `fail_on_error=False`,
+per-trial `PolicyError`s are caught and the run stays `success` unless every
+trial errored). It says nothing about the task verdict, which lives in the
+metrics lines.
+
+Operators misread it. A run whose only trial hit the step horizon, or whose
+LLM agent exhausted its `max_llm_calls` budget and was forced into `give_up`,
+prints a green `status: success` and exits 0 even though every scorer said
+failure. `max_steps` truncations at least trigger the yellow step-limit note;
+`give_up` (and every other policy-stop reason) surfaces nowhere in the
+summary.
+
+## 2. Non-goals
+
+- No change to the on-disk `EvalLog` schema. `EvalLog.status` /
+  `SceneResult.status` keep their `"success" | "error" | "cancelled"`
+  (+ transient `"started"`) values; old logs stay readable and the Python API
+  is untouched.
+- No change to exit codes. For runs that reach the summary, `run` and
+  `inspect` keep exiting 0 iff `log.status == "success"`; the cancellation
+  path (`run` returns 130 before the summary prints, cli.py:768-774) is
+  untouched.
+- No invented task-success verdict. The `outcome:` line reports the
+  termination reasons the log already records; it does not aggregate scorer
+  values (the operator can score a truncated trial as a success, and the
+  metrics lines already carry that).
+
+## 3. Design
+
+### 3a. `run status:` label, `completed` display value (options A+B)
+
+In both `_print_run_summary` and `_cmd_inspect`, the label becomes
+`run status:` and the displayed value maps through a tiny shared helper:
+
+```python
+_STATUS_DISPLAY = {"success": "completed"}
+
+def _display_status(status: str) -> str:
+    ...  # _STATUS_DISPLAY.get(status, status)
+```
+
+Unmapped values (`error`, `cancelled`, a transient or hand-edited `started`)
+display as-is via the `dict.get(status, status)` fallback.
+
+- Run summary: `run status: completed` (value green), `run status: error`
+  (value red). Label styling stays exactly as today: cyan in the run summary
+  only. Note `run status: cancelled` is unreachable here: `eval()` re-raises
+  the interrupt and `_cmd_run` returns 130 before `_print_run_summary` runs;
+  cancelled logs surface through `inspect`.
+- Inspect view: labels in that block are plain unstyled prints and stay so
+  (ANSI codes would also break the fixed-width alignment). The literal is
+  `"run status:  "`: 11-char label + 2 spaces = the block's 13 columns
+  (matching `task:        `, 13 chars).
+
+### 3b. `outcome:` line (option E)
+
+A new line aggregating per-trial termination reasons across
+`log.samples[*].termination_reasons` (`read_eval_log` backfills `()` for logs
+written before the field existed, so the line is simply omitted for them —
+see 3c).
+
+Reason-to-phrase mapping (`_OUTCOME_PHRASES`):
+
+| recorded reason | phrase |
+|---|---|
+| `success` | `succeeded` |
+| `failure` | `failed` |
+| `max_steps` | `hit step limit` |
+| `give_up` | `gave up` |
+| `done` | `reported done` |
+| `policy_stop` | `stopped by policy` (rollout's default when a stop request names no reason, rollout.py:259) |
+| `truncated` | `truncated` |
+| any other non-empty string | the raw reason string, unquoted (foreign text; see 3d) |
+| `None` or `""` | `no reason recorded` |
+
+(A policy that explicitly sets `stop_reason=None` records the literal string
+`"None"` today — rollout.py:259 applies `str()` — and that renders raw via
+the unmapped path. Pre-existing rollout behavior, accepted; not a bug in the
+outcome line.)
+
+`None` is deliberately neutral, not "did not finish": an adapter may
+terminate a successful trial without naming a reason
+(`StepResult.termination_reason` defaults to `None`), and errored/cancelled
+trials also record `None`. Error visibility already comes from the
+`(N errored)` trials suffix and the per-scene failure list, so the outcome
+phrase must not guess. `""` (a policy setting `stop_reason=""`) folds into
+the same phrase so no group renders blank.
+
+Hand-edited logs: `EvalLog.from_dict` does no field validation, so
+`termination_reasons` entries can be ints, bools, lists, or dicts. Every
+non-`None` entry is coerced with `str()` before the phrase lookup (an int
+`3` renders as the raw reason `3`), keeping the degrade-don't-crash norm the
+inspect reader already follows for `max_steps` (cli.py:464-470). No
+unhashable keys or mixed-type sorts can reach the aggregation.
+
+Grouping key is the *phrase*, after mapping and coercion. A policy-authored
+raw reason that collides with a mapped phrase (e.g. `stop_reason="gave up"`
+alongside `give_up` trials) merges into one group; the line still routes
+through the degraded printer because an unmapped raw reason was present
+(see 3d).
+
+Format: counts joined by commas, largest first, ties broken alphabetically by
+phrase. The count prefix is dropped when the collected reasons list (not
+`results.total_trials`, which can disagree in hand-edited logs) has exactly
+one entry:
+
+```text
+outcome: 2 succeeded, 1 gave up, 1 hit step limit   # multiple reasons recorded
+outcome: gave up                                    # exactly one reason recorded
+```
+
+`outcome: 2 no reason recorded` is accepted as slightly awkward English; it
+is factual, rare, and must not be showcased in the docs examples (the docs
+writing-style gate applies to `docs/guide/cli.md`).
+
+Placement:
+
+- Run summary: immediately after the `run status:` line (before the `error:`
+  line and per-scene failure list), so the two lines read as a pair:
+  machinery status, then what the trials did. Label cyan, value unstyled (a
+  factual digest, not an alarm; the yellow step-limit note keeps the alarm
+  role).
+- Inspect view: `outcome:     ...` (8-char label + 5 spaces = 13 columns)
+  directly under `run status:`, plain like its siblings.
+
+### 3c. Omission rule
+
+No recorded reasons (`termination_reasons` empty across all samples: an old
+log, or a failure before any trial was recorded) → no `outcome:` line. An
+all-`None` reasons list still prints (`outcome: 2 no reason recorded`): that
+is signal, not absence of data. (A cancelled run normally does record its
+partial trial's `None` reason, so it prints the line; only a cancel outside
+rollout leaves reasons empty.)
+
+### 3d. Foreign text
+
+Unmapped reasons are foreign text from two sources: policy-authored
+`action.meta["stop_reason"]` (a hostile model server writes this freely, so
+it can contain lone UTF-16 surrogates that crash `print` on strict-UTF-8
+stdout) and embodiment-authored `StepResult.termination_reason` (open
+vocabulary; types.py names `"collision"` as an example). The raw reason is
+kept verbatim (no `repr`-quoting, which would neutralize surrogates into
+ASCII escapes and defeat the degradation path), and the whole outcome line is
+emitted via `_print_degraded` whenever at least one unmapped reason is
+present. `_print_degraded` is byte-identical to `print` for clean text, so
+benign embodiment reasons like `collision` render normally. Lines built only
+from mapped phrases keep plain `print`.
+
+### 3e. Scene-level status vocabulary untouched
+
+The per-scene markers (`[success]` / `[error]` / `[cancelled]` in both the
+run summary's failure list and inspect's scenes block) keep the raw
+`SceneSample.status` values. Only the top-level line gets the display
+mapping; the mixed vocabulary (`run status: completed` above `[success] s0`)
+is a deliberate scope cut, not a bug.
+
+### 3f. Step-limit notice unchanged
+
+`_print_step_limit_notice` stays as-is: it carries the `max_steps=N, ~Ss at
+R Hz` parenthetical and the horizon-ownership hint, which the outcome digest
+does not duplicate. The overlap is one count, and the note only fires when
+the step limit was actually hit.
+
+## 4. Touched files
+
+Helper contract: `_outcome_line(log: EvalLog) -> tuple[str, bool] | None`
+returns `(digest, has_unmapped)` or `None` when there is nothing to print
+(3c). It does NOT print. Each call site formats its own label and padding
+and picks `print` vs `_print_degraded` from `has_unmapped`, which is what
+gives each call site its own omit-vs-print and degraded-vs-plain branches
+(see tests 5-6).
+
+```
+src/inspect_robots/cli.py         # _display_status, _outcome_line, both call sites
+tests/test_registry_cli.py        # updated assertions + new outcome cases
+tests/test_string_resolution.py   # "status:      success" assertion at :44
+docs/guide/cli.md                 # inspect example block; "status: error" wording
+```
+
+No new modules, no API surface change (`__all__` untouched), no schema bump.
+
+## 5. Tests
+
+Update existing assertions (`status: success` → `run status: completed`,
+`status: error` → `run status: error`, the inspect padded variants in both
+test files).
+
+New cases, all through the public CLI entry points with the CubePick mock or
+synthesized logs (existing `_transcript_log`-style fixtures):
+
+1. Timeout run: summary shows `run status: completed` and
+   `outcome: hit step limit` (single reason, no count).
+2. Multi-trial mixed reasons: counts and ordering
+   (`2 succeeded, 1 hit step limit`).
+3. `give_up` truncation (synthesized record): `outcome: gave up`.
+4. Errored trial (reason `None`): `outcome: no reason recorded`; the errored
+   scene list and `(N errored)` suffix still print.
+5. Unmapped foreign reason containing a lone surrogate: line prints via the
+   degraded path (assert the U+FFFD replacement, mirroring the existing
+   transcript-degradation test). Exercised through BOTH the run summary and
+   inspect (branch coverage runs at 100%, and each call site carries its own
+   degraded-vs-plain branch).
+6. Old log with no `termination_reasons`: no `outcome:` line. Also exercised
+   through BOTH call sites (omit-vs-print branch each).
+7. Inspect view prints both `run status:` and `outcome:` with 13-column
+   block padding; a cancelled log shows `run status:  cancelled` plus its
+   partial trial's `outcome: no reason recorded`. NOTE: the existing
+   `_transcript_log(status="cancelled")` fixture has `termination_reasons=()`
+   (omission branch) and three epochs; this test needs a synthesized log with
+   exactly one recorded trial whose reason is `None`, or the output is the
+   counted plural form.
+8. `started` (hand-edited/in-flight) status displays raw via the `.get`
+   fallback.
+9. Hand-edited log with non-string `termination_reasons` entries (int, bool,
+   list): coerced via `str()`, no crash (mirrors the existing
+   non-numeric-max_steps hand-edit test).
+10. Empty-string reason folds into `no reason recorded`.
+11. Phrase collision (`stop_reason="gave up"` next to `give_up`): one merged
+    group, line still degraded-printed.
+
+Gates: `ruff check`, `ruff format --check`, `mypy --strict` (src+tests),
+`pytest --cov` at 100%.
+
+## 6. Docs
+
+- `docs/guide/cli.md`: update the inspect example block (add `run status:`
+  and an `outcome:` line) and the `status: error` prose at line ~197. Add one
+  sentence stating that `completed` is the display form of the log's
+  `success` status value, so users grepping their JSON for `completed` are
+  not stranded (the on-disk field and the Python API docs keep `"success"`).
+- README has no CLI status output; its `log.status` Python example is
+  unaffected.

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -77,6 +77,18 @@ _GREEN = "32"
 _RED = "31"
 _YELLOW = "33"
 
+_STATUS_DISPLAY = {"success": "completed"}
+
+_OUTCOME_PHRASES = {
+    "success": "succeeded",
+    "failure": "failed",
+    "max_steps": "hit step limit",
+    "give_up": "gave up",
+    "done": "reported done",
+    "policy_stop": "stopped by policy",
+    "truncated": "truncated",
+}
+
 
 _KIND_BY_PLURAL = {
     "tasks": "task",
@@ -453,6 +465,37 @@ def _step_limit_count(log: EvalLog) -> int:
     )
 
 
+def _display_status(status: str) -> str:
+    """Return the human-facing form of a run status."""
+    return _STATUS_DISPLAY.get(status, status)
+
+
+def _outcome_line(log: EvalLog) -> tuple[str, bool] | None:
+    """Return an outcome digest and unmapped flag, or ``None`` with no reasons."""
+    reasons: list[object] = [
+        reason for scene in log.samples for reason in scene.termination_reasons
+    ]
+    if not reasons:
+        return None
+
+    counts: dict[str, int] = {}
+    has_unmapped = False
+    for reason in reasons:
+        text = "" if reason is None else str(reason)
+        if not text:
+            phrase = "no reason recorded"
+        else:
+            phrase = _OUTCOME_PHRASES.get(text, text)
+            if text not in _OUTCOME_PHRASES:
+                has_unmapped = True
+        counts[phrase] = counts.get(phrase, 0) + 1
+
+    ordered = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    if len(reasons) == 1:
+        return ordered[0][0], has_unmapped
+    return ", ".join(f"{count} {phrase}" for phrase, count in ordered), has_unmapped
+
+
 def _print_step_limit_notice(log: EvalLog, is_adhoc: bool) -> None:
     """Print the shared timeout note and the horizon-ownership hint when needed."""
     count = _step_limit_count(log)
@@ -571,7 +614,15 @@ def _print_run_summary(log: EvalLog, log_path: str, is_adhoc: bool) -> None:
     failed = log.status != "success"
     errored_count = log.results.errored_trials
     status_color = _RED if failed else _GREEN
-    print(f"{_styled('status:', _CYAN)} {_styled(log.status, status_color)}")
+    print(f"{_styled('run status:', _CYAN)} {_styled(_display_status(log.status), status_color)}")
+    outcome = _outcome_line(log)
+    if outcome is not None:
+        digest, has_unmapped = outcome
+        line = f"{_styled('outcome:', _CYAN)} {digest}"
+        if has_unmapped:
+            _print_degraded(line)
+        else:
+            print(line)
     if failed and log.error is not None:
         print(f"{_styled('error:', _CYAN)} {_styled(log.error, _RED)}")
     if failed or errored_count:
@@ -799,7 +850,15 @@ def _cmd_inspect(path: str, *, transcript: bool = False) -> int:
         _print_degraded(f"instruction: {shared}")
     print(f"policy:      {log.eval.policy}")
     print(f"embodiment:  {log.eval.embodiment}")
-    print(f"status:      {log.status}")
+    print(f"run status:  {_display_status(log.status)}")
+    outcome = _outcome_line(log)
+    if outcome is not None:
+        digest, has_unmapped = outcome
+        line = f"outcome:     {digest}"
+        if has_unmapped:
+            _print_degraded(line)
+        else:
+            print(line)
     print(f"created:     {log.eval.created}")
     print(f"git:         {log.eval.git_commit}")
     trials = f"trials: {log.results.total_trials}"

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -561,11 +561,27 @@ def test_run_outcome_groups_counts_and_orders_by_count_then_phrase(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    log = _step_limit_log(reasons=("success", "max_steps", "success"))
+    # Insertion order (max_steps first) differs from the required order, so
+    # this fails if the count-descending sort is dropped.
+    log = _step_limit_log(reasons=("max_steps", "success", "success"))
 
     assert _run_with_synthesized_log(log, monkeypatch, tmp_path) == 0
 
     assert "outcome: 2 succeeded, 1 hit step limit" in capsys.readouterr().out
+
+
+def test_run_outcome_breaks_count_ties_alphabetically_by_phrase(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Insertion order ("succeeded" first) differs from alphabetical order, so
+    # this fails if the tie-break is dropped.
+    log = _step_limit_log(reasons=("success", "max_steps"))
+
+    assert _run_with_synthesized_log(log, monkeypatch, tmp_path) == 0
+
+    assert "outcome: 1 hit step limit, 1 succeeded" in capsys.readouterr().out
 
 
 def test_inspect_outcome_maps_give_up_reason(
@@ -613,13 +629,14 @@ def test_unmapped_outcome_degrades_lone_surrogate_in_run_and_inspect(
     assert _run_with_synthesized_log(log, monkeypatch, tmp_path / "run") == 0
     run_out = capsys.readouterr().out
     assert "\ud800" not in run_out
-    assert "outcome: bad � reason" in run_out or "outcome: bad ? reason" in run_out
+    # encode(errors="replace") substitutes ASCII "?" on the encode side.
+    assert "outcome: bad ? reason" in run_out
 
     path = _write_log(log, tmp_path, "hostile-reason.json")
     assert main(["inspect", str(path)]) == 0
     inspect_out = capsys.readouterr().out
     assert "\ud800" not in inspect_out
-    assert "outcome:     bad � reason" in inspect_out or "outcome:     bad ? reason" in inspect_out
+    assert "outcome:     bad ? reason" in inspect_out
 
 
 def test_outcome_is_omitted_without_recorded_reasons_in_run_and_inspect(

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -102,7 +102,7 @@ def test_cli_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     )
     assert rc == 0
     out = capsys.readouterr().out
-    assert "status: success" in out
+    assert "run status: completed" in out
     assert "success_at_end" in out
     (written,) = tmp_path.glob("*.json")
     assert f"log: {written}" in out  # the CLI tells the user where the log went
@@ -206,7 +206,7 @@ def test_cli_run_embodiment_fault_prints_error_scene_and_inspect_hint(
 
     assert rc == 1
     out = capsys.readouterr().out
-    assert "status: error" in out
+    assert "run status: error" in out
     assert "error: EmbodimentFault: reset exploded" in out
     assert "  [error] scene-1\n" in out
     assert "scene-0" not in out  # successful scenes are not failure context
@@ -288,7 +288,7 @@ def test_cli_all_errored_run_exits_nonzero_with_diagnostics(
 
     assert rc == 1
     out = capsys.readouterr().out
-    assert "status: error" in out
+    assert "run status: error" in out
     assert "error: all 1 trial(s) errored; nothing was scored" in out
     assert "[error] scene-0: PolicyError: invalid API key" in out
     assert "trials: 1 (1 errored)" in out
@@ -297,7 +297,7 @@ def test_cli_all_errored_run_exits_nonzero_with_diagnostics(
     # And `inspect` on the written log shows the same headline facts.
     assert main(["inspect", str(written)]) == 1
     out = capsys.readouterr().out
-    assert "status:      error" in out
+    assert "run status:  error" in out
     assert "trials: 1 (1 errored)" in out
 
 
@@ -342,7 +342,7 @@ def test_cli_partial_errors_stay_success_but_are_visible(
 
     assert rc == 0  # data survived; library semantics unchanged for partials
     out = capsys.readouterr().out
-    assert "status: success" in out
+    assert "run status: completed" in out
     assert "trials: 2 (1 errored)" in out
     assert "[error] scene-1: PolicyError: policy reset exploded" in out
     (written,) = tmp_path.glob("*.json")
@@ -504,6 +504,207 @@ def _transcript_log(*, status: str = "success") -> EvalLog:
         ),
         error="trial failed" if status == "error" else None,
     )
+
+
+def _run_with_synthesized_log(log: EvalLog, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> int:
+    import inspect_robots
+
+    def synthesized_eval(*args: object, **kwargs: object) -> list[EvalLog]:
+        del args, kwargs
+        return [log]
+
+    monkeypatch.setattr(inspect_robots, "eval", synthesized_eval)
+    return main(
+        [
+            "run",
+            "--task",
+            "cubepick-reach",
+            "--policy",
+            "scripted",
+            "--embodiment",
+            "cubepick",
+            "--log-dir",
+            str(tmp_path),
+        ]
+    )
+
+
+def _write_log(log: EvalLog, tmp_path: Path, name: str) -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(log.to_dict()), encoding="utf-8")
+    return path
+
+
+def test_run_outcome_shows_timeout_without_a_count(
+    _hermetic_defaults: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_config(
+        _hermetic_defaults,
+        "[defaults]\n"
+        "policy = scripted\n"
+        "embodiment = cubepick\n"
+        "scorer = success_at_end\n"
+        "max_steps = 3\n",
+    )
+
+    assert main(["reach the cube", "--log-dir", str(tmp_path / "logs")]) == 0
+
+    out = capsys.readouterr().out
+    assert "run status: completed" in out
+    assert "outcome: hit step limit" in out
+
+
+def test_run_outcome_groups_counts_and_orders_by_count_then_phrase(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    log = _step_limit_log(reasons=("success", "max_steps", "success"))
+
+    assert _run_with_synthesized_log(log, monkeypatch, tmp_path) == 0
+
+    assert "outcome: 2 succeeded, 1 hit step limit" in capsys.readouterr().out
+
+
+def test_inspect_outcome_maps_give_up_reason(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_log(_step_limit_log(reasons=("give_up",)), tmp_path, "give-up.json")
+
+    assert main(["inspect", str(path)]) == 0
+
+    assert "outcome:     gave up" in capsys.readouterr().out
+
+
+def test_run_outcome_keeps_errored_trial_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    log = _step_limit_log(reasons=(None,))
+    scene = dataclasses.replace(
+        log.samples[0], status="error", error="PolicyError: policy exploded"
+    )
+    log = dataclasses.replace(
+        log,
+        status="error",
+        results=dataclasses.replace(log.results, errored_trials=1),
+        samples=(scene,),
+        error="all 1 trial(s) errored; nothing was scored",
+    )
+
+    assert _run_with_synthesized_log(log, monkeypatch, tmp_path) == 1
+
+    out = capsys.readouterr().out
+    assert "outcome: no reason recorded" in out
+    assert "[error] s0: PolicyError: policy exploded" in out
+    assert "trials: 1 (1 errored)" in out
+
+
+def test_unmapped_outcome_degrades_lone_surrogate_in_run_and_inspect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    log = _step_limit_log(reasons=("bad \ud800 reason",))
+
+    assert _run_with_synthesized_log(log, monkeypatch, tmp_path / "run") == 0
+    run_out = capsys.readouterr().out
+    assert "\ud800" not in run_out
+    assert "outcome: bad � reason" in run_out or "outcome: bad ? reason" in run_out
+
+    path = _write_log(log, tmp_path, "hostile-reason.json")
+    assert main(["inspect", str(path)]) == 0
+    inspect_out = capsys.readouterr().out
+    assert "\ud800" not in inspect_out
+    assert "outcome:     bad � reason" in inspect_out or "outcome:     bad ? reason" in inspect_out
+
+
+def test_outcome_is_omitted_without_recorded_reasons_in_run_and_inspect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    log = _transcript_log()
+
+    assert _run_with_synthesized_log(log, monkeypatch, tmp_path / "run") == 0
+    assert "outcome:" not in capsys.readouterr().out
+
+    path = _write_log(log, tmp_path, "old-log.json")
+    assert main(["inspect", str(path)]) == 0
+    assert "outcome:" not in capsys.readouterr().out
+
+
+def test_inspect_cancelled_status_and_singular_no_reason_outcome_are_aligned(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    log = _step_limit_log(reasons=(None,))
+    scene = dataclasses.replace(log.samples[0], status="cancelled")
+    log = dataclasses.replace(log, status="cancelled", samples=(scene,))
+    path = _write_log(log, tmp_path, "cancelled.json")
+
+    assert main(["inspect", str(path)]) == 1
+
+    out = capsys.readouterr().out
+    assert "run status:  cancelled\n" in out
+    assert "outcome:     no reason recorded\n" in out
+
+
+def test_inspect_started_status_uses_raw_fallback(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    log = dataclasses.replace(_step_limit_log(reasons=("done",)), status="started")
+    path = _write_log(log, tmp_path, "started.json")
+
+    assert main(["inspect", str(path)]) == 1
+
+    assert "run status:  started" in capsys.readouterr().out
+
+
+def test_inspect_outcome_coerces_non_string_hand_edited_reasons(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    data = _step_limit_log(reasons=("success", "success", "success")).to_dict()
+    data["samples"][0]["termination_reasons"] = [3, True, ["nested"]]
+    path = tmp_path / "non-string-reasons.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    assert main(["inspect", str(path)]) == 0
+
+    assert "outcome:     1 3, 1 True, 1 ['nested']" in capsys.readouterr().out
+
+
+def test_inspect_outcome_folds_empty_reason_into_no_reason_recorded(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_log(_step_limit_log(reasons=("",)), tmp_path, "empty-reason.json")
+
+    assert main(["inspect", str(path)]) == 0
+
+    assert "outcome:     no reason recorded" in capsys.readouterr().out
+
+
+def test_inspect_outcome_merges_phrase_collision_and_uses_degraded_print(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = _write_log(_step_limit_log(reasons=("give_up", "gave up")), tmp_path, "collision.json")
+    degraded_lines: list[str] = []
+    original_print_degraded = cli._print_degraded
+
+    def record_degraded(line: str) -> None:
+        degraded_lines.append(line)
+        original_print_degraded(line)
+
+    monkeypatch.setattr(cli, "_print_degraded", record_degraded)
+
+    assert main(["inspect", str(path)]) == 0
+
+    assert "outcome:     2 gave up" in capsys.readouterr().out
+    assert "outcome:     2 gave up" in degraded_lines
 
 
 def test_inspect_transcript_renders_chat_and_unknown_shapes_after_summary(
@@ -1484,7 +1685,7 @@ def test_sim_works_with_registered_task(
     out = capsys.readouterr().out
     # env beats config for the sim chain, and the header says so.
     assert f"embodiment: cubepick (--sim, from ${ENV_SIM_EMBODIMENT})" in out
-    assert "status: success" in out
+    assert "run status: completed" in out
 
 
 def test_sim_ignores_real_embodiment_env_var(

--- a/tests/test_string_resolution.py
+++ b/tests/test_string_resolution.py
@@ -41,6 +41,6 @@ def test_cli_inspect(tmp_path: Path, capsys: object) -> None:
         rc = main(["inspect", str(log_path)])
     assert rc == 0
     out = buf.getvalue()
-    assert "status:      success" in out
+    assert "run status:  completed" in out
     assert "success_at_end" in out
     assert "scenes:" in out


### PR DESCRIPTION
Closes #122

The run summary and inspect views printed `status: success` (green, exit 0) whenever the eval machinery ran without a halting error, even when every trial hit the step horizon or the LLM agent exhausted `max_llm_calls` and was forced into `give_up`. Operators misread the line as the task verdict.

Per the approved design in `plans/0017-run-status-outcome-line.md`:

- The label becomes `run status:` in both views, and the log's `success` value displays as `completed` via a display-only mapping. The on-disk schema, Python API, and exit codes are unchanged; `error`, `cancelled`, and hand-edited values display as-is.
- A new `outcome:` line aggregates recorded per-trial termination reasons (`outcome: 2 succeeded, 1 gave up, 1 hit step limit`), with the count dropped for a single recorded reason. `None` and empty reasons fold into `no reason recorded` (neutral: adapters may terminate successful trials without naming a reason). The line is omitted for logs with no recorded reasons (pre-field logs).
- Unmapped reasons are policy- or embodiment-authored foreign text: they render raw and the line routes through `_print_degraded`, so a hostile reason with lone UTF-16 surrogates degrades instead of crashing strict-UTF-8 stdout.
- Scene-level `[success]`/`[error]` markers and the step-limit notice are deliberately untouched (plan §3e-§3f).

Tests cover the 11 cases in plan §5, including both-call-site omission and degradation branches, non-string hand-edited reasons, and phrase collisions. Docs updated with the new example block and a sentence mapping the `completed` display form to the on-disk `success` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)