### PR TITLE
feat(agent): -P transcript_echo=true streams the conversation to stderr

### DIFF
--- a/plans/0019-transcript-echo.md
+++ b/plans/0019-transcript-echo.md
@@ -1,0 +1,158 @@
+# 0019 — `-P transcript_echo=true`: follow the agent conversation live on stderr
+
+Issue: #123. Status: draft.
+
+## Problem
+
+During a run the agent policy's conversation lives only in
+`LLMAgentPolicy._messages` and is persisted to the eval log at rollout end
+(plan 0015). The operator standing at the rig cannot see what the model is
+thinking or which tool it called until the run is over. The Rerun viewer shows
+frames and actions live, but not the text.
+
+## Design
+
+A single opt-in constructor param on the agent plugin. No core changes.
+
+`LLMAgentPolicy(transcript_echo=False)` — when true, the policy prints
+conversation events to **stderr** as they happen. The CLI already coerces
+`-P transcript_echo=true` to a real `bool` (`parse_value` in
+`_defaults.py`), so no parsing work is needed. Stderr, not stdout: the run's
+summary/log-path lines go to stdout and must stay machine-consumable.
+
+No LLM is involved anywhere: every echoed line is string formatting of values
+the policy already holds in local variables.
+
+### What gets echoed, and where the calls sit in `policy.py`
+
+All echo sites are inside `reset()` / `act()`. Most sit right where the
+corresponding message is appended to `self._messages`; two are deliberately
+one-way (echo without a transcript message, or message without an echo), as
+called out below:
+
+| Event | Line format (one `print` each) |
+|---|---|
+| `reset(scene)` | `[agent] goal: {scene.instruction}` |
+| observation appended in `act()` | `[agent] >> step {n}: {k} camera(s), state[{key}]: {rounded}` (one line; **never** the base64 payloads) |
+| assistant message returned | `[agent] << {text}` for the text content (verbatim, may be multi-line) and one `[agent] << tool_call {name}({arguments})` per tool call |
+| tool result appended (executed call) | `[agent] -- {result.error or result.note}` |
+| extra tool calls in one turn | `[agent] -- ignored: one tool call per turn` (one per extra, mirroring the filler message appended for each) |
+| budget exhausted (`_forced_give_up`) | `[agent] -- LLM call budget exhausted; forcing give_up` |
+
+Not echoed: the retry nudge (`"Respond with exactly one tool call."`) — it is
+bookkeeping the plugin generates, not model output — and the system prompt
+built in `reset()` (static template plus embodiment docs; the goal line
+carries the per-trial information). The ignored-filler for extra tool calls
+*is* echoed (unlike the nudge) because without it an operator seeing two
+`tool_call` lines followed by one `--` result could not tell which call
+executed. The convention follows the code (`call, *extras =
+message.tool_calls`; `raw()` preserves wire order): the **first**
+`tool_call` line is the executed call, each subsequent line is an extra,
+then one `-- ignored` line per extra, and the final plain `--` line is the
+executed call's result — exactly matching the transcript order. Do not
+reorder the echo to put the executed call last; the lines mirror the
+message order verbatim.
+
+Two sites are one-way by design and must not be "fixed" into symmetry:
+`reset()` appends two messages (system + goal) but echoes only the goal, and
+`_forced_give_up` echoes a line while appending nothing to `_messages` (the
+synthetic give_up call never enters the transcript today; this plan does not
+change that).
+
+The observation summary reads the step from `observation.extra["env_step"]`
+(reserved by plan 0018; rollout injects it) with the **same
+`isinstance(step, int)` gate the prompt label uses** — extract the current
+suffix expression into a shared helper so any `env_step` value renders
+identically in both places (string and `np.int64` are rejected; `True` is
+accepted and renders as `step True`, since bool is an int subclass — the
+pinned fallback test asserts exactly that, so do not add a bool
+exclusion); a bare presence
+check would let echo and prompt drift (the prompt's fallbacks are pinned by
+`test_observation_content_step_label_fallbacks`). When the gate rejects,
+the step field is omitted: `[agent] >> observation: ...`. State lines reuse
+the exact `state[{key}]:` rendering already produced for the prompt — the
+summary calls the same formatting helper, so echo and prompt can never
+drift. To keep it one line, multiple state keys are joined with `" | "`.
+
+### Implementation sketch
+
+```python
+def _echo(self, text: str) -> None:
+    if self._transcript_echo:
+        print(text, file=sys.stderr, flush=True)
+```
+
+- `flush=True` per line: the whole point is liveness; stderr is typically
+  line-buffered under a TTY but block-buffered when piped (e.g. `2>&1 | tee`).
+- The state-text formatting currently inlined in `_observation_content()` is
+  extracted into a module-level helper `_state_lines(observation,
+  state_labels) -> list[str]` used by both the prompt builder and the echo
+  summary. Pure refactor; prompt bytes are unchanged.
+- Assistant echo: `message.raw()` is the wire dict. `content` may be `None`
+  or `str` (this client never receives list content from the API). Echo the
+  string form only when non-empty; then iterate `message.tool_calls`
+  (already parsed `ToolCall` objects) for the `tool_call` lines —
+  `arguments` is echoed as the raw JSON string from the wire, not re-encoded.
+
+### Config surface
+
+- Constructor: `transcript_echo: bool = False`.
+- `AgentPolicyConfig` gains `transcript_echo: bool = False` so the setting is
+  recorded in `EvalSpec.policy_config` like every other inference-time knob.
+- No validation needed (any Python truthiness is acceptable; annotate `bool`).
+
+## Versioning
+
+`plugins/inspect-robots-agent` 0.7.0 → **0.8.0** (new feature, minor). Update
+the version pin in `plugins/inspect-robots-agent/tests/test_package.py`
+together with `pyproject.toml`, and run `uv lock` (workspace lockfile tracks
+plugin versions).
+
+## Tests (plugin suite; not under the core 100% gate but plugin CI runs them)
+
+In `plugins/inspect-robots-agent/tests/` (reuse the existing fake-transport
+harness from `test_policy_e2e.py`):
+
+1. Default off: a full reset→act cycle writes nothing to stderr (capsys).
+2. `transcript_echo=True`: stderr contains, in order, the goal line, a
+   `>> step 0:` observation summary, the assistant `<<` echo (text and
+   `tool_call` line), and the `--` tool-result line. The existing response
+   helpers are either/or (`_tool_response` hardcodes `content: None`,
+   `_text_response` has no tool_calls), so add a small combined
+   text-plus-tool-call response helper for this test.
+2b. Multi-tool-call turn: two `tool_call` lines followed by one
+   `-- ignored: one tool call per turn` line and the executed call's `--`
+   result, in that order, and the **first** `tool_call` line names the
+   executed call. Use the existing `_multi_tool_response` helper in
+   `test_policy_e2e.py` — no new helper needed for this test (the combined
+   text-plus-tool-call helper is only for test 2).
+2c. `flush=True` is pinned: run one echoing `act()` with `sys.stderr`
+   monkeypatched to a fake TextIO recording `flush()` calls (`print`
+   forwards `flush=True` to the stream); assert at least one flush per
+   echoed line. capsys alone cannot observe flushes.
+3. The observation summary contains the camera count and `state[...]` text
+   but no `data:image` substring (the no-base64 guarantee).
+4. Missing `env_step` (direct `act()` with plain extra): summary line uses the
+   stepless form and does not raise.
+5. Budget exhaustion path echoes the forced-give-up line
+   (`max_llm_calls=1`, second `act` → forced give_up).
+6. Assistant message with no text content (tool-call only): no empty `<<`
+   text line is printed.
+7. `AgentPolicyConfig` round-trip: `transcript_echo=True` lands in
+   `policy.config`.
+
+## Docs
+
+- Plugin README: the README has no parameter table — the knobs live in a
+  prose "Configuration knobs (all `-P key=value`)" sentence. Add
+  `transcript_echo` to that list and follow with one sentence on the stderr
+  format plus the `-P transcript_echo=true` example. Do not introduce a new
+  table. Follow the writing-style rules (no em dashes, no mid-sentence bold).
+
+## Out of scope
+
+- Streaming the transcript into Rerun (plan 0020 / issue #124).
+- Echoing token usage or latency (the `inference` transcript event already
+  records latency).
+- Truncating or wrapping long assistant messages: terminals wrap, and
+  truncation would destroy information the operator opted into seeing.

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -89,7 +89,11 @@ motion fall short of the tool's requested total.
 > on real hardware** unless you fully trust the policy and the rig.
 
 Configuration knobs (all `-P key=value`): `model`, `base_url`, `api_key_env`,
-`max_llm_calls` (default `100`), `temperature`, `effort`, `max_speed_frac`.
+`max_llm_calls` (default `100`), `temperature`, `effort`, `max_speed_frac`,
+`transcript_echo`.
+Set `-P transcript_echo=true` to print live `[agent]` conversation lines to
+stderr, including goals, observation summaries, assistant output, tool calls,
+and tool results.
 The speed fraction defaults to `0.1` and applies only to absolute modes.
 
 `LLMAgentPolicy.transcript()` returns the current conversation as a deep copy with streamed camera frames replaced by omission markers, ready for core eval-log persistence.

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.7.0"
+version = "0.8.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import copy
 import json
 import os
+import sys
 from dataclasses import dataclass
 from typing import Any
 
@@ -59,6 +60,7 @@ class AgentPolicyConfig(PolicyConfig):
     max_llm_calls: int = 100
     effort: str | None = "low"
     max_speed_frac: float = 0.1
+    transcript_echo: bool = False
 
 
 class LLMAgentPolicy(PolicyBase):
@@ -78,6 +80,7 @@ class LLMAgentPolicy(PolicyBase):
         temperature: float | None = None,
         effort: str | None = "low",
         max_speed_frac: float = 0.1,
+        transcript_echo: bool = False,
         transport: httpx.BaseTransport | None = None,
         env: dict[str, str] | None = None,
     ):
