### PR TITLE
feat(agent): -P wire=responses — dial reasoning effort on OpenAI models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+
+- **Agent plugin:** `-P wire=responses` selects the OpenAI Responses API wire,
+  so reasoning effort works together with function tools on recent OpenAI
+  models (Chat Completions rejects the combination, observed on
+  `gpt-5.6-sol`). The chat-wire rejection now names the fix in its error
+  message (#131).
+
 ### Removed
 
 - **`Task.control_hz`** (breaking). `rollout()` never actually paced the

--- a/plans/0021-agent-responses-wire.md
+++ b/plans/0021-agent-responses-wire.md
@@ -1,0 +1,186 @@
+# 0021 — `-P wire=responses`: dial reasoning effort on OpenAI models
+
+Issue: #131. Status: draft.
+
+## Problem
+
+The agent plugin speaks only the Chat Completions wire format. OpenAI rejects
+`tools` + `reasoning_effort` together on `/v1/chat/completions` for its recent
+models (observed on `gpt-5.6-sol`; the restriction dates back to gpt-5.4):
+
+```
+Function tools with reasoning_effort are not supported for gpt-5.6-sol in
+/v1/chat/completions. To use function tools, use /v1/responses or set
+reasoning_effort to 'none'.
+```
+
+Since the agent policy is tool calls or nothing, the only working
+configuration for OpenAI models today is `-P effort=none` — reasoning off. An
+eval of an OpenAI reasoning model cannot be run at all. (First hit as a failed
+YAM fork-task eval, 2026-07-15.)
+
+## Design
+
+One new policy param, one new client class, zero changes to the conversation
+loop. The chat-completions message format stays the single source of truth for
+`_messages`, the transcript, sanitization, and echo; the Responses client
+translates at the wire boundary only. Same no-SDK doctrine: httpx, raw JSON.
+
+### `wire` param
+
+`LLMAgentPolicy(wire="chat")`, values `"chat" | "responses"`; anything else is
+a `ValueError` at construction (mirrors the `effort` validation). Recorded in
+`AgentPolicyConfig` so it lands in the eval log. The CLI forwards
+`-P wire=responses` for free.
+
+Default stays `"chat"`: it works for OpenRouter, vLLM, Ollama, and the
+Anthropic/Gemini compat endpoints, none of which serve `/responses`. No
+auto-selection by provider — implicit switching would change wire behavior
+under users' feet based on which env key happens to be set.
+
+`base_url` composes: `wire=responses` posts to `{base_url}/responses`, so an
+Azure or proxy endpoint that serves the Responses API works unchanged.
+
+### `ResponsesClient` (new module `_responses.py`)
+
+Same constructor and `complete(messages, tools, temperature, reasoning_effort)
+-> AssistantMessage` signature as `ChatClient`, same bounded retry policy
+(429/5xx/transport retried with exponential backoff, other 4xx fail fast), so
+`policy.py`'s only change is choosing the client class in `__init__`.
+`Provider`, `ToolCall`, `AssistantMessage`, and the retry loop shape are
+shared vocabulary from `_llm.py`; the retry loop itself is small enough to
+keep duplicated rather than extracting a base class.
+
+Request body: `model`, `input` (translated items), `tools` (translated),
+`store: false`, `include: ["reasoning.encrypted_content"]`, and when set
+`temperature` and `reasoning: {"effort": ...}` (the Responses spelling of
+`reasoning_effort`). Current OpenAI returns encrypted reasoning content by
+default when `store: false`, so the explicit `include` is belt-and-braces
+for older/Azure/proxy deployments, not load-bearing against openai.com —
+keep it, but it is not the thing to "fix" if reasoning replay breaks.
+
+One effort caveat: `_EFFORT_LEVELS` includes `"max"`, which `/responses`
+does not accept (none/minimal/low/medium/high/xhigh). Construction-time
+validation stays wire-agnostic; `wire=responses` + `effort=max` fails fast
+with OpenAI's own 400, which names the valid values. Accepted, not guarded.
+
+Stateless by design (`store: false`): no server-side conversation retention,
+works on ZDR orgs, every request is reproducible from the transcript alone,
+and tests are plain request/response pairs against `httpx.MockTransport`.
+`previous_response_id` chaining was rejected: it leaves conversation state on
+OpenAI's servers, breaks on ZDR orgs, and makes retries after an ambiguous
+transport failure double-append.
+
+### Translation: chat messages → Responses input items
+
+| Chat form | Responses input item |
+|---|---|
+| `{"role": "system"/"user"/"assistant", "content": "<str>"}` | same-role **untyped** message (`{"role": ..., "content": "<str>"}`, no `"type"` key) — the untyped EasyInputMessage form is load-bearing: the typed `{"type": "message"}` item rejects plain-string assistant content (assistant parts must be `output_text`), so a "uniformity" refactor adding `type` would 400 |
+| user content part `{"type": "text", ...}` | `{"type": "input_text", "text": ...}` |
+| user content part `{"type": "image_url", "image_url": {"url": u}}` | `{"type": "input_image", "image_url": u}` |
+| assistant msg `tool_calls[i]` | `{"type": "function_call", "call_id": id, "name": ..., "arguments": ...}` (after the assistant text item, if any; skipped when the turn is served from the raw-item cache, below) |
+| `{"role": "tool", "tool_call_id": id, "content": c}` | `{"type": "function_call_output", "call_id": id, "output": c}` |
+
+`ToolCall.id` carries the Responses `call_id` (that is what
+`function_call_output` must reference), so the policy's existing
+`tool_call_id` bookkeeping works untouched.
+
+Tool schemas flatten from the chat nesting to the Responses shape:
+`{"type": "function", "function": {name, description, parameters}}` →
+`{"type": "function", "name": ..., "description": ..., "parameters": ...,
+"strict": false}`. `strict: false` is explicit and non-negotiable: unlike
+Chat Completions (non-strict unless asked), Responses auto-normalizes tool
+schemas into strict mode "when possible", and the move tool's
+`targets`/`deltas` parameter is a free-form object with no `properties`
+(dimension names live in the description) — exactly the shape strict
+normalization would mangle into an empty closed object, making every move
+call unrepresentable. Explicit `strict: false` preserves chat-wire parity.
+`Toolset.schemas()` stays chat-shaped; the client owns the translation both
+ways.
+
+### The reasoning-item constraint
+
+OpenAI reasoning models require that when a `function_call` item is resent,
+the `reasoning` item that preceded it is resent too; a bare replay of
+chat-format history 400s with "function_call was provided without its
+required reasoning item". With `store: false` the reasoning item's content
+comes back encrypted (`reasoning.encrypted_content`) and is replayed
+verbatim.
+
+So the client keeps a raw-item cache: after each successful response, the
+response's verbatim `output` item list is stored keyed by the `call_id` of
+each `function_call` item in it. During translation, an assistant message
+whose first `tool_call.id` hits the cache emits the cached raw items instead
+of synthesized ones (this also preserves item `id`s and any interleaved
+message items exactly as the API produced them). A miss falls back to the
+synthesized `function_call` translation — correct for histories this client
+instance did not produce, and for non-reasoning models, where no reasoning
+item is required.
+
+Cache lifetime: entries whose `call_id` no longer appears in the submitted
+history are pruned on each `complete()` call, so a `reset()` (fresh
+`_messages`) empties it without the client needing a reset hook.
+
+Accepted loss: text-only assistant turns (the no-tool-call retry path) cache
+nothing, so their reasoning items are dropped from replay. That is legal —
+only `function_call` items require their preceding reasoning item — and
+costs at most some reasoning reuse on the next turn.
+
+### Response parsing → `AssistantMessage`
+
+From `response["output"]`: concatenate the `text` of every
+`output_text` content part of `message` items (None if there are none), and
+one `ToolCall(id=item["call_id"], name, arguments)` per `function_call` item,
+in output order. `reasoning` items influence nothing here — they only matter
+for the cache. An `incomplete` status with no usable output falls into the
+existing no-tool-call retry path in `act()`.
+
+A body with `status: "failed"` (HTTP 200, top-level `error` object) raises
+`RuntimeError` carrying `error.message` — parsing it as an empty
+`AssistantMessage` would burn three "Respond with exactly one tool call."
+nudges and then die with a generic no-tool-call error while the real cause
+sits discarded in the body.
+
+### Guided error for the motivating failure
+
+When `ChatClient` (wire=chat) gets the 4xx above — detected by
+`"reasoning_effort"` and `"/v1/responses"` both appearing in the error body —
+the raised `RuntimeError` appends:
+`fix: pass -P wire=responses (OpenAI models), or -P effort=none`.
+House style: the error names the fix, never just the failure.
+
+## Tests (`tests/test_responses.py` + small additions)
+
+All against `httpx.MockTransport`, mirroring `test_llm.py` conventions.
+
+- Translation goldens: each row of the table above, including multi-part
+  observation content with an image data URL, and multi-tool-call turns with
+  their ignored-extra `function_call_output`s.
+- Request body: `store: false`, `include`, `reasoning.effort` present only
+  when effort set, `temperature` only when set, tools flattened with
+  `strict: false`, history messages emitted in the untyped (no `"type"` key)
+  form.
+- Reasoning-item replay: turn 1 returns `reasoning` + `function_call` items;
+  the turn-2 request must contain both verbatim, before the
+  `function_call_output`. Plus cache-prune on a fresh history, and cache-miss
+  synthesis — including the tool-call-only turn (`content: None`), which must
+  emit no null-content message item, only the `function_call`.
+- Parsing: text-only, tool-call-only, text+tool-call, `output_text` spread
+  across multiple message items; `status: "failed"` raises with
+  `error.message` in the text.
+- Retry/fail-fast parity with `ChatClient`.
+- Policy wiring: `wire="responses"` end-to-end through `LLMAgentPolicy.act()`
+  (mock embodiment), invalid `wire` value raises, `wire` recorded in config.
+- Chat-side: the guided error suffix on the motivating 4xx body.
+
+## Docs
+
+Plugin README: a "Reasoning effort on OpenAI models" section — the error, why
+it happens (Chat Completions restriction, not an inspect-robots bug), and the
+`-P wire=responses -P effort=medium` fix. One line in the wire-format
+paragraph noting the default and when to switch.
+
+## Version
+
+`inspect-robots-agent` 0.9.0 → 0.10.0 (new feature, backward compatible;
+default behavior unchanged). Core untouched.

--- a/plans/0021-agent-responses-wire.md
+++ b/plans/0021-agent-responses-wire.md
@@ -1,6 +1,6 @@
 # 0021 — `-P wire=responses`: dial reasoning effort on OpenAI models
 
-Issue: #131. Status: draft.
+Issue: #131. Status: accepted (3 critique rounds).
 
 ## Problem
 
@@ -43,10 +43,13 @@ Azure or proxy endpoint that serves the Responses API works unchanged.
 
 ### `ResponsesClient` (new module `_responses.py`)
 
-Same constructor and `complete(messages, tools, temperature, reasoning_effort)
--> AssistantMessage` signature as `ChatClient`, same bounded retry policy
-(429/5xx/transport retried with exponential backoff, other 4xx fail fast), so
-`policy.py`'s only change is choosing the client class in `__init__`.
+Same constructor (including `transport=` injection) and
+`complete(messages, tools, temperature, reasoning_effort)
+-> AssistantMessage` and `close()` surface as `ChatClient`, same bounded
+retry policy (429/5xx/transport retried with exponential backoff, other 4xx
+fail fast), so `policy.py`'s changes are confined to `__init__` (the `wire`
+param, its `ValueError` validation, client selection) and the config
+dataclass.
 `Provider`, `ToolCall`, `AssistantMessage`, and the retry loop shape are
 shared vocabulary from `_llm.py`; the retry loop itself is small enough to
 keep duplicated rather than extracting a base class.
