### PR TITLE
Fix/delta limit rot6d displacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,16 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **`DeltaLimitApprover` refuses `rot6d` rotation deltas in displacement pose
+  modes** (#150, breaking for any embodiment currently declaring them). A
+  `rot6d` delta's identity is `(1, 0, 0, 0, 1, 0)`, not the zero vector, so
+  per-dimension clamping toward a symmetric `±max_delta` box drags it away
+  from identity; the Gram-Schmidt re-normalization every consumer applies can
+  then amplify the rotation instead of limiting it — the same failure class
+  as clamping an absolute quaternion, and pre-existing behavior rather than a
+  regression (`eef_delta_pose` + `rot6d` already reached the displacement
+  clamp path before #143/#144). `euler_xyz` and `axis_angle` deltas have no
+  such problem and remain guardrail-conformant.
 - **An explicit invalid `--max-action-delta` now fails fast instead of silently
   running with weaker guardrails** (#154). Non-finite or non-positive values
   were previously caught by `_build_guardrails`'s degrade-per-component path

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -112,7 +112,7 @@ constructor hardware-free; connect in `reset()`).
 | `bounds` | Finite `low`/`high` on every dim. Without them the bounds clamp is skipped and no default delta limit can be derived. |
 | `dim_labels` | Every dim is named (`("left_j0", ..., "right_gripper")`), uniquely. The agent moves joints by these names. |
 | `state_alignment` | Absolute-target modes (`joint_pos`, `eef_abs_pose`) declare exactly one `StateSpec` field with `shape == (action_dim,)`: the proprioceptive reference the agent interpolates from. |
-| `guardrails` | `DeltaLimitApprover(action_space)` constructs. This catches absolute pose modes (`eef_abs_pose`) whose rotation representation cannot be clamped per dimension (`quat_*`, `axis_angle`, `euler_xyz`; use `none` or `rot6d`), and displacement pose modes (`eef_delta_pose`) carrying a quaternion delta (`quat_wxyz`, `quat_xyzw`; use `none`, `rot6d`, `axis_angle`, or `euler_xyz`). |
+| `guardrails` | `DeltaLimitApprover(action_space)` constructs. This catches absolute pose modes (`eef_abs_pose`) whose rotation representation cannot be clamped per dimension (`quat_*`, `axis_angle`, `euler_xyz`; use `none` or `rot6d`), and displacement pose modes (`eef_delta_pose`) whose rotation representation's identity is not the zero vector (`quat_*`, `rot6d`; use `none`, `axis_angle`, or `euler_xyz`). |
 
 ### Warnings
 

--- a/docs/guide/policies-and-embodiments.md
+++ b/docs/guide/policies-and-embodiments.md
@@ -25,7 +25,7 @@ class MyVLA:
             action_space=Box(
                 shape=(7,),
                 semantics=ActionSemantics(
-                    control_mode="eef_delta_pose", rotation_repr="rot6d", gripper="continuous"
+                    control_mode="eef_delta_pose", rotation_repr="euler_xyz", gripper="continuous"
                 ),
             ),
             observation_space=ObservationSpace(

--- a/src/inspect_robots/approver.py
+++ b/src/inspect_robots/approver.py
@@ -84,7 +84,8 @@ _POSE_MODES = frozenset({"eef_abs_pose", "eef_delta_pose"})
 # dimension has wraparound and axis-coupling problems, so those reps are
 # refused. Displacement pose modes (eef_delta_pose) carry small rotation
 # *deltas*, which mostly clamp per dimension like any other bounded
-# displacement — except quaternions (see _DISPLACEMENT_POSE_UNSAFE_ROT below).
+# displacement — except reps whose no-op is not the origin (see
+# _DISPLACEMENT_POSE_UNSAFE_ROT below).
 _ABSOLUTE_POSE_MODES = _ABSOLUTE_MODES & _POSE_MODES
 _DISPLACEMENT_POSE_MODES = _POSE_MODES - _ABSOLUTE_POSE_MODES
 # Rotation reps that survive independent per-dimension clamping of an absolute
@@ -92,13 +93,16 @@ _DISPLACEMENT_POSE_MODES = _POSE_MODES - _ABSOLUTE_POSE_MODES
 # averaging).
 _LIMITABLE_ROT = frozenset({"none", "rot6d"})
 # Displacement pose modes carry rotation *deltas*, whose no-op is not the zero
-# vector for these reps (a quaternion identity is (1, 0, 0, 0)). Clamping such
-# a delta per dimension toward a symmetric ±max_delta box drags it away from
-# identity, and downstream re-normalization can amplify the rotation instead
-# of limiting it — the same failure class as clamping an absolute quaternion.
-# euler_xyz/axis_angle deltas have no such problem (their no-op is the zero
-# vector) and clamp fine.
-_DISPLACEMENT_POSE_UNSAFE_ROT = frozenset({"quat_wxyz", "quat_xyzw"})
+# vector for these reps (a quaternion identity is (1, 0, 0, 0); a rot6d
+# identity is (1, 0, 0, 0, 1, 0)). Clamping such a delta per dimension toward
+# a symmetric ±max_delta box drags it away from identity, and downstream
+# re-normalization (Gram-Schmidt orthonormalization for rot6d) can then
+# amplify the rotation instead of limiting it — the same failure class as
+# clamping an absolute quaternion. euler_xyz/axis_angle deltas have no such
+# problem (their no-op is the zero vector) and clamp fine. Note rot6d is
+# limitable for *absolute* orientations (_LIMITABLE_ROT above) but not for
+# displacement deltas — the two sets are deliberately not related.
+_DISPLACEMENT_POSE_UNSAFE_ROT = frozenset({"quat_wxyz", "quat_xyzw", "rot6d"})
 # Derived from RotationRepr itself (not hand-listed) so a rep added there
 # defaults to the safe side of this message without anyone remembering to
 # update it — the refusal set above is still the one source of truth for
@@ -126,8 +130,8 @@ class DeltaLimitApprover:
     Construction never guesses: missing semantics, a needed missing/non-finite
     bound without an explicit ``max_delta``, an absolute pose mode whose
     rotation representation cannot be clamped per-dimension, or a displacement
-    pose mode carrying a quaternion delta (whose identity is not the zero
-    vector, so per-dimension clamping distorts it) all raise ``ValueError``.
+    pose mode carrying a quaternion or rot6d delta (whose identity is not the
+    zero vector, so per-dimension clamping distorts it) all raise ``ValueError``.
     ``NaN`` anywhere in a reviewed action raises
     [`SafetyAbort`][inspect_robots.errors.SafetyAbort]. A modified action is
     flagged ``meta["delta_clamped"]``; an unmodified one is returned as the

--- a/tests/test_approvers.py
+++ b/tests/test_approvers.py
@@ -61,8 +61,9 @@ def test_refuses_absolute_pose_mode_with_unaverageable_rotation() -> None:
 def test_delta_pose_rotation_deltas_clamp_per_dim(rotation_repr: RotationRepr) -> None:
     # eef_delta_pose carries small rotation *deltas*, not absolute orientations.
     # euler_xyz/axis_angle deltas have a zero-vector no-op, so they clamp per
-    # dimension like a bounded displacement (#143). Quaternion deltas are the
-    # exception — see test_refuses_displacement_pose_mode_with_quat_rotation.
+    # dimension like a bounded displacement (#143). Quaternion and rot6d
+    # deltas are the exception — see
+    # test_refuses_displacement_pose_mode_with_off_origin_rotation.
     # BridgeData V2 shape: 3 xyz + 3 euler deltas + 1 gripper.
     space = Box(
         shape=(7,),
@@ -77,17 +78,24 @@ def test_delta_pose_rotation_deltas_clamp_per_dim(rotation_repr: RotationRepr) -
     assert out.meta.get("delta_clamped") is True
 
 
-@pytest.mark.parametrize("rotation_repr", ["quat_wxyz", "quat_xyzw"])
-def test_refuses_displacement_pose_mode_with_quat_rotation(rotation_repr: RotationRepr) -> None:
-    # A quaternion delta's identity is (1, 0, 0, 0), not the zero vector:
-    # clamping it per dimension toward a symmetric ±max_delta box drags it away
-    # from identity, and downstream re-normalization can amplify the rotation
-    # instead of limiting it — same failure class as an absolute quat.
-    # 3 xyz + 4 quat + 1 gripper = 8 dims.
+@pytest.mark.parametrize(
+    ("rotation_repr", "rot_dim"),
+    [("quat_wxyz", 4), ("quat_xyzw", 4), ("rot6d", 6)],
+)
+def test_refuses_displacement_pose_mode_with_off_origin_rotation(
+    rotation_repr: RotationRepr, rot_dim: int
+) -> None:
+    # These reps' identity/no-op is not the zero vector (quaternion identity is
+    # (1, 0, 0, 0); rot6d identity is (1, 0, 0, 0, 1, 0)): clamping a delta per
+    # dimension toward a symmetric ±max_delta box drags it away from identity,
+    # and downstream re-normalization can amplify the rotation instead of
+    # limiting it — same failure class as clamping an absolute quat (#150).
+    # 3 xyz + rot_dim + 1 gripper.
+    dim = 3 + rot_dim + 1
     space = Box(
-        shape=(8,),
-        low=np.full(8, -1.0),
-        high=np.full(8, 1.0),
+        shape=(dim,),
+        low=np.full(dim, -1.0),
+        high=np.full(dim, 1.0),
         semantics=ActionSemantics("eef_delta_pose", rotation_repr=rotation_repr),
     )
     with pytest.raises(ValueError, match="rotation_repr"):

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -314,6 +314,27 @@ def test_delta_pose_euler_rotation_deltas_are_guardrail_conformant() -> None:
     assert "guardrails" not in _codes(info)
 
 
+def test_delta_pose_rot6d_rotation_deltas_are_a_guardrail_error() -> None:
+    # A rot6d delta's identity is (1, 0, 0, 0, 1, 0), not the zero vector:
+    # per-dimension clamping distorts it and post-clamp Gram-Schmidt
+    # re-normalization can amplify the rotation instead of limiting it, the
+    # same failure class as an absolute quaternion. 3 xyz + 6 rot6d + 1
+    # gripper = 10 dims.
+    info = _info(
+        space=Box(
+            shape=(10,),
+            low=np.full(10, -0.1),
+            high=np.full(10, 0.1),
+            semantics=ActionSemantics(
+                "eef_delta_pose",
+                rotation_repr="rot6d",
+                dim_labels=tuple("abcdefghij"),
+            ),
+        ),
+    )
+    assert _codes(info)["guardrails"] == "error"
+
+
 def test_missing_control_hz_is_a_warning() -> None:
     info = _good_absolute()
     silent = EmbodimentInfo(


### PR DESCRIPTION
# Fix unsafe `rot6d` displacement pose handling in `DeltaLimitApprover`

## Summary

`DeltaLimitApprover` incorrectly allowed `rot6d` in displacement pose mode (`eef_delta_pose`).

Unlike translation deltas, a `rot6d` "no-op" is **not** the zero vector—it is `(1, 0, 0, 0, 1, 0)`. Clamping each dimension independently toward a symmetric `±max_delta` range distorts this representation. Since every downstream consumer re-normalizes `rot6d` using Gram-Schmidt, the distorted value can become an arbitrarily large rotation.

As a result, the delta limiter can **amplify** rotations instead of limiting them.

This is the same underlying failure mode as clamping absolute quaternions, and the same class of issue already addressed for `quat_wxyz`/`quat_xyzw` displacement poses in **#144**.

This is **not a regression**—the behavior existed before #143 and #144.

---

## Changes

### Validation

- Added `"rot6d"` to `_DISPLACEMENT_POSE_UNSAFE_ROT`.
  - The set is now:
    ```python
    {quat_wxyz, quat_xyzw, rot6d}
    ```
- No additional logic was required.
  - The existing constructor validation and error message already handle all entries in this set.
- `rot6d` **remains supported** for absolute orientation modes.
  - Only displacement (`eef_delta_pose`) is rejected.

### Tests

- Generalized the displacement validation test to accept `(rotation_repr, rot_dim)` pairs.
  - This allows testing both quaternion (4D) and `rot6d` (6D) action spaces.
- Added a conformance test verifying that `eef_delta_pose + rot6d` now raises the expected guardrails error.
  - This mirrors the existing coverage for:
    - valid Euler displacement
    - invalid absolute quaternion

### Documentation

- Updated `adapters.md` to describe the guardrail based on the actual failure condition instead of listing individual rotation representations.
- Added a **breaking** entry under **Unreleased → Fixed** in `CHANGELOG.md`.

---

## Why this change?

`rot6d` cannot be safely limited using independent per-dimension clamping in displacement mode because:

1. Its identity rotation is **not** the origin.
2. Clamping distorts the representation.
3. Gram-Schmidt normalization projects the distorted vector back onto SO(3).
4. The resulting rotation can be much larger than the intended delta.

Rejecting this configuration is therefore the correct and safe behavior.

---

## Checklist

- [x] Added unit and conformance tests
- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `mypy` (strict)
- [x] Full test suite passes
  - 730 tests
  - 100% coverage
- [x] Updated `CHANGELOG.md`
- [x] No public API changes
- [x] No new dependencies (NumPy-only)

> **Note:** `pre-commit run --all-files` could not be executed locally because it shells out to `uv`, which was unavailable. The equivalent checks (`ruff`, `mypy`, `pytest --cov`) were run directly, along with the full Linux test suite.

---

## Related

**Closes #150**

This branch is based on **#144**, since it builds directly on the `_DISPLACEMENT_POSE_MODES` and `_DISPLACEMENT_POSE_UNSAFE_ROT` infrastructure introduced there. It will be rebased onto `main` once #144 is merged.