@@ -105,6 +108,7 @@ class LLMAgentPolicy(PolicyBase):
         # below the model, so effort trades thinking time, not safety).
         self._effort = effort
         self._max_speed_frac = max_speed_frac
+        self._transcript_echo = transcript_echo
         self.config = AgentPolicyConfig(
             temperature=temperature,
             model=provider.model,
@@ -113,6 +117,7 @@ class LLMAgentPolicy(PolicyBase):
             max_llm_calls=max_llm_calls,
             effort=effort,
             max_speed_frac=max_speed_frac,
+            transcript_echo=transcript_echo,
         )
         # Placeholder until bind(); eval() always binds before compat/rollout.
         self.info = PolicyInfo(name="agent", action_space=Box(shape=(1,)))
@@ -157,6 +162,7 @@ class LLMAgentPolicy(PolicyBase):
             },
             {"role": "user", "content": f"Goal: {scene.instruction}"},
         ]
+        self._echo(f"[agent] goal: {scene.instruction}")
         self._calls_used = 0
 
     def transcript(self) -> list[dict[str, Any]] | None:
@@ -192,9 +198,19 @@ class LLMAgentPolicy(PolicyBase):
                 "content": _observation_content(observation, self._state_labels),
             }
         )
+        summary = f"{len(observation.images)} camera(s)"
+        state_summary = " | ".join(_state_lines(observation, self._state_labels))
+        if state_summary:
+            summary = f"{summary}, {state_summary}"
+        step_label = _step_label(observation)
+        if step_label:
+            self._echo(f"[agent] >> {step_label}: {summary}")
+        else:
+            self._echo(f"[agent] >> observation: {summary}")
         failures = 0
         while True:
             if self._calls_used >= self._max_llm_calls:
