### PR TITLE
feat(agent): mandatory per-tool-call note for user visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- **Agent plugin:** move tool calls now require a note describing the current
+  observation and why the agent chose the motion, so users can follow its
+  perception and decisions live and in saved transcripts (#130).
 - **`inspect-robots eval-set TASK [TASK ...]`**: run several registered tasks
   against one resolved policy/embodiment pair in a single invocation, matching
   task names exactly or by shell-quoted `fnmatch` glob (e.g.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,16 @@ All notable changes to this project are documented here. The format is based on
   rationale). `compat`'s policy/embodiment rate-mismatch warning is
   unaffected.
 
-### Added
+### Changed
 
 - **Agent plugin:** move tool calls now require a note describing the current
   observation and why the agent chose the motion, so users can follow its
-  perception and decisions live and in saved transcripts (#130).
+  perception and decisions live and in saved transcripts (#130). This tightens
+  the tool contract: a model that persistently omits the note errors the trial
+  (unscored) after three consecutive failures, and each correction turn spends
+  one `max_llm_calls` unit.
+
+### Added
 - **`inspect-robots eval-set TASK [TASK ...]`**: run several registered tasks
   against one resolved policy/embodiment pair in a single invocation, matching
   task names exactly or by shell-quoted `fnmatch` glob (e.g.

--- a/plans/0021-agent-mandatory-notes.md
+++ b/plans/0021-agent-mandatory-notes.md
@@ -1,0 +1,199 @@
+# 0021 — Mandatory per-tool-call notes: see what the agent sees and decides
+
+Issue: #130. Status: draft.
+
+## Problem
+
+The persisted agent transcript (plan 0015) records observations, tool calls,
+and tool results, but nothing records what the model believed it was seeing or
+why it chose an action. A user replaying a trial sees `move_by({"deltas":
+{"x": 0.05}})` and has to guess the intent. Users running evals explicitly
+want that visibility: what did the model see, what did it decide, why.
+
+The model *could* volunteer assistant text before each tool call, but in
+practice tool-trained models often emit bare tool calls, and nothing today
+tells them anyone is reading. Visibility that depends on the model's mood is
+not visibility.
+
+## Design
+
+Make the note a **mandatory argument of the move tool**, enforced the same way
+every other argument mistake is enforced: a structured tool error the model
+must correct. No core changes; the notes ride inside the tool-call arguments,
+so they land in the persisted policy transcript, `inspect-robots inspect
+--transcript`, the stderr echo (plan 0019), and the Rerun transcript stream
+(plan 0020) with zero schema or plumbing changes.
+
+Three coordinated edits, all in the agent plugin:
+
+### 1. Tool schema (`_tools.py`, `Toolset.schemas()`)
+
+The move tool (whichever of `move_joints`/`move_to`/`move_by` was built) gains
+a `note` property and lists it in `required` alongside the values key:
+
+```json
+"note": {
+  "type": "string",
+  "description": "What you observe right now in the observation (images, if
+    any, and state), and why you chose this motion. The user reads these
+    notes live and in the saved transcript to follow what you see and what
+    you decide. Write for them, in one or two plain sentences."
+}
+```
+
+(The wrapping above is presentational; the wire string is a single line.
+Camera-less embodiments exist, hence "if any".)
+
+(The `required` array carrying both the values key and `note` is standard
+JSON Schema; OpenAI-compatible endpoints accept multi-entry `required`
+lists. "Mandatory" is expressed by `required`, not repeated in the
+description.)
+
+Naming note: `ToolResult.note` (the success confirmation string sent back to
+the model) is an unrelated, pre-existing field. The implementation keeps both
+but disambiguates in docstrings ("the call's note argument" vs "the result
+note").
+
+`done` and `give_up` already carry mandatory free-text fields (`summary` /
+`reason`) that serve the same purpose at trial end; they are unchanged.
+
+### 2. Enforcement (`_tools.py`, `Toolset._move()`)
+
+A move call whose `note` is missing, not a string, or empty/whitespace-only
+returns `ToolResult(error="note is required: describe what you observe and
+why you chose this motion")`. This reuses the existing correction loop in
+`policy.py` (`failures` counter, `_MAX_CONSECUTIVE_FAILURES`); no new control
+flow.
+
+Placement, precisely: the existing broken-sensor guard in `_move()`
+(non-finite proprioceptive reference **raises** before any argument
+validation, so a malformed call can never mask a dead sensor) stays first,
+and it lives inside the `if self._absolute:` block. The note check goes
+**after that block, unconditionally** — it must fire for displacement mode
+(`move_by`) exactly as for absolute mode — and before the `values`
+validation. Error strings stay single-issue like every existing `ToolResult`
+error; the note error leads because the note is the new contract and the
+most likely omission from a model whose training predates it. Worst case, a
+call wrong in both ways costs two correction turns (2 LLM calls, 2 of the 3
+consecutive-failure budget); acceptable, and simpler than a combined
+multi-error message that no existing error path uses (every current
+`ToolResult` error reports a single problem).
+
+The note is a sibling of `targets`/`deltas` in the arguments object, so it
+never enters the per-dimension `values` loop; no motion code changes.
+
+### 3. System prompt (`policy.py`, `_SYSTEM_TEMPLATE`)
+
+One added sentence, stating the *reason* (the user wants to see through the
+model's eyes) and the *contract* (every move carries a note):
+
+> Every move tool call must include a `note`: in one or two sentences, say
+> what you observe in the current observation and why you chose this
+> motion. The user is watching these notes to see what you see and what you
+> decide, so write them for a human reader.
+
+The `reset()` code path is untouched (the template already flows through
+`str.format`; the new sentence has no placeholders).
+
+## What is deliberately NOT changed
+
+- **No new echo line.** The plan-0019 echo already prints every tool call
+  verbatim as `[agent] << tool_call move_by({...})`; the note is inside the
+  arguments and therefore already visible live. Adding a second, prettified
+  line for the same data would duplicate plan 0019's one-line-per-message
+  contract.
+- **No `ToolResult` change.** The note travels in the request arguments, not
+  the result; the tool-result message the LLM sees back stays the compact
+  `executing … over N steps` confirmation.
+- **No note on `done`/`give_up`.** Their existing mandatory `summary`/`reason`
+  fields are the note; requiring a second free-text field would be noise.
+  Their empty-string laxness (`str(arguments.get("summary") or ...)`) is
+  pre-existing and out of scope.
+- **`_forced_give_up()` untouched.** The synthetic budget-exhaustion call is
+  plugin-generated, not model output, and never enters the transcript.
+- **No core/log/CLI changes.** Downstream rendering (the HTML viewer, planned
+  separately) can extract `note` from tool-call arguments generically.
+
+## Compatibility
+
+- Old transcripts (no notes) still render everywhere; nothing reads the field
+  by name in this plan.
+- The stricter schema is announced in both the tool description and the
+  system prompt, and enforcement produces a self-explanatory correction
+  error, but this **does change eval outcomes for models that persistently
+  omit the note**: three consecutive note-less calls hit
+  `_MAX_CONSECUTIVE_FAILURES` and the trial errors (unscored `PolicyError`),
+  exactly like any other persistently malformed call. Each correction turn
+  also burns one `max_llm_calls` unit, and a budget exhausted mid-correction
+  ends the trial as a scored forced `give_up` instead. This is the intended
+  trade: notes are a hard contract, and a model that cannot follow the tool
+  schema after two corrections is already failing the existing contract.
+- Agent plugin version: `0.9.0 → 0.10.0` (behavioral change to the tool
+  surface).
+
+## Tests (plugin suite, `plugins/inspect-robots-agent/tests/`)
+
+`test_tools_motion.py`:
+- `schemas()`: move tool declares `note` as a string property and its
+  `required` list is exactly `[values_key, "note"]`; `done`/`give_up`
+  schemas unchanged. (`test_schemas_match_control_mode_and_remove_duration`
+  asserts the exact `required` lists today and is updated in place.)
+- `execute()` on a move call with `note` missing → structured error, no
+  chunk — asserted on **both** an absolute toolset and a displacement
+  toolset, so the unconditional placement can't regress to
+  absolute-only.
+- Same for `note: ""`, `note: "   "`, and non-string `note` (e.g. `42`).
+- A valid note leaves the produced chunk byte-identical to today's (motion
+  math untouched); the note never counts as an unknown dimension.
+- Broken-sensor ordering: non-finite reference still raises even when the
+  same call also omits the note.
+- Mechanical churn, named so it can be audited: the `_call` /
+  `_execute_absolute` helpers gain a default note (single edit point for
+  most fixtures); `test_tool_errors_are_messages_not_exceptions` asserts an
+  unknown-dimension error mentioning `left_elbow` on a call that would now
+  fail the note check first, so its fixture gains a note to keep testing
+  what it names; `test_stray_duration_key_is_ignored` likewise.
+
+`test_policy_e2e.py`:
+- System prompt contains the note contract sentence.
+- End-to-end with the mock transport: a first response missing the note gets
+  the correction error as a tool message and a second, corrected response
+  succeeds; the persisted transcript contains the note text inside the
+  tool-call arguments.
+- `_tool_response` **and** `_multi_tool_response` payloads gain notes.
+  Two tests are re-checked against silent drift:
+  `test_llm_call_budget_forces_give_up` must keep sending valid noted calls
+  (or it silently tests note correction instead of the budget path), and
+  `test_extra_tool_calls_are_answered_but_not_executed` builds its executed
+  first call via `_multi_tool_response` — without a note there, its
+  assertions all still pass while it stops exercising "the first call
+  executes".
+
+Gates (what actually blocks): ruff, `mypy` on the plugin src, plugin pytest
+green, and the core suite untouched/green. CI runs plugin coverage at
+`--cov-fail-under=0` (visibility only, no 100% gate for plugins); this
+change keeps the plugin's report at 100% anyway since every new branch is
+enumerated above.
+
+## Docs
+
+- `plugins/inspect-robots-agent/README.md`: the "How it works" tool-surface
+  description gains the `note` argument (what it is, that it is required,
+  and why: the user reads it), and the transcript-echo prose gains one
+  sentence noting that notes appear inside the echoed tool-call arguments
+  (the section is prose only today; this is an addition, not an edit of an
+  example line). Follows the repo's public-text style rules (no em dashes,
+  no mid-sentence bold).
+- `CHANGELOG.md`: an entry under the agent plugin for the new mandatory
+  note argument (behavioral change to the tool surface).
+
+## Rollout
+
+Single PR (`Closes #130`), agent plugin only. **Before** cutting the
+release, audit downstream embodiment docs (`EmbodimentInfo.docs`
+cheat-sheets, e.g. the yam plugin's) for example tool calls that lack a
+note: such examples would show the model a counterexample inside the same
+system prompt, and rigs install from PyPI the moment the release lands, so
+a post-release audit ships the contradiction for a whole release window.
+Then release `inspect-robots-agent 0.10.0` with the next core release cut
+immediately after merge.

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -59,6 +59,11 @@ split-the-move error and issues it as two smaller motions; raise the fraction
 result reports the computed step count and, when the embodiment declares
 `control_hz`, the corresponding playout time. `duration_s` is not part of either motion tool.
 
+Every move tool call also requires a `note` with one or two plain sentences
+describing the current observation and why the agent chose that motion. The
+user reads these notes live and in the saved transcript to follow what the
+agent sees and decides.
+
 For displacement modes, `move_by` splits the requested total so every action
 fits the box side in that direction. The action box is the embodiment author's
 per-step speed statement, so `max_speed_frac` does not apply to displacement
@@ -94,6 +99,7 @@ Configuration knobs (all `-P key=value`): `model`, `base_url`, `api_key_env`,
 Set `-P transcript_echo=true` to print live `[agent]` conversation lines to
 stderr, including goals, observation summaries, assistant output, tool calls,
 and tool results.
+Move notes appear inside the echoed tool-call arguments.
 The speed fraction defaults to `0.1` and applies only to absolute modes.
 
 `LLMAgentPolicy.transcript()` returns the current conversation as a deep copy with streamed camera frames replaced by omission markers, ready for core eval-log persistence.

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.9.0"
+version = "0.10.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -43,8 +43,8 @@ class ToolsetError(Exception):
 class ToolResult:
     """One executed tool call: an action chunk to play, or an error for the LLM.
 
-    Exactly one of ``chunk``/``error`` is set. ``note`` is the human/LLM-facing
-    confirmation text for successful calls.
+    Exactly one of ``chunk``/``error`` is set. ``note`` is the result confirmation
+    text for a successful call, distinct from the call's required ``note`` argument.
     """
 
     chunk: ActionChunk | None = None
@@ -146,8 +146,18 @@ class Toolset:
                                 + ", ".join(self._labels)
                             ),
                         },
+                        "note": {
+                            "type": "string",
+                            "description": (
+                                "What you observe right now in the observation (images, if any, "
+                                "and state), and why you chose this motion. The user reads these "
+                                "notes live and in the saved transcript to follow what you see "
+                                "and what you decide. Write for them, in one or two plain "
+                                "sentences."
+                            ),
+                        },
                     },
-                    "required": [values_key],
+                    "required": [values_key, "note"],
                 },
             },
         }
