### PR TITLE
fix(cli): guard --max-action-delta against invalid explicit values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,16 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **An explicit invalid `--max-action-delta` now fails fast instead of silently
+  running with weaker guardrails** (#154). Non-finite or non-positive values
+  were previously caught by `_build_guardrails`'s degrade-per-component path
+  (meant for derived limits an embodiment's space can't support) and
+  downgraded to a stderr warning, so the run proceeded with clamp-only
+  guardrails despite the operator explicitly asking for a tighter limit. Both
+  `run` and `eval-set` now reject a malformed explicit value in the shared
+  conflict check, before anything resolves or energizes. Derived-limit
+  degradation (no explicit flag, an embodiment declaring no bounds) is
+  unaffected — it still warns and continues.
 - **`--epochs 0` or a negative value now exits with a guided error instead of a
   raw traceback** (#145). Both `inspect-robots run` and `inspect-robots eval-set`
   catch the `ConfigError` raised by `Task`'s epoch validation and surface it

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -745,7 +745,7 @@ class _ResolvedComponents(NamedTuple):
 
 
 def _check_shared_run_conflicts(args: argparse.Namespace) -> None:
-    """Reject flag combinations invalid for both ``run`` and ``eval-set``."""
+    """Reject flag combinations and malformed values invalid for both ``run`` and ``eval-set``."""
     if args.sim and args.embodiment:
         raise SystemExit(
             "--sim selects your configured sim_embodiment; "
@@ -755,6 +755,15 @@ def _check_shared_run_conflicts(args: argparse.Namespace) -> None:
         raise SystemExit(
             "--max-action-delta tunes the guardrails that --disable-guardrails turns off — drop one"
         )
+    if args.max_action_delta is not None and not (
+        math.isfinite(args.max_action_delta) and args.max_action_delta > 0
+    ):
+        # A malformed *explicit* value is a CLI input error, not an embodiment
+        # limitation: fail fast here rather than let _build_guardrails's
+        # degrade-per-component path (meant for derived limits an embodiment's
+        # space can't support) downgrade it to a warning and run with weaker
+        # guardrails than the operator explicitly asked for.
+        raise SystemExit(f"--max-action-delta must be finite and > 0, got {args.max_action_delta}")
 
 
 def _resolve_components(args: argparse.Namespace, defaults: Defaults) -> _ResolvedComponents:

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -2835,6 +2835,36 @@ def test_cli_max_action_delta_conflicts_with_disable(tmp_path: Path) -> None:
         )
 
 
+@pytest.mark.parametrize("value", ["-1", "0", "inf", "nan"])
+def test_cli_run_rejects_invalid_max_action_delta(value: str, tmp_path: Path) -> None:
+    """An explicit malformed --max-action-delta fails fast (#154), not a soft warning:
+    it is a CLI input error, distinct from a derived limit an embodiment's space
+    cannot support (test_cli_degraded_guardrails_warn_but_run stays a warning)."""
+    with pytest.raises(SystemExit, match="finite and > 0"):
+        main(
+            [
+                "run",
+                "--task",
+                "cubepick-reach",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(tmp_path),
+                "--max-action-delta",
+                value,
+            ]
+        )
+
+
+@pytest.mark.parametrize("value", ["-1", "0", "inf", "nan"])
+def test_cli_eval_set_rejects_invalid_max_action_delta(value: str) -> None:
+    """Same guard as run, exercised through eval-set's shared conflict check (#154)."""
+    with pytest.raises(SystemExit, match="finite and > 0"):
+        main(["eval-set", "cubepick-reach", "--max-action-delta", value])
+
+
 def test_cli_degraded_guardrails_warn_but_run(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary

An explicit invalid `--max-action-delta` silently weakened guardrails instead of erroring.

The bug:
- `_build_guardrails` wraps `DeltaLimitApprover(space, max_delta=max_action_delta)` in a blanket `except ValueError` and degrades to a stderr warning for any failure.
- That degrade-per-component design is correct for a *derived* default an embodiment's space can't support — there was never a working default to lose.
- It is not correct for an explicitly passed, malformed value (negative, zero, non-finite). That is a CLI input error, not an embodiment limitation, but it hit the same blanket handler and got downgraded to a warning.
- Result: the operator asks for a tighter per-step limit, mistypes it, and the run proceeds on real hardware with clamp-only guardrails and exit code `0` — silently, unless they are watching stderr.

## Changes

- Validate `args.max_action_delta` in `_check_shared_run_conflicts`, which already runs before component resolution in both `run` and `eval-set`, and already houses the sibling `--disable-guardrails` conflict check. A non-finite or non-positive value now exits with a guided `SystemExit` before anything resolves or energizes.
- No change needed in `_build_guardrails` or `DeltaLimitApprover` — `argparse`'s `type=float` means the CLI value is always a plain float, so the other failure mode in `_validate_max_delta` (array broadcast) can only be reached via the Python API, not this flag.
- Derived-limit degradation is untouched: an embodiment with no declared bounds and no explicit `--max-action-delta` still warns and continues, exactly as before. Verified manually and confirmed the existing `test_cli_degraded_guardrails_warn_but_run` still passes unchanged.
- Added parametrized tests for both `run` and `eval-set` (`-1`, `0`, `inf`, `nan`).
- Added a `CHANGELOG.md` entry under `Unreleased` → `Fixed`.

## Checklist

- [x] pre-commit hooks pass — `pre-commit run --all-files` shells out to `uv`, not on PATH here; ran `ruff check .`, `ruff format --check .`, `mypy`, and `pytest --cov` directly, plus the full suite on a Linux checkout.
- [x] Tests added/updated — 8 new parametrized cases (4 values × run/eval-set).
- [x] Coverage stays at 100% — verified on Linux: 100.00% total, 738 passed.
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `mypy` passes (strict) — full run, 63 source files.
- [x] `CHANGELOG.md` updated under "Unreleased" — `Fixed` entry.
- [x] Public API unaffected — `_check_shared_run_conflicts` is a private CLI function.
- [x] Core stays NumPy-only — no new deps.

Note: I did not run the `docs-build` job locally (it needs a full Node/npm toolchain for the Docusaurus site). Confirmed by inspection this diff is out of scope for it — no changes to `docs/`, `website/`, or any public docstring, and `CHANGELOG.md` is not referenced by the site build.

## Related

Closes #154.