@@ -64,8 +67,10 @@ does not accept (none/minimal/low/medium/high/xhigh). Construction-time
 validation stays wire-agnostic; `wire=responses` + `effort=max` fails fast
 with OpenAI's own 400, which names the valid values. Accepted, not guarded.
 
-Stateless by design (`store: false`): no server-side conversation retention,
-works on ZDR orgs, every request is reproducible from the transcript alone,
+Stateless by design (`store: false`): no server-side conversation state to
+lose, works on ZDR orgs, every request can be legally rebuilt from the
+transcript alone (byte-identical replay additionally needs the in-memory
+raw-item cache; a fresh client synthesizes a legal, if different, request),
 and tests are plain request/response pairs against `httpx.MockTransport`.
 `previous_response_id` chaining was rejected: it leaves conversation state on
 OpenAI's servers, breaks on ZDR orgs, and makes retries after an ambiguous
@@ -78,8 +83,9 @@ transport failure double-append.
 | `{"role": "system"/"user"/"assistant", "content": "<str>"}` | same-role **untyped** message (`{"role": ..., "content": "<str>"}`, no `"type"` key) — the untyped EasyInputMessage form is load-bearing: the typed `{"type": "message"}` item rejects plain-string assistant content (assistant parts must be `output_text`), so a "uniformity" refactor adding `type` would 400 |
 | user content part `{"type": "text", ...}` | `{"type": "input_text", "text": ...}` |
 | user content part `{"type": "image_url", "image_url": {"url": u}}` | `{"type": "input_image", "image_url": u}` |