+                self._echo("[agent] -- LLM call budget exhausted; forcing give_up")
                 return self._forced_give_up(toolset, observation, "LLM call budget exhausted")
             message = self._client.complete(
                 self._messages,
@@ -203,7 +219,13 @@ class LLMAgentPolicy(PolicyBase):
                 reasoning_effort=self._effort,
             )
             self._calls_used += 1
-            self._messages.append(message.raw())
+            raw_message = message.raw()
+            self._messages.append(raw_message)
+            content = raw_message.get("content")
+            if isinstance(content, str) and content:
+                self._echo(f"[agent] << {content}")
+            for tool_call in message.tool_calls:
+                self._echo(f"[agent] << tool_call {tool_call.name}({tool_call.arguments})")
 
             if not message.tool_calls:
                 failures += 1
@@ -225,10 +247,12 @@ class LLMAgentPolicy(PolicyBase):
                         "content": "ignored: one tool call per turn",
                     }
                 )
+                self._echo("[agent] -- ignored: one tool call per turn")
             result = toolset.execute(call, observation)
             self._messages.append(
                 {"role": "tool", "tool_call_id": call.id, "content": result.error or result.note}
             )
+            self._echo(f"[agent] -- {result.error or result.note}")
             if result.error:
                 failures += 1
                 if failures >= _MAX_CONSECUTIVE_FAILURES:
