### PR TITLE
feat: stream the LLM transcript onto the Rerun step timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- Live agent-policy transcript rows on the Rerun `step` timeline, with
+  best-effort non-blocking streaming and complete eval-log persistence (#124).
 - Remote Rerun streaming via `inspect-robots run --rerun-connect [URL]`, so
   headless evaluations can connect over gRPC to a viewer on another machine
   (including through an SSH reverse tunnel) (#86).

--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -74,6 +74,20 @@ The three modes are mutually exclusive: rerun's `save`/`spawn`/`connect_grpc`
 calls each replace the SDK's global sink, so combining them raises `ValueError`
 rather than silently dropping a stream.
 
+### Live transcript in the viewer
+
+Policies that support transcript streaming automatically add conversation rows
+at `trial/<scene>/e<epoch>/llm`. In the Rerun viewer, add a TextLog view and
+select that entity path. Tool results use the DEBUG level and system prompts use
+TRACE, so enable both levels in the view's log-level filter to see the whole
+conversation.
+
+Scrubbing the `step` timeline highlights the transcript rows emitted for that
+control step alongside its camera and state data. This live stream is a
+best-effort visualization and transcript updates may be dropped under
+backpressure. The transcript persisted in the eval log is collected separately
+at trial end and remains the complete audit record.
+
 On a headless robot box, `spawn=True` has nowhere to open a window. Run the
 viewer on your own machine instead and stream to it: `rerun` on your laptop,
 `ssh -R 9876:localhost:9876 <robot>` for the tunnel, then

--- a/plans/0020-rerun-transcript-stream.md
+++ b/plans/0020-rerun-transcript-stream.md
@@ -1,0 +1,392 @@
+# 0020 — Stream the LLM transcript onto the Rerun step timeline
+
+Issue: #124. Status: draft.
+
+## Problem
+
+An agent-policy run with the Rerun viewer open shows camera frames, state,
+and actions live, but the conversation driving those actions is invisible
+until the eval log is written. The transcript should scrub alongside the
+video: pause the timeline at step 480 and see what the model said there.
+
+## Design overview
+
+Three small pieces, each following an existing pattern in this codebase:
+
+1. **Policy side** — a new optional duck-typed hook `transcript_delta()`
+   (same mechanism as the existing `bind()` / `transcript()` hooks): return
+   the sanitized transcript messages appended since the previous call.
+   Implemented by the agent plugin; absent everywhere else.
+2. **Rollout side** — `rollout()` already knows the exact step at which an
+   inference happened: the `len(inferences) > prev_inferences` check on the
+   controller store that emits `inference_event`. At that seam, fetch the
+   delta and hand it to the sink via a new **optional** sink hook
+   `log_policy_messages(t, messages)`.
+3. **Sink side** — `RerunSink` renders each message as one `rr.TextLog`
+   entity row under `{trial-prefix}/llm` on the existing `step` timeline,
+   through the existing backpressure-safe worker queue.
+
+Live streaming is best-effort visualization, like everything else the sink
+does: any failure degrades to "no live text" and never affects the control
+loop, the eval log, or the persisted transcript (which keeps coming from the
+end-of-trial `_collect_transcript` path, unchanged).
+
+## Core: the sink hook (`logging/sink.py`, `eval.py`)
+
+`log_policy_messages(self, t: int, messages: Sequence[Any]) -> None`
+
+- **Not added to the `LogSink` Protocol.** The Protocol is structural and
+  `runtime_checkable`; adding a sixth method would silently break every
+  third-party sink (isinstance checks and mypy conformance). Instead the
+  hook is duck-typed and documented in the `sink.py` module docstring as the
+  optional extension, mirroring how optional policy hooks are documented in
+  `policy.py`.
+- `NullSink` does **not** gain a stub either. A no-op on `NullSink` would
+  be inherited by every sink built on it ("a convenient base for partial
+  implementations"), advertising the hook and opening the `_Broadcast`
+  gate below just to feed a no-op — exactly the per-inference
+  `transcript_delta()` waste that gate exists to avoid. The hook is purely
+  duck-typed. (Note the policy side is *not* a precedent for stubs-off:
+  `PolicyBase` does ship `bind()`/`transcript()` defaults; the sink side
+  deliberately diverges because a stub here has a per-inference cost via
+  the gate, and the divergence is documented.) The contract lives in the
+  `sink.py` module docstring: called at most once per control step, only for steps
+  where the policy performed an inference. On message shape, the docstring
+  words it as an **expectation on policy implementations**, not a
+  core-enforced invariant: policies are documented to return plain JSON
+  types (the same shape as `TrialRecord.policy_transcript` entries), but the
+  core does **not** json-normalize the delta path the way
+  `_collect_transcript` does, so sinks must render defensively. Sinks must
+  not mutate the messages.
+- `_Broadcast` (eval.py) fans to exactly those child sinks where
+  `getattr(s, "log_policy_messages", None)` is callable, and — key detail —
+  exposes the hook **only when at least one child implements it**, computed
+  at construction: `__init__` collects the **getattr-resolved callables**,
+  not the sinks (`self._sinks` is `list[LogSink]` and the Protocol has no
+  such method, so calling it on a `LogSink`-typed element is an
+  `[attr-defined]` mypy-strict error; `getattr` returns `Any`, collected as
+  `list[Callable[[int, Sequence[Any]], None]]`), and binds
+  `self.log_policy_messages = self._fan_policy_messages` as an *instance*
+  attribute only when that list is non-empty (no class-level definition —
+  an ordinary `__init__`-inferred attribute, not a `[method-assign]`
+  violation, and the API snapshot is untouched since `__all__` doesn't
+  change).
+  Otherwise the rollout's own `getattr` gate sees no hook and the policy's
+  `transcript_delta()` deepcopy never runs — without this, a plain
+  JsonLogSink-only run would pay an O(delta) deepcopy every inference and
+  discard the result. Accepted residual: a `RerunSink` in the list whose
+  `rerun-sdk` turns out missing/disabled still opens the gate (its
+  `log_policy_messages` is an unconditional method; availability is lazy
+  and only known after construction), so that configuration pays the
+  deepcopy for calls that `_ensure_rerun()` turns into no-ops. The cost is
+  small and the configuration is transient; do not engineer around it. `JsonLogSink` does not implement the hook (the JSON
+  log already gets the full transcript at trial end).
+
+## Core: the rollout seam (`rollout.py`)
+
+Both hooks are resolved **once before the loop** (not per step, and not via
+a per-call helper):
+
+```python
+delta_hook = getattr(policy, "transcript_delta", None)
+messages_hook = getattr(sink, "log_policy_messages", None)
+stream_ok = callable(delta_hook) and callable(messages_hook)
+```
+
+Inside the existing inference-detection block:
+
+```python
+inferences = store.get(_INFER_KEY, [])
+if len(inferences) > prev_inferences:
+    latency, chunk_len = inferences[-1]
+    record.events.append(inference_event(t, latency, chunk_len))
+    if stream_ok:
+        try:
+            delta = delta_hook()
+            entries = list(delta) if delta is not None else []
+            if entries:
+                messages_hook(t, entries)
+        except Exception as exc:  # visualization must never kill the loop
+            stream_ok = False
+            warnings.warn(..., RuntimeWarning)
+```
+
+- Note the emptiness test happens **after** `list(delta)`: an exhausted
+  generator (or any empty non-list iterable) is truthy as an object, so a
+  bare `if delta:` would call the sink with zero entries. Materialize
+  first, then test the list.
+- `stream_ok` starts as the callable check and doubles as the failure
+  latch. If the policy hook or the sink hook raises, emit **one**
+  `RuntimeWarning` naming the exception and clear `stream_ok` for the rest
+  of the trial — visualization must not spam or crash a multi-hour run.
+  (`_collect_transcript` degrades similarly at trial end.) `rollout.py`
+  does not currently import `warnings`; add the import, and pass
+  `stacklevel=2` to satisfy ruff B028.
+- The sink hook is called only when the materialized delta is non-empty.
+- Ordering: the delta is fetched *after* `inference_event` is appended and
+  *before* `sink.log_step(t, ...)` for the same `t` — sinks see the text at
+  the same step index as the frames the model was acting from. (`log_step`
+  for step `t` happens later in the same loop iteration, so both land on the
+  same timeline point.)
+- The hook is consumed only here. The end-of-trial `_collect_transcript`
+  still calls `transcript()` and is unaffected: `transcript_delta()`'s
+  cursor is internal to the policy, and `transcript()` remains the full
+  conversation.
+
+## Core: policy hook contract (`policy.py` docstring)
+
+Document `transcript_delta()` next to the existing `transcript()` hook
+documentation. The `Policy` Protocol docstring currently says policies "may
+additionally define two optional hooks" and that "`PolicyBase` ships
+defaults for both" — reword to **three** hooks and state explicitly that
+`transcript_delta` has **no** `PolicyBase` default (deliberate: a default
+returning `None` would make every `PolicyBase` policy pass the rollout's
+`callable(delta_hook)` check and pay a no-op call per inference; policies
+opt in by defining it). `PolicyBase` itself is unchanged.
+
+Contract for the new hook:
+
+- Returns `list` of plain-JSON-type messages appended since the previous
+  `transcript_delta()` call (or since `reset` for the first call), or
+  `None`/empty when nothing is new.
+- Must be O(new messages): implementations sanitize only the delta slice.
+- Must already be sanitized (image bytes elided) — the core forwards it
+  verbatim to visualization sinks.
+- `reset()` must rewind the cursor so a new trial starts from its first
+  message.
+
+## Core: RerunSink (`logging/rerun_sink.py`)
+
+New frozen payload dataclass:
+
+```python
+@dataclasses.dataclass(frozen=True)
+class _TranscriptPayload:
+    prefix: str
+    t: int
+    entries: tuple[tuple[str, str], ...]  # (level, text) per message
+```
+
+- `log_policy_messages(t, messages)` **mirrors `log_step`'s exact
+  sequence**: `_ensure_rerun()` guard first (return if the SDK is
+  unavailable/disabled), render, `_ensure_worker()`, then `_enqueue`. It
+  is a public method on a public class, so ruff D102 requires a
+  contract-style docstring (state the best-effort semantics and the
+  do-not-mutate expectation, not the method name).
+  Skipping `_ensure_worker()` would be a real bug, not an optimization:
+  on step-error paths a transcript payload can be the *first* thing
+  enqueued in a trial, and without the worker-spawn call it would sit in a
+  workerless queue, stalling `flush()` for its full timeout at trial end
+  with no drop accounting.
+- Rendering happens eagerly on the caller thread (pure string work, no SDK
+  calls — SDK timeline state stays worker-only), snapshotting
+  `self._prefix`.
+- Rendering `_render_message(msg) -> tuple[str, str]` (levels are plain
+  uppercase string literals, see below):
+  - Non-dict message: `("INFO", str(msg))` (defensive; contract says dicts).
+  - `role` maps to a Rerun `TextLog` level so the viewer color-codes rows:
+    `assistant → "INFO"`, `user → "INFO"` (the observation text is a
+    primary thing an operator scrubs for; the `role: ` text prefix keeps
+    the two apart), `tool → "DEBUG"`, `system`/other → `"TRACE"`. Rerun's
+    levels are **uppercase** (lowercase strings lose the viewer's color
+    coding). Pass the string literals `"INFO"`/`"DEBUG"`/`"TRACE"`
+    directly to `rr.TextLog(text, level=...)` — the SDK's `TextLogLevel`
+    constants are a `str` subclass with exactly these values and the
+    `level` parameter accepts any string, so a
+    `getattr(rr, "TextLogLevel", ...)` resolution would add an
+    SDK-present/absent branch that the fake-`rr` test harness can never
+    exercise (100% branch gate). No resolution, no branch.
+  - Implementation checkpoint: eyeball one run in a real viewer to confirm
+    DEBUG/TRACE rows are visible under the default TextLog view filter;
+    the docs subsection documents the level filter either way.
+  - Text: `role: ` prefix, then `content` if it is a non-empty `str`; if
+    `content` is a list (multi-part observation), join the `text` fields of
+    dict parts with newlines and render any non-text part as
+    `[{type} part]`; if the message has `tool_calls`, append one
+    `tool_call {name}({arguments})` line per call. The wire shape is
+    **nested**: each entry is
+    `{"id": ..., "type": "function", "function": {"name": ..., "arguments": ...}}`
+    (`_llm.py` stores them exactly as received), so name/arguments come
+    from `call.get("function", {})`, not the top level. Defensive `.get`s
+    throughout — a malformed entry must render, not raise.
+- `_enqueue` / eviction bookkeeping: the queue becomes
+  `deque[_StepPayload | _TranscriptPayload]`. The camera-frame watermark
+  drop and the `len(evicted.images)` counters apply only to `_StepPayload`
+  (isinstance-guarded); an evicted transcript payload increments a **new
+  third counter** `_dropped_transcripts` (not `_dropped_steps` — the
+  end-of-run warning says "dropped N camera frame(s) and M full step(s)"
+  and its "reduce camera bandwidth" advice would be wrong for text rows,
+  so transcript drops get their own count reported as "K transcript
+  update(s)"). Transcript payloads are small text and never trigger the
+  image watermark. Update the warning message and the module docstring's
+  degradation ladder ("camera frames are dropped first ... then whole
+  steps") to mention transcript rows. Three parts of the drop-report block
+  must change together, not just the message: the warning **gate** becomes
+  `if self._dropped_frames or self._dropped_steps or
+  self._dropped_transcripts:`, and **all three** counters are reset inside
+  it — otherwise a run whose only drops are transcript payloads warns
+  never, and the stale transcript count leaks into the next eval's report.
+  (Branch coverage cannot catch a missed `or` arm, so the transcript-only
+  test below is the real guard.) The existing assertion
+  `"dropped 1 camera frame(s) and 1 full step(s)"` in
+  `tests/test_rerun_sink.py` must survive the reword: the transcript
+  fragment is appended only when its counter is non-zero.
+- `_shutdown`'s wedged-drain accounting has the same mixed-queue problem:
+  today it does `self._dropped_frames += sum(len(p.images) for p in
+  self._queue)` over the disowned backlog, which raises `AttributeError`
+  on a `_TranscriptPayload`. Guard with the same isinstance split: step
+  payloads add their image count to `_dropped_frames` and one to
+  `_dropped_steps`; transcript payloads add one to `_dropped_transcripts`,
+  consistent with eviction.
+- `_emit` dispatches on payload type; `_emit_transcript` does
+  `self._set_step(rr, payload.t)` then one
+  `rr.log(f"{payload.prefix}/llm", rr.TextLog(text, level=level))` per
+  entry. Multiple messages at one step become multiple rows at the same
+  timeline point, in conversation order (the worker preserves queue order).
+- The `llm` segment joins the existing per-trial namespace
+  (`trial/<scene_id>/e<epoch>/llm`), so successive trials never interleave.
+
+## Agent plugin (`plugins/inspect-robots-agent`)
+
+- Extract the elision loop from `transcript()` into a module-level
+  `_sanitize(messages: list[dict[str, Any]]) -> list[dict[str, Any]]`
+  (deepcopy + image-part elision; the bare-`dict` spelling would fail the
+  plugin's mypy-strict `disallow_any_generics`); `transcript()` becomes
+  `_sanitize(self._messages)` on non-empty.
+- New method:
+
+```python
+def transcript_delta(self) -> list[dict[str, Any]] | None:
+    """Sanitized messages appended since the previous call (core live-stream hook)."""
+    new = self._messages[self._delta_cursor :]
+    self._delta_cursor = len(self._messages)
+    return _sanitize(new) if new else None
+```
+
+- `__init__` and `reset()` set `self._delta_cursor = 0`. The cursor is
+  independent of `transcript()`, which stays the full conversation.
+- Cost: O(delta) deepcopy once per chunk boundary (seconds apart), the
+  elision then drops the only large objects (base64 parts) before the list
+  crosses into the sink queue.
+
+## Versioning
+
+- Agent plugin 0.7.0 → **0.8.0** (minor: new hook). If plan 0019 merges
+  first and already claims 0.8.0, this becomes 0.9.0 — whichever lands
+  second takes the next minor. Update the `test_package.py` version pin and
+  `uv lock` together with the bump.
+- Core: minor release (new sink capability), version derived from the git
+  tag at release time as usual.
+
+## Tests
+
+Core (`tests/`, 100% branch gate):
+
+- **rollout** (extend `tests/test_rollout*.py` with the mock world):
+  1. Policy with `transcript_delta` + sink with `log_policy_messages`: hook
+     receives exactly the delta at the inference step `t`, before that
+     step's `log_step` (capture call order in a recording sink).
+  2. Policy without the hook: sink hook never called (gate branch).
+  3. Sink without the hook (a plain `NullSink` works — it deliberately
+     does not implement the hook): no error, no call (gate branch).
+  4. Hook returns `None` / empty list: sink hook not called (both branches).
+  5. Hook raises: exactly one `RuntimeWarning`, rollout completes, sink hook
+     not called again within the trial (`stream_ok` latch), trial record
+     unaffected.
+  6. Sink hook raises: same latch behavior.
+  7. Non-list iterable delta is materialized (`list(delta)`), and an
+     **empty generator** delta does not call the sink hook (the truthy-
+     generator trap: emptiness is tested after materialization).
+- **eval `_Broadcast`**: fans only to sinks defining the hook; mixed sink
+  list works; and when **no** child sink implements the hook,
+  `getattr(broadcast, "log_policy_messages", None)` is not callable — the
+  rollout gate stays closed and a policy `transcript_delta` spy is never
+  called.
+- **`NullSink`** does not expose `log_policy_messages`
+  (`getattr(NullSink(), "log_policy_messages", None) is None`) — pins the
+  deliberate omission so a helpful future refactor doesn't re-add it.
+- **RerunSink** (extend `tests/test_rerun_sink.py` fake-`rr` harness —
+  note the harness's `fake.TextLog = lambda t: ("TextLog", t)` must first
+  grow a `level` keyword, since the real call becomes
+  `rr.TextLog(text, level=...)`; without it the new call raises inside
+  `_emit`, gets swallowed by `_warn_emit_failure`, and test 1 fails
+  confusingly. No existing test asserts on a `TextLog` tuple (nothing
+  drives `terminated=True`), so nothing else ripples; the separate 1-arg
+  fake in `tests/test_coverage_completion.py` runs only `ScriptedPolicy`,
+  which has no `transcript_delta`, and must be left alone):
+  1. `log_policy_messages` → worker emits `TextLog` rows at the right
+     entity path and step, correct level per role, conversation order.
+     For the step assertion the fake harness must also record `set_time`
+     calls (today `fake.set_time = lambda *a, **k: None` discards them).
+  2. Rendering table: str content; list-of-parts content (text parts joined,
+     image part → `[image_url part]`); tool_calls line; non-dict message;
+     missing role; empty content with tool_calls only. Fixtures must be
+     **`raw()`-shaped**, i.e. tool_calls nested under `"function"` exactly
+     as `_llm.py` stores them — a flat `{"name": ..., "arguments": ...}`
+     fixture would let a flat-shape rendering bug pass.
+  3. Eviction: a transcript payload evicted under queue pressure increments
+     `_dropped_transcripts` and neither `_dropped_steps` nor
+     `_dropped_frames`; a `_StepPayload` evicted past a queued transcript
+     payload still counts its images; the end-of-run warning mentions
+     "transcript update(s)" only when that counter is non-zero.
+  3b. Transcript-only drops still warn: a run where the **only** drops are
+     transcript payloads emits the drop warning (pins the widened
+     `or self._dropped_transcripts` gate, which branch coverage alone
+     cannot force), and the test asserts **all three counters are zero
+     afterwards** — that reset assertion is the real pin (a bare
+     "second shutdown is quiet" check would pass trivially via the
+     worker-is-None early return, proving nothing about the reset). The
+     existing `"dropped 1 camera frame(s) and 1 full step(s)"` assertion
+     must keep passing unchanged (frames-and-steps-only run gets no
+     transcript fragment).
+  4. `log_policy_messages` as the **first** call of a trial (before any
+     `log_step`) spawns the worker and the row is emitted — pins the
+     `_ensure_rerun`/`_ensure_worker`/`_enqueue` sequence against the
+     workerless-queue stall.
+  5. Wedged shutdown with a `_TranscriptPayload` in the disowned backlog:
+     `_shutdown`'s drain accounting takes the isinstance branch for both
+     payload kinds (transcript → `_dropped_transcripts += 1`, step → its image
+     count), no `AttributeError`; the existing wedged-shutdown test only
+     fills the backlog with `_StepPayload`s, so this covers the new branch
+     the 100% gate demands.
+  6. Disabled sink: hook is a silent no-op. Use the `sink._disabled = True`
+     path to cover the `rr is None` return arc — it is environment-
+     independent and truly silent. (The SDK-missing path is *not* silent:
+     the first `_ensure_rerun()` emits the "rerun-sdk is not installed"
+     RuntimeWarning and needs a `skipif(_RERUN_INSTALLED)` gate, like the
+     existing `test_noop_and_warns_when_absent`.)
+
+Agent plugin:
+
+- `transcript_delta()` returns only new messages across two `act()` calls;
+  a second call with no intervening messages returns `None` (the
+  `if new else None` branch); cursor resets on `reset()`; returned
+  messages contain no `data:image` substring; `transcript()` still returns
+  the full conversation afterwards.
+
+## Docs
+
+- `docs/guide/logging-and-rerun.md`: new subsection "Live transcript in the
+  viewer" — entity path `trial/<scene>/e<epoch>/llm`, how to add a TextLog
+  view, the view's log-level filter (tool results log at DEBUG and system
+  prompts at TRACE, so show those levels to see the whole conversation),
+  note that scrubbing the `step` timeline highlights the rows for that
+  step, and that the stream is best-effort (drops under backpressure) while
+  the eval log transcript stays complete.
+- `src/inspect_robots/CLAUDE.md` module map: update the `policy.py`,
+  `rollout.py`, and `logging/` rows to mention the new hook pair.
+- `logging/sink.py` and core `policy.py` docstrings as described above.
+- Plugin README: one line that the agent policy supports live Rerun
+  transcript streaming automatically when a Rerun sink is attached.
+- `CHANGELOG.md`: an entry under `Unreleased`/Added referencing #124
+  (the repo keeps a manual Keep-a-Changelog file; the API snapshot test's
+  docstring instructs noting changes there).
+
+## Out of scope
+
+- stderr echo of the transcript (plan 0019 / issue #123).
+- A `TextDocument` "latest message" panel or any custom viewer blueprint;
+  the default TextLog view covers the scrub-alongside-video ask.
+- Streaming for policies other than the agent plugin (the hook is public
+  and documented; VLA policies have no text to stream).
+- Replaying transcripts into Rerun from a saved eval log.

--- a/plans/0020-rerun-transcript-stream.md
+++ b/plans/0020-rerun-transcript-stream.md
@@ -1,6 +1,6 @@
 # 0020 — Stream the LLM transcript onto the Rerun step timeline
 
-Issue: #124. Status: draft.
+Issue: #124. Status: approved (critique rounds 1-4 applied; round 4 found no substantive design issues).
 
 ## Problem
 

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -98,6 +98,7 @@ The speed fraction defaults to `0.1` and applies only to absolute modes.
 
 `LLMAgentPolicy.transcript()` returns the current conversation as a deep copy with streamed camera frames replaced by omission markers, ready for core eval-log persistence.
 Camera labels such as `camera 'top_cam' (step 480):` provide the join key from a transcript observation to its stored frame.
+Live Rerun transcript streaming happens automatically when a Rerun sink is attached.
 
 Reasoning effort defaults to `low`: robot control is latency-sensitive (the
 arm stands still while the model thinks), safety guardrails sit below the

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.8.0"
+version = "0.9.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -45,6 +45,22 @@ done; if it cannot be achieved call give_up. You have a budget of \
 {budget} LLM calls for the whole trial."""
 
 
+def _sanitize(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return an image-free deep copy suitable for persistence or visualization."""
+    sanitized = copy.deepcopy(messages)
+    for message in sanitized:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for index, part in enumerate(content):
+            if isinstance(part, dict) and part.get("type") == "image_url":
+                content[index] = {
+                    "type": "text",
+                    "text": "[image omitted: streamed camera frame]",
+                }
+    return sanitized
+
+
 @dataclass(frozen=True)
 class AgentPolicyConfig(PolicyConfig):
     """Inference-time configuration recorded in the eval log.
@@ -126,6 +142,7 @@ class LLMAgentPolicy(PolicyBase):
         self._embodiment_docs: str | None = None
         self._state_labels: tuple[str, tuple[str, ...]] | None = None
         self._messages: list[dict[str, Any]] = []
+        self._delta_cursor = 0
         self._calls_used = 0
 
     # -- lifecycle ---------------------------------------------------------------
@@ -163,24 +180,20 @@ class LLMAgentPolicy(PolicyBase):
             {"role": "user", "content": f"Goal: {scene.instruction}"},
         ]
         self._echo(f"[agent] goal: {scene.instruction}")
+        self._delta_cursor = 0
         self._calls_used = 0
 
     def transcript(self) -> list[dict[str, Any]] | None:
         """Return an image-free deep copy of the current trial's conversation."""
         if not self._messages:
             return None
-        messages = copy.deepcopy(self._messages)
-        for message in messages:
-            content = message.get("content")
-            if not isinstance(content, list):
-                continue
-            for index, part in enumerate(content):
-                if isinstance(part, dict) and part.get("type") == "image_url":
-                    content[index] = {
-                        "type": "text",
-                        "text": "[image omitted: streamed camera frame]",
-                    }
-        return messages
+        return _sanitize(self._messages)
+
+    def transcript_delta(self) -> list[dict[str, Any]] | None:
+        """Sanitized messages appended since the previous call (core live-stream hook)."""
+        new = self._messages[self._delta_cursor :]
+        self._delta_cursor = len(self._messages)
+        return _sanitize(new) if new else None
 
     # -- the loop ------------------------------------------------------------------
 

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,5 +6,5 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.8.0"
+    assert inspect_robots_agent.__version__ == "0.9.0"
     assert callable(inspect_robots_agent.agent_policy)

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -608,6 +608,44 @@ def test_transcript_is_deeply_isolated_in_both_directions() -> None:
     assert first[1]["content"] == "Goal: reach"
 
 
+def test_transcript_delta_tracks_new_sanitized_messages_and_reset() -> None:
+    script = _Script(
+        [
+            _tool_response("move_by", {"deltas": {"dx": 0.05}}),
+            _tool_response("done", {"summary": "finished"}),
+        ]
+    )
+    policy = _policy(script)
+    policy.bind(CubePickEmbodiment().info)
+    scene = Scene(id="s0", instruction="reach")
+    image = np.zeros((1, 1, 3), dtype=np.uint8)
+    policy.reset(scene)
+
+    policy.act(Observation(images={"top": image}))
+    first = policy.transcript_delta()
+    assert first is not None
+    assert policy.transcript_delta() is None
+    assert "data:image" not in json.dumps(first)
+
+    policy.act(Observation(images={"top": image}))
+    second = policy.transcript_delta()
+    assert second is not None
+    assert second[0]["role"] == "user"
+    assert all(message["role"] != "system" for message in second)
+    assert "data:image" not in json.dumps(second)
+
+    full = policy.transcript()
+    assert full is not None
+    assert len(full) == len(first) + len(second)
+    assert full[: len(first)] == first
+    assert full[len(first) :] == second
+
+    policy.reset(scene)
+    reset_delta = policy.transcript_delta()
+    assert reset_delta is not None
+    assert [message["role"] for message in reset_delta] == ["system", "user"]
+
+
 def test_outbound_messages_carry_state_images_and_tools(tmp_path: Path) -> None:
     script = _Script([_tool_response("done", {"summary": "looked around"})])
     ir_eval(_task(), _policy(script), CubePickEmbodiment(), log_dir=str(tmp_path))

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -9,14 +9,14 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 |--------|----------------|
 | `types.py` | `Observation`, `Action`, `ActionChunk`, `StepResult` (frozen, NumPy-native) |
 | `spaces.py` | `Box`, `ObservationSpace`, `ActionSemantics`, `StateSpec` + canonical state vocab |
-| `policy.py` | `Policy` Protocol + `PolicyBase` ABC, `PolicyInfo`, `PolicyConfig`; optional duck-typed `bind(embodiment_info)` hook for embodiment-adaptive policies and `transcript()` hook for per-trial audit records |
+| `policy.py` | `Policy` Protocol + `PolicyBase` ABC, `PolicyInfo`, `PolicyConfig`; optional duck-typed `bind(embodiment_info)` hook for embodiment-adaptive policies plus `transcript()` and `transcript_delta()` hooks for complete and live per-trial audit records |
 | `embodiment.py` | `Embodiment` Protocol + `EmbodimentBase` ABC, `EmbodimentInfo`, capability flags; optional duck-typed `bind_task(envelope)` hook for horizon-aware adapters (called by `eval()` before compat; optional input — never fires on direct `rollout()`, keep a fallback) |
 | `scene.py` | `Scene` (the Inspect `Sample` analog), `Target`, `ListSceneDataset` |
 | `task.py` | `Task` (scenes + scorer + horizon), `Epochs`, `TaskEnvelope` (`Task.envelope` — the adapter-safe identity+limits view passed to `bind_task` hooks) |
 | `scorer.py` | `Score`/`Scorer`, epoch reducers, builtin scorers (incl. operator/VLM) |
 | `controller.py` | `Controller` middleware: `DefaultController` (open-loop chunking), `SmoothingController` |
 | `approver.py` | `Approver` safety gate: `AutoApprover`, `ClampApprover`, `DeltaLimitApprover` (semantics-aware no-wild-swings limit), `ChainApprover` |
-| `rollout.py` | `rollout()` closed loop, `TrialRecord`/`StepRecord`, per-trial seeding and best-effort normalized policy-transcript capture; honors a policy-requested stop via pre-review `action.meta["request_stop"]` (truncation; embodiment termination wins; not preserved under ensembling) |
+| `rollout.py` | `rollout()` closed loop, `TrialRecord`/`StepRecord`, per-trial seeding, best-effort normalized policy-transcript capture, and the duck-typed `transcript_delta()` to sink `log_policy_messages()` live-stream bridge; honors a policy-requested stop via pre-review `action.meta["request_stop"]` (truncation; embodiment termination wins; not preserved under ensembling) |
 | `frames.py` | `FrameStore`/`FrameRef` — stream camera frames to disk (R5) |
 | `transcript.py` | typed event stream (reset/inference/step/approval/operator/error) |
 | `compat.py` | `check_compatibility`/`assert_compatible` — fail-fast before rollout |
@@ -24,7 +24,7 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `errors.py` | error taxonomy (continue vs halt) |
 | `eval.py` | `eval()` / `eval_set()` orchestration |
 | `log.py` | immutable, schema-versioned `EvalLog` + `read_eval_log`, including per-trial policy transcripts parallel to epochs |
-| `logging/` | `LogSink` protocol, `JsonLogSink` (atomic), optional `RerunSink` (non-blocking worker thread; drops frames, never delays control) |
+| `logging/` | `LogSink` protocol and optional duck-typed `log_policy_messages()` hook, `JsonLogSink` (atomic), optional `RerunSink` (non-blocking worker thread for steps and transcript rows; drops under pressure, never delays control) |
 | `registry.py` | decorators + entry-point discovery; `_builtins.py` registers in-tree components |
 | `cli.py` | `inspect-robots list` / `run` / `inspect` (with `--transcript` policy-audit rendering) / `video` (frames-to-MP4 via `_video.py`) / `config set|show` / `setup` (first-run wizard) / `doctor` (adapter conformance), plus the zero-config form `inspect-robots "<instruction>"` (ad-hoc single-scene task; operator prompt on TTY). Every run wires guardrails (Clamp + DeltaLimit) by default; `--disable-guardrails` is the loud opt-out and the chain degrades per component with stderr warnings |
 | `_video.py` | `inspect-robots video`: reunite a log with its `FrameStore` side-cars and pipe them to the ffmpeg binary, one MP4 per (trial, camera) stream (plan 0016: stderr temp file not pipe, per-stream failure isolation, strict uint8) |

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -84,6 +84,18 @@ class _Broadcast:
 
     def __init__(self, sinks: list[LogSink]):
         self._sinks = sinks
+        policy_message_hooks: list[Callable[[int, Sequence[Any]], None]] = []
+        for sink in sinks:
+            hook = getattr(sink, "log_policy_messages", None)
+            if callable(hook):
+                policy_message_hooks.append(hook)
+        self._policy_message_hooks = policy_message_hooks
+        if policy_message_hooks:
+            self.log_policy_messages = self._fan_policy_messages
+
+    def _fan_policy_messages(self, t: int, messages: Sequence[Any]) -> None:
+        for hook in self._policy_message_hooks:
+            hook(t, messages)
 
     def on_eval_start(self, spec: EvalSpec) -> None:
         for s in self._sinks:

--- a/src/inspect_robots/logging/rerun_sink.py
+++ b/src/inspect_robots/logging/rerun_sink.py
@@ -14,8 +14,8 @@ Emission happens on a daemon worker thread: ``log_step`` snapshots the
 transition and enqueues it, so a slow or stalled viewer connection can never
 block the control-rate rollout loop. Under backpressure the sink degrades
 visualization instead of delaying control: camera frames are dropped first
-(scalar plots stay complete), then whole steps, and the drop counts are
-reported as a ``RuntimeWarning`` when the eval ends. The queue is drained at
+(scalar plots stay complete), then whole steps or transcript rows, and the drop
+counts are reported as a ``RuntimeWarning`` when the eval ends. The queue is drained at
 every trial boundary (bounded by ``flush_timeout``), so an eval that aborts
 mid-run loses at most the current trial's queued tail. Camera frames are
 JPEG-compressed by default (``jpeg_quality=75``); pass ``jpeg_quality=None``
@@ -59,9 +59,48 @@ import numpy.typing as npt
 from inspect_robots.types import ImageArray
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from inspect_robots.log import EvalLog, EvalSpec
     from inspect_robots.rollout import TrialRecord
     from inspect_robots.types import Action, Observation, StepResult
+
+
+def _render_message(message: Any) -> tuple[str, str]:
+    if not isinstance(message, dict):
+        return "INFO", str(message)
+
+    role = str(message.get("role", "unknown"))
+    level = {
+        "assistant": "INFO",
+        "user": "INFO",
+        "tool": "DEBUG",
+    }.get(role, "TRACE")
+    lines: list[str] = []
+    content = message.get("content")
+    if isinstance(content, str) and content:
+        lines.append(content)
+    elif isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                parts.append(str(part.get("text", "")))
+            else:
+                part_type = part.get("type", "unknown") if isinstance(part, dict) else "unknown"
+                parts.append(f"[{part_type} part]")
+        if parts:
+            lines.append("\n".join(parts))
+
+    tool_calls = message.get("tool_calls")
+    if isinstance(tool_calls, list):
+        for call in tool_calls:
+            function = call.get("function", {}) if isinstance(call, dict) else {}
+            if not isinstance(function, dict):
+                function = {}
+            name = function.get("name", "")
+            arguments = function.get("arguments", "")
+            lines.append(f"tool_call {name}({arguments})")
+    return level, f"{role}: " + "\n".join(lines)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -76,6 +115,15 @@ class _StepPayload:
     reward: float | None
     terminated: bool
     termination_reason: str | None
+
+
+@dataclasses.dataclass(frozen=True)
+class _TranscriptPayload:
+    """Rendered conversation rows snapshotted for one control step."""
+
+    prefix: str
+    t: int
+    entries: tuple[tuple[str, str], ...]
 
 
 @dataclasses.dataclass
@@ -131,12 +179,13 @@ class RerunSink:
         self._warned = False
         self._disabled = False
         self._prefix = "trial"
-        self._queue: deque[_StepPayload] = deque()
+        self._queue: deque[_StepPayload | _TranscriptPayload] = deque()
         self._cond = threading.Condition()
         self._worker: threading.Thread | None = None
         self._state: _WorkerState | None = None
         self._dropped_frames = 0
         self._dropped_steps = 0
+        self._dropped_transcripts = 0
         self._image_watermark = max(1, queue_size // 4)
         self._emit_warned = False
         self._compress_warned = False
@@ -205,7 +254,10 @@ class RerunSink:
             stacklevel=2,
         )
 
-    def _emit(self, rr: Any, payload: _StepPayload) -> None:
+    def _emit(self, rr: Any, payload: _StepPayload | _TranscriptPayload) -> None:
+        if isinstance(payload, _TranscriptPayload):
+            self._emit_transcript(rr, payload)
+            return
         self._set_step(rr, payload.t)
         pre = payload.prefix
         for cam, image in payload.images.items():
@@ -223,6 +275,11 @@ class RerunSink:
                 rr.TextLog(payload.termination_reason or "terminated"),
             )
 
+    def _emit_transcript(self, rr: Any, payload: _TranscriptPayload) -> None:
+        self._set_step(rr, payload.t)
+        for level, text in payload.entries:
+            rr.log(f"{payload.prefix}/llm", rr.TextLog(text, level=level))
+
     def _ensure_worker(self) -> None:
         if self._worker is not None and self._worker.is_alive():
             return
@@ -236,15 +293,22 @@ class RerunSink:
         )
         self._worker.start()
 
-    def _enqueue(self, payload: _StepPayload) -> None:
+    def _enqueue(self, payload: _StepPayload | _TranscriptPayload) -> None:
         with self._cond:
-            if payload.images and len(self._queue) >= self._image_watermark:
+            if (
+                isinstance(payload, _StepPayload)
+                and payload.images
+                and len(self._queue) >= self._image_watermark
+            ):
                 self._dropped_frames += len(payload.images)
                 payload = dataclasses.replace(payload, images={})
             if len(self._queue) >= self.queue_size:
                 evicted = self._queue.popleft()
-                self._dropped_steps += 1
-                self._dropped_frames += len(evicted.images)
+                if isinstance(evicted, _StepPayload):
+                    self._dropped_steps += 1
+                    self._dropped_frames += len(evicted.images)
+                else:
+                    self._dropped_transcripts += 1
             self._queue.append(payload)
             self._cond.notify_all()
 
@@ -302,8 +366,12 @@ class RerunSink:
                 if wedged:
                     # Disown the wedged worker: clear its backlog into the drop
                     # counters so a restarted worker never double-consumes it.
-                    self._dropped_steps += len(self._queue)
-                    self._dropped_frames += sum(len(p.images) for p in self._queue)
+                    for payload in self._queue:
+                        if isinstance(payload, _StepPayload):
+                            self._dropped_steps += 1
+                            self._dropped_frames += len(payload.images)
+                        else:
+                            self._dropped_transcripts += 1
                     self._queue.clear()
             self._emit_warned = False
 
@@ -317,10 +385,16 @@ class RerunSink:
                 RuntimeWarning,
                 stacklevel=2,
             )
-        if self._dropped_frames or self._dropped_steps:
+        if self._dropped_frames or self._dropped_steps or self._dropped_transcripts:
+            transcript_fragment = (
+                f" and {self._dropped_transcripts} transcript update(s)"
+                if self._dropped_transcripts
+                else ""
+            )
             warnings.warn(
                 f"RerunSink dropped {self._dropped_frames} camera frame(s) and "
-                f"{self._dropped_steps} full step(s) to keep the control loop "
+                f"{self._dropped_steps} full step(s){transcript_fragment} "
+                "to keep the control loop "
                 "unblocked; record to a .rrd file or reduce camera bandwidth "
                 "to avoid drops",
                 RuntimeWarning,
@@ -328,6 +402,7 @@ class RerunSink:
             )
             self._dropped_frames = 0
             self._dropped_steps = 0
+            self._dropped_transcripts = 0
 
     def _probe_recording_flush(self) -> None:
         rr = self._rr
@@ -421,6 +496,19 @@ class RerunSink:
             reward=None if result.reward is None else float(result.reward),
             terminated=result.terminated,
             termination_reason=result.termination_reason,
+        )
+        self._ensure_worker()
+        self._enqueue(payload)
+
+    def log_policy_messages(self, t: int, messages: Sequence[Any]) -> None:
+        """Queue best-effort transcript rows without mutating policy messages."""
+        rr = self._ensure_rerun()
+        if rr is None:
+            return
+        payload = _TranscriptPayload(
+            prefix=self._prefix,
+            t=t,
+            entries=tuple(_render_message(message) for message in messages),
         )
         self._ensure_worker()
         self._enqueue(payload)

--- a/src/inspect_robots/logging/sink.py
+++ b/src/inspect_robots/logging/sink.py
@@ -1,8 +1,18 @@
-"""The LogSink protocol and a no-op base implementation.
+"""The LogSink protocol, its optional extension, and a no-op base implementation.
 
 A sink observes a run's lifecycle. The rollout engine and ``eval()`` call these
 hooks in a fixed order: ``on_eval_start`` → (per trial: ``on_trial_start`` →
 ``log_step``* → ``on_trial_end``) → ``on_eval_end``.
+
+Sinks may additionally define the duck-typed
+``log_policy_messages(t, messages)`` extension. The rollout calls it at most
+once per control step and only when the policy performed an inference. Policy
+implementations are expected to supply plain-JSON-type messages shaped like
+``TrialRecord.policy_transcript`` entries, but core does not enforce or
+normalize that shape on this live path, so sinks must render defensively.
+Sinks must not mutate the supplied messages. The extension deliberately stays
+off both ``LogSink`` and ``NullSink``: it must not change structural protocol
+conformance or advertise a no-op that makes policies build transcript deltas.
 """
 
 from __future__ import annotations

--- a/src/inspect_robots/policy.py
+++ b/src/inspect_robots/policy.py
@@ -54,7 +54,7 @@ class PolicyInfo:
 class Policy(Protocol):
     """The VLA contract.
 
-    Policies may additionally define two optional hooks, neither part of this
+    Policies may additionally define three optional hooks, none part of this
     Protocol so existing policies stay conformant. ``bind(embodiment_info)``
     lets embodiment-adaptive policies adopt the embodiment's spaces; ``eval()``
     calls it after resolving both components and before compatibility checking.
@@ -66,7 +66,14 @@ class Policy(Protocol):
     embedded because frame sidecars already persist them. Collection runs on
     the rollout thread and is best-effort: the framework normalizes and bounds
     the result, and a raising or misbehaving hook cannot change trial outcome.
-    ``PolicyBase`` ships defaults for both hooks.
+    ``transcript_delta()`` returns plain-JSON-type messages appended since its
+    previous call, or since ``reset()`` on the first call, and returns ``None``
+    or an empty list when nothing is new. Implementations must sanitize only
+    the new slice in O(new messages), including eliding image bytes before the
+    result reaches visualization sinks, and ``reset()`` must rewind the cursor.
+    ``PolicyBase`` ships defaults for ``bind()`` and ``transcript()`` but
+    deliberately has no ``transcript_delta()`` default: policies must opt in so
+    every inference does not pay for a no-op hook call.
     """
 
     info: PolicyInfo

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -249,8 +249,8 @@ def rollout(
                     except Exception as exc:
                         stream_ok = False
                         warnings.warn(
-                            "Live policy transcript streaming disabled after "
-                            f"{type(exc).__name__}: {exc}",
+                            "Live policy transcript streaming disabled for this "
+                            f"trial after {type(exc).__name__}: {exc}",
                             RuntimeWarning,
                             stacklevel=2,
                         )

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -10,6 +10,7 @@ gate, logging each step to the sinks, and returns an immutable
 from __future__ import annotations
 
 import json
+import warnings
 import zlib
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
@@ -200,6 +201,9 @@ def rollout(
     store: dict[str, Any] = {}
     expected_dim = embodiment.info.action_space.dim
     policy_reset_ok = False
+    delta_hook: Any = getattr(policy, "transcript_delta", None)
+    messages_hook: Any = getattr(sink, "log_policy_messages", None)
+    stream_ok = callable(delta_hook) and callable(messages_hook)
 
     try:
         t = -1
@@ -236,6 +240,20 @@ def rollout(
             if len(inferences) > prev_inferences:
                 latency, chunk_len = inferences[-1]
                 record.events.append(inference_event(t, latency, chunk_len))
+                if stream_ok:
+                    try:
+                        delta = delta_hook()
+                        entries = list(delta) if delta is not None else []
+                        if entries:
+                            messages_hook(t, entries)
+                    except Exception as exc:
+                        stream_ok = False
+                        warnings.warn(
+                            "Live policy transcript streaming disabled after "
+                            f"{type(exc).__name__}: {exc}",
+                            RuntimeWarning,
+                            stacklevel=2,
+                        )
 
             # A malformed action is the policy's fault; catching it here keeps it
             # from surfacing inside the approver/embodiment as a halting fault.

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -12,12 +12,19 @@ import time
 import types
 import warnings
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
 
 from inspect_robots import eval
 from inspect_robots.logging import RerunSink
+from inspect_robots.logging.rerun_sink import (
+    _render_message,
+    _StepPayload,
+    _TranscriptPayload,
+    _WorkerState,
+)
 from inspect_robots.mock import CubePickEmbodiment, ScriptedPolicy
 from inspect_robots.registry import registered
 from inspect_robots.scene import Scene
@@ -255,11 +262,15 @@ def _install_fake_rerun(
 
     fake.init = lambda *a, **k: None  # type: ignore[attr-defined]
     fake.save = lambda p: None  # type: ignore[attr-defined]
-    fake.set_time = lambda *a, **k: None  # type: ignore[attr-defined]
+
+    def _set_time(timeline: str, **kwargs: object) -> None:
+        logged.append(("set_time", (timeline, kwargs)))
+
+    fake.set_time = _set_time  # type: ignore[attr-defined]
     fake.log = _log  # type: ignore[attr-defined]
     fake.Image = image_cls  # type: ignore[attr-defined]
     fake.Scalars = lambda v: ("Scalars", v)  # type: ignore[attr-defined]
-    fake.TextLog = lambda t: ("TextLog", t)  # type: ignore[attr-defined]
+    fake.TextLog = lambda t, *, level=None: ("TextLog", t, level)  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "rerun", fake)
     return logged
 
@@ -328,6 +339,201 @@ def _step_result() -> StepResult:
 
 def _log_one(sink: RerunSink, t: int = 0, *, with_image: bool = True) -> None:
     sink.log_step(t, _obs(with_image=with_image), Action(data=np.array([0.5])), _step_result())
+
+
+def _step_payload(t: int, *, with_image: bool = True) -> _StepPayload:
+    """Build a queue payload without starting a worker."""
+    images = {"cam": np.zeros((1, 1, 3), dtype=np.uint8)} if with_image else {}
+    return _StepPayload(
+        prefix="trial/scene/e0",
+        t=t,
+        images=images,
+        state={},
+        action=np.array([0.0]),
+        reward=None,
+        terminated=False,
+        termination_reason=None,
+    )
+
+
+def _arm_completed_worker(sink: RerunSink) -> None:
+    """Give shutdown a completed generation so it reports existing counters."""
+    worker = threading.Thread(target=lambda: None)
+    worker.start()
+    worker.join()
+    sink._worker = worker
+    sink._state = _WorkerState(stop=threading.Event())
+
+
+def test_policy_messages_emit_ordered_levels_on_the_step_timeline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged = _install_fake_rerun(monkeypatch)
+    sink = RerunSink()
+    sink.on_trial_start("scene", 2)
+
+    sink.log_policy_messages(
+        7,
+        [
+            {"role": "assistant", "content": "answer"},
+            {"role": "user", "content": "question"},
+            {"role": "tool", "content": "result"},
+            {"role": "system", "content": "prompt"},
+            {"role": "critic", "content": "other"},
+        ],
+    )
+
+    assert sink.flush(timeout=5.0)
+    assert logged == [
+        ("set_time", ("step", {"sequence": 7})),
+        ("trial/scene/e2/llm", ("TextLog", "assistant: answer", "INFO")),
+        ("trial/scene/e2/llm", ("TextLog", "user: question", "INFO")),
+        ("trial/scene/e2/llm", ("TextLog", "tool: result", "DEBUG")),
+        ("trial/scene/e2/llm", ("TextLog", "system: prompt", "TRACE")),
+        ("trial/scene/e2/llm", ("TextLog", "critic: other", "TRACE")),
+    ]
+    sink.on_eval_end(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ({"role": "assistant", "content": "hello"}, ("INFO", "assistant: hello")),
+        (
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "camera 'top':"},
+                    {"type": "image_url", "image_url": {"url": "elided"}},
+                    {"type": "text", "text": "after"},
+                    7,
+                ],
+            },
+            ("INFO", "user: camera 'top':\n[image_url part]\nafter\n[unknown part]"),
+        ),
+        (
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_move",
+                        "type": "function",
+                        "function": {"name": "move_by", "arguments": '{"dx": 0.1}'},
+                    }
+                ],
+            },
+            ("INFO", 'assistant: tool_call move_by({"dx": 0.1})'),
+        ),
+        ("plain row", ("INFO", "plain row")),
+        ({"content": "orphan"}, ("TRACE", "unknown: orphan")),
+        ({"role": "tool", "content": "result"}, ("DEBUG", "tool: result")),
+        ({"role": "system", "content": "prompt"}, ("TRACE", "system: prompt")),
+        ({"role": "assistant", "content": ""}, ("INFO", "assistant: ")),
+        (
+            {
+                "role": "assistant",
+                "content": [],
+                "tool_calls": [{"function": "malformed"}, "malformed"],
+            },
+            ("INFO", "assistant: tool_call ()\ntool_call ()"),
+        ),
+    ],
+)
+def test_policy_message_rendering_table(message: Any, expected: tuple[str, str]) -> None:
+    assert _render_message(message) == expected
+
+
+def test_mixed_queue_eviction_counts_transcripts_steps_and_images() -> None:
+    sink = RerunSink(queue_size=2)
+    sink._image_watermark = 99
+    sink._enqueue(_TranscriptPayload("trial/scene/e0", 0, (("INFO", "first"),)))
+    sink._enqueue(_step_payload(1))
+
+    sink._enqueue(_TranscriptPayload("trial/scene/e0", 2, (("INFO", "second"),)))
+    assert sink._dropped_transcripts == 1
+    assert sink._dropped_steps == 0
+    assert sink._dropped_frames == 0
+
+    sink._enqueue(_step_payload(3, with_image=False))
+    assert sink._dropped_transcripts == 1
+    assert sink._dropped_steps == 1
+    assert sink._dropped_frames == 1
+
+    with sink._cond:
+        sink._queue.clear()
+    _arm_completed_worker(sink)
+    with pytest.warns(RuntimeWarning, match=r"1 transcript update\(s\)"):
+        sink.on_eval_end(None)  # type: ignore[arg-type]
+
+
+def test_transcript_only_drops_warn_and_reset_all_counters() -> None:
+    sink = RerunSink(queue_size=1)
+    sink._enqueue(_TranscriptPayload("trial/scene/e0", 0, (("INFO", "first"),)))
+    sink._enqueue(_TranscriptPayload("trial/scene/e0", 1, (("INFO", "second"),)))
+    with sink._cond:
+        sink._queue.clear()
+    _arm_completed_worker(sink)
+
+    with pytest.warns(RuntimeWarning, match=r"1 transcript update\(s\)"):
+        sink.on_eval_end(None)  # type: ignore[arg-type]
+
+    assert sink._dropped_frames == 0
+    assert sink._dropped_steps == 0
+    assert sink._dropped_transcripts == 0
+
+
+def test_policy_messages_as_first_trial_call_spawn_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged = _install_fake_rerun(monkeypatch)
+    sink = RerunSink()
+
+    sink.log_policy_messages(0, [{"role": "assistant", "content": "first"}])
+
+    assert sink._worker is not None
+    assert sink.flush(timeout=5.0)
+    assert ("trial/llm", ("TextLog", "assistant: first", "INFO")) in logged
+    sink.on_eval_end(None)  # type: ignore[arg-type]
+
+
+def test_wedged_shutdown_accounts_for_mixed_backlog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gate = threading.Event()
+    _install_fake_rerun(monkeypatch, gate=gate)
+    sink = RerunSink(flush_timeout=0.05)
+    worker: threading.Thread | None = None
+    try:
+        _log_one(sink, 0)
+        _wait_for_inflight(sink)
+        worker = sink._worker
+        assert worker is not None
+        with sink._cond:
+            sink._queue.append(_TranscriptPayload("trial/scene/e0", 1, (("INFO", "queued"),)))
+            sink._queue.append(_step_payload(2))
+        with pytest.warns(RuntimeWarning) as caught:
+            sink.on_eval_end(None)  # type: ignore[arg-type]
+        messages = [str(item.message) for item in caught]
+        assert any("1 transcript update(s)" in message for message in messages)
+        assert any("1 camera frame(s) and 1 full step(s)" in message for message in messages)
+    finally:
+        gate.set()
+    assert worker is not None
+    worker.join(timeout=5.0)
+    assert not worker.is_alive()
+
+
+def test_disabled_sink_silently_ignores_policy_messages() -> None:
+    sink = RerunSink()
+    sink._disabled = True
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        sink.log_policy_messages(0, [{"role": "assistant", "content": "unused"}])
+
+    assert sink._worker is None
+    assert not sink._queue
 
 
 def test_images_jpeg_compressed_by_default(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_rollout_transcript_stream.py
+++ b/tests/test_rollout_transcript_stream.py
@@ -1,0 +1,192 @@
+"""Live policy transcript deltas follow inference events without affecting rollout."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+import pytest
+
+from inspect_robots.approver import AutoApprover
+from inspect_robots.controller import DefaultController
+from inspect_robots.eval import _Broadcast
+from inspect_robots.logging.sink import LogSink, NullSink
+from inspect_robots.mock import CubePickEmbodiment, ScriptedPolicy
+from inspect_robots.rollout import TrialRecord, rollout
+from inspect_robots.scene import Scene
+from inspect_robots.types import Action, Observation, StepResult
+
+_SCENE = Scene(id="transcript", instruction="reach")
+
+
+class _DeltaPolicy(ScriptedPolicy):
+    """Return configured transcript deltas after successive inferences."""
+
+    def __init__(self, deltas: list[Iterable[Any] | None]) -> None:
+        super().__init__(chunk_size=1)
+        self._deltas = list(deltas)
+        self.delta_calls = 0
+
+    def transcript_delta(self) -> Iterable[Any] | None:
+        """Return the next configured delta and count hook invocations."""
+        self.delta_calls += 1
+        return self._deltas.pop(0) if self._deltas else None
+
+
+class _RaisingDeltaPolicy(ScriptedPolicy):
+    """Raise from every attempted transcript delta collection."""
+
+    def __init__(self) -> None:
+        super().__init__(chunk_size=1)
+        self.delta_calls = 0
+
+    def transcript_delta(self) -> Iterable[Any] | None:
+        """Raise after recording the attempted live-stream collection."""
+        self.delta_calls += 1
+        raise RuntimeError("delta exploded")
+
+
+class _RecordingSink(NullSink):
+    """Capture transcript and step call order, optionally raising on transcript rows."""
+
+    def __init__(self, *, raise_messages: bool = False) -> None:
+        self.raise_messages = raise_messages
+        self.message_calls: list[tuple[int, list[Any]]] = []
+        self.message_batches_were_lists: list[bool] = []
+        self.order: list[tuple[str, int]] = []
+
+    def log_policy_messages(self, t: int, messages: Sequence[Any]) -> None:
+        """Record a defensive copy of the delivered batch."""
+        self.message_batches_were_lists.append(isinstance(messages, list))
+        self.message_calls.append((t, list(messages)))
+        self.order.append(("messages", t))
+        if self.raise_messages:
+            raise RuntimeError("sink exploded")
+
+    def log_step(
+        self, t: int, observation: Observation, action: Action, result: StepResult
+    ) -> None:
+        """Record each normal step after any same-step transcript batch."""
+        self.order.append(("step", t))
+
+
+def _run(policy: ScriptedPolicy, sink: LogSink, *, max_steps: int = 3) -> TrialRecord:
+    return rollout(
+        policy,
+        CubePickEmbodiment(),
+        _SCENE,
+        max_steps=max_steps,
+        seed=0,
+        epoch=0,
+        controller=DefaultController(),
+        approver=AutoApprover(),
+        sink=sink,
+    )
+
+
+def test_delta_is_delivered_at_inference_step_before_log_step() -> None:
+    message = {"role": "assistant", "content": "moving"}
+    policy = _DeltaPolicy([[message], None])
+    sink = _RecordingSink()
+
+    _run(policy, sink, max_steps=2)
+
+    assert sink.message_calls == [(0, [message])]
+    assert sink.order[:3] == [("messages", 0), ("step", 0), ("step", 1)]
+
+
+def test_policy_without_delta_hook_never_calls_sink_hook() -> None:
+    sink = _RecordingSink()
+
+    _run(ScriptedPolicy(chunk_size=1), sink)
+
+    assert sink.message_calls == []
+
+
+def test_sink_without_message_hook_never_collects_delta() -> None:
+    policy = _DeltaPolicy([[{"role": "assistant", "content": "unused"}]])
+
+    _run(policy, NullSink())
+
+    assert policy.delta_calls == 0
+
+
+def test_none_and_empty_deltas_do_not_call_sink_hook() -> None:
+    policy = _DeltaPolicy([None, []])
+    sink = _RecordingSink()
+
+    _run(policy, sink, max_steps=2)
+
+    assert policy.delta_calls == 2
+    assert sink.message_calls == []
+
+
+def test_raising_delta_hook_warns_once_and_latches_off() -> None:
+    policy = _RaisingDeltaPolicy()
+    sink = _RecordingSink()
+
+    with pytest.warns(RuntimeWarning, match="RuntimeError: delta exploded") as caught:
+        record = _run(policy, sink)
+
+    assert len(caught) == 1
+    assert policy.delta_calls == 1
+    assert sink.message_calls == []
+    assert len(record.steps) == 3
+    assert record.status == "success"
+    assert record.truncated and record.termination_reason == "max_steps"
+
+
+def test_raising_sink_hook_warns_once_and_latches_off() -> None:
+    policy = _DeltaPolicy([[1], [2], [3]])
+    sink = _RecordingSink(raise_messages=True)
+
+    with pytest.warns(RuntimeWarning, match="RuntimeError: sink exploded") as caught:
+        record = _run(policy, sink)
+
+    assert len(caught) == 1
+    assert policy.delta_calls == 1
+    assert sink.message_calls == [(0, [1])]
+    assert len(record.steps) == 3
+    assert record.status == "success"
+
+
+def test_iterable_delta_is_materialized_and_empty_generator_is_skipped() -> None:
+    def _entries() -> Iterable[dict[str, str]]:
+        yield {"role": "tool", "content": "done"}
+
+    sink = _RecordingSink()
+    empty_source: list[dict[str, str]] = []
+    policy = _DeltaPolicy([_entries(), (item for item in empty_source)])
+
+    _run(policy, sink, max_steps=2)
+
+    assert sink.message_calls == [(0, [{"role": "tool", "content": "done"}])]
+    assert sink.message_batches_were_lists == [True]
+
+
+def test_broadcast_fans_messages_only_to_implementing_sinks() -> None:
+    first = _RecordingSink()
+    second = NullSink()
+    third = _RecordingSink()
+    broadcast = _Broadcast([first, second, third])
+    hook = getattr(broadcast, "log_policy_messages", None)
+
+    assert callable(hook)
+    hook(4, ["row"])
+
+    assert first.message_calls == [(4, ["row"])]
+    assert third.message_calls == [(4, ["row"])]
+
+
+def test_broadcast_without_message_sinks_keeps_rollout_gate_closed() -> None:
+    broadcast = _Broadcast([NullSink(), NullSink()])
+    policy = _DeltaPolicy([["unused"]])
+
+    assert not callable(getattr(broadcast, "log_policy_messages", None))
+    _run(policy, broadcast)
+
+    assert policy.delta_calls == 0
+
+
+def test_null_sink_deliberately_omits_policy_message_hook() -> None:
+    assert getattr(NullSink(), "log_policy_messages", None) is None

--- a/uv.lock
+++ b/uv.lock
@@ -520,7 +520,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #124

## What

Live-streams the agent policy's conversation into the Rerun viewer as \`TextLog\` rows under \`trial/<scene>/e<epoch>/llm\` on the existing \`step\` timeline. Pause the timeline at step 480 and read what the model said there, next to the frames it was acting from.

## How

Three pieces, each riding an existing pattern:

- Policy hook \`transcript_delta()\`: optional and duck-typed like \`bind()\`/\`transcript()\`, returns sanitized messages appended since the last call (O(delta), images elided, cursor rewound on \`reset()\`). Implemented by the agent plugin; no \`PolicyBase\` default, deliberately.
- Rollout seam: at the existing inference-detection point, the delta is fetched and handed to the sink before that step's \`log_step\`, so text and frames land on the same timeline index. Failures latch off after one \`RuntimeWarning\`; a multi-hour run can never be spammed or crashed by visualization.
- Sink hook \`log_policy_messages(t, messages)\`: optional and duck-typed, kept off the \`LogSink\` Protocol (structural conformance of third-party sinks unchanged) and off \`NullSink\` (a stub would advertise the hook and make policies pay the delta cost to feed a no-op). \`_Broadcast\` binds a fan-out only when a child sink implements it. \`RerunSink\` renders on the caller thread, emits on its backpressure-safe worker, and counts dropped transcript rows separately from frames and steps.

The eval-log transcript is untouched: still collected at trial end, still the complete audit record; the live stream is best-effort visualization.

## Notes

- Agent plugin 0.7.0 -> 0.9.0 (0.8.0 shipped with #126); pin + \`uv lock\` updated.
- Design doc: \`plans/0020-rerun-transcript-stream.md\` (four critique rounds).
- Core suite stays at 100% branch coverage (623 tests); docs subsection added to the logging guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)