-| assistant msg `tool_calls[i]` | `{"type": "function_call", "call_id": id, "name": ..., "arguments": ...}` (after the assistant text item, if any; skipped when the turn is served from the raw-item cache, below) |
+| assistant msg `tool_calls[i]` | `{"type": "function_call", "call_id": id, "name": ..., "arguments": ...}`, after the assistant text item if any — but a raw-item cache hit (below) replaces **every** synthesized item for that assistant message, text and tool calls alike, with the cached item list verbatim in cached order; emitting both would show the model its own text twice per turn |
 | `{"role": "tool", "tool_call_id": id, "content": c}` | `{"type": "function_call_output", "call_id": id, "output": c}` |
+| assistant msg, no tool calls, content `None` or `""` | **no input item** — the `incomplete`-status retry path appends exactly this message (`raw()` of an empty turn) before the nudge, and consecutive user messages are legal input; emitting `content: null` would 400 and turn a recoverable no-tool-call turn fatal |
 
 `ToolCall.id` carries the Responses `call_id` (that is what
 `function_call_output` must reference), so the policy's existing
@@ -107,19 +113,24 @@ required reasoning item". With `store: false` the reasoning item's content
 comes back encrypted (`reasoning.encrypted_content`) and is replayed
 verbatim.
 
-So the client keeps a raw-item cache: after each successful response, the
-response's verbatim `output` item list is stored keyed by the `call_id` of
-each `function_call` item in it. During translation, an assistant message
-whose first `tool_call.id` hits the cache emits the cached raw items instead
-of synthesized ones (this also preserves item `id`s and any interleaved
-message items exactly as the API produced them). A miss falls back to the
-synthesized `function_call` translation — correct for histories this client
-instance did not produce, and for non-reasoning models, where no reasoning
-item is required.
+So the client keeps a raw-item cache: after each successfully *parsed*
+response (never a failed or raising one), the response's verbatim `output`
+item list is stored keyed by the `call_id` of each `function_call` item in
+it. During translation, an assistant message whose first `tool_call.id` hits
+the cache emits the cached raw items in place of all synthesized items for
+that message (this preserves item `id`s and any interleaved message items
+exactly as the API produced them). A miss falls back to the synthesized
+translation — correct for histories this client instance did not produce,
+and for non-reasoning models, where no reasoning item is required.
 
 Cache lifetime: entries whose `call_id` no longer appears in the submitted
-history are pruned on each `complete()` call, so a `reset()` (fresh
-`_messages`) empties it without the client needing a reset hook.
+history are pruned on each `complete()` call, against the submitted history
+**before** the new response is cached (prune-after-store would evict every
+fresh entry and make the cache always miss) — call ids are harvested from
+both places history carries them, assistant `tool_calls[i].id` and tool
+message `tool_call_id`, so a future history-trimming feature cannot silently
+break replay. A `reset()` (fresh `_messages`) empties the cache without the
+client needing a reset hook.
 
 Accepted loss: text-only assistant turns (the no-tool-call retry path) cache
 nothing, so their reasoning items are dropped from replay. That is legal —
@@ -139,15 +150,23 @@ A body with `status: "failed"` (HTTP 200, top-level `error` object) raises
 `RuntimeError` carrying `error.message` — parsing it as an empty
 `AssistantMessage` would burn three "Respond with exactly one tool call."
 nudges and then die with a generic no-tool-call error while the real cause
-sits discarded in the body.
+sits discarded in the body. Decision: failed status fails fast, no retry
+(one request on the wire, mirroring the 4xx path) — the deliberate,
+message-bearing terminal state of a request the server accepted, unlike a
+5xx where the server never answered. A failed response never populates the
+raw-item cache.
 
 ### Guided error for the motivating failure
 
 When `ChatClient` (wire=chat) gets the 4xx above — detected by
 `"reasoning_effort"` and `"/v1/responses"` both appearing in the error body —
 the raised `RuntimeError` appends:
-`fix: pass -P wire=responses (OpenAI models), or -P effort=none`.
-House style: the error names the fix, never just the failure.
+`fix: pass -P wire=responses (needs a direct OpenAI endpoint, e.g.
+$OPENAI_API_KEY set), or -P effort=none`.
+The endpoint caveat matters: the same error is reachable via OpenRouter
+routing to an OpenAI model, where `wire=responses` alone would dead-end at a
+nonexistent `openrouter.ai/api/v1/responses`. House style: the error names
+the fix, never just the failure.
 
 ## Tests (`tests/test_responses.py` + small additions)
 
@@ -159,16 +178,24 @@ All against `httpx.MockTransport`, mirroring `test_llm.py` conventions.
 - Request body: `store: false`, `include`, `reasoning.effort` present only
   when effort set, `temperature` only when set, tools flattened with
   `strict: false`, history messages emitted in the untyped (no `"type"` key)
-  form.
-- Reasoning-item replay: turn 1 returns `reasoning` + `function_call` items;
-  the turn-2 request must contain both verbatim, before the
-  `function_call_output`. Plus cache-prune on a fresh history, and cache-miss
-  synthesis — including the tool-call-only turn (`content: None`), which must
-  emit no null-content message item, only the `function_call`.
+  form, and the request path is `{base_url}/responses`.
+- Reasoning-item replay: turn 1 returns `[reasoning, message, function_call]`;
+  the turn-2 request must contain all three verbatim, before the
+  `function_call_output`, with the message text appearing exactly once (no
+  extra synthesized assistant message for that turn). A second replay case
+  returns two `function_call` items on turn 1 and asserts each cached item
+  appears exactly once in the turn-2 request (cache hit is per assistant
+  message, keyed on the first call id — not per tool call). Plus cache-prune
+  on a fresh history, and cache-miss synthesis — including the tool-call-only turn
+  (`content: None`), which must emit no null-content message item, only the
+  `function_call`.
+- Empty assistant turn (`content: None`/`""`, no tool calls — the
+  `incomplete` retry path) translates to no input item.
 - Parsing: text-only, tool-call-only, text+tool-call, `output_text` spread
   across multiple message items; `status: "failed"` raises with