@@ -243,15 +267,16 @@ class LLMAgentPolicy(PolicyBase):
         assert result.chunk is not None
         return result.chunk
 
+    def _echo(self, text: str) -> None:
+        if self._transcript_echo:
+            print(text, file=sys.stderr, flush=True)
 
-def _observation_content(
+
+def _state_lines(
     observation: Observation,
     state_labels: tuple[str, tuple[str, ...]] | None = None,
-) -> list[dict[str, Any]]:
-    """State as readable text plus camera frames as inline PNG data URLs."""
-    lines = ["Current observation."]
-    if observation.instruction:
-        lines.append(f"Instruction: {observation.instruction}")
+) -> list[str]:
+    lines: list[str] = []
     for key, value in observation.state.items():
         array = np.asarray(value, dtype=np.float64)
         rounded = np.round(array, 4).tolist()
@@ -264,9 +289,26 @@ def _observation_content(
                 lines.append(f"state[{key}]: {labeled}")
                 continue
         lines.append(f"state[{key}]: {rounded}")
-    parts: list[dict[str, Any]] = [{"type": "text", "text": "\n".join(lines)}]
+    return lines
+
+
+def _step_label(observation: Observation) -> str:
     step = observation.extra.get("env_step")
-    suffix = f" (step {step})" if isinstance(step, int) else ""
+    return f"step {step}" if isinstance(step, int) else ""
+
+
+def _observation_content(
+    observation: Observation,
+    state_labels: tuple[str, tuple[str, ...]] | None = None,
+) -> list[dict[str, Any]]:
+    """State as readable text plus camera frames as inline PNG data URLs."""
+    lines = ["Current observation."]
+    if observation.instruction:
+        lines.append(f"Instruction: {observation.instruction}")
+    lines.extend(_state_lines(observation, state_labels))
+    parts: list[dict[str, Any]] = [{"type": "text", "text": "\n".join(lines)}]
+    step_label = _step_label(observation)
+    suffix = f" ({step_label})" if step_label else ""
     for name, image in observation.images.items():
         parts.append({"type": "text", "text": f"camera {name!r}{suffix}:"})
         parts.append({"type": "image_url", "image_url": {"url": png_data_url(image)}})

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -210,7 +210,6 @@ class LLMAgentPolicy(PolicyBase):
         failures = 0
         while True:
             if self._calls_used >= self._max_llm_calls:
-                self._echo("[agent] -- LLM call budget exhausted; forcing give_up")
                 return self._forced_give_up(toolset, observation, "LLM call budget exhausted")
             message = self._client.complete(
                 self._messages,
@@ -262,6 +261,9 @@ class LLMAgentPolicy(PolicyBase):
             return result.chunk
 
     def _forced_give_up(self, toolset: Toolset, observation: Observation, why: str) -> ActionChunk:
+        # Echoed but never appended to _messages: the synthetic call is not
+        # model output, so it stays out of the transcript.
+        self._echo(f"[agent] -- {why}; forcing give_up")
         synthetic = ToolCall(id="budget", name="give_up", arguments=json.dumps({"reason": why}))
         result = toolset.execute(synthetic, observation)
         assert result.chunk is not None
@@ -276,6 +278,7 @@ def _state_lines(
     observation: Observation,
     state_labels: tuple[str, tuple[str, ...]] | None = None,
 ) -> list[str]:
+    """One state[key] line per state entry, shared by prompt and echo so they never drift."""
     lines: list[str] = []
     for key, value in observation.state.items():
         array = np.asarray(value, dtype=np.float64)
@@ -293,6 +296,7 @@ def _state_lines(
 
 
 def _step_label(observation: Observation) -> str:
+    """Shared prompt/echo step gate: "step {n}" for int env_step (bool included), else ""."""
     step = observation.extra.get("env_step")
     return f"step {step}" if isinstance(step, int) else ""
 

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,5 +6,5 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.7.0"
+    assert inspect_robots_agent.__version__ == "0.8.0"
     assert callable(inspect_robots_agent.agent_policy)

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -7,7 +7,9 @@ guardrails, policy-stop, budgets, error taxonomy) runs for real.
 
 from __future__ import annotations
 
+import io
 import json
+import sys
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
@@ -30,7 +32,7 @@ from inspect_robots.types import Action, Observation, StepResult
 from inspect_robots_agent import LLMAgentPolicy
 from inspect_robots_agent._llm import ChatClient, resolve_provider
 from inspect_robots_agent._png import encode_png
-from inspect_robots_agent.policy import _SYSTEM_TEMPLATE, _observation_content
+from inspect_robots_agent.policy import _SYSTEM_TEMPLATE, AgentPolicyConfig, _observation_content
 
 # --- scripted-conversation harness ---------------------------------------------
 
@@ -57,6 +59,26 @@ def _tool_response(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
 
 def _text_response(text: str) -> dict[str, Any]:
     return {"choices": [{"message": {"role": "assistant", "content": text}}]}
+
+
+def _text_and_tool_response(text: str, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": text,
+                    "tool_calls": [
+                        {
+                            "id": f"call_{name}",
+                            "type": "function",
+                            "function": {"name": name, "arguments": json.dumps(arguments)},
+                        }
+                    ],
+                }
+            }
+        ]
+    }
 
 
 def _multi_tool_response(calls: list[tuple[str, dict[str, Any]]]) -> dict[str, Any]:
@@ -91,6 +113,21 @@ class _Script:
         self.requests.append(json.loads(request.content))
         payload = self.queue.pop(0) if len(self.queue) > 1 else self.queue[0]
         return httpx.Response(200, json=payload)
+
+
+class _FlushRecordingStream(io.StringIO):
+    def __init__(self) -> None:
+        super().__init__()
+        self.write_calls: list[str] = []
+        self.flush_calls = 0
+
+    def write(self, text: str) -> int:
+        self.write_calls.append(text)
+        return super().write(text)
+
+    def flush(self) -> None:
+        self.flush_calls += 1
+        super().flush()
 
 
 def _policy(script: _Script, **kwargs: Any) -> LLMAgentPolicy:
@@ -302,6 +339,162 @@ def test_observation_content_step_label_fallbacks() -> None:
     assert string_step[1]["text"] == "camera 'top':"
     assert bool_step[1]["text"] == "camera 'top' (step True):"
     assert numpy_step[1]["text"] == "camera 'top':"
+
+
+def test_transcript_echo_defaults_off(capsys: pytest.CaptureFixture[str]) -> None:
+    policy = _policy(_Script([_tool_response("done", {"summary": "quiet"})]))
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="observe quietly"))
+    policy.act(Observation(extra={"env_step": 0}))
+
+    assert capsys.readouterr().err == ""
+
+
+def test_transcript_echo_reports_conversation_in_order(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    policy = _policy(
+        _Script([_text_and_tool_response("The goal is complete.", "done", {"summary": "ok"})]),
+        transcript_echo=True,
+    )
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="inspect the cube"))
+    policy.act(
+        Observation(
+            state={"eef_pos": np.array([0.123456, -0.2])},
+            extra={"env_step": 0},
+        )
+    )
+
+    lines = capsys.readouterr().err.splitlines()
+    expected = [
+        "[agent] goal: inspect the cube",
+        "[agent] >> step 0: 0 camera(s), state[eef_pos]: [0.1235, -0.2]",
+        "[agent] << The goal is complete.",
+        '[agent] << tool_call done({"summary": "ok"})',
+        "[agent] -- done: ok",
+    ]
+    positions = [lines.index(line) for line in expected]
+    assert positions == sorted(positions)
+
+
+def test_transcript_echo_marks_extra_tool_calls_before_executed_result(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    policy = _policy(
+        _Script(
+            [
+                _multi_tool_response(
+                    [
+                        ("done", {"summary": "first executes"}),
+                        ("give_up", {"reason": "extra"}),
+                    ]
+                )
+            ]
+        ),
+        transcript_echo=True,
+    )
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="stop"))
+    policy.act(Observation(extra={"env_step": 0}))
+
+    event_lines = [
+        line
+        for line in capsys.readouterr().err.splitlines()
+        if "tool_call" in line or line.startswith("[agent] --")
+    ]
+    assert event_lines == [
+        '[agent] << tool_call done({"summary": "first executes"})',
+        '[agent] << tool_call give_up({"reason": "extra"})',
+        "[agent] -- ignored: one tool call per turn",
+        "[agent] -- done: first executes",
+    ]
+
+
+def test_transcript_echo_flushes_every_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    policy = _policy(
+        _Script([_tool_response("done", {"summary": "flushed"})]), transcript_echo=True
+    )
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="flush"))
+    stream = _FlushRecordingStream()
+    monkeypatch.setattr(sys, "stderr", stream)
+
+    policy.act(Observation(extra={"env_step": 0}))
+
+    newline_count = sum(part.count("\n") for part in stream.write_calls)
+    assert newline_count > 0
+    assert stream.flush_calls >= newline_count
+
+
+def test_transcript_echo_observation_omits_image_payloads(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    policy = _policy(
+        _Script([_tool_response("done", {"summary": "observed"})]), transcript_echo=True
+    )
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="observe"))
+    policy.act(
+        Observation(
+            state={"eef_pos": np.array([0.123456])},
+            images={"top": np.zeros((1, 1, 3), dtype=np.uint8)},
+            extra={"env_step": 0},
+        )
+    )
+
+    stderr = capsys.readouterr().err
+    assert "[agent] >> step 0: 1 camera(s), state[eef_pos]: [0.1235]" in stderr
+    assert "data:image" not in stderr
+
+
+def test_transcript_echo_observation_without_environment_step(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    policy = _policy(
+        _Script([_tool_response("done", {"summary": "observed"})]), transcript_echo=True
+    )
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="observe"))
+    policy.act(Observation(state={"eef_pos": np.array([0.0])}))
+
+    assert "[agent] >> observation: 0 camera(s), state[eef_pos]: [0.0]" in capsys.readouterr().err
+
+
+def test_transcript_echo_reports_forced_give_up(capsys: pytest.CaptureFixture[str]) -> None:
+    policy = _policy(
+        _Script([_tool_response("move_by", {"deltas": {"dx": 0.01}})]),
+        max_llm_calls=1,
+        transcript_echo=True,
+    )
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="move"))
+    policy.act(Observation(extra={"env_step": 0}))
+    policy.act(Observation(extra={"env_step": 1}))
+
+    assert "[agent] -- LLM call budget exhausted; forcing give_up" in capsys.readouterr().err
+
+
+def test_transcript_echo_omits_empty_assistant_text(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    policy = _policy(
+        _Script([_tool_response("done", {"summary": "no text"})]), transcript_echo=True
+    )
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="stop"))
+    policy.act(Observation(extra={"env_step": 0}))
+
+    assert not any(
+        line in {"[agent] <<", "[agent] << "} for line in capsys.readouterr().err.splitlines()
+    )
+
+
+def test_transcript_echo_lands_in_policy_config() -> None:
+    policy = _policy(_Script([_text_response("unused")]), transcript_echo=True)
+
+    assert isinstance(policy.config, AgentPolicyConfig)
+    assert policy.config.transcript_echo is True
 
 
 def test_transcript_preserves_step_label_next_to_elided_image() -> None:

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -388,6 +388,7 @@ def test_transcript_echo_marks_extra_tool_calls_before_executed_result(
                     [
                         ("done", {"summary": "first executes"}),
                         ("give_up", {"reason": "extra"}),
+                        ("give_up", {"reason": "second extra"}),
                     ]
                 )
             ]