@@ -221,6 +231,12 @@ class Toolset:
             current = self._current_state(observation)
             if not bool(np.all(np.isfinite(current))):
                 raise ValueError("proprioceptive reference contains a non-finite value")
+
+        call_note = arguments.get("note")
+        if not isinstance(call_note, str) or not call_note.strip():
+            return ToolResult(
+                error=("note is required: describe what you observe and why you chose this motion")
+            )
 
         values_key = "targets" if self._absolute else "deltas"
         values = arguments.get(values_key)

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -39,6 +39,10 @@ _SYSTEM_TEMPLATE = """You are controlling a real robot embodiment named {name!r}
 through tool calls. Each observation message gives you the current \
 proprioceptive state and camera images. Work toward the user's goal in \
 small, deliberate motions; re-check the observation after every motion. \
+Every move tool call must include a `note`: in one or two sentences, say what \
+you observe in the current observation and why you chose this motion. The user \
+is watching these notes to see what you see and what you decide, so write them \
+for a human reader. \
 Safety approvers clamp out-of-bounds and too-fast actions below you. \
 Respond with exactly one tool call per turn. When the goal is achieved call \
 done; if it cannot be achieved call give_up. You have a budget of \

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,5 +6,5 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.9.0"
+    assert inspect_robots_agent.__version__ == "0.10.0"
     assert callable(inspect_robots_agent.agent_policy)

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -36,8 +36,30 @@ from inspect_robots_agent.policy import _SYSTEM_TEMPLATE, AgentPolicyConfig, _ob
 
 # --- scripted-conversation harness ---------------------------------------------
 
+_MOVE_TOOL_NAMES = frozenset({"move_joints", "move_to", "move_by"})
+_DEFAULT_MOVE_NOTE = "The target is ahead, so I chose this motion to move toward it."
+_NOTE_CONTRACT = (
+    "Every move tool call must include a `note`: in one or two sentences, say what you observe "
+    "in the current observation and why you chose this motion. The user is watching these notes "
+    "to see what you see and what you decide, so write them for a human reader."
+)
+_NOTE_ERROR = "note is required: describe what you observe and why you chose this motion"
 
-def _tool_response(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+
+def _with_default_note(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    wire_arguments = dict(arguments)
+    if name in _MOVE_TOOL_NAMES:
+        wire_arguments.setdefault("note", _DEFAULT_MOVE_NOTE)
+    return wire_arguments
+
+
+def _tool_response(
+    name: str,
+    arguments: dict[str, Any],
+    *,
+    add_default_note: bool = True,
+) -> dict[str, Any]:
+    wire_arguments = _with_default_note(name, arguments) if add_default_note else arguments
     return {
         "choices": [
             {
@@ -48,7 +70,7 @@ def _tool_response(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
                         {
                             "id": f"call_{name}",
                             "type": "function",
-                            "function": {"name": name, "arguments": json.dumps(arguments)},
+                            "function": {"name": name, "arguments": json.dumps(wire_arguments)},
                         }
                     ],
                 }
@@ -92,7 +114,10 @@ def _multi_tool_response(calls: list[tuple[str, dict[str, Any]]]) -> dict[str, A
                         {
                             "id": f"call_{index}",
                             "type": "function",
-                            "function": {"name": name, "arguments": json.dumps(arguments)},
+                            "function": {
+                                "name": name,
+                                "arguments": json.dumps(_with_default_note(name, arguments)),
+                            },
                         }
                         for index, (name, arguments) in enumerate(calls)
                     ],
@@ -260,6 +285,17 @@ def test_absent_embodiment_docs_leave_the_prompt_unchanged(docs: str | None) -> 
 
     assert transcript is not None
     assert transcript[0]["content"] == _SYSTEM_TEMPLATE.format(name="cubepick", budget=100)
+
+
+def test_system_prompt_requires_human_readable_move_notes() -> None:
+    policy = _policy(_Script([_text_response("unused")]))
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="reach"))
+
+    transcript = policy.transcript()
+
+    assert transcript is not None
+    assert _NOTE_CONTRACT in transcript[0]["content"]
 
 
 def test_bind_accepts_legacy_embodiment_info_without_docs() -> None:
@@ -744,6 +780,42 @@ def test_recoverable_tool_error_is_fed_back_and_corrected(tmp_path: Path) -> Non
         m for request in script.requests for m in request["messages"] if m.get("role") == "tool"
     ]
     assert any("unknown dimension 'dz'" in str(m["content"]) for m in tool_messages)
+
+
+def test_missing_note_is_fed_back_and_corrected_in_persisted_transcript(
+    tmp_path: Path,
+) -> None:
+    corrected_note = "The cube is still ahead, so I will move the end effector toward it."
+    script = _Script(
+        [
+            _tool_response(
+                "move_by",
+                {"deltas": {"dx": 0.05}},
+                add_default_note=False,
+            ),
+            _tool_response(
+                "move_by",
+                {"deltas": {"dx": 0.05}, "note": corrected_note},
+            ),
+            _tool_response("done", {"summary": "corrected"}),
+        ]
+    )
+    logs = ir_eval(_task(), _policy(script), CubePickEmbodiment(), log_dir=str(tmp_path))
+
+    assert logs[0].status == "success"
+    correction_messages = [
+        message for message in script.requests[1]["messages"] if message.get("role") == "tool"
+    ]
+    assert any(message["content"] == _NOTE_ERROR for message in correction_messages)
+
+    (transcript,) = logs[0].samples[0].policy_transcripts
+    assert transcript is not None
+    tool_arguments = [
+        json.loads(call["function"]["arguments"])
+        for message in transcript
+        for call in message.get("tool_calls", [])
+    ]
+    assert any(arguments.get("note") == corrected_note for arguments in tool_arguments)
 
 
 def test_persistent_tool_errors_become_policy_error(tmp_path: Path) -> None:

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -21,6 +21,8 @@ _ARM_LABELS = tuple(
     for side in ("left", "right")
     for part in (*[f"j{i}" for i in range(6)], "gripper")
 )
+_DEFAULT_MOVE_NOTE = "The robot state is visible, so I chose this motion to make progress."
+_NOTE_ERROR = "note is required: describe what you observe and why you chose this motion"
 
 
 def _bimanual_space() -> Box:
@@ -66,6 +68,8 @@ def _delta_space(
 
 
 def _call(name: str, **arguments: object) -> ToolCall:
+    if name in ("move_joints", "move_to", "move_by"):
+        arguments.setdefault("note", _DEFAULT_MOVE_NOTE)
     return ToolCall(id="call_1", name=name, arguments=json.dumps(arguments))
 
 
@@ -79,6 +83,7 @@ def _execute_absolute(
     *,
     control_hz: float | None = 10.0,
     max_speed_frac: float = 0.1,
+    note: object = _DEFAULT_MOVE_NOTE,
 ) -> ToolResult:
     toolset = build_toolset(
         _absolute_space(),
@@ -87,7 +92,7 @@ def _execute_absolute(
         max_speed_frac=max_speed_frac,
     )
     return toolset.execute(
-        _call("move_joints", targets={"joint": target}),
+        _call("move_joints", note=note, targets={"joint": target}),
         _obs({"q": np.array([current])}),
     )
 
@@ -380,12 +385,36 @@ def test_schemas_match_control_mode_and_remove_duration() -> None:
     move_schema = json.dumps(absolute.schemas()[0])
     assert "left_j0" in move_schema and "right_gripper" in move_schema
     assert "duration_s" not in move_schema
-    assert absolute.schemas()[0]["function"]["parameters"]["required"] == ["targets"]
+    absolute_parameters = [schema["function"]["parameters"] for schema in absolute.schemas()]
+    assert [parameters["required"] for parameters in absolute_parameters] == [
+        ["targets", "note"],
+        ["summary"],
+        ["reason"],
+    ]
+    assert absolute_parameters[0]["properties"]["note"] == {
+        "type": "string",
+        "description": (
+            "What you observe right now in the observation (images, if any, and state), and why "
+            "you chose this motion. The user reads these notes live and in the saved transcript "
+            "to follow what you see and what you decide. Write for them, in one or two plain "
+            "sentences."
+        ),
+    }
+    assert "note" not in absolute_parameters[1]["properties"]
+    assert "note" not in absolute_parameters[2]["properties"]
 
     displacement = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
     names = [t["function"]["name"] for t in displacement.schemas()]
     assert names == ["move_by", "done", "give_up"]
-    assert displacement.schemas()[0]["function"]["parameters"]["required"] == ["deltas"]
+    displacement_parameters = [
+        schema["function"]["parameters"] for schema in displacement.schemas()
+    ]
+    assert [parameters["required"] for parameters in displacement_parameters] == [
+        ["deltas", "note"],
+        ["summary"],
+        ["reason"],
+    ]
+    assert displacement_parameters[0]["properties"]["note"]["type"] == "string"
 
 
 # --- absolute-mode synthesis ---------------------------------------------------
@@ -524,7 +553,11 @@ def test_broken_sensor_raises_even_with_malformed_arguments() -> None:
     # correctable structured error.
     with pytest.raises(ValueError, match="non-finite"):
         toolset.execute(
-            _call("move_joints", targets={"unknown_dim": 0.1}),
+            ToolCall(
+                id="call_1",
+                name="move_joints",
+                arguments=json.dumps({"targets": {"unknown_dim": 0.1}}),
+            ),
             _obs({"q": np.array([float("nan")])}),
         )
 
@@ -674,6 +707,51 @@ def test_arbitrary_precision_json_integer_is_a_structured_error() -> None:
 # --- done, notes, and structured errors ---------------------------------------
 
 
+def test_missing_move_note_is_a_structured_error_in_both_modes() -> None:
+    absolute = build_toolset(_absolute_space(), _absolute_obs_space(), control_hz=10.0)
+    absolute_call = ToolCall(
+        id="call_1",
+        name="move_joints",
+        arguments=json.dumps({"targets": {"joint": 0.1}}),
+    )
+    absolute_result = absolute.execute(absolute_call, _obs())
+    assert absolute_result.chunk is None
+    assert absolute_result.error == _NOTE_ERROR
+
+    displacement = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+    displacement_call = ToolCall(
+        id="call_1",
+        name="move_by",
+        arguments=json.dumps({"deltas": {"0": 0.05}}),
+    )
+    displacement_result = displacement.execute(displacement_call, _obs({}))
+    assert displacement_result.chunk is None
+    assert displacement_result.error == _NOTE_ERROR
+
+
+@pytest.mark.parametrize("note", ["", "   ", 42])
+def test_invalid_move_note_is_a_structured_error(note: object) -> None:
+    toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+    result = toolset.execute(_call("move_by", note=note, deltas={"0": 0.05}), _obs({}))
+    assert result.chunk is None
+    assert result.error == _NOTE_ERROR
+
+
+def test_valid_move_note_does_not_change_the_motion_chunk() -> None:
+    toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+    result = toolset.execute(
+        _call(
+            "move_by",
+            note="The end effector is short of the target, so I will move it along x.",
+            deltas={"0": 0.05},
+        ),
+        _obs({}),
+    )
+    assert result.error is None and result.chunk is not None
+    assert len(result.chunk.actions) == 1
+    assert result.chunk.actions[0].data.tobytes() == np.array([0.05, 0.0]).tobytes()
+
+
 def test_done_and_give_up_emit_control_mode_hold() -> None:
     absolute = build_toolset(_bimanual_space(), _bimanual_obs_space(), control_hz=10.0)
     state = np.full(14, 0.3)
@@ -697,7 +775,11 @@ def test_done_and_give_up_emit_control_mode_hold() -> None:
 def test_tool_errors_are_messages_not_exceptions() -> None:
     toolset = build_toolset(_bimanual_space(), _bimanual_obs_space(), control_hz=10.0)
     cases = [
-        _call("move_joints", targets={"left_elbow": 0.1}),
+        _call(
+            "move_joints",
+            note="The arm is centered, so I will test an invalid named joint.",
+            targets={"left_elbow": 0.1},
+        ),
         _call("move_joints", targets={"left_j0": float("nan")}),
         _call("move_joints", targets={"left_j0": "fast"}),
         _call("move_joints", targets={}),
@@ -716,7 +798,12 @@ def test_tool_errors_are_messages_not_exceptions() -> None:
 def test_stray_duration_key_is_ignored() -> None:
     toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
     result = toolset.execute(
-        _call("move_by", deltas={"0": 0.05}, duration_s=0.001),
+        _call(
+            "move_by",
+            note="The target is ahead, so I will move slightly along x.",
+            deltas={"0": 0.05},
+            duration_s=0.001,
+        ),
         _obs({}),
     )
     assert result.error is None and result.chunk is not None

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -707,6 +707,19 @@ def test_arbitrary_precision_json_integer_is_a_structured_error() -> None:
 # --- done, notes, and structured errors ---------------------------------------
 
 
+def test_missing_note_error_precedes_values_validation() -> None:
+    """A call wrong in both ways reports the note error first (plan 0021 ordering)."""
+    toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+    call = ToolCall(
+        id="call_1",
+        name="move_by",
+        arguments=json.dumps({"deltas": {"not_a_dimension": 0.05}}),
+    )
+    result = toolset.execute(call, _obs())
+    assert result.chunk is None
+    assert result.error == _NOTE_ERROR
+
+
 def test_missing_move_note_is_a_structured_error_in_both_modes() -> None:
     absolute = build_toolset(_absolute_space(), _absolute_obs_space(), control_hz=10.0)
     absolute_call = ToolCall(

--- a/uv.lock
+++ b/uv.lock
@@ -520,7 +520,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #130.

Implements plan 0021 (included in this PR): every agent move tool call now requires a `note` argument where the model states what it observes and why it chose the motion. The system prompt tells the model the user reads these notes; a missing/empty/non-string note is a structured tool error the model corrects through the existing failure loop. Notes ride inside tool-call arguments, so persistence, `--transcript`, stderr echo, and the Rerun stream carry them with no plumbing changes.

Plugin version 0.9.0 -> 0.10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)