-  `error.message` in the text.
-- Retry/fail-fast parity with `ChatClient`.
+  `error.message` in the text, exactly one request on the wire, cache left
+  unpopulated.
+- Retry/fail-fast parity with `ChatClient`, plus `close()`.
 - Policy wiring: `wire="responses"` end-to-end through `LLMAgentPolicy.act()`
   (mock embodiment), invalid `wire` value raises, `wire` recorded in config.
 - Chat-side: the guided error suffix on the motivating 4xx body.

--- a/plans/0022-agent-responses-wire.md
+++ b/plans/0022-agent-responses-wire.md
@@ -1,4 +1,4 @@
-# 0021 — `-P wire=responses`: dial reasoning effort on OpenAI models
+# 0022 — `-P wire=responses`: dial reasoning effort on OpenAI models
 
 Issue: #131. Status: accepted (3 critique rounds).
 
@@ -209,5 +209,6 @@ paragraph noting the default and when to switch.
 
 ## Version
 
-`inspect-robots-agent` 0.9.0 → 0.10.0 (new feature, backward compatible;
+`inspect-robots-agent` 0.9.0 → 0.11.0 (0.10.0 was claimed by #134 while this
+was in review; new feature, backward compatible;
 default behavior unchanged). Core untouched.

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -45,6 +45,10 @@ Providers resolved directly by prefix:
 | `mistralai/*` | `MISTRAL_API_KEY` | Mistral |
 | `deepseek/*` | `DEEPSEEK_API_KEY` | DeepSeek |
 
+The wire format defaults to Chat Completions (`-P wire=chat`) for broad
+OpenAI-compatible endpoint support. Switch to `-P wire=responses` when a
+direct OpenAI or compatible endpoint requires the Responses API.
+
 ## How it works
 
 Motion tool calls state where to go, not how long to move. For absolute modes,
@@ -94,8 +98,8 @@ motion fall short of the tool's requested total.
 > on real hardware** unless you fully trust the policy and the rig.
 
 Configuration knobs (all `-P key=value`): `model`, `base_url`, `api_key_env`,
-`max_llm_calls` (default `100`), `temperature`, `effort`, `max_speed_frac`,
-`transcript_echo`.
+`wire`, `max_llm_calls` (default `100`), `temperature`, `effort`,
+`max_speed_frac`, `transcript_echo`.
 Set `-P transcript_echo=true` to print live `[agent]` conversation lines to
 stderr, including goals, observation summaries, assistant output, tool calls,
 and tool results.
@@ -116,3 +120,22 @@ pass `-P effort=none` to omit the parameter for endpoints that reject it
 chat completions requires the literal `none` when function tools are in
 play (any other value, or omitting the field, is a 400). In Python,
 `effort=None` omits the field and `effort="none"` sends the wire value.
+
+## Reasoning effort on OpenAI models
+
+Recent OpenAI reasoning models can reject function tools on the Chat
+Completions wire with an error like this:
+
+```text
+Function tools with reasoning_effort are not supported. To use function
+tools, use /v1/responses or set reasoning_effort to 'none'.
+```
+
+This is a Chat Completions API restriction, not an inspect-robots bug. Use a
+direct OpenAI endpoint and select the Responses wire to keep reasoning enabled:
+
+```bash
+inspect-robots "pick up the cube" --policy agent \
+    -P model=openai/gpt-5.6-sol -P wire=responses -P effort=medium \
+    --embodiment cubepick
+```

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.10.0"
+version = "0.11.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -19,10 +19,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Typing :: Typed",
 ]
