### PR TITLE
feat(cli): inspect-robots view renders an eval log as a self-contained HTML page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,6 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
-### Added
-
-- **Agent plugin:** `-P wire=responses` selects the OpenAI Responses API wire,
-  so reasoning effort works together with function tools on recent OpenAI
-  models (Chat Completions rejects the combination, observed on
-  `gpt-5.6-sol`). The chat-wire rejection now names the fix in its error
-  message (#131).
-
 ### Removed
 
 - **`Task.control_hz`** (breaking). `rollout()` never actually paced the
@@ -38,6 +30,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- **Agent plugin:** `-P wire=responses` selects the OpenAI Responses API wire,
+  so reasoning effort works together with function tools on recent OpenAI
+  models (Chat Completions rejects the combination, observed on
+  `gpt-5.6-sol`). The chat-wire rejection now names the fix in its error
+  message (#131).
 - **`inspect-robots view LOG.json`**: render a saved eval log as a
   self-contained HTML report with run metadata, scores, scene results,
   collapsible policy conversations, and highlighted agent notes (#132).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ All notable changes to this project are documented here. The format is based on
   one `max_llm_calls` unit.
 
 ### Added
+
+- **`inspect-robots view LOG.json`**: render a saved eval log as a
+  self-contained HTML report with run metadata, scores, scene results,
+  collapsible policy conversations, and highlighted agent notes (#132).
 - **`inspect-robots eval-set TASK [TASK ...]`**: run several registered tasks
   against one resolved policy/embodiment pair in a single invocation, matching
   task names exactly or by shell-quoted `fnmatch` glob (e.g.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ inspect-robots "place the fork on the plate" --policy agent \
     -P model=anthropic/claude-fable-5 -P effort=low
 ```
 
-Read the recorded agent conversation with `inspect-robots inspect LOG.json --transcript`.
+Read the recorded agent conversation with
+`inspect-robots inspect LOG.json --transcript`, or open the HTML report with
+`inspect-robots view LOG.json`.
 
 ### Run in simulation
 
@@ -179,6 +181,12 @@ Pretty-print a saved eval log:
 
 ```bash
 inspect-robots inspect logs/cubepick-reach_*.json
+```
+
+Render a saved eval log as a self-contained HTML report:
+
+```bash
+inspect-robots view logs/cubepick-reach_*.json
 ```
 
 Render a `--store-frames` run's camera frames to MP4 videos (needs the

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -264,6 +264,28 @@ scenes:
 `completed` is the display form of the log's `success` status value; the
 on-disk field and Python API keep `success`.
 
+## `inspect-robots view`
+
+Render a saved [`EvalLog`][inspect_robots.log.EvalLog] as a self-contained HTML
+report:
+
+```bash
+inspect-robots view logs/cubepick-reach_xxxx.json
+```
+
+The report puts the run status, configuration, metrics, scene results, and
+recorded policy conversations on one page. Agent notes from tool calls are
+highlighted above their call lines. The file contains its stylesheet inline
+and uses native browser controls to collapse transcripts, so it has no network
+or JavaScript dependency.
+
+By default, `view` replaces the log path's suffix with `.html` and prints the
+written path. Use `-o REPORT.html` to choose another file, `-o -` to write only
+the HTML document to stdout, or `--open` to launch the written file in the
+default browser. Missing output directories are created. The command returns
+0 whenever it produces the report, even when the evaluation recorded a failed
+or cancelled run.
+
 ## `inspect-robots video`
 
 Render a `--store-frames` run's stored camera frames into one MP4 per

--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -122,8 +122,14 @@ hint whenever a log has stored frames.
 ## Policy transcripts
 
 Policies can persist a per-trial audit record in the eval log; read it with
-`inspect-robots inspect LOG.json --transcript`. The agent policy stores its
-conversation, with streamed image bytes replaced by
+`inspect-robots inspect LOG.json --transcript`, or render a self-contained
+conversation page with [`inspect-robots view`](cli.md#inspect-robots-view):
+
+```bash
+inspect-robots view LOG.json
+```
+
+The agent policy stores its conversation, with streamed image bytes replaced by
 `[image omitted: streamed camera frame]`. The preceding label, such as
 `camera 'top_cam' (step 480):`, is emitted whether or not frames are stored,
 and when they are (`store_frames=True`) it provides the step join key from a

--- a/plans/0022-html-log-viewer.md
+++ b/plans/0022-html-log-viewer.md
@@ -205,7 +205,8 @@ CLI:
 - `--open`: `webbrowser.open` receives the resolved `file://` URI
   (monkeypatched); a `False` return warns on stderr; a raising open warns
   on stderr; exit code unchanged in both.
-- Exit code 0 for success logs, 1 otherwise.
+- Exit code 0 once the page is produced, regardless of the log's run status
+  (artifact-producer convention, per the design section).
 - New hint lines from `run` summary and `inspect`; reworded existing
   "inspect it with" hints asserted.
 

--- a/plans/0022-html-log-viewer.md
+++ b/plans/0022-html-log-viewer.md
@@ -1,0 +1,229 @@
+# 0022 — `inspect-robots view`: render an eval log as a self-contained HTML page
+
+Issue: #132. Status: draft.
+
+## Problem
+
+`inspect-robots inspect LOG.json --transcript` prints a faithful but flat text
+dump. For an agent trial with dozens of turns, the operator wants what Inspect
+AI's log viewer gives LLM evals: a scannable page with the run header, scores,
+and a conversation view where roles, tool calls, and the model's mandatory
+per-call notes (issue #130) are visually distinct. Nothing in the ecosystem
+renders robotics eval logs today.
+
+## Design
+
+A new subcommand and one new private module. No new dependencies (core stays
+NumPy-only; rendering is stdlib: `html.escape` + string templates).
+
+```
+inspect-robots view LOG.json [-o OUT.html] [--open]
+```
+
+- Writes a **single self-contained HTML file** (inline CSS, no JS, no
+  external assets, no network) rendering the full `EvalLog`.
+- Default output path: the log path with its suffix replaced by `.html`
+  (`with_suffix(".html")`; a suffixless path gains `.html` — covered by a
+  test). `-o` overrides. `-o -` writes the document to stdout for piping.
+- File mode prints `wrote OUT.html` to stdout; **stdout mode suppresses the
+  wrote line** (it would corrupt the piped document).
+- Guard rails (guidance-over-traceback, like `video`'s output handling —
+  note `video --out` names a directory so its guard condition is the
+  inverse; do not copy its message verbatim): an output path that exists
+  **and is a directory** is a `SystemExit` with guidance; a missing parent
+  directory is created (`parent.mkdir(parents=True, exist_ok=True)`, the
+  same courtesy `video` extends); `-o -` together with `--open` is a
+  `SystemExit` ("no file to open").
+- `--open` opens the written file with stdlib `webbrowser.open` on the
+  `resolve()`d path's `as_uri()` (relative paths make `as_uri()` raise).
+  Best-effort: a `False` return **or** an exception degrades to a stderr
+  warning; exit code unchanged.
+- Exit code: 0 when the page was produced, nonzero only on production
+  failure — the `video` artifact-producer convention, not `inspect`'s
+  status mirror. The command's job is rendering; `view ... && xdg-open`
+  must not read a failed *run* as a failed *render*. (The page itself shows
+  the status badge front and center.)
+
+### Module: `src/inspect_robots/_html.py`
+
+Private, like `_video.py`; `__all__` and the API snapshot are untouched.
+Entry point:
+
+```python
+def render_html(log: EvalLog, *, title: str) -> str
+```
+
+pure function from log to document text — trivially testable, no IO. The CLI
+command owns path derivation, writing, and `--open`, and passes
+`title=f"{log.eval.task} - {Path(path).name}"` (task identity plus which
+file, ASCII separator).
+
+**Import direction:** `_html.py` never imports from `cli.py`. The shared
+transcript predicates `_is_chat_transcript` and `_chat_content`, and the
+status display mapping (`_STATUS_DISPLAY` / `_display_status`), migrate into
+`_html.py`; `cli.py` imports them from there (top-level is fine — `_html`
+is stdlib-only, so it cannot violate the lazy-import rule that exists for
+heavy optional deps). The text renderer's behavior is unchanged.
+
+**Encoding:** the file handle opens with `encoding="utf-8",
+errors="replace"` — lone surrogates survive the log's JSON round-trip but
+not strict UTF-8. Stdout mode funnels through the same degrade
+(`doc.encode("utf-8", errors="replace").decode("utf-8")` before writing),
+because `sys.stdout` is strict on most terminals. Encode-time `replace`
+substitutes ASCII `?` (U+FFFD is the *decode*-time replacement); the tests
+assert `?` appears in place of the surrogate rather than an exception.
+
+### Page structure (Inspect AI-viewer-inspired, dependency-free)
+
+1. **Header bar** — task name, status badge, created timestamp,
+   inspect-robots version, git commit (or an "unknown" chip when `None`).
+   Badge classes: completed=green, error=red, cancelled=grey,
+   started/anything-else=neutral. Labels come from the shared
+   `_display_status` mapping so the page and the CLI never diverge
+   (`success` displays as `completed`); unknown statuses render their raw
+   text escaped in the neutral badge.
+2. **Spec strip** — policy, embodiment, `policy_config` entries as
+   definition pairs, seed / max_steps / mean inference latency (each with a
+   None-omitted branch), duration, total steps.
+3. **Metrics row** — one stat tile per `results.metrics` entry, plus
+   scenes/trials/errored counts.
+4. **Scene cards** — one `<section>` per `SceneResult`: instruction, status,
+   reduced scores, per-epoch score chips, termination reasons (None entries
+   render as an em-dash-free "n/a" chip), operator judgements, error text
+   when present.
+5. **Transcript panels** — inside each scene card, one `<details>` per trial
+   with a recorded transcript. Default-open rule: open exactly when the
+   whole log carries **exactly one non-None transcript**; otherwise all
+   collapsed (both states tested). Chat-shaped transcripts (shared
+   `_is_chat_transcript`) render as a conversation:
+   - `system` → nested collapsed `<details>` (long, static);
+   - `user` → observation bubble; content lists collapse media parts to an
+     `[image]` chip exactly like `_chat_content`; content that is neither
+     str nor list renders as a role-only bubble (the `_chat_content` → None
+     branch);
+   - `assistant` → response bubble; each entry of `tool_calls` renders as a
+     monospace call line `move_by({...})`, with the same defensive guards
+     as `_render_chat_transcript` (non-dict message/call/function,
+     non-list `tool_calls` — each guard tested);
+   - **notes** — for every tool call whose arguments carry a non-empty
+     string under `"note"` (and for `done`/`give_up`'s `summary`/`reason`),
+     the text renders as a highlighted callout labeled "agent note" above
+     the call line. Arguments may arrive as a JSON string **or** as a dict
+     (the wire format allows both; the text renderer already tolerates
+     non-str); both are consulted. A string that fails `json.loads` renders
+     escaped-verbatim with no callout. This is the issue-#130 visibility
+     channel and the reason this page exists;
+   - `tool` → result line attached under the calling bubble.
+   Non-chat transcripts fall back to pretty-printed JSON in a `<pre>`,
+   with long string values elided at 2048 chars and an explicit ASCII
+   `[... N chars truncated]` marker (ASCII to match every other
+   CLI-emitted string and to survive a C-locale stdout in `-o -` mode) — a
+   transcript that fails the chat predicate can carry full base64 image
+   parts, and an unbounded dump produces a file browsers cannot open.
+   Elision runs on the **raw** value, then the result is escaped, so a cut
+   can never land mid-HTML-entity.
+
+Collapsing uses native `<details>/<summary>` only (no JavaScript). Colors
+respect `prefers-color-scheme` (light and dark rules in one inline
+stylesheet).
+
+### Foreign-data rules (the security section)
+
+Transcript text, instructions, scene ids, error strings, metric names —
+everything from the log — is **foreign data** and is passed through
+`html.escape(..., quote=True)` exactly once at interpolation time. No code
+path emits log text unescaped; a transcript containing `<script>` must
+render as literal text.
+
+## CLI touchpoints (enumerated so none is forgotten)
+
+- New `sub.add_parser("view", ...)` with help text, `-o`, `--open`.
+- `_SUBCOMMANDS` tuple gains `"view"` (instruction-sugar guard; `view` has
+  no interior whitespace so behavior is identical, but the tuple must not
+  drift).
+- `main()` dispatch chain gains the branch.
+- Module docstring's subcommand list gains the entry.
+- The two existing hints reading `hint: view it with: inspect-robots
+  inspect …` (`_print_run_summary` and the KeyboardInterrupt path) are
+  reworded to `hint: inspect it with: …` in the same PR — "view" now names
+  a different command. Five assertions in `tests/test_registry_cli.py`
+  hard-code the old wording and are updated with it.
+  `_print_run_summary`, `inspect`'s "policy transcripts: recorded" line,
+  and the eval-set surfaces that print log hints
+  (`_print_eval_set_summary` and eval-set's KeyboardInterrupt path) each
+  gain one hint advertising `inspect-robots view <log>`.
+- README's "Read the recorded agent conversation with `inspect-robots
+  inspect ... --transcript`" line gains the view alternative.
+
+## Compatibility
+
+- Works on any schema-v1 log: every field the renderer touches has a
+  reading-old-logs default. Logs with no transcripts render
+  header/metrics/scenes and a "no policy transcripts recorded" line.
+- Notes are duck-typed from tool-call arguments; pre-#130 agent logs show
+  no callouts. Nothing imports the agent plugin.
+- Core version: minor bump on release (new user-facing command).
+
+## Tests
+
+Renderer tests in a new `tests/test_html_view.py` (mirroring `_video.py`'s
+dedicated test file); CLI wiring in `tests/test_registry_cli.py` (the
+existing `main([...])` + capsys/tmp_path/monkeypatch convention).
+
+`render_html` (pure, no IO):
+- Header/status/metrics/scene content present and escaped; badge class per
+  status: success ("completed"), error, cancelled, started, and an unknown
+  string (neutral fallback).
+- None-vs-present branches: `git_commit`, `seed`, `max_steps`,
+  `mean_inference_latency_s`, `scene.error`, `scene.instruction`, empty
+  `epochs`/`operator_judgements`, None entries in `termination_reasons`.
+- XSS: `<script>alert(1)</script>` in instruction, message content, tool
+  arguments, scene id, error string, metric name, and status → appears only
+  escaped.
+- Chat transcript: roles, tool-call lines, tool results; system message in
+  a nested collapsed details; note in string-JSON arguments → exactly one
+  callout; note in dict arguments → callout; `done` summary and `give_up`
+  reason → callouts; malformed argument string → escaped verbatim, no
+  callout; non-string/empty/whitespace note → no callout.
+- Defensive guards: non-dict message, non-list `tool_calls`, non-dict call,
+  non-dict function, content neither str nor list.
+- Media parts collapse to `[image]`.
+- Non-chat transcript → `<pre>` fallback; a long string value is elided
+  with the truncation marker; `None` transcripts skipped; transcript-free
+  log renders the "none recorded" line.
+- Default-open: exactly-one-transcript log renders an open panel;
+  two-transcript log renders all collapsed.
+
+CLI:
+- Default path derivation (including a suffixless log path), `-o` override,
+  `-o -` stdout mode (document on stdout, **no** wrote line).
+- `-o` pointing at an existing directory → SystemExit guidance; `-o -`
+  plus `--open` → SystemExit; `-o` with a missing parent directory →
+  parents created and the file written.
+- Surrogate content: file mode writes replacement chars; stdout mode
+  degrades identically instead of crashing.
+- `--open`: `webbrowser.open` receives the resolved `file://` URI
+  (monkeypatched); a `False` return warns on stderr; a raising open warns
+  on stderr; exit code unchanged in both.
+- Exit code 0 for success logs, 1 otherwise.
+- New hint lines from `run` summary and `inspect`; reworded existing
+  "inspect it with" hints asserted.
+
+Gates: 100% core coverage (`--cov-fail-under=100`), `mypy --strict`
+(src+tests), ruff incl. D1.
+
+## Docs
+
+- README subcommand list gains `view` (drafted to the repo's public-text
+  style rules: no em dashes, no mid-sentence bold).
+- `docs/guide/cli.md` gains a `## inspect-robots view` section beside
+  `inspect` and `video`.
+- `docs/guide/logging-and-rerun.md`'s transcript-reading passage mentions
+  the HTML viewer.
+- `CHANGELOG.md` entry under core.
+
+## Rollout
+
+Single PR (`Closes #132`), core only, after the mandatory-notes PR
+(issue #130) merges — the note-callout fixtures mirror the real agent's
+argument shape. Release the next core minor immediately after merge.

--- a/src/inspect_robots/_html.py
+++ b/src/inspect_robots/_html.py
@@ -1,0 +1,467 @@
+"""Render evaluation logs as dependency-free, self-contained HTML documents."""
+
+from __future__ import annotations
+
+import html
+import json
+from collections.abc import Mapping
+from typing import Any, cast
+
+from inspect_robots.log import EvalLog, SceneResult
+
+_STATUS_DISPLAY = {"success": "completed"}
+_JSON_STRING_LIMIT = 2048
+
+_STYLES = """
+:root {
+  color-scheme: light dark;
+  --bg: #f7f8fa;
+  --panel: #ffffff;
+  --text: #20242b;
+  --muted: #68707d;
+  --line: #dfe3e8;
+  --green: #19723b;
+  --green-bg: #e9f6ed;
+  --red: #a12a2a;
+  --red-bg: #fbecec;
+  --grey: #626a75;
+  --grey-bg: #eef0f2;
+  --neutral: #45546a;
+  --neutral-bg: #edf1f6;
+  --user: #3178c6;
+  --assistant: #7a55b5;
+  --tool: #36866a;
+  --system: #7a828d;
+  --amber: #8a5700;
+  --amber-line: #d69b2d;
+  --amber-bg: #fff5d9;
+}
+@media (prefers-color-scheme: light) {
+  :root { color-scheme: light; }
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #111419;
+    --panel: #191d24;
+    --text: #e7eaf0;
+    --muted: #a4acb8;
+    --line: #343a45;
+    --green: #7ed99a;
+    --green-bg: #193b27;
+    --red: #ff9b9b;
+    --red-bg: #492323;
+    --grey: #c0c5cd;
+    --grey-bg: #343943;
+    --neutral: #b9c9df;
+    --neutral-bg: #293342;
+    --user: #73b7ff;
+    --assistant: #bd9bed;
+    --tool: #79c9ab;
+    --system: #adb4be;
+    --amber: #ffd484;
+    --amber-line: #b77a16;
+    --amber-bg: #3b2d12;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 15px/1.55 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+main { width: min(1120px, calc(100% - 32px)); margin: 0 auto 64px; }
+header { border-bottom: 1px solid var(--line); background: var(--panel); }
+.header-inner { width: min(1120px, calc(100% - 32px)); margin: auto; padding: 28px 0 22px; }
+.header-top { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+h1 { margin: 0; font-size: 24px; font-weight: 650; }
+h2 { margin: 0; font-size: 18px; font-weight: 650; }
+h3 { margin: 24px 0 10px; font-size: 13px; text-transform: uppercase; letter-spacing: .06em; }
+.meta { color: var(--muted); margin-top: 8px; display: flex; gap: 16px; flex-wrap: wrap; }
+.badge, .chip { display: inline-block; border-radius: 999px; padding: 2px 9px; font-size: 12px; }
+.status-completed { color: var(--green); background: var(--green-bg); }
+.status-error { color: var(--red); background: var(--red-bg); }
+.status-cancelled { color: var(--grey); background: var(--grey-bg); }
+.status-neutral { color: var(--neutral); background: var(--neutral-bg); }
+.chip { color: var(--muted); background: var(--grey-bg); }
+.spec-strip {
+  margin: 24px 0; padding: 18px 20px; background: var(--panel);
+  border: 1px solid var(--line); border-radius: 8px;
+}
+dl {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(145px, 1fr));
+  gap: 14px 24px; margin: 0;
+}
+dt { color: var(--muted); font-size: 12px; }
+dd { margin: 2px 0 0; overflow-wrap: anywhere; }
+.metrics {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(135px, 1fr));
+  gap: 12px; margin-bottom: 28px;
+}
+.stat {
+  padding: 14px 16px; background: var(--panel);
+  border: 1px solid var(--line); border-radius: 8px;
+}
+.stat-name { color: var(--muted); font-size: 12px; overflow-wrap: anywhere; }
+.stat-value { margin-top: 3px; font-size: 19px; font-weight: 620; }
+.scene {
+  margin: 18px 0; padding: 22px; background: var(--panel);
+  border: 1px solid var(--line); border-radius: 9px;
+}
+.scene-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.instruction, .error { margin: 12px 0 0; white-space: pre-wrap; }
+.error { color: var(--red); }
+.score-row { display: flex; flex-wrap: wrap; gap: 7px; margin: 8px 0 0; }
+.score-chip {
+  border: 1px solid var(--line); border-radius: 999px; padding: 2px 8px; font-size: 12px;
+}
+details { border-top: 1px solid var(--line); margin-top: 18px; padding-top: 12px; }
+summary { cursor: pointer; color: var(--muted); font-weight: 600; }
+.conversation { margin-top: 14px; }
+.message { margin: 13px 0; padding: 2px 0 2px 13px; border-left: 3px solid var(--system); }
+.message.user { border-color: var(--user); }
+.message.assistant { border-color: var(--assistant); }
+.message.tool { border-color: var(--tool); margin-left: 20px; }
+.role { color: var(--muted); font-size: 12px; font-weight: 650; text-transform: uppercase; }
+.content { margin-top: 3px; white-space: pre-wrap; overflow-wrap: anywhere; }
+.system-message {
+  margin: 13px 0; padding: 0 0 0 13px; border: 0;
+  border-left: 3px solid var(--system);
+}
+.system-message summary { color: var(--muted); }
+.call {
+  margin-top: 8px; overflow-wrap: anywhere;
+  font: 13px/1.5 ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+.agent-note {
+  margin: 10px 0 6px; padding: 9px 11px; color: var(--amber);
+  background: var(--amber-bg); border-left: 3px solid var(--amber-line);
+}
+.note-label {
+  display: block; font-size: 10px; font-weight: 750;
+  letter-spacing: .09em; text-transform: uppercase;
+}
+pre {
+  padding: 14px; overflow: auto; background: var(--bg);
+  border: 1px solid var(--line); border-radius: 6px;
+  font: 12px/1.5 ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+.none { color: var(--muted); margin: 28px 0; }
+""".strip()
+
+
+def _display_status(status: str) -> str:
+    """Return the stable human-facing form of a persisted status value."""
+    return _STATUS_DISPLAY.get(status, status)
+
+
+def _chat_content(content: object) -> str | None:
+    """Render text from an OpenAI-style content value, collapsing media parts."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return None
+    parts: list[str] = []
+    for part in content:
+        if isinstance(part, dict) and part.get("type") == "text":
+            parts.append(str(part.get("text", "")))
+        else:
+            parts.append("[image]")
+    return "\n".join(parts)
+
+
+def _is_chat_transcript(transcript: object) -> bool:
+    """Recognize a non-empty list of role-bearing message dictionaries."""
+    return (
+        isinstance(transcript, list)
+        and bool(transcript)
+        and all(isinstance(message, dict) and "role" in message for message in transcript)
+    )
+
+
+def _escape(value: object) -> str:
+    """Escape one foreign value at its HTML interpolation boundary."""
+    return html.escape(str(value), quote=True)
+
+
+def _number(value: int | float) -> str:
+    """Format numeric log values compactly before their interpolation boundary."""
+    return f"{value:.4g}"
+
+
+def _value(value: object) -> str:
+    """Format a scalar or structured spec value without HTML escaping it."""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, sort_keys=True)
+
+
+def _definition(label: object, value: object) -> str:
+    """Render one escaped definition pair."""
+    return f"<div><dt>{_escape(label)}</dt><dd>{_escape(value)}</dd></div>"
+
+
+def _status_class(status: str) -> str:
+    """Map a persisted status to one of the fixed badge color classes."""
+    displayed = _display_status(status)
+    if displayed == "completed":
+        return "status-completed"
+    if status == "error":
+        return "status-error"
+    if status == "cancelled":
+        return "status-cancelled"
+    return "status-neutral"
+
+
+def _status_badge(status: str) -> str:
+    """Render a status with a fixed class and escaped display label."""
+    return f'<span class="badge {_status_class(status)}">{_escape(_display_status(status))}</span>'
+
+
+def _agent_notes(name: str, arguments: object) -> list[str]:
+    """Extract non-empty agent notes from supported tool argument shapes."""
+    parsed: object = arguments
+    if isinstance(arguments, str):
+        try:
+            parsed = json.loads(arguments)
+        except json.JSONDecodeError:
+            return []
+    if not isinstance(parsed, dict):
+        return []
+
+    keys = ["note"]
+    if name == "done":
+        keys.append("summary")
+    elif name == "give_up":
+        keys.append("reason")
+    notes: list[str] = []
+    for key in keys:
+        note = parsed.get(key)
+        if isinstance(note, str) and note.strip():
+            notes.append(note)
+    return notes
+
+
+def _render_tool_call(raw_call: object) -> str:
+    """Render one tolerant OpenAI-style tool call, or nothing when malformed."""
+    if not isinstance(raw_call, dict):
+        return ""
+    function = raw_call.get("function")
+    if not isinstance(function, dict):
+        return ""
+    name = str(function.get("name", "unknown"))
+    arguments = function.get("arguments", "")
+    shown_arguments = arguments if isinstance(arguments, str) else json.dumps(arguments)
+    notes = "".join(
+        f'<div class="agent-note"><span class="note-label">agent note</span>{_escape(note)}</div>'
+        for note in _agent_notes(name, arguments)
+    )
+    return f'{notes}<div class="call">{_escape(name)}({_escape(shown_arguments)})</div>'
+
+
+def _render_message(raw_message: object) -> str:
+    """Render one tolerant chat message without trusting its role or content."""
+    if not isinstance(raw_message, dict):
+        return ""
+    role = str(raw_message["role"])
+    content = _chat_content(raw_message.get("content"))
+    if role == "system":
+        body = "" if content is None else f'<div class="content">{_escape(content)}</div>'
+        return f'<details class="system-message"><summary>system</summary>{body}</details>'
+
+    role_class = role if role in {"user", "assistant", "tool"} else "unknown"
+    body = "" if content is None else f'<div class="content">{_escape(content)}</div>'
+    if role == "tool":
+        return (
+            f'<div class="message {role_class}"><div class="role">{_escape(role)}</div>{body}</div>'
+        )
+    calls = ""
+    tool_calls = raw_message.get("tool_calls")
+    if isinstance(tool_calls, list):
+        calls = "".join(_render_tool_call(raw_call) for raw_call in tool_calls)
+    return (
+        f'<div class="message {role_class}"><div class="role">{_escape(role)}</div>'
+        f"{body}{calls}</div>"
+    )
+
+
+def _render_chat_transcript(transcript: list[object]) -> str:
+    """Render a defensive role-oriented conversation."""
+    return (
+        '<div class="conversation">'
+        + "".join(_render_message(message) for message in transcript)
+        + "</div>"
+    )
+
+
+def _elide_json_values(value: Any) -> Any:
+    """Recursively bound long JSON string values before serialization."""
+    if isinstance(value, str):
+        if len(value) <= _JSON_STRING_LIMIT:
+            return value
+        omitted = len(value) - _JSON_STRING_LIMIT
+        return value[:_JSON_STRING_LIMIT] + f"[... {omitted} chars truncated]"
+    if isinstance(value, list):
+        return [_elide_json_values(item) for item in value]
+    if isinstance(value, tuple):
+        return [_elide_json_values(item) for item in value]
+    if isinstance(value, Mapping):
+        return {key: _elide_json_values(item) for key, item in value.items()}
+    return value
+
+
+def _render_transcript(transcript: object) -> str:
+    """Render chat-shaped records conversationally and all others as bounded JSON."""
+    if _is_chat_transcript(transcript):
+        return _render_chat_transcript(cast(list[object], transcript))
+    dumped = json.dumps(_elide_json_values(transcript), indent=2, sort_keys=True)
+    return f"<pre>{_escape(dumped)}</pre>"
+
+
+def _score_chips(values: Mapping[str, float], *, prefix: str = "") -> str:
+    """Render sorted score values as compact escaped chips."""
+    return "".join(
+        f'<span class="score-chip">{_escape(prefix + name)}={_escape(_number(value))}</span>'
+        for name, value in sorted(values.items())
+    )
+
+
+def _scene_section(scene: SceneResult, *, open_transcript: bool) -> str:
+    """Render one complete scene card and its available trial transcripts."""
+    instruction = (
+        ""
+        if scene.instruction is None
+        else f'<p class="instruction">{_escape(scene.instruction)}</p>'
+    )
+    error = "" if scene.error is None else f'<p class="error">{_escape(scene.error)}</p>'
+
+    reduced = _score_chips(scene.reduced)
+    reduced_block = (
+        "" if not reduced else f'<h3>Reduced scores</h3><div class="score-row">{reduced}</div>'
+    )
+    epoch_chips = "".join(
+        _score_chips(epoch, prefix=f"trial {index} ") for index, epoch in enumerate(scene.epochs)
+    )
+    epoch_block = (
+        ""
+        if not epoch_chips
+        else f'<h3>Epoch scores</h3><div class="score-row">{epoch_chips}</div>'
+    )
+    reasons = "".join(
+        '<span class="score-chip">n/a</span>'
+        if reason is None
+        else f'<span class="score-chip">{_escape(reason)}</span>'
+        for reason in scene.termination_reasons
+    )
+    reasons_block = (
+        "" if not reasons else f'<h3>Termination reasons</h3><div class="score-row">{reasons}</div>'
+    )
+    judgements = "".join(
+        '<span class="score-chip">n/a</span>'
+        if judgement is None
+        else f'<span class="score-chip">{_escape(judgement)}</span>'
+        for judgement in scene.operator_judgements
+    )
+    judgements_block = (
+        ""
+        if not judgements
+        else f'<h3>Operator judgements</h3><div class="score-row">{judgements}</div>'
+    )
+
+    transcripts = "".join(
+        (
+            f'<details class="transcript"{" open" if open_transcript else ""}>'
+            f"<summary>Trial {trial} transcript</summary>{_render_transcript(transcript)}</details>"
+        )
+        for trial, transcript in enumerate(scene.policy_transcripts)
+        if transcript is not None
+    )
+    return (
+        '<section class="scene">'
+        f'<div class="scene-head"><h2>{_escape(scene.scene_id)}</h2>'
+        f"{_status_badge(scene.status)}</div>{instruction}{error}{reduced_block}{epoch_block}"
+        f"{reasons_block}{judgements_block}{transcripts}</section>"
+    )
+
+
+def render_html(log: EvalLog, *, title: str) -> str:
+    """Return one self-contained HTML document describing the complete evaluation log."""
+    git = (
+        'git <span class="chip">unknown</span>'
+        if log.eval.git_commit is None
+        else f"git {_escape(log.eval.git_commit)}"
+    )
+    definitions = [
+        _definition("policy", log.eval.policy),
+        _definition("embodiment", log.eval.embodiment),
+    ]
+    definitions.extend(
+        _definition(key, _value(value)) for key, value in sorted(log.eval.policy_config.items())
+    )
+    if log.eval.seed is not None:
+        definitions.append(_definition("seed", log.eval.seed))
+    if log.eval.max_steps is not None:
+        definitions.append(_definition("max steps", log.eval.max_steps))
+    if log.stats.mean_inference_latency_s is not None:
+        definitions.append(
+            _definition(
+                "mean inference latency", f"{_number(log.stats.mean_inference_latency_s)} s"
+            )
+        )
+    definitions.extend(
+        [
+            _definition("duration", f"{_number(log.stats.duration_s)} s"),
+            _definition("total steps", log.stats.total_steps),
+        ]
+    )
+
+    metric_tiles = "".join(
+        '<div class="stat">'
+        f'<div class="stat-name">{_escape(name)}</div>'
+        f'<div class="stat-value">{_escape(_number(value))}</div></div>'
+        for name, value in sorted(log.results.metrics.items())
+    )
+    metric_tiles += "".join(
+        '<div class="stat">'
+        f'<div class="stat-name">{label}</div>'
+        f'<div class="stat-value">{_escape(value)}</div></div>'
+        for label, value in (
+            ("scenes", log.results.total_scenes),
+            ("trials", log.results.total_trials),
+            ("errored", log.results.errored_trials),
+        )
+    )
+
+    transcript_count = sum(
+        transcript is not None for scene in log.samples for transcript in scene.policy_transcripts
+    )
+    scenes = "".join(
+        _scene_section(scene, open_transcript=transcript_count == 1) for scene in log.samples
+    )
+    no_transcripts = (
+        '<p class="none">no policy transcripts recorded</p>' if transcript_count == 0 else ""
+    )
+    document = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{_escape(title)}</title>
+<style>{_STYLES}</style>
+</head>
+<body>
+<header><div class="header-inner">
+  <div class="header-top"><h1>{_escape(log.eval.task)}</h1>{_status_badge(log.status)}</div>
+  <div class="meta"><span>{_escape(log.eval.created)}</span>
+  <span>inspect-robots {_escape(log.eval.inspect_robots_version)}</span><span>{git}</span></div>
+</div></header>
+<main>
+  <section class="spec-strip"><dl>{"".join(definitions)}</dl></section>
+  <section class="metrics">{metric_tiles}</section>
+  {scenes}
+  {no_transcripts}
+</main>
+</body>
+</html>
+"""
+    return document

--- a/src/inspect_robots/_html.py
+++ b/src/inspect_robots/_html.py
@@ -74,8 +74,8 @@ main { width: min(1120px, calc(100% - 32px)); margin: 0 auto 64px; }
 header { border-bottom: 1px solid var(--line); background: var(--panel); }
 .header-inner { width: min(1120px, calc(100% - 32px)); margin: auto; padding: 28px 0 22px; }
 .header-top { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
-h1 { margin: 0; font-size: 24px; font-weight: 650; }
-h2 { margin: 0; font-size: 18px; font-weight: 650; }
+h1 { margin: 0; font-size: 24px; font-weight: 650; min-width: 0; overflow-wrap: anywhere; }
+h2 { margin: 0; font-size: 18px; font-weight: 650; min-width: 0; overflow-wrap: anywhere; }
 h3 { margin: 24px 0 10px; font-size: 13px; text-transform: uppercase; letter-spacing: .06em; }
 .meta { color: var(--muted); margin-top: 8px; display: flex; gap: 16px; flex-wrap: wrap; }
 .badge, .chip { display: inline-block; border-radius: 999px; padding: 2px 9px; font-size: 12px; }
@@ -109,11 +109,12 @@ dd { margin: 2px 0 0; overflow-wrap: anywhere; }
   border: 1px solid var(--line); border-radius: 9px;
 }
 .scene-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-.instruction, .error { margin: 12px 0 0; white-space: pre-wrap; }
+.instruction, .error { margin: 12px 0 0; white-space: pre-wrap; overflow-wrap: anywhere; }
 .error { color: var(--red); }
 .score-row { display: flex; flex-wrap: wrap; gap: 7px; margin: 8px 0 0; }
 .score-chip {
   border: 1px solid var(--line); border-radius: 999px; padding: 2px 8px; font-size: 12px;
+  overflow-wrap: anywhere;
 }
 details { border-top: 1px solid var(--line); margin-top: 18px; padding-top: 12px; }
 summary { cursor: pointer; color: var(--muted); font-weight: 600; }
@@ -193,7 +194,7 @@ def _value(value: object) -> str:
     """Format a scalar or structured spec value without HTML escaping it."""
     if isinstance(value, str):
         return value
-    return json.dumps(value, sort_keys=True)
+    return json.dumps(value, sort_keys=True, ensure_ascii=False)
 
 
 def _definition(label: object, value: object) -> str:
@@ -314,7 +315,11 @@ def _render_transcript(transcript: object) -> str:
     """Render chat-shaped records conversationally and all others as bounded JSON."""
     if _is_chat_transcript(transcript):
         return _render_chat_transcript(cast(list[object], transcript))
-    dumped = json.dumps(_elide_json_values(transcript), indent=2, sort_keys=True)
+    # Escaping happens on the dumped text below, so raw non-ASCII is safe and
+    # far more readable than \uXXXX escapes.
+    dumped = json.dumps(
+        _elide_json_values(transcript), indent=2, sort_keys=True, ensure_ascii=False
+    )
     return f"<pre>{_escape(dumped)}</pre>"
 
 
@@ -345,7 +350,7 @@ def _scene_section(scene: SceneResult, *, open_transcript: bool) -> str:
     epoch_block = (
         ""
         if not epoch_chips
-        else f'<h3>Epoch scores</h3><div class="score-row">{epoch_chips}</div>'
+        else f'<h3>Trial scores</h3><div class="score-row">{epoch_chips}</div>'
     )
     reasons = "".join(
         '<span class="score-chip">n/a</span>'

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -15,6 +15,8 @@ Subcommands:
   per-task row instead of a full summary per task.
 - ``inspect-robots inspect LOG.json [--transcript]`` — print a saved eval log and
   optionally append recorded policy conversations.
+- ``inspect-robots view LOG.json [-o OUT.html] [--open]`` — render a saved eval log
+  as a self-contained HTML report.
 - ``inspect-robots video LOG.json`` — render a ``--store-frames`` run's stored
   camera frames to one MP4 per (trial, camera) stream via the ffmpeg binary.
 - ``inspect-robots setup`` — interactively configure defaults and camera devices.
@@ -39,7 +41,7 @@ import shutil
 import sys
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from inspect_robots import __version__
 from inspect_robots._defaults import (
@@ -55,6 +57,15 @@ from inspect_robots._defaults import (
     set_default,
 )
 from inspect_robots._dotenv import init_dotenv
+from inspect_robots._html import (
+    _STATUS_DISPLAY as _STATUS_DISPLAY,
+)
+from inspect_robots._html import (
+    _chat_content,
+    _display_status,
+    _is_chat_transcript,
+    render_html,
+)
 
 if TYPE_CHECKING:
     from inspect_robots.approver import Approver
@@ -83,8 +94,6 @@ _GREEN = "32"
 _RED = "31"
 _YELLOW = "33"
 
-_STATUS_DISPLAY = {"success": "completed"}
-
 _OUTCOME_PHRASES = {
     "success": "succeeded",
     "failure": "failed",
@@ -106,7 +115,17 @@ _KIND_BY_PLURAL = {
 
 _PLURAL_BY_KIND = {kind: plural for plural, kind in _KIND_BY_PLURAL.items()}
 
-_SUBCOMMANDS = ("list", "run", "eval-set", "inspect", "video", "config", "setup", "doctor")
+_SUBCOMMANDS = (
+    "list",
+    "run",
+    "eval-set",
+    "inspect",
+    "view",
+    "video",
+    "config",
+    "setup",
+    "doctor",
+)
 
 _ENV_BY_KIND = {"policy": ENV_POLICY, "embodiment": ENV_EMBODIMENT}
 
@@ -259,6 +278,21 @@ def build_parser() -> argparse.ArgumentParser:
         "--transcript",
         action="store_true",
         help="append recorded policy transcripts",
+    )
+
+    p_view = sub.add_parser("view", help="render a saved eval log as a self-contained HTML report")
+    p_view.add_argument("log", help="path to an EvalLog JSON file")
+    p_view.add_argument(
+        "-o",
+        "--out",
+        default=None,
+        metavar="FILE",
+        help="output HTML file (default: LOG with an .html suffix; - writes to stdout)",
+    )
+    p_view.add_argument(
+        "--open",
+        action="store_true",
+        help="open the written report in the default web browser",
     )
 
     p_video = sub.add_parser(
@@ -522,11 +556,6 @@ def _step_limit_count(log: EvalLog) -> int:
     )
 
 
-def _display_status(status: str) -> str:
-    """Return the human-facing form of a run status."""
-    return _STATUS_DISPLAY.get(status, status)
-
-
 def _outcome_line(log: EvalLog) -> tuple[str, bool] | None:
     """Return an outcome digest and unmapped flag, or ``None`` with no reasons."""
     reasons: list[object] = [
@@ -593,30 +622,6 @@ def _print_degraded(line: str) -> None:
     reader must degrade, never crash, on the episodes it exists to explain.
     """
     print(line.encode("utf-8", errors="replace").decode("utf-8"))
-
-
-def _chat_content(content: object) -> str | None:
-    """Render text from an OpenAI-style content value, collapsing media parts."""
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, list):
-        return None
-    parts: list[str] = []
-    for part in content:
-        if isinstance(part, dict) and part.get("type") == "text":
-            parts.append(str(part.get("text", "")))
-        else:
-            parts.append("[image]")
-    return "\n".join(parts)
-
-
-def _is_chat_transcript(transcript: object) -> bool:
-    """Recognize a non-empty list of role-bearing message dictionaries."""
-    return (
-        isinstance(transcript, list)
-        and bool(transcript)
-        and all(isinstance(message, dict) and "role" in message for message in transcript)
-    )
 
 
 def _render_chat_transcript(transcript: list[object]) -> None:
@@ -699,7 +704,8 @@ def _print_run_summary(log: EvalLog, log_path: str, is_adhoc: bool) -> None:
     print(f"{_styled('log:', _CYAN)} {_styled(log_path, _DIM)}")
     # Every run ends with the copy-pasteable read-back command (issue #90):
     # a bare path teaches a first-time user nothing about what to do next.
-    print(_styled(f"hint: view it with: inspect-robots inspect {log_path}", _DIM))
+    print(_styled(f"hint: inspect it with: inspect-robots inspect {log_path}", _DIM))
+    print(_styled(f"hint: HTML viewer: inspect-robots view {log_path}", _DIM))
     if _has_policy_transcripts(log):
         print(
             _styled(
@@ -919,7 +925,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         except KeyboardInterrupt:
             if sink.path is not None and sink.path.exists():
                 _print_degraded(f"cancelled: partial log written to {sink.path}")
-                print(_styled(f"hint: view it with: inspect-robots inspect {sink.path}", _DIM))
+                print(_styled(f"hint: inspect it with: inspect-robots inspect {sink.path}", _DIM))
             else:
                 _print_degraded("cancelled: no log written")
             return 130
@@ -964,6 +970,12 @@ def _print_eval_set_summary(success: bool, logs: Sequence[EvalLog], log_dir: str
                 _DIM,
             )
         )
+    print(
+        _styled(
+            f"hint: HTML viewer: inspect-robots view {log_dir}/<task>_<id>.json",
+            _DIM,
+        )
+    )
 
 
 def _cmd_eval_set(args: argparse.Namespace) -> int:
@@ -1016,6 +1028,12 @@ def _cmd_eval_set(args: argparse.Namespace) -> int:
                 _styled(
                     f"hint: inspect a log with: inspect-robots inspect "
                     f"{args.log_dir}/<task>_<id>.json",
+                    _DIM,
+                )
+            )
+            print(
+                _styled(
+                    f"hint: HTML viewer: inspect-robots view {args.log_dir}/<task>_<id>.json",
                     _DIM,
                 )
             )
@@ -1092,7 +1110,52 @@ def _cmd_inspect(path: str, *, transcript: bool = False) -> int:
         _print_policy_transcripts(log)
     elif _has_policy_transcripts(log):
         print("policy transcripts: recorded (--transcript to print)")
+        print(_styled(f"hint: HTML viewer: inspect-robots view {path}", _DIM))
     return 0 if log.status == "success" else 1
+
+
+def _cmd_view(args: argparse.Namespace) -> int:
+    """Render a saved log to a UTF-8 HTML artifact and optionally open it."""
+    import webbrowser
+
+    from inspect_robots import read_eval_log
+
+    stdout_mode = args.out == "-"
+    if stdout_mode and args.open:
+        raise SystemExit("--open cannot be used with -o -: no file to open")
+
+    log_path = Path(args.log)
+    out_path = (
+        None
+        if stdout_mode
+        else (log_path.with_suffix(".html") if args.out is None else Path(args.out))
+    )
+    if out_path is not None and out_path.exists() and out_path.is_dir():
+        raise SystemExit(f"--out {out_path} is a directory; pass an HTML file path")
+
+    log = read_eval_log(args.log)
+    document = render_html(log, title=f"{log.eval.task} - {log_path.name}")
+    if stdout_mode:
+        degraded = document.encode("utf-8", errors="replace").decode("utf-8")
+        sys.stdout.write(degraded)
+        return 0
+
+    file_path = cast(Path, out_path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with file_path.open("w", encoding="utf-8", errors="replace") as handle:
+        handle.write(document)
+    print(f"wrote {file_path}")
+
+    if args.open:
+        uri = file_path.resolve().as_uri()
+        try:
+            opened = webbrowser.open(uri)
+        except Exception as exc:
+            print(f"warning: could not open browser for {file_path}: {exc}", file=sys.stderr)
+        else:
+            if not opened:
+                print(f"warning: could not open browser for {file_path}", file=sys.stderr)
+    return 0
 
 
 def _cmd_video(args: argparse.Namespace) -> int:
@@ -1277,6 +1340,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _cmd_eval_set(args)
     if args.command == "inspect":
         return _cmd_inspect(args.log, transcript=args.transcript)
+    if args.command == "view":
+        return _cmd_view(args)
     if args.command == "video":
         return _cmd_video(args)
     if args.command == "config":

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -58,9 +58,6 @@ from inspect_robots._defaults import (
 )
 from inspect_robots._dotenv import init_dotenv
 from inspect_robots._html import (
-    _STATUS_DISPLAY as _STATUS_DISPLAY,
-)
-from inspect_robots._html import (
     _chat_content,
     _display_status,
     _is_chat_transcript,
@@ -1132,6 +1129,9 @@ def _cmd_view(args: argparse.Namespace) -> int:
     )
     if out_path is not None and out_path.exists() and out_path.is_dir():
         raise SystemExit(f"--out {out_path} is a directory; pass an HTML file path")
+    if out_path is not None and out_path.resolve() == log_path.resolve():
+        # The one data-loss path in this command: rendering over the log it reads.
+        raise SystemExit(f"--out {out_path} would overwrite the input log; pass a different path")
 
     log = read_eval_log(args.log)
     document = render_html(log, title=f"{log.eval.task} - {log_path.name}")

--- a/tests/test_html_view.py
+++ b/tests/test_html_view.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from inspect_robots._html import _render_chat_transcript, render_html
+from inspect_robots._html import _JSON_STRING_LIMIT, _render_chat_transcript, render_html
 from inspect_robots.log import EvalLog, EvalResults, EvalSpec, EvalStats, SceneResult
 
 
@@ -91,7 +91,7 @@ def test_header_status_metrics_and_scene_content(status: str, label: str, badge_
     assert "success_at_end" in document and "0.75" in document
     assert "scenes" in document and "trials" in document and "errored" in document
     assert "scene-0" in document and "pick up the cube" in document
-    assert "Reduced scores" in document and "Epoch scores" in document
+    assert "Reduced scores" in document and "Trial scores" in document
     assert "Termination reasons" in document and "Operator judgements" in document
     assert "one trial failed" in document
     assert document.count(">n/a</span>") == 2
@@ -131,7 +131,7 @@ def test_absent_optional_fields_and_empty_scene_sequences_are_omitted() -> None:
     assert "pick up the cube" not in document
     assert "one trial failed" not in document
     assert "Reduced scores" not in document
-    assert "Epoch scores" not in document
+    assert "Trial scores" not in document
     assert "Termination reasons" not in document
     assert "Operator judgements" not in document
 
@@ -307,6 +307,15 @@ def test_media_parts_collapse_to_image_chip() -> None:
     assert "look here\n[image]\n[image]" in document
     assert "large-data" not in document
     assert "unknown media" not in document
+
+
+def test_json_fallback_keeps_a_string_at_exactly_the_limit_untruncated() -> None:
+    """A value of exactly the elision limit must not gain a truncation marker."""
+    transcript = ({"payload": "x" * _JSON_STRING_LIMIT},)
+
+    document = render_html(_log(transcripts=(transcript,)), title="boundary")
+
+    assert "chars truncated" not in document
 
 
 def test_non_chat_json_fallback_elides_long_raw_string_values_before_escaping() -> None:

--- a/tests/test_html_view.py
+++ b/tests/test_html_view.py
@@ -1,0 +1,350 @@
+"""Pure rendering tests for the self-contained HTML eval-log viewer."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import pytest
+
+from inspect_robots._html import _render_chat_transcript, render_html
+from inspect_robots.log import EvalLog, EvalResults, EvalSpec, EvalStats, SceneResult
+
+
+def _chat(*messages: object) -> list[object]:
+    return list(messages)
+
+
+def _log(
+    *,
+    status: str = "success",
+    transcripts: tuple[Any, ...] = (),
+) -> EvalLog:
+    return EvalLog(
+        version=1,
+        status=status,
+        eval=EvalSpec(
+            task="pick-cube",
+            policy="agent",
+            embodiment="arm",
+            created="2026-07-16T12:00:00Z",
+            inspect_robots_version="0.7.0",
+            git_commit="abc123",
+            policy_config={"effort": "low", "temperature": 0.2},
+            seed=7,
+            max_steps=120,
+        ),
+        results=EvalResults(
+            total_scenes=1,
+            total_trials=max(1, len(transcripts)),
+            metrics={"success_at_end": 0.75},
+            errored_trials=1,
+        ),
+        stats=EvalStats(
+            started_at="start",
+            completed_at="end",
+            duration_s=12.5,
+            total_steps=42,
+            mean_inference_latency_s=0.125,
+        ),
+        samples=(
+            SceneResult(
+                scene_id="scene-0",
+                status=status,
+                reduced={"success_at_end": 0.75},
+                epochs=({"success_at_end": 1.0}, {}),
+                error="one trial failed",
+                instruction="pick up the cube",
+                operator_judgements=("y", None),
+                termination_reasons=("success", None),
+                policy_transcripts=transcripts,
+            ),
+        ),
+        error="run warning",
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "label", "badge_class"),
+    [
+        ("success", "completed", "status-completed"),
+        ("error", "error", "status-error"),
+        ("cancelled", "cancelled", "status-cancelled"),
+        ("started", "started", "status-neutral"),
+        ("unexpected", "unexpected", "status-neutral"),
+    ],
+)
+def test_header_status_metrics_and_scene_content(status: str, label: str, badge_class: str) -> None:
+    document = render_html(_log(status=status), title="pick-cube - run.json")
+
+    assert "<!doctype html>" in document
+    assert "pick-cube - run.json" in document
+    assert f'class="badge {badge_class}">{label}</span>' in document
+    assert "2026-07-16T12:00:00Z" in document
+    assert "inspect-robots 0.7.0" in document
+    assert "git abc123" in document
+    assert "agent" in document and "arm" in document
+    assert "effort" in document and "temperature" in document
+    assert "seed" in document and "max steps" in document
+    assert "mean inference latency" in document
+    assert "duration" in document and "total steps" in document
+    assert "success_at_end" in document and "0.75" in document
+    assert "scenes" in document and "trials" in document and "errored" in document
+    assert "scene-0" in document and "pick up the cube" in document
+    assert "Reduced scores" in document and "Epoch scores" in document
+    assert "Termination reasons" in document and "Operator judgements" in document
+    assert "one trial failed" in document
+    assert document.count(">n/a</span>") == 2
+    assert "prefers-color-scheme: light" in document
+    assert "prefers-color-scheme: dark" in document
+    assert "<script" not in document
+
+
+def test_absent_optional_fields_and_empty_scene_sequences_are_omitted() -> None:
+    log = _log()
+    spec = dataclasses.replace(
+        log.eval,
+        git_commit=None,
+        policy_config={},
+        seed=None,
+        max_steps=None,
+    )
+    stats = dataclasses.replace(log.stats, mean_inference_latency_s=None)
+    scene = dataclasses.replace(
+        log.samples[0],
+        instruction=None,
+        error=None,
+        reduced={},
+        epochs=(),
+        operator_judgements=(),
+        termination_reasons=(),
+    )
+
+    document = render_html(
+        dataclasses.replace(log, eval=spec, stats=stats, samples=(scene,)), title="minimal"
+    )
+
+    assert '<span class="chip">unknown</span>' in document
+    assert "<dt>seed</dt>" not in document
+    assert "<dt>max steps</dt>" not in document
+    assert "mean inference latency" not in document
+    assert "pick up the cube" not in document
+    assert "one trial failed" not in document
+    assert "Reduced scores" not in document
+    assert "Epoch scores" not in document
+    assert "Termination reasons" not in document
+    assert "Operator judgements" not in document
+
+
+def test_every_foreign_text_surface_is_escaped_exactly_once() -> None:
+    attack = "<script>alert(1)</script>"
+    transcript = _chat(
+        {"role": "user", "content": attack},
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"function": {"name": "move_by", "arguments": attack}},
+            ],
+        },
+    )
+    log = _log(status=attack, transcripts=(transcript,))
+    scene = dataclasses.replace(
+        log.samples[0],
+        scene_id=attack,
+        status=attack,
+        instruction=attack,
+        error=attack,
+    )
+    results = dataclasses.replace(log.results, metrics={attack: 1.0})
+
+    document = render_html(
+        dataclasses.replace(log, samples=(scene,), results=results), title=attack
+    )
+
+    assert attack not in document
+    assert document.count("&lt;script&gt;alert(1)&lt;/script&gt;") >= 8
+    assert "&amp;lt;script" not in document
+
+
+def test_chat_roles_system_details_tool_call_and_result_are_rendered() -> None:
+    transcript = _chat(
+        {"role": "system", "content": "follow the rules"},
+        {"role": "user", "content": "where is the cube?"},
+        {
+            "role": "assistant",
+            "content": "moving now",
+            "tool_calls": [
+                {"function": {"name": "move_by", "arguments": '{"dx": 0.1}'}},
+            ],
+        },
+        {"role": "tool", "content": "moved 2 steps"},
+    )
+
+    document = render_html(_log(transcripts=(transcript,)), title="conversation")
+
+    assert '<details class="system-message"><summary>system</summary>' in document
+    assert '<details class="system-message" open>' not in document
+    assert '<div class="message user">' in document
+    assert '<div class="message assistant">' in document
+    assert '<div class="message tool">' in document
+    assert "where is the cube?" in document and "moving now" in document
+    assert "move_by({&quot;dx&quot;: 0.1})" in document
+    assert "moved 2 steps" in document
+
+
+@pytest.mark.parametrize(
+    ("name", "arguments", "expected"),
+    [
+        ("move_by", '{"note": "edge closer"}', "edge closer"),
+        ("move_by", {"note": "dict note"}, "dict note"),
+        ("done", {"summary": "cube secured"}, "cube secured"),
+        ("give_up", '{"reason": "blocked"}', "blocked"),
+    ],
+)
+def test_agent_note_callouts_support_all_argument_shapes(
+    name: str, arguments: object, expected: str
+) -> None:
+    transcript = _chat(
+        {
+            "role": "assistant",
+            "tool_calls": [{"function": {"name": name, "arguments": arguments}}],
+        }
+    )
+
+    document = render_html(_log(transcripts=(transcript,)), title="notes")
+
+    assert document.count('class="agent-note"') == 1
+    assert document.count(">agent note</span>") == 1
+    assert expected in document
+    assert document.index(expected) < document.index(f'class="call">{name}')
+
+
+def test_malformed_json_arguments_render_verbatim_without_a_callout() -> None:
+    arguments = '{"note": <broken>}'
+    transcript = _chat(
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"function": {"name": "move_by", "arguments": arguments}},
+            ],
+        }
+    )
+
+    document = render_html(_log(transcripts=(transcript,)), title="malformed")
+
+    assert 'class="agent-note"' not in document
+    assert "{&quot;note&quot;: &lt;broken&gt;}" in document
+
+
+def test_non_string_empty_and_whitespace_notes_do_not_render_callouts() -> None:
+    transcript = _chat(
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"function": {"name": "move", "arguments": {"note": 3}}},
+                {"function": {"name": "move", "arguments": {"note": ""}}},
+                {"function": {"name": "move", "arguments": {"note": "  \n "}}},
+                {"function": {"name": "move", "arguments": "[1, 2]"}},
+            ],
+        }
+    )
+
+    document = render_html(_log(transcripts=(transcript,)), title="empty notes")
+
+    assert 'class="agent-note"' not in document
+    assert document.count('class="call"') == 4
+
+
+def test_chat_defensive_guards_skip_malformed_calls_and_role_only_content() -> None:
+    transcript = _chat(
+        {"role": "assistant", "content": 42, "tool_calls": "not a list"},
+        {
+            "role": "assistant",
+            "tool_calls": [
+                "not a call",
+                {"function": "not a function"},
+                {"function": {"name": "move", "arguments": {"dx": 1}}},
+            ],
+        },
+    )
+
+    document = render_html(_log(transcripts=(transcript,)), title="defensive")
+
+    assert document.count('<div class="message assistant">') == 2
+    assert "not a list" not in document
+    assert "not a call" not in document
+    assert "not a function" not in document
+    assert "move({&quot;dx&quot;: 1})" in document
+    assert 'class="content"' not in document
+
+    assert _render_chat_transcript(["not a message"]) == '<div class="conversation"></div>'
+
+
+def test_non_dict_message_falls_back_to_preformatted_json() -> None:
+    transcript = [{"role": "user", "content": "hello"}, "not a message"]
+
+    document = render_html(_log(transcripts=(transcript,)), title="fallback")
+
+    assert "<pre>" in document
+    assert "not a message" in document
+    assert '<div class="conversation">' not in document
+
+
+def test_media_parts_collapse_to_image_chip() -> None:
+    transcript = _chat(
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look here"},
+                {"type": "image_url", "image_url": {"url": "large-data"}},
+                "unknown media",
+            ],
+        }
+    )
+
+    document = render_html(_log(transcripts=(transcript,)), title="media")
+
+    assert "look here\n[image]\n[image]" in document
+    assert "large-data" not in document
+    assert "unknown media" not in document
+
+
+def test_non_chat_json_fallback_elides_long_raw_string_values_before_escaping() -> None:
+    long_value = "x" * 2047 + "<" + "y" * 10
+    transcript = ({"payload": [long_value, 3], "short": "kept"},)
+
+    document = render_html(_log(transcripts=(transcript,)), title="large fallback")
+
+    assert "<pre>" in document
+    assert "[... 10 chars truncated]" in document
+    assert "&lt;[... 10 chars truncated]" in document
+    assert "short" in document and "kept" in document
+    assert long_value not in document
+
+
+def test_none_transcripts_are_skipped_and_exactly_one_panel_opens() -> None:
+    transcript = _chat({"role": "user", "content": "hello"})
+
+    document = render_html(_log(transcripts=(None, transcript, None)), title="one")
+
+    assert document.count('<details class="transcript" open>') == 1
+    assert "Trial 1 transcript" in document
+    assert "Trial 0 transcript" not in document
+    assert "Trial 2 transcript" not in document
+
+
+def test_two_transcripts_leave_every_panel_collapsed() -> None:
+    first = _chat({"role": "user", "content": "first"})
+    second = {"custom": "second"}
+
+    document = render_html(_log(transcripts=(first, second)), title="two")
+
+    assert document.count('<details class="transcript">') == 2
+    assert '<details class="transcript" open>' not in document
+
+
+def test_transcript_free_log_reports_none_recorded() -> None:
+    document = render_html(_log(transcripts=(None,)), title="none")
+
+    assert "no policy transcripts recorded" in document
+    assert '<details class="transcript"' not in document

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -996,6 +996,13 @@ def test_view_rejects_directory_output_with_guidance(tmp_path: Path) -> None:
         main(["view", str(path), "-o", str(output)])
 
 
+def test_view_rejects_overwriting_the_input_log(tmp_path: Path) -> None:
+    path = _write_log(_step_limit_log(), tmp_path, "run.json")
+
+    with pytest.raises(SystemExit, match="would overwrite the input log"):
+        main(["view", str(path), "-o", str(path)])
+
+
 def test_view_rejects_open_with_stdout(tmp_path: Path) -> None:
     path = _write_log(_step_limit_log(), tmp_path, "run.json")
 

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -107,9 +107,10 @@ def test_cli_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     (written,) = tmp_path.glob("*.json")
     assert f"log: {written}" in out  # the CLI tells the user where the log went
     assert "error:" not in out
-    # A clean run still teaches how to read the log — and nothing else hints.
-    assert f"hint: view it with: inspect-robots inspect {written}" in out
-    assert out.count("hint:") == 1
+    # A clean run teaches both terminal and browser read-back commands.
+    assert f"hint: inspect it with: inspect-robots inspect {written}" in out
+    assert f"hint: HTML viewer: inspect-robots view {written}" in out
+    assert out.count("hint:") == 2
 
 
 @pytest.mark.parametrize(
@@ -212,7 +213,7 @@ def test_cli_run_embodiment_fault_prints_error_scene_and_inspect_hint(
     assert "scene-0" not in out  # successful scenes are not failure context
     assert out.count("EmbodimentFault: reset exploded") == 1
     (written,) = tmp_path.glob("*.json")
-    assert f"hint: view it with: inspect-robots inspect {written}" in out
+    assert f"hint: inspect it with: inspect-robots inspect {written}" in out
 
 
 def test_cli_run_prints_distinct_scene_error(
@@ -293,7 +294,7 @@ def test_cli_all_errored_run_exits_nonzero_with_diagnostics(
     assert "[error] scene-0: PolicyError: invalid API key" in out
     assert "trials: 1 (1 errored)" in out
     (written,) = tmp_path.glob("*.json")
-    assert f"hint: view it with: inspect-robots inspect {written}" in out
+    assert f"hint: inspect it with: inspect-robots inspect {written}" in out
     # And `inspect` on the written log shows the same headline facts.
     assert main(["inspect", str(written)]) == 1
     out = capsys.readouterr().out
@@ -346,7 +347,7 @@ def test_cli_partial_errors_stay_success_but_are_visible(
     assert "trials: 2 (1 errored)" in out
     assert "[error] scene-1: PolicyError: policy reset exploded" in out
     (written,) = tmp_path.glob("*.json")
-    assert f"hint: view it with: inspect-robots inspect {written}" in out
+    assert f"hint: inspect it with: inspect-robots inspect {written}" in out
 
 
 def test_cli_run_epochs_fail_on_error_store_frames(
@@ -423,6 +424,7 @@ def test_cli_eval_set_runs_multiple_exact_tasks(
     assert "[completed] kb/a" in out
     assert "[completed] kb/b" in out
     assert out.count("log dir:") == 1  # one shared line, not one per task
+    assert "hint: HTML viewer: inspect-robots view" in out
     assert len(list(tmp_path.glob("*.json"))) == 2
 
 
@@ -784,6 +786,7 @@ def test_cli_eval_set_ctrl_c_reports_partial_logs_and_exits_130(
     out = capsys.readouterr().out
     assert f"cancelled: partial logs are under {tmp_path}" in out
     assert "inspect-robots inspect" in out
+    assert "inspect-robots view" in out
 
 
 def test_cli_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
@@ -796,6 +799,10 @@ def test_cli_help_lists_setup(capsys: pytest.CaptureFixture[str]) -> None:
         main(["--help"])
     assert excinfo.value.code == 0
     assert "setup" in capsys.readouterr().out
+
+
+def test_view_is_protected_by_instruction_sugar_guard() -> None:
+    assert "view" in cli._SUBCOMMANDS
 
 
 def test_setup_is_protected_by_instruction_sugar_guard() -> None:
@@ -941,6 +948,156 @@ def _write_log(log: EvalLog, tmp_path: Path, name: str) -> Path:
     path = tmp_path / name
     path.write_text(json.dumps(log.to_dict()), encoding="utf-8")
     return path
+
+
+@pytest.mark.parametrize("name", ["run.json", "run"])
+def test_view_derives_default_html_path(
+    name: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_log(_step_limit_log(), tmp_path, name)
+    expected = path.with_suffix(".html")
+
+    assert main(["view", str(path)]) == 0
+
+    document = expected.read_text(encoding="utf-8")
+    assert document.startswith("<!doctype html>")
+    assert f"<title>adhoc - {name}</title>" in document
+    assert capsys.readouterr().out == f"wrote {expected}\n"
+
+
+def test_view_honors_output_override(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    path = _write_log(_step_limit_log(), tmp_path, "run.json")
+    output = tmp_path / "report.htm"
+
+    assert main(["view", str(path), "-o", str(output)]) == 0
+
+    assert output.read_text(encoding="utf-8").startswith("<!doctype html>")
+    assert capsys.readouterr().out == f"wrote {output}\n"
+
+
+def test_view_stdout_contains_only_the_document(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_log(_step_limit_log(), tmp_path, "run.json")
+
+    assert main(["view", str(path), "-o", "-"]) == 0
+
+    out = capsys.readouterr().out
+    assert out.startswith("<!doctype html>")
+    assert "wrote " not in out
+
+
+def test_view_rejects_directory_output_with_guidance(tmp_path: Path) -> None:
+    path = _write_log(_step_limit_log(), tmp_path, "run.json")
+    output = tmp_path / "existing-directory"
+    output.mkdir()
+
+    with pytest.raises(SystemExit, match="is a directory; pass an HTML file path"):
+        main(["view", str(path), "-o", str(output)])
+
+
+def test_view_rejects_open_with_stdout(tmp_path: Path) -> None:
+    path = _write_log(_step_limit_log(), tmp_path, "run.json")
+
+    with pytest.raises(SystemExit, match="no file to open"):
+        main(["view", str(path), "-o", "-", "--open"])
+
+
+def test_view_creates_missing_output_parents(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_log(_step_limit_log(), tmp_path, "run.json")
+    output = tmp_path / "new" / "nested" / "report.html"
+
+    assert main(["view", str(path), "-o", str(output)]) == 0
+
+    assert output.is_file()
+    assert capsys.readouterr().out == f"wrote {output}\n"
+
+
+@pytest.mark.parametrize("stdout_mode", [False, True])
+def test_view_degrades_lone_surrogates_in_both_output_modes(
+    stdout_mode: bool,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    log = _step_limit_log()
+    scene = dataclasses.replace(log.samples[0], instruction="bad \ud800 data")
+    path = _write_log(dataclasses.replace(log, samples=(scene,)), tmp_path, "hostile.json")
+
+    if stdout_mode:
+        assert main(["view", str(path), "-o", "-"]) == 0
+        document = capsys.readouterr().out
+    else:
+        output = tmp_path / "hostile.html"
+        assert main(["view", str(path), "-o", str(output)]) == 0
+        capsys.readouterr()
+        document = output.read_text(encoding="utf-8")
+
+    assert "\ud800" not in document
+    assert "bad ? data" in document
+
+
+def test_view_open_receives_resolved_file_uri(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = _write_log(_step_limit_log(), tmp_path, "run.json")
+    output = tmp_path / "report.html"
+    opened: list[str] = []
+
+    def open_browser(uri: str) -> bool:
+        opened.append(uri)
+        return True
+
+    monkeypatch.setattr("webbrowser.open", open_browser)
+
+    assert main(["view", str(path), "-o", str(output), "--open"]) == 0
+    assert opened == [output.resolve().as_uri()]
+    assert capsys.readouterr().err == ""
+
+
+def test_view_false_browser_result_warns_without_changing_exit_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = _write_log(_step_limit_log(), tmp_path, "run.json")
+    monkeypatch.setattr("webbrowser.open", lambda _uri: False)
+
+    assert main(["view", str(path), "--open"]) == 0
+
+    assert "warning: could not open browser" in capsys.readouterr().err
+
+
+def test_view_browser_exception_warns_without_changing_exit_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = _write_log(_step_limit_log(), tmp_path, "run.json")
+
+    def fail_to_open(_uri: str) -> bool:
+        raise RuntimeError("browser unavailable")
+
+    monkeypatch.setattr("webbrowser.open", fail_to_open)
+
+    assert main(["view", str(path), "--open"]) == 0
+
+    err = capsys.readouterr().err
+    assert "warning: could not open browser" in err
+    assert "browser unavailable" in err
+
+
+@pytest.mark.parametrize("status", ["success", "error"])
+def test_view_exit_code_reports_artifact_production_not_eval_status(
+    status: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_log(_transcript_log(status=status), tmp_path, f"{status}.json")
+
+    assert main(["view", str(path)]) == 0
+    capsys.readouterr()
 
 
 def test_run_outcome_shows_timeout_without_a_count(
@@ -1175,6 +1332,7 @@ def test_plain_inspect_mentions_recorded_policy_transcripts(
     assert main(["inspect", str(path)]) == 0
     out = capsys.readouterr().out
     assert "policy transcripts: recorded (--transcript to print)" in out
+    assert f"hint: HTML viewer: inspect-robots view {path}" in out
     assert "scene s0, trial 0:" not in out
 
 
@@ -1183,7 +1341,8 @@ def test_run_summary_adds_agent_conversation_hint_when_recorded(
 ) -> None:
     cli._print_run_summary(_transcript_log(), "run.json", is_adhoc=False)
     out = capsys.readouterr().out
-    assert "hint: view it with: inspect-robots inspect run.json" in out
+    assert "hint: inspect it with: inspect-robots inspect run.json" in out
+    assert "hint: HTML viewer: inspect-robots view run.json" in out
     assert "hint: agent conversation: inspect-robots inspect run.json --transcript" in out
 
 


### PR DESCRIPTION
Closes #132.

Implements plan 0022 (included in this PR): `inspect-robots view LOG.json [-o OUT.html] [--open]` renders the full EvalLog into a single self-contained HTML file (stdlib only, inline CSS, no JS, no network). Run header with status badge, spec strip, metric tiles, scene cards, and per-trial conversation panels with role bubbles, tool-call lines, and highlighted "agent note" callouts (the #130 visibility channel). Everything from the log is escaped exactly once; the non-chat JSON fallback is size-bounded.

Merges after #134 (fixture shape for note callouts mirrors the real agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)