### PR TITLE
docs(readme): start the policy server before the quickstart run

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ and it identifies which is which), then writes
 instead and type its component names at the prompts; to write the config file
 by hand, see [the CLI guide](https://inspectrobots.org/guide/cli/).
 
+The `molmoact2` policy is only a client: nothing moves until the MolmoAct2
+server is listening, and the server does not start itself or survive a
+reboot (full setup in the
+[yam plugin README](https://github.com/robocurve/inspect-robots-yam#install-on-the-robotgpu-machine)):
+
+```bash
+# On the GPU machine, from the MolmoAct2 repo. Leave it running, e.g. in tmux:
+python examples/yam/host_server_yam.py --host 0.0.0.0 --port 8202
+curl http://127.0.0.1:8202/act      # 200 means the server is ready
+```
+
+On a different rig, start whatever serves your policy instead; in-process
+policies (such as `agent` or the mock `scripted`) need no server.
+
 Then tell the robot what to do:
 
 ```bash


### PR DESCRIPTION
Following the Quickstart verbatim on a fresh rig currently ends in `PolicyError: ... port 8202 ... Connection refused`: the section goes from `inspect-robots setup` straight to `inspect-robots "place the fork on the plate"` without ever saying the MolmoAct2 `/act` server must be listening. The `molmoact2` policy installed by `inspect-robots-yam` is only a client.

This adds one paragraph and one code block between the setup wizard and the run command:

- the `host_server_yam.py` start command, noting it must be left running (e.g. in tmux) and does not survive a reboot
- a `curl http://127.0.0.1:8202/act` readiness check
- a link to the [yam plugin README](https://github.com/robocurve/inspect-robots-yam#install-on-the-robotgpu-machine) for full setup
- a note that other rigs start their own policy server, and that in-process policies (`agent`, `scripted`) need none

Same fix as robocurve/inspect-robots-yam#59, applied to the framework README's quickstart. Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)