-# NOTE: no provider SDKs. The adapter speaks the OpenAI chat-completions wire
-# format over one httpx client, which covers OpenRouter, OpenAI, local
-# vLLM/Ollama, and Anthropic's OpenAI-compat endpoint (plan 0008 §4a) — the
-# same "speak the protocol, don't import the package" doctrine as the
+# NOTE: no provider SDKs. The adapters speak raw OpenAI wire formats over
+# httpx. Chat Completions remains the broad-compatibility default, while the
+# Responses wire is available for direct endpoints that serve it. This keeps
+# the same "speak the protocol, don't import the package" doctrine as the
 # xpolicylab plugin.
 dependencies = [
     "inspect-robots>=0.4",

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
@@ -139,7 +139,7 @@ class ToolCall:
 
 @dataclass(frozen=True)
 class AssistantMessage:
-    """The parsed ``choices[0].message`` of a chat completion."""
+    """One parsed assistant turn shared by the supported API wire clients."""
 
     content: str | None
     tool_calls: tuple[ToolCall, ...]
@@ -216,7 +216,13 @@ class ChatClient:
                 last_error = f"HTTP {response.status_code}: {response.text[:500]}"
                 if response.status_code not in (429,) and response.status_code < 500:
                     # A 4xx is our request's fault; retrying cannot help.
-                    raise RuntimeError(f"LLM request rejected — {last_error}")
+                    guidance = ""
+                    if "reasoning_effort" in response.text and "/v1/responses" in response.text:
+                        guidance = (
+                            "\nfix: pass -P wire=responses (needs a direct OpenAI endpoint, e.g. "
+                            "$OPENAI_API_KEY set), or -P effort=none"
+                        )
+                    raise RuntimeError(f"LLM request rejected — {last_error}{guidance}")
             if attempt + 1 < self._max_retries:
                 time.sleep(self._backoff_s * 2**attempt)
         raise RuntimeError(f"LLM request failed after {self._max_retries} attempts — {last_error}")

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_responses.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_responses.py
@@ -1,0 +1,205 @@
+"""Stateless OpenAI Responses client with chat-history translation."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, cast
+
+import httpx
+
+from inspect_robots_agent._llm import AssistantMessage, Provider, ToolCall
+
+
+class ResponsesClient:
+    """Blocking Responses client with raw reasoning-item replay and bounded retries.
+
+    Chat-format messages remain the policy transcript. This boundary translates
+    them to Responses input items and preserves raw output items required to
+    replay reasoning-backed function calls.
+    """
+
+    def __init__(
+        self,
+        provider: Provider,
+        *,
+        timeout_s: float = 120.0,
+        max_retries: int = 3,
+        backoff_s: float = 1.0,
+        transport: httpx.BaseTransport | None = None,
+    ):
+        self._provider = provider
+        self._max_retries = max_retries
+        self._backoff_s = backoff_s
+        self._raw_items_by_call_id: dict[str, list[dict[str, Any]]] = {}
+        headers = {}
+        if provider.api_key:
+            headers["Authorization"] = f"Bearer {provider.api_key}"
+        self._http = httpx.Client(
+            base_url=provider.base_url,
+            headers=headers,
+            timeout=timeout_s,
+            transport=transport,
+        )
+
+    def complete(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        temperature: float | None = None,
+        reasoning_effort: str | None = None,
+    ) -> AssistantMessage:
+        """Return one assistant turn for the translated chat-format history."""
+        history_call_ids = _history_call_ids(messages)
+        self._raw_items_by_call_id = {
+            call_id: items
+            for call_id, items in self._raw_items_by_call_id.items()
+            if call_id in history_call_ids
+        }
+        body: dict[str, Any] = {
+            "model": self._provider.model,
+            "input": _translate_messages(messages, self._raw_items_by_call_id),
+            "tools": _translate_tools(tools),
+            "store": False,
+            "include": ["reasoning.encrypted_content"],
+        }
+        if temperature is not None:
+            body["temperature"] = temperature
+        if reasoning_effort is not None:
+            body["reasoning"] = {"effort": reasoning_effort}
+
+        last_error = "unknown error"
+        for attempt in range(self._max_retries):
+            try:
+                response = self._http.post("/responses", json=body)
+            except httpx.TransportError as exc:
+                last_error = str(exc)
+            else:
+                if response.status_code == 200:
+                    message, output = _parse_response(response.json())
+                    for item in output:
+                        if item.get("type") == "function_call":
+                            self._raw_items_by_call_id[str(item["call_id"])] = output
+                    return message
+                last_error = f"HTTP {response.status_code}: {response.text[:500]}"
+                if response.status_code not in (429,) and response.status_code < 500:
+                    raise RuntimeError(f"LLM request rejected — {last_error}")
+            if attempt + 1 < self._max_retries:
+                time.sleep(self._backoff_s * 2**attempt)
+        raise RuntimeError(f"LLM request failed after {self._max_retries} attempts — {last_error}")
+
+    def close(self) -> None:
+        """Release the underlying HTTP connection pool."""
+        self._http.close()
+
+
+def _history_call_ids(messages: list[dict[str, Any]]) -> set[str]:
+    """Collect every function call id still referenced by the submitted history."""
+    call_ids: set[str] = set()
+    for message in messages:
+        for call in message.get("tool_calls") or []:
+            call_ids.add(str(call["id"]))
+        if message.get("role") == "tool" and message.get("tool_call_id") is not None:
+            call_ids.add(str(message["tool_call_id"]))
+    return call_ids
+
+
+def _translate_messages(
+    messages: list[dict[str, Any]],
+    raw_items_by_call_id: dict[str, list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    """Translate canonical chat messages to stateless Responses input items."""
+    items: list[dict[str, Any]] = []
+    for message in messages:
+        role = message["role"]
+        if role == "tool":
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": message["tool_call_id"],
+                    "output": message["content"],
+                }
+            )
+            continue
+
+        tool_calls = message.get("tool_calls") or []
+        if role == "assistant" and tool_calls:
+            cached = raw_items_by_call_id.get(str(tool_calls[0]["id"]))
+            if cached is not None:
+                items.extend(cached)
+                continue
+
+        content = message.get("content")
+        if isinstance(content, list):
+            items.append({"role": role, "content": _translate_content_parts(content)})
+        elif role != "assistant" or content:
+            items.append({"role": role, "content": content})
+
+        if role == "assistant":
+            for call in tool_calls:
+                function = call["function"]
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": call["id"],
+                        "name": function["name"],
+                        "arguments": function["arguments"],
+                    }
+                )
+    return items
+
+
+def _translate_content_parts(parts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Translate chat text and image parts to Responses input content parts."""
+    translated: list[dict[str, Any]] = []
+    for part in parts:
+        if part["type"] == "text":
+            translated.append({"type": "input_text", "text": part["text"]})
+        elif part["type"] == "image_url":
+            translated.append({"type": "input_image", "image_url": part["image_url"]["url"]})
+    return translated
+
+
+def _translate_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Flatten chat function schemas and explicitly retain non-strict behavior."""
+    translated: list[dict[str, Any]] = []
+    for tool in tools:
+        function = tool["function"]
+        translated.append(
+            {
+                "type": "function",
+                "name": function["name"],
+                "description": function["description"],
+                "parameters": function["parameters"],
+                "strict": False,
+            }
+        )
+    return translated
+
+
+def _parse_response(payload: dict[str, Any]) -> tuple[AssistantMessage, list[dict[str, Any]]]:
+    """Parse usable assistant output while retaining the exact raw item list."""
+    if payload.get("status") == "failed":
+        error = payload.get("error")
+        message = error.get("message") if isinstance(error, dict) else None
+        raise RuntimeError(f"LLM response failed — {message or 'unknown error'}")
+
+    output = cast(list[dict[str, Any]], payload["output"])
+    texts: list[str] = []
+    calls: list[ToolCall] = []
+    for item in output:
+        if item.get("type") == "message":
+            for part in item.get("content") or []:
+                if part.get("type") == "output_text":
+                    texts.append(str(part["text"]))
+        elif item.get("type") == "function_call":
+            calls.append(
+                ToolCall(
+                    id=str(item["call_id"]),
+                    name=str(item["name"]),
+                    arguments=str(item["arguments"]),
+                )
+            )
+    return (
+        AssistantMessage(content="".join(texts) if texts else None, tool_calls=tuple(calls)),
+        output,
+    )

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -5,7 +5,8 @@ text + camera frames), one validated tool call out, synthesized into an
 open-loop ``ActionChunk`` by the motion layer. The LLM never sees raw
 actuation, and every emitted action still passes the rollout's approver
 chain — this module contains no safety-critical code path of its own
-(plan 0008 §4b).
+(plan 0008 §4b). Chat-format history stays canonical while the selected
+client translates it to the configured API wire format.
 """
 
 from __future__ import annotations
@@ -27,6 +28,7 @@ from inspect_robots.spaces import Box
 from inspect_robots.types import ActionChunk, Observation
 from inspect_robots_agent._llm import ENV_MODEL, ChatClient, ToolCall, resolve_provider
 from inspect_robots_agent._png import png_data_url
+from inspect_robots_agent._responses import ResponsesClient
 from inspect_robots_agent._tools import Toolset, build_toolset
 
 _MAX_CONSECUTIVE_FAILURES = 3
@@ -34,6 +36,7 @@ _MAX_CONSECUTIVE_FAILURES = 3
 # reasoning_effort values accepted across OpenAI-compatible endpoints
 # (Anthropic compat maps these to thinking effort; OpenRouter forwards them).
 _EFFORT_LEVELS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max"})
+_WIRE_FORMATS = frozenset({"chat", "responses"})
 
 _SYSTEM_TEMPLATE = """You are controlling a real robot embodiment named {name!r} \
 through tool calls. Each observation message gives you the current \
@@ -77,6 +80,7 @@ class AgentPolicyConfig(PolicyConfig):
     model: str | None = None
     base_url: str | None = None
     api_key_env: str | None = None
+    wire: str = "chat"
     max_llm_calls: int = 100
     effort: str | None = "low"
     max_speed_frac: float = 0.1
@@ -88,7 +92,8 @@ class LLMAgentPolicy(PolicyBase):
 
     Embodiment-adaptive: ``bind()`` (called by ``eval()`` before the
     compatibility check) adopts the embodiment's spaces and builds the tool
-    surface from them. Conversation state is per-trial (``reset``).
+    surface from them. Conversation state is per-trial (``reset``), and the
+    selected wire client translates that state without changing the loop.
     """
 
     def __init__(
@@ -96,6 +101,7 @@ class LLMAgentPolicy(PolicyBase):
         model: str | None = None,
         base_url: str | None = None,
         api_key_env: str | None = None,
+        wire: str = "chat",
         max_llm_calls: int = 100,
         temperature: float | None = None,
         effort: str | None = "low",
@@ -120,7 +126,14 @@ class LLMAgentPolicy(PolicyBase):
                 f"effort must be one of {sorted(_EFFORT_LEVELS)}, or None to omit "
                 f"the field, got {effort!r}"
             )
-        self._client = ChatClient(provider, transport=transport)
+        if wire not in _WIRE_FORMATS:
+            raise ValueError(f"wire must be one of {sorted(_WIRE_FORMATS)}, got {wire!r}")
+        if wire == "responses":
+            self._client: ChatClient | ResponsesClient = ResponsesClient(
+                provider, transport=transport
+            )
+        else:
+            self._client = ChatClient(provider, transport=transport)
         self._max_llm_calls = max_llm_calls
         self._temperature = temperature
         # Robot control is latency-sensitive: default to low reasoning effort
@@ -134,6 +147,7 @@ class LLMAgentPolicy(PolicyBase):
             model=provider.model,
             base_url=provider.base_url,
             api_key_env=api_key_env,
+            wire=wire,
             max_llm_calls=max_llm_calls,
             effort=effort,
             max_speed_frac=max_speed_frac,

--- a/plugins/inspect-robots-agent/tests/test_llm.py
+++ b/plugins/inspect-robots-agent/tests/test_llm.py
@@ -315,3 +315,23 @@ def test_client_error_does_not_retry() -> None:
     with pytest.raises(RuntimeError, match="bad tool schema"):
         client.complete(messages=[], tools=[])
     assert calls["n"] == 1  # 4xx is our bug, not weather; retrying can't help
+
+
+def test_reasoning_tools_rejection_has_responses_wire_guidance() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            text=(
+                "Function tools with reasoning_effort are not supported. "
+                "To use function tools, use /v1/responses."
+            ),
+        )
+
+    client = _client(handler, backoff_s=0.0)
+    with pytest.raises(RuntimeError) as excinfo:
+        client.complete(messages=[], tools=[])
+
+    assert str(excinfo.value).endswith(
+        "fix: pass -P wire=responses (needs a direct OpenAI endpoint, e.g. "
+        "$OPENAI_API_KEY set), or -P effort=none"
+    )

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,5 +6,5 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.10.0"
+    assert inspect_robots_agent.__version__ == "0.11.0"
     assert callable(inspect_robots_agent.agent_policy)