@@ -406,6 +407,8 @@ def test_transcript_echo_marks_extra_tool_calls_before_executed_result(
     assert event_lines == [
         '[agent] << tool_call done({"summary": "first executes"})',
         '[agent] << tool_call give_up({"reason": "extra"})',
+        '[agent] << tool_call give_up({"reason": "second extra"})',
+        "[agent] -- ignored: one tool call per turn",
         "[agent] -- ignored: one tool call per turn",
         "[agent] -- done: first executes",
     ]
@@ -448,17 +451,45 @@ def test_transcript_echo_observation_omits_image_payloads(
     assert "data:image" not in stderr
 
 
+@pytest.mark.parametrize(
+    "extra",
+    [{}, {"env_step": "3"}],
+    ids=["missing", "non_int_string"],
+)
 def test_transcript_echo_observation_without_environment_step(
-    capsys: pytest.CaptureFixture[str],
+    extra: dict[str, Any], capsys: pytest.CaptureFixture[str]
 ) -> None:
     policy = _policy(
         _Script([_tool_response("done", {"summary": "observed"})]), transcript_echo=True
     )
     policy.bind(CubePickEmbodiment().info)
     policy.reset(Scene(id="s0", instruction="observe"))
-    policy.act(Observation(state={"eef_pos": np.array([0.0])}))
+    policy.act(Observation(state={"eef_pos": np.array([0.0])}, extra=extra))
 
-    assert "[agent] >> observation: 0 camera(s), state[eef_pos]: [0.0]" in capsys.readouterr().err
+    stderr = capsys.readouterr().err
+    assert "[agent] >> observation: 0 camera(s), state[eef_pos]: [0.0]" in stderr
+    assert ">> step" not in stderr
+
+
+def test_transcript_echo_never_echoes_retry_nudge(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    policy = _policy(
+        _Script(
+            [
+                _text_response("thinking out loud, no tool call"),
+                _tool_response("done", {"summary": "recovered"}),
+            ]
+        ),
+        transcript_echo=True,
+    )
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="recover"))
+    policy.act(Observation(extra={"env_step": 0}))
+
+    stderr = capsys.readouterr().err
+    assert "[agent] << thinking out loud, no tool call" in stderr
+    assert "Respond with exactly one tool call." not in stderr
 
 
 def test_transcript_echo_reports_forced_give_up(capsys: pytest.CaptureFixture[str]) -> None:
@@ -475,19 +506,26 @@ def test_transcript_echo_reports_forced_give_up(capsys: pytest.CaptureFixture[st
     assert "[agent] -- LLM call budget exhausted; forcing give_up" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize(
+    "response",
+    [
+        _tool_response("done", {"summary": "no text"}),
+        _text_and_tool_response("", "done", {"summary": "no text"}),
+    ],
+    ids=["content_none", "content_empty_string"],
+)
 def test_transcript_echo_omits_empty_assistant_text(
-    capsys: pytest.CaptureFixture[str],
+    response: dict[str, Any], capsys: pytest.CaptureFixture[str]
 ) -> None:
-    policy = _policy(
-        _Script([_tool_response("done", {"summary": "no text"})]), transcript_echo=True
-    )
+    policy = _policy(_Script([response]), transcript_echo=True)
     policy.bind(CubePickEmbodiment().info)
     policy.reset(Scene(id="s0", instruction="stop"))
     policy.act(Observation(extra={"env_step": 0}))
 
-    assert not any(
-        line in {"[agent] <<", "[agent] << "} for line in capsys.readouterr().err.splitlines()
-    )
+    assistant_lines = [
+        line for line in capsys.readouterr().err.splitlines() if line.startswith("[agent] <<")
+    ]
+    assert assistant_lines == ['[agent] << tool_call done({"summary": "no text"})']
 
 
 def test_transcript_echo_lands_in_policy_config() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -520,7 +520,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #123

## What

An opt-in \`-P transcript_echo=true\` knob on the agent plugin's \`LLMAgentPolicy\`. When enabled, the policy prints each conversation event to stderr the moment it happens, so an operator standing at the rig can follow what the model is thinking during a live run instead of waiting for the eval log.

## Format

\`\`\`
[agent] goal: pick up the cube
[agent] >> step 480: 2 camera(s), state[eef_pos]: [0.1235, -0.2]
[agent] << The cube is visible on the left.
[agent] << tool_call move_by({"deltas": {"dx": 0.01}})
[agent] -- moved by requested deltas
\`\`\`

- Stderr with \`flush=True\` per line (stdout stays machine-consumable; piped output stays live).
- Tool calls echo in wire order; the first \`tool_call\` line is the executed call, extras each get an \`-- ignored: one tool call per turn\` line, matching the transcript exactly.
- Image payloads are never echoed; the observation summary is camera count plus the same \`state[...]\` text the prompt uses (shared helper, prompt bytes unchanged).
- Budget exhaustion echoes the forced give_up. The retry nudge is not echoed (plugin bookkeeping, not model output).

## Notes

- No core changes; agent plugin only, 0.7.0 -> 0.8.0 (pin + \`uv lock\` updated).
- Design doc: \`plans/0019-transcript-echo.md\` (three critique rounds).
- 9 new tests: default-off, full ordering, multi-tool-call ordering, flush pinning, no-base64, stepless fallback, forced give_up, empty assistant text, config round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)