--- a/plugins/inspect-robots-agent/tests/test_responses.py
+++ b/plugins/inspect-robots-agent/tests/test_responses.py
@@ -311,6 +311,9 @@ def test_two_function_calls_replay_cached_output_once_per_assistant_turn() -> No
     replay = requests[1]["input"]
     for cached_item in (reasoning, first_call, second_call):
         assert replay.count(cached_item) == 1
+    # No synthesized duplicates alongside the cached items: exactly the two
+    # cached function_call items, however they are keyed.
+    assert sum(item.get("type") == "function_call" for item in replay) == 2
 
 
 def test_cache_is_pruned_when_submitted_history_drops_call_ids() -> None:

--- a/plugins/inspect-robots-agent/tests/test_responses.py
+++ b/plugins/inspect-robots-agent/tests/test_responses.py
@@ -1,0 +1,542 @@
+"""OpenAI Responses wire client and policy integration."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from inspect_robots.mock import CubePickEmbodiment
+from inspect_robots.scene import Scene
+from inspect_robots.types import Observation
+from inspect_robots_agent import LLMAgentPolicy
+from inspect_robots_agent._llm import Provider
+from inspect_robots_agent._responses import ResponsesClient
+from inspect_robots_agent.policy import AgentPolicyConfig
+
+
+def _response(*output: dict[str, Any]) -> dict[str, Any]:
+    return {"id": "resp_1", "status": "completed", "output": list(output)}
+
+
+def _message(text: str, *, item_id: str = "msg_1") -> dict[str, Any]:
+    return {
+        "id": item_id,
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "content": [{"type": "output_text", "text": text, "annotations": []}],
+    }
+
+
+def _call(
+    call_id: str = "call_1",
+    name: str = "done",
+    arguments: str = '{"summary":"ok"}',
+    *,
+    item_id: str = "fc_1",
+) -> dict[str, Any]:
+    return {
+        "id": item_id,
+        "type": "function_call",
+        "status": "completed",
+        "call_id": call_id,
+        "name": name,
+        "arguments": arguments,
+    }
+
+
+def _tool_call(call_id: str, name: str, arguments: str) -> dict[str, Any]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
+def _client(handler: Any, **kwargs: Any) -> ResponsesClient:
+    provider = Provider(base_url="http://llm.test/v1", api_key="sk-test", model="m")
+    return ResponsesClient(provider, transport=httpx.MockTransport(handler), **kwargs)
+
+
+def test_translates_history_tools_and_request_options() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json=_response(_message("done")))
+
+    client = _client(handler)
+    image_url = "data:image/png;base64,cG5n"
+    client.complete(
+        messages=[
+            {"role": "system", "content": "control the robot"},
+            {"role": "user", "content": "reach the cube"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Current observation."},
+                    {"type": "image_url", "image_url": {"url": image_url}},
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": "I will move.",
+                "tool_calls": [
+                    _tool_call("call_move", "move_by", '{"deltas":{"dx":0.1}}'),
+                    _tool_call("call_extra", "give_up", '{"reason":"extra"}'),
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_extra",
+                "content": "ignored: one tool call per turn",
+            },
+            {"role": "tool", "tool_call_id": "call_move", "content": "moved"},
+            {"role": "assistant", "content": "plain assistant history"},
+        ],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "move_by",
+                    "description": "Move by a delta.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        temperature=0.2,
+        reasoning_effort="medium",
+    )
+
+    (request,) = seen
+    assert request.url == httpx.URL("http://llm.test/v1/responses")
+    assert request.headers["authorization"] == "Bearer sk-test"
+    body = json.loads(request.content)
+    assert body == {
+        "model": "m",
+        "input": [
+            {"role": "system", "content": "control the robot"},
+            {"role": "user", "content": "reach the cube"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Current observation."},
+                    {"type": "input_image", "image_url": image_url},
+                ],
+            },
+            {"role": "assistant", "content": "I will move."},
+            {
+                "type": "function_call",
+                "call_id": "call_move",
+                "name": "move_by",
+                "arguments": '{"deltas":{"dx":0.1}}',
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_extra",
+                "name": "give_up",
+                "arguments": '{"reason":"extra"}',
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_extra",
+                "output": "ignored: one tool call per turn",
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_move",
+                "output": "moved",
+            },
+            {"role": "assistant", "content": "plain assistant history"},
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "name": "move_by",
+                "description": "Move by a delta.",
+                "parameters": {"type": "object", "properties": {}},
+                "strict": False,
+            }
+        ],
+        "store": False,
+        "include": ["reasoning.encrypted_content"],
+        "temperature": 0.2,
+        "reasoning": {"effort": "medium"},
+    }
+    history_messages = [item for item in body["input"] if "role" in item]
+    assert all("type" not in item for item in history_messages)
+
+
+def test_optional_request_fields_are_omitted_when_unset() -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(200, json=_response())
+
+    client = _client(handler)
+    client.complete(messages=[], tools=[])
+
+    assert bodies[0]["tools"] == []
+    assert "temperature" not in bodies[0]
+    assert "reasoning" not in bodies[0]
+
+
+@pytest.mark.parametrize("content", [None, ""])
+def test_empty_assistant_turn_emits_no_input_item(content: str | None) -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(200, json=_response())
+
+    client = _client(handler)
+    client.complete(
+        messages=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": content},
+            {"role": "user", "content": "Respond with exactly one tool call."},
+        ],
+        tools=[],
+    )
+
+    assert bodies[0]["input"] == [
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "Respond with exactly one tool call."},
+    ]
+
+
+def test_cache_miss_synthesizes_tool_call_only_turn_without_null_message() -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(200, json=_response())
+
+    client = _client(handler)
+    client.complete(
+        messages=[
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [_tool_call("external", "done", '{"summary":"ok"}')],
+            },
+            {"role": "tool", "tool_call_id": "external", "content": "done: ok"},
+        ],
+        tools=[],
+    )
+
+    assert bodies[0]["input"] == [
+        {
+            "type": "function_call",
+            "call_id": "external",
+            "name": "done",
+            "arguments": '{"summary":"ok"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "external",
+            "output": "done: ok",
+        },
+    ]
+    assert not any("content" in item and item["content"] is None for item in bodies[0]["input"])
+
+
+def test_replays_all_raw_items_once_before_function_output() -> None:
+    reasoning = {
+        "id": "rs_1",
+        "type": "reasoning",
+        "encrypted_content": "encrypted-turn-one",
+        "summary": [],
+    }
+    message = _message("I will move once.")
+    call = _call("call_move", "move_by", '{"deltas":{"dx":0.1}}')
+    requests: list[dict[str, Any]] = []
+    responses = [_response(reasoning, message, call), _response()]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, json=responses.pop(0))
+
+    client = _client(handler)
+    first = client.complete(messages=[{"role": "user", "content": "move"}], tools=[])
+    client.complete(
+        messages=[
+            {"role": "user", "content": "move"},
+            first.raw(),
+            {"role": "tool", "tool_call_id": "call_move", "content": "moved"},
+        ],
+        tools=[],
+    )
+
+    replay = requests[1]["input"]
+    assert replay[1:4] == [reasoning, message, call]
+    assert replay[4] == {
+        "type": "function_call_output",
+        "call_id": "call_move",
+        "output": "moved",
+    }
+    assert replay.count(reasoning) == 1
+    assert replay.count(message) == 1
+    assert replay.count(call) == 1
+    assert json.dumps(replay).count("I will move once.") == 1
+
+
+def test_two_function_calls_replay_cached_output_once_per_assistant_turn() -> None:
+    reasoning = {"id": "rs_1", "type": "reasoning", "encrypted_content": "encrypted"}
+    first_call = _call("call_1", "move_by", "{}", item_id="fc_1")
+    second_call = _call("call_2", "give_up", "{}", item_id="fc_2")
+    requests: list[dict[str, Any]] = []
+    responses = [_response(reasoning, first_call, second_call), _response()]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, json=responses.pop(0))
+
+    client = _client(handler)
+    first = client.complete(messages=[{"role": "user", "content": "move"}], tools=[])
+    client.complete(
+        messages=[
+            {"role": "user", "content": "move"},
+            first.raw(),
+            {"role": "tool", "tool_call_id": "call_2", "content": "ignored"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "moved"},
+        ],
+        tools=[],
+    )
+
+    replay = requests[1]["input"]
+    for cached_item in (reasoning, first_call, second_call):
+        assert replay.count(cached_item) == 1
+
+
+def test_cache_is_pruned_when_submitted_history_drops_call_ids() -> None:
+    cached_call = _call("old_call")
+    requests: list[dict[str, Any]] = []
+    responses = [_response(cached_call), _response(), _response()]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, json=responses.pop(0))
+
+    client = _client(handler)
+    client.complete(messages=[{"role": "user", "content": "first"}], tools=[])
+    client.complete(messages=[{"role": "user", "content": "fresh history"}], tools=[])
+    client.complete(
+        messages=[
+            {
+                "role": "assistant",
+                "content": "synthesized",
+                "tool_calls": [_tool_call("old_call", "done", '{"summary":"ok"}')],
+            }
+        ],
+        tools=[],
+    )
+
+    assert requests[2]["input"] == [
+        {"role": "assistant", "content": "synthesized"},
+        {
+            "type": "function_call",
+            "call_id": "old_call",
+            "name": "done",
+            "arguments": '{"summary":"ok"}',
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("output", "content", "calls"),
+    [
+        ([_message("hello")], "hello", []),
+        ([_call("call_1", "done", "{}")], None, [("call_1", "done", "{}")]),
+        (
+            [_message("moving"), _call("call_2", "move_by", '{"deltas":{}}')],
+            "moving",
+            [("call_2", "move_by", '{"deltas":{}}')],
+        ),
+        (
+            [_message("one", item_id="msg_1"), _message("two", item_id="msg_2")],
+            "onetwo",
+            [],
+        ),
+    ],
+    ids=["text", "tool", "text_and_tool", "multiple_messages"],
+)
+def test_parses_response_output(
+    output: list[dict[str, Any]],
+    content: str | None,
+    calls: list[tuple[str, str, str]],
+) -> None:
+    client = _client(lambda request: httpx.Response(200, json=_response(*output)))
+
+    result = client.complete(messages=[], tools=[])
+
+    assert result.content == content
+    assert [(call.id, call.name, call.arguments) for call in result.tool_calls] == calls
+
+
+def test_parser_concatenates_only_output_text_parts() -> None:
+    item = _message("first")
+    item["content"].extend(
+        [
+            {"type": "refusal", "refusal": "no"},
+            {"type": "output_text", "text": " second", "annotations": []},
+        ]
+    )
+    client = _client(lambda request: httpx.Response(200, json=_response(item)))
+
+    result = client.complete(messages=[], tools=[])
+
+    assert result.content == "first second"
+
+
+def test_failed_status_raises_once_and_does_not_populate_cache() -> None:
+    failed_call = _call("failed_call")
+    requests: list[dict[str, Any]] = []
+    responses = [
+        {
+            "id": "resp_failed",
+            "status": "failed",
+            "error": {"message": "reasoning token limit reached"},
+            "output": [failed_call],
+        },
+        _response(),
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, json=responses.pop(0))
+
+    client = _client(handler, max_retries=3, backoff_s=0.0)
+    with pytest.raises(RuntimeError, match="reasoning token limit reached"):
+        client.complete(messages=[], tools=[])
+    assert len(requests) == 1
+
+    client.complete(
+        messages=[
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [_tool_call("failed_call", "done", "{}")],
+            }
+        ],
+        tools=[],
+    )
+    assert requests[1]["input"] == [
+        {
+            "type": "function_call",
+            "call_id": "failed_call",
+            "name": "done",
+            "arguments": "{}",
+        }
+    ]
+
+
+@pytest.mark.parametrize("status_code", [429, 500, 503])
+def test_transient_http_errors_retry_then_succeed(status_code: int) -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            return httpx.Response(status_code, text="temporary")
+        return httpx.Response(200, json=_response(_message("ok")))
+
+    client = _client(handler, backoff_s=0.0)
+
+    assert client.complete(messages=[], tools=[]).content == "ok"
+    assert calls == 3
+
+
+def test_transport_errors_retry_then_succeed() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls < 2:
+            raise httpx.ConnectError("offline", request=request)
+        return httpx.Response(200, json=_response())
+
+    client = _client(handler, backoff_s=0.0)
+
+    client.complete(messages=[], tools=[])
+    assert calls == 2
+
+
+def test_retries_exhausted_and_client_errors_fail_fast() -> None:
+    server_calls = 0
+
+    def unavailable(request: httpx.Request) -> httpx.Response:
+        nonlocal server_calls
+        server_calls += 1
+        return httpx.Response(503, text="down")
+
+    client = _client(unavailable, backoff_s=0.0, max_retries=2)
+    with pytest.raises(RuntimeError, match="503"):
+        client.complete(messages=[], tools=[])
+    assert server_calls == 2
+
+    client_calls = 0
+
+    def rejected(request: httpx.Request) -> httpx.Response:
+        nonlocal client_calls
+        client_calls += 1
+        return httpx.Response(400, json={"error": {"message": "bad input"}})
+
+    client = _client(rejected, backoff_s=0.0)
+    with pytest.raises(RuntimeError, match="bad input"):
+        client.complete(messages=[], tools=[])
+    assert client_calls == 1
+
+
+def test_close_closes_underlying_http_client() -> None:
+    client = _client(lambda request: httpx.Response(200, json=_response()))
+
+    client.close()
+
+    assert client._http.is_closed
+
+
+def test_policy_uses_responses_wire_through_act_and_records_config() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=_response(_call()))
+
+    policy = LLMAgentPolicy(
+        model="test/model",
+        base_url="http://llm.test/v1",
+        wire="responses",
+        transport=httpx.MockTransport(handler),
+        env={},
+    )
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="stop"))
+
+    policy.act(Observation())
+
+    assert requests[0].url.path == "/v1/responses"
+    body = json.loads(requests[0].content)
+    assert body["reasoning"] == {"effort": "low"}
+    assert isinstance(policy.config, AgentPolicyConfig)
+    assert policy.config.wire == "responses"
+
+
+def test_policy_rejects_invalid_wire_and_defaults_config_to_chat() -> None:
+    with pytest.raises(ValueError, match="wire must be one of"):
+        LLMAgentPolicy(
+            model="test/model",
+            base_url="http://llm.test/v1",
+            wire="messages",
+            env={},
+        )
+
+    policy = LLMAgentPolicy(model="test/model", base_url="http://llm.test/v1", env={})
+    assert isinstance(policy.config, AgentPolicyConfig)
+    assert policy.config.wire == "chat"

--- a/uv.lock
+++ b/uv.lock
@@ -520,7 +520,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #131.

OpenAI rejects `tools` + `reasoning_effort` on `/v1/chat/completions` for its recent models (observed on `gpt-5.6-sol`), so the agent policy could only run OpenAI models with reasoning off. This adds an opt-in Responses API wire:

```bash
-P model=openai/gpt-5.6-sol -P wire=responses -P effort=medium
```

Design (plan `plans/0021-agent-responses-wire.md`, accepted after 3 critique rounds):

- New `ResponsesClient` (`_responses.py`, httpx only, no SDK): same `complete()`/`close()` surface and retry policy as `ChatClient`, posts to `{base_url}/responses`.
- Chat-format history stays the single source of truth for the transcript/echo/sanitization; the client translates to Responses input items at the wire boundary.
- Stateless (`store: false`): a raw-item cache replays reasoning + function_call items verbatim across turns (OpenAI requires the reasoning item preceding a `function_call` to be resent), pruned against the submitted history before each store.
- `strict: false` pinned on translated tools: Responses auto-normalizes schemas into strict mode, which would mangle the move tool's free-form `targets`/`deltas` object.
- `status: "failed"` bodies raise with `error.message` (fail fast, never cached); empty assistant turns translate to no input item so the `incomplete` nudge path stays recoverable.
- Chat wire keeps working everywhere else and now appends a guided fix (`-P wire=responses` needs a direct OpenAI endpoint, or `-P effort=none`) to the motivating 4xx.
- Plugin version 0.9.0 → 0.10.0; 17 new tests (167 total in the plugin suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)