### PR TITLE
docs: robocurve-style landing page; quickstart catches up with the README

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -38,11 +38,11 @@ Resolved in order (first hit wins):
 ```ini
 [defaults]
 policy = molmoact2
-embodiment = yam_arms  ; the default: real hardware
-sim_embodiment = my-sim  ; what --sim swaps in (any registered sim embodiment)
-scorer = operator      ; optional, ad-hoc runs only
-max_steps = 300        ; optional, ad-hoc runs only
-store_frames = true    ; optional, capture frames on every run
+embodiment = yam_arms     ; the default: real hardware
+sim_embodiment = my-sim   ; what --sim swaps in (any registered sim embodiment)
+scorer = operator         ; optional, ad-hoc runs only
+max_steps = 300           ; optional, ad-hoc runs only
+store_frames = true       ; optional, capture frames on every run
 
 [policy.args]          ; default -P key=value pairs
 server_url = http://gpu-box:8202

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -37,18 +37,18 @@ Resolved in order (first hit wins):
 
 ```ini
 [defaults]
-policy = molmoact2-yam
-embodiment = yam-bimanual            ; the default: real hardware
-sim_embodiment = yam-bimanual-isaac  ; what --sim swaps in
+policy = molmoact2
+embodiment = yam_arms  ; the default: real hardware
+sim_embodiment = my-sim  ; what --sim swaps in (any registered sim embodiment)
 scorer = operator      ; optional, ad-hoc runs only
 max_steps = 300        ; optional, ad-hoc runs only
 store_frames = true    ; optional, capture frames on every run
 
 [policy.args]          ; default -P key=value pairs
-checkpoint = ~/ckpts/molmoact2-yam.pt
+server_url = http://gpu-box:8202
 
 [embodiment.args]      ; default -E key=value pairs
-cameras = wrist,front
+top_cam_device = /dev/v4l/by-id/usb-CAM123-video-index0
 
 [sim_embodiment.args]  ; -E pairs used only under --sim
 headless = true
@@ -71,7 +71,7 @@ Real hardware is the default (it is whatever you configured as `embodiment`).
 
 ```bash
 inspect-robots "place the spoon on the plate" --sim
-inspect-robots run --task my-benchmark --policy molmoact2-yam --sim
+inspect-robots run --task my-benchmark --policy molmoact2 --sim
 ```
 
 The sim embodiment resolves as `$INSPECT_ROBOTS_SIM_EMBODIMENT` > config
@@ -263,6 +263,13 @@ scenes:
 
 `completed` is the display form of the log's `success` status value; the
 on-disk field and Python API keep `success`.
+
+For runs whose policy recorded conversations (such as `--policy agent`),
+`--transcript` appends each trial's recorded transcript after the summary:
+
+```bash
+inspect-robots inspect logs/cubepick-reach_xxxx.json --transcript
+```
 
 ## `inspect-robots view`
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -65,9 +65,8 @@ from inspect_robots import eval
 
 ## From the command line
 
-On a real rig, configure defaults once with the interactive wizard
-(`inspect-robots setup`, covered in [the CLI guide](cli.md)). The explicit
-form below needs no configuration:
+The CLI resolves any registered task, policy, or embodiment (builtins plus
+installed plugins):
 
 ```bash
 inspect-robots list                                          # all registered components
@@ -75,6 +74,125 @@ inspect-robots list policies                                 # just policies
 inspect-robots run --task cubepick-reach --policy scripted --embodiment cubepick
 inspect-robots run --task cubepick-reach --policy scripted --embodiment cubepick -P chunk_size=6
 inspect-robots inspect logs/cubepick-reach_*.json            # print a saved log
+inspect-robots view logs/cubepick-reach_*.json               # render an HTML report
+inspect-robots video logs/cubepick-reach_*.json              # camera frames to MP4
+```
+
+`view` writes a self-contained HTML page. `video` needs a run captured with
+`--store-frames` and the `ffmpeg` binary on PATH. Every command is covered in
+[the CLI guide](cli.md).
+
+## On a real robot
+
+Install the plugin for your rig and set your defaults once:
+
+```bash
+source .venv/bin/activate
+uv pip install inspect-robots-yam   # provides the molmoact2 policy + yam_arms rig
+inspect-robots setup
+```
+
+The wizard picks your defaults and finds your cameras, then writes
+`~/.config/inspect-robots/config.ini`. On a different rig, install its plugin
+instead and type its component names at the prompts; to write the config file
+by hand, see [the CLI guide](cli.md).
+
+The `molmoact2` policy is only a client: nothing moves until the MolmoAct2
+server is listening, and the server does not start itself or survive a reboot
+(full setup in the
+[yam plugin README](https://github.com/robocurve/inspect-robots-yam#install-on-the-robotgpu-machine)):
+
+```bash
+# On the GPU machine, from the MolmoAct2 repo. Leave it running, e.g. in tmux:
+python examples/yam/host_server_yam.py --host 0.0.0.0 --port 8202
+curl http://127.0.0.1:8202/act      # 200 means the server is ready
+```
+
+On a different rig, start whatever serves your policy instead; in-process
+policies (such as `agent` or the mock `scripted`) need no server.
+
+Then tell the robot what to do:
+
+```bash
+inspect-robots "place the fork on the plate"
+```
+
+Every run opens a live Rerun viewer streaming the cameras, proprioception,
+and actions straight from the eval pipeline, so you watch exactly what the
+policy sees while the robot moves. CLI flags override any default
+(`--no-rerun`, `--no-store-frames`, `--max-steps 300`, ...).
+
+Safety guardrails (a bounds clamp plus a per-step delta limit derived from
+the embodiment's action space) are wired into every CLI run by default, for
+every policy. Turning them off requires an explicit `--disable-guardrails`.
+
+## Drive the robot with an LLM
+
+The policy slot is not limited to VLAs. With the
+[inspect-robots-agent](https://github.com/robocurve/inspect-robots/tree/main/plugins/inspect-robots-agent)
+plugin, a frontier LLM drives the same rig through tool calls, one
+approver-checked motion chunk per call.
+
+Put a `.env` with your API key in the working directory (the CLI loads it
+automatically):
+
+```ini
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Install the add-on:
+
+```bash
+uv pip install inspect-robots-agent
+```
+
+Run the LLM on the robot:
+
+```bash
+inspect-robots "place the fork on the plate" --policy agent \
+    -P model=anthropic/claude-fable-5 -P effort=low
+```
+
+No rig? The same policy drives the mock world, no hardware or GPU required
+(an exported key works in place of `.env`):
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+inspect-robots "pick up the cube" --policy agent \
+    -P model=anthropic/claude-fable-5 -P effort=low --embodiment cubepick
+```
+
+Read the recorded agent conversation with
+`inspect-robots inspect LOG.json --transcript`, or open the HTML report with
+`inspect-robots view LOG.json`; for `--store-frames` runs it includes the
+camera frames the model saw.
+
+## Generate robot policy code with CaP-X
+
+The
+[inspect-robots-capx](https://github.com/robocurve/inspect-robots/tree/main/plugins/inspect-robots-capx)
+plugin evaluates a code-as-policy agent in the same policy slot. The LLM
+writes Python against SAM3 segmentation, Contact-GraspNet planning, Pyroki
+IK, and speed-limited joint-motion helpers.
+
+```bash
+uv pip install inspect-robots-capx
+
+inspect-robots "place the fork on the plate" --policy capx \
+    --embodiment <joint-space-embodiment> \
+    -P model=anthropic/claude-fable-5 -P sam3_url=http://gpu-box:8114
+```
+
+See the plugin README for embodiment requirements, model-server bringup, and
+the model-code trust boundary.
+
+## Run in simulation
+
+The same instruction runs on your configured simulator instead of the real
+robot (the mapping is explained in [the CLI guide](cli.md)):
+
+```bash
+inspect-robots "place the fork on the plate" --sim
 ```
 
 ## Next steps
@@ -82,3 +200,5 @@ inspect-robots inspect logs/cubepick-reach_*.json            # print a saved log
 - [Concepts](concepts.md): the core abstractions.
 - [Writing a benchmark](writing-a-benchmark.md): define your own `Task`.
 - [Policies and embodiments](policies-and-embodiments.md): plug in a real VLA or robot/sim.
+- [Plugins](plugins.md): the first-party adapters for ROS, Isaac Lab, XPolicyLab, LLM agents, and CaP-X.
+- [The CLI](cli.md): configuration, `--sim` mapping, scoring, and every command.

--- a/plans/0025-landing-style-and-quickstart-refresh.md
+++ b/plans/0025-landing-style-and-quickstart-refresh.md
@@ -1,0 +1,205 @@
+# 0025: Robocurve-style landing page and quickstart refresh
+
+## Goal
+
+Two user-visible changes to inspectrobots.org, no framework code touched:
+
+1. `docs/guide/quickstart.md` catches up with the README rewrite (#147): the
+   real-rig setup wizard, LLM-as-policy (`--policy agent`), CaP-X, `--sim`,
+   and the `view`/`video` commands are absent from the page today.
+2. The landing page (`website/src/pages/index.tsx` + CSS) adopts the clean
+   editorial style of robocurve.org, the parent org's site.
+
+## Non-goals
+
+- No changes to guide pages other than quickstart and the `cli.md`
+  carve-outs listed in Changes §5.
+- No changes to the API generator, CI, or URL structure.
+- No content removal from the landing page: same sections, restyled.
+- Dark mode stays supported; it follows the existing dark palette, not a
+  dark variant of the robocurve cream.
+
+## Source of truth for the style
+
+Extracted from robocurve.org's shipped CSS (site.TKPXBSW6.css):
+
+- Fonts: Space Grotesk (display + body), IBM Plex Mono (eyebrows/data).
+- Page surface `#FFFAED`; cards are white (`#ffffff`) with 1px hairline
+  border `#e6ddcd`; radius 6-10px; shadows absent or near-invisible.
+- Text: strong `#1a1511`, body `#403830`, muted `#736853`. Headings are
+  weight 500-600 with letter-spacing -0.01em to -0.03em, near-black (not
+  teal).
+- Accent: `#005f73` (identical to our existing primary), hover `#024e5e`.
+  Used only for buttons, links, eyebrows, small marks.
+- Eyebrow pattern: mono, uppercase, 0.16em tracking, accent color.
+- Hero: text left on bare cream (no band, no gradient), illustration right,
+  one filled accent button + one hairline outline button.
+
+## Changes
+
+### 1. Fonts (self-hosted, no external requests)
+
+- `npm install @fontsource/space-grotesk @fontsource/ibm-plex-mono` in
+  `website/` (lockfile updated).
+- `custom.css` imports weights 400/500/600/700 (Space Grotesk) and 400/500
+  (IBM Plex Mono), then sets `--ifm-font-family-base` to Space Grotesk and
+  keeps the default code font for code blocks (IBM Plex Mono is for
+  eyebrow labels, not code; Infima's monospace stack stays).
+
+### 2. Sitewide theme (`website/src/css/custom.css`), light mode only
+
+Scoping rule: every light-mode value goes under `[data-theme='light']`,
+never bare `:root`. Infima defines several of these variables only on
+`:root` (`--ifm-font-color-base`, `--ifm-heading-color`,
+`--ifm-navbar-background-color`) and implements dark mode by swapping
+*other* variables, so a bare-`:root` override in custom.css (loaded after
+Infima) would leak near-black text and a cream navbar into dark mode.
+Docusaurus 3 always stamps `data-theme` on `<html>`, so the selector is
+reliable.
+
+- `[data-theme='light']`: `--ifm-background-color: #FFFAED`,
+  `--ifm-background-surface-color: #ffffff`,
+  `--ifm-font-color-base: #403830`, `--ifm-heading-color: #1a1511`,
+  navbar background cream.
+- Heading weight drops from 700 to 600 (mode-independent, fine on
+  `:root`); add the negative tracking via an `h1-h4` rule.
+- Navbar: keep the existing `--ifm-navbar-shadow` faux-hairline mechanism
+  (a real `border-bottom` would add 1px to the fixed navbar's box and
+  nudge anchor-scroll offsets) but recolor it to `0 1px 0 #e6ddcd` in
+  light mode; dark mode keeps the current value.
+- Footer: keep `#003f4d` dark footer (robocurve also closes on an ink
+  band); unchanged.
+- Dark mode block: untouched except anything needed to keep contrast after
+  the font swap (no color changes expected).
+- Docs pages inherit the cream background and new type automatically;
+  admonitions/code blocks keep their Infima surfaces (white/gray) which
+  reads as "cards on cream", consistent with the target style.
+
+### 3. Landing page restyle (`index.module.css`, minor `index.tsx` edits)
+
+Same sections, same copy (except where noted), new skin:
+
+- Hero: drop the gradient band and logo drop-shadow. Bare cream, two-column
+  grid: text left (H1 near-black ~clamp(2.5rem,6vw,3.75rem), weight 600,
+  -0.03em; tagline becomes body-size muted lead, not teal bold), logo right
+  at a calmer size. Buttons: filled teal `Get started` (radius 6px) +
+  hairline outline `Concepts` (border `#d2c6b2`, text near-black), matching
+  robocurve's button pair.
+- `cardLabel` (THE VLA BRAIN / THE ROBOT OR SIM) becomes the robocurve
+  eyebrow: IBM Plex Mono, uppercase, 0.16em tracking, teal, on **white**
+  cards with hairline borders; H3 near-black; body text `#403830`. The
+  dark-teal gradient fill, big radius, and 45px shadows go away.
+- `creamSection` alternation disappears (whole page is cream); section
+  separation via spacing and, where needed, a hairline `border-top`.
+- Feature cards and plugin cards: white surface, hairline border, 10px
+  radius, no translateY hover; hover = border-color to teal. Plugin strip
+  goes from 5 skinny columns to exactly 3 (3+2 rows; 2 columns would
+  orphan the fifth card), collapsing to 1 on mobile as today.
+- Section H2s: near-black, weight 600, -0.02em tracking, robocurve's
+  section size (~clamp(1.6rem,4vw,2.125rem)); optional mono eyebrows above
+  key sections ("THE FRAMEWORK", "QUICKSTART", ...) only if they read
+  naturally; skip if forced.
+- Inspect AI mapping table: hairline borders, white header row; override
+  `--ifm-table-stripe-background` (Infima's default gray zebra) so rows
+  sit flat on the card surface.
+- Dark mode: every literal light value in `index.module.css` (`#ffffff`
+  card surfaces, `#e6ddcd` hairlines, near-black text) gets an explicit
+  `[data-theme='dark'] .class` override (attribute selectors are not
+  hashed by CSS modules, so this composes with module classes). The
+  existing scoped `.heroOutlineButton` fix is superseded by the new
+  button styles under the same rule. Test both modes by screenshot; this
+  exact class of bug (light literal leaking into dark mode) already bit
+  once.
+
+### 4. CLI guide carve-outs (`docs/guide/cli.md`)
+
+Two small consistency edits, no restructuring:
+
+- Document the existing `--transcript` flag in the `inspect` section (the
+  new quickstart references it; the CLI reference must not lag a flag the
+  quickstart teaches).
+- The page mixes fictional component names with the real YAM ones its own
+  walkthrough uses. Fix every occurrence, not just the first: the generic
+  config example (`policy = molmoact2-yam`, `embodiment = yam-bimanual`,
+  `sim_embodiment = yam-bimanual-isaac`), the `checkpoint =
+  ~/ckpts/molmoact2-yam.pt` `-P` example (implausible for `molmoact2`,
+  which is a server client), and the `--sim` run example
+  (`--policy molmoact2-yam`). Use the real names (`molmoact2`,
+  `yam_arms`) wherever a real counterpart exists; where none does (the
+  sim embodiment, the checkpoint illustration), use openly generic
+  placeholders or a real parameter so the page never presents a
+  half-real name. The result must be internally consistent across the
+  whole page.
+
+### 5. Quickstart guide (`docs/guide/quickstart.md`)
+
+Restructured to mirror the README while staying a docs page (links instead
+of duplicating deep detail). Section order:
+
+1. **Install** (unchanged).
+2. **Run your first evaluation** (mock world Python, unchanged): stays
+   first because it is the only zero-hardware path. This block keeps the
+   docs variant (separate `print` lines with output comments); the
+   verbatim-README rule below applies to the newly added CLI blocks, not
+   to this pre-existing one.
+3. **Use registry names** (unchanged).
+4. **From the command line**: extend the existing block with `view` and
+   `video` (with the ffmpeg note), keeping `list`/`run`/`inspect`. Drop
+   the section's current intro sentence about the setup wizard: with the
+   new "On a real robot" section immediately following, that forward
+   reference becomes redundant.
+5. **On a real robot** (new): rig plugin install (`inspect-robots-yam`
+   example), `inspect-robots setup` wizard writing
+   `~/.config/inspect-robots/config.ini`, the policy-server caveat
+   (molmoact2 is a client; server start + `curl .../act` check, link to
+   the yam plugin README), then `inspect-robots "place the fork on the
+   plate"`, the Rerun live-viewer paragraph, flag overrides, and the
+   default guardrails sentence (`--disable-guardrails` opt-out). Link to
+   the CLI guide for config-file details.
+6. **Drive the robot with an LLM** (new): `.env` with `ANTHROPIC_API_KEY`,
+   `uv pip install inspect-robots-agent`, the README's run command, plus
+   the no-hardware variant `--embodiment cubepick` so readers without a
+   rig can run it immediately; transcript reading via
+   `inspect logs/... --transcript` and `view`.
+7. **Generate robot policy code with CaP-X** (new, short): one paragraph +
+   install/run block + link to the plugin README for server bringup and
+   the trust boundary.
+8. **Run in simulation** (new, short): `--sim`.
+9. **Next steps** (unchanged links; add Plugins guide link).
+
+Style rules apply (no em dashes, restrained bold, no decorative emoji).
+Code blocks must match the README verbatim where they overlap (the README
+was reviewed for correctness in #147; do not invent new flags). The
+surrounding prose is paraphrased, not copied: the README's prose contains
+em dashes the docs style rules forbid.
+
+## Verification
+
+- `cd website && npm run build` green (strict broken-link/anchor checks)
+  and `npm run typecheck` green (`docusaurus build` transpiles TS without
+  type-checking, and CI's docs job only builds, so this is the only gate
+  that type-checks `index.tsx`).
+- Screenshots of `/` and `/guide/quickstart/` in light and dark mode
+  (headless Chrome, `--blink-settings=preferredColorScheme=1` for light,
+  `=0` for dark; Blink's enum is kDark=0, kLight=1) reviewed
+  against robocurve.org for: cream page, near-black headings, hairline
+  cards, no gradients, legible dark mode.
+- `npm run serve` preview offered to the user before merge (explicit user
+  request for this change).
+- CI `docs-build` green on the PR.
+
+## Risks
+
+- Font imports from `@fontsource` must resolve through the css-loader
+  module resolution (`@import "@fontsource/space-grotesk/400.css";`); if
+  the build rejects bare module imports, fall back to importing them via
+  `docusaurus.config.ts` client modules.
+- Cream background sitewide could reduce code-block contrast in docs;
+  verify one guide page screenshot, and if it reads poorly keep docs pages
+  on the default background by scoping the cream to the landing page only
+  (decision recorded in the PR description).
+- The local-search plugin styles inputs against Infima variables; check the
+  navbar search field still looks right on cream.
+- Space Grotesk ships no italic cuts, so markdown emphasis renders as
+  browser-synthesized oblique. Accepted tradeoff (robocurve.org has the
+  same property); revisit only if emphasis-heavy pages read badly.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -98,8 +98,38 @@ const config: Config = {
       ],
     },
     footer: {
-      style: 'dark',
-      copyright: 'Copyright © Inspect Robots contributors',
+      style: 'light',
+      links: [
+        {
+          title: 'Docs',
+          items: [
+            {label: 'Quickstart', to: '/guide/quickstart/'},
+            {label: 'Concepts', to: '/guide/concepts/'},
+            {label: 'API reference', to: '/api/'},
+          ],
+        },
+        {
+          title: 'Community',
+          items: [
+            {
+              label: 'GitHub',
+              href: 'https://github.com/robocurve/inspect-robots',
+            },
+            {
+              label: 'Issues',
+              href: 'https://github.com/robocurve/inspect-robots/issues',
+            },
+          ],
+        },
+        {
+          title: 'More',
+          items: [
+            {label: 'Robocurve', href: 'https://robocurve.org/'},
+            {label: 'For LLMs: llms.txt', href: 'pathname:///llms.txt'},
+          ],
+        },
+      ],
+      copyright: `Copyright © ${new Date().getFullYear()} Robocurve. Released under the <a href="https://github.com/robocurve/inspect-robots/blob/main/LICENSE">MIT License</a>.`,
     },
     prism: {
       theme: prismThemes.github,

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,6 +11,8 @@
         "@docusaurus/core": "3.10.2",
         "@docusaurus/preset-classic": "3.10.2",
         "@easyops-cn/docusaurus-search-local": "^0.55.2",
+        "@fontsource/ibm-plex-mono": "^5.3.0",
+        "@fontsource/space-grotesk": "^5.3.0",
         "@mdx-js/react": "^3.0.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
@@ -4297,6 +4299,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.3.0.tgz",
+      "integrity": "sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/space-grotesk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/space-grotesk/-/space-grotesk-5.3.0.tgz",
+      "integrity": "sha512-ksnGizDPXIDuvqcTYTSrmZ+evx9sDlS8rp7+42BQ7wU+spt3twEoXfbJz672C+5CLg6VeUQwRy5RXshWb67LcQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@hapi/hoek": {

--- a/website/package.json
+++ b/website/package.json
@@ -22,6 +22,8 @@
     "@docusaurus/core": "3.10.2",
     "@docusaurus/preset-classic": "3.10.2",
     "@easyops-cn/docusaurus-search-local": "^0.55.2",
+    "@fontsource/ibm-plex-mono": "^5.3.0",
+    "@fontsource/space-grotesk": "^5.3.0",
     "@mdx-js/react": "^3.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -63,6 +63,9 @@ h4 {
   border-radius: 0.45rem;
 }
 
-.footer--dark {
-  --ifm-footer-background-color: #003f4d;
+/* The footer matches the navbar surface in both modes (cream in light,
+   Infima's dark surface in dark) instead of introducing a third color. */
+.footer {
+  --ifm-footer-background-color: var(--ifm-navbar-background-color);
+  border-top: 1px solid var(--ir-hairline);
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,3 +1,10 @@
+@import '@fontsource/space-grotesk/400.css';
+@import '@fontsource/space-grotesk/500.css';
+@import '@fontsource/space-grotesk/600.css';
+@import '@fontsource/space-grotesk/700.css';
+@import '@fontsource/ibm-plex-mono/400.css';
+@import '@fontsource/ibm-plex-mono/500.css';
+
 :root {
   --ifm-color-primary: #005f73;
   --ifm-color-primary-dark: #005568;
@@ -7,9 +14,27 @@
   --ifm-color-primary-lighter: #006e86;
   --ifm-color-primary-lightest: #007c97;
   --ifm-code-font-size: 95%;
-  --ifm-heading-font-weight: 700;
-  --ifm-navbar-shadow: 0 1px 0 rgb(0 95 115 / 14%);
+  --ifm-font-family-base: 'Space Grotesk', ui-sans-serif, system-ui,
+    -apple-system, sans-serif;
+  --ifm-heading-font-weight: 600;
+  --ir-font-mono-label: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo,
+    monospace;
   --docusaurus-highlighted-code-line-bg: rgb(0 95 115 / 10%);
+}
+
+/* Light mode only. Infima defines these on :root and swaps *other* variables
+   for dark mode, so a bare :root override here would leak into dark mode. */
+[data-theme='light'] {
+  --ifm-background-color: #fffaed;
+  --ifm-background-surface-color: #fff;
+  --ifm-font-color-base: #403830;
+  --ifm-heading-color: #1a1511;
+  --ifm-navbar-background-color: #fffaed;
+  --ifm-navbar-shadow: 0 1px 0 #e6ddcd;
+  --ifm-toc-border-color: #e6ddcd;
+  --ir-hairline: #e6ddcd;
+  --ir-hairline-strong: #d2c6b2;
+  --ir-text-muted: #736853;
 }
 
 [data-theme='dark'] {
@@ -20,7 +45,18 @@
   --ifm-color-primary-light: #89dcd3;
   --ifm-color-primary-lighter: #96e0d8;
   --ifm-color-primary-lightest: #c3eee9;
+  --ifm-navbar-shadow: 0 1px 0 rgb(255 255 255 / 12%);
+  --ir-hairline: rgb(255 255 255 / 14%);
+  --ir-hairline-strong: rgb(255 255 255 / 25%);
+  --ir-text-muted: rgb(255 255 255 / 62%);
   --docusaurus-highlighted-code-line-bg: rgb(111 211 200 / 18%);
+}
+
+h1,
+h2,
+h3,
+h4 {
+  letter-spacing: -0.02em;
 }
 
 .navbar__logo img {

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -1,77 +1,125 @@
 .hero {
-  background:
-    radial-gradient(circle at 15% 20%, rgb(255 250 237 / 90%) 0 8rem, transparent 8.1rem),
-    linear-gradient(135deg, #e2f1ef, #fff 65%);
-  border-bottom: 1px solid rgb(0 95 115 / 15%);
-  padding: 5.5rem 0;
+  padding: 5.5rem 0 5rem;
 }
 
 .heroInner {
   align-items: center;
   display: grid;
-  gap: 4.5rem;
-  grid-template-columns: minmax(220px, 340px) minmax(0, 1fr);
+  gap: 4rem;
+  grid-template-columns: minmax(0, 1fr) minmax(200px, 280px);
   max-width: 1100px;
 }
 
 .heroLogo {
-  filter: drop-shadow(0 18px 28px rgb(0 95 115 / 15%));
   width: 100%;
 }
 
 .heroTitle {
-  color: #003f4d;
-  font-size: clamp(3rem, 7vw, 5.5rem);
-  letter-spacing: -0.055em;
-  line-height: 0.95;
+  font-size: clamp(2.5rem, 6vw, 3.75rem);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
   margin-bottom: 1.25rem;
 }
 
 .tagline {
-  color: #005f73;
-  font-size: clamp(1.35rem, 2.4vw, 2rem);
-  font-weight: 650;
-  line-height: 1.25;
-  max-width: 780px;
+  color: var(--ifm-heading-color);
+  font-size: clamp(1.2rem, 2vw, 1.45rem);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.35;
+  max-width: 620px;
 }
 
 .heroCopy {
-  color: #334e54;
-  font-size: 1.1rem;
-  max-width: 700px;
+  color: var(--ir-text-muted);
+  font-size: 1.05rem;
+  line-height: 1.65;
+  max-width: 560px;
 }
 
 .heroActions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.8rem;
-  margin-top: 1.8rem;
+  gap: 0.9rem;
+  margin-top: 2rem;
 }
 
-/* The hero band keeps its light background in dark mode, so this button must
-   not inherit dark-mode button colors (white on white). */
-.heroActions .heroOutlineButton {
-  border-color: #005f73;
-  color: #005f73;
+.ctaPrimary {
+  background: var(--ifm-color-primary);
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: #fff;
+  display: inline-flex;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  padding: 0.85rem 1.7rem;
+  transition: background 140ms ease;
 }
 
-.heroActions .heroOutlineButton:hover {
-  background: rgb(0 95 115 / 8%);
-  color: #003f4d;
+.ctaPrimary:hover {
+  background: #024e5e;
+  color: #fff;
+  text-decoration: none;
+}
+
+[data-theme='dark'] .ctaPrimary {
+  color: #06251f;
+}
+
+[data-theme='dark'] .ctaPrimary:hover {
+  background: var(--ifm-color-primary-light);
+  color: #06251f;
+}
+
+.ctaOutline {
+  background: transparent;
+  border: 1px solid var(--ir-hairline-strong);
+  border-radius: 6px;
+  color: var(--ifm-heading-color);
+  display: inline-flex;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  padding: 0.85rem 1.7rem;
+  transition: border-color 140ms ease, color 140ms ease;
+}
+
+.ctaOutline:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.landing {
+  --ifm-table-stripe-background: transparent;
+  --ifm-table-border-color: var(--ir-hairline);
 }
 
 .section {
-  padding: 5rem 0;
+  border-top: 1px solid var(--ir-hairline);
+  padding: 4.5rem 0;
 }
 
 .section h2 {
-  font-size: clamp(2rem, 4vw, 3rem);
-  letter-spacing: -0.035em;
+  font-size: clamp(1.6rem, 4vw, 2.125rem);
+  font-weight: 600;
+}
+
+.eyebrow {
+  color: var(--ifm-color-primary);
+  font-family: var(--ir-font-mono-label);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
 }
 
 .sectionLead {
-  font-size: 1.1rem;
-  max-width: 760px;
+  font-size: 1.05rem;
+  max-width: 640px;
 }
 
 .inputGrid {
@@ -82,35 +130,33 @@
 }
 
 .inputCard {
-  background: linear-gradient(145deg, #005f73, #003f4d);
-  border-radius: 1.25rem;
-  box-shadow: 0 18px 45px rgb(0 63 77 / 18%);
-  color: #f4fffd;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ir-hairline);
+  border-radius: 10px;
   padding: 2rem;
 }
 
 .inputCard h3 {
-  color: #fff;
-  font-size: 2rem;
-  margin: 0.3rem 0 0.75rem;
+  font-size: 1.6rem;
+  margin: 0.5rem 0 0.75rem;
+}
+
+.inputCard p {
+  margin-bottom: 0;
 }
 
 .cardLabel {
-  color: #91e1da;
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 0.82rem;
-  letter-spacing: 0.08em;
+  color: var(--ifm-color-primary);
+  font-family: var(--ir-font-mono-label);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
 }
 
 .afterCards {
   margin-top: 1.5rem;
-  max-width: 900px;
-}
-
-.creamSection {
-  background: #fffaed;
-  color: #243d42;
+  max-width: 760px;
 }
 
 .sectionHeadingRow {
@@ -129,48 +175,57 @@
 }
 
 .featureCard {
-  border: 1px solid rgb(0 95 115 / 18%);
-  border-radius: 1rem;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ir-hairline);
+  border-radius: 10px;
   padding: 1.5rem;
 }
 
 .featureCard h3 {
-  color: var(--ifm-color-primary-darkest);
-  font-size: 1.15rem;
+  font-size: 1.1rem;
+}
+
+.featureCard p {
+  font-size: 0.95rem;
+  margin-bottom: 0;
 }
 
 .pluginStrip {
   display: grid;
-  gap: 0.8rem;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   margin-top: 2rem;
 }
 
 .pluginCard {
   background: var(--ifm-background-surface-color);
-  border: 1px solid rgb(0 95 115 / 20%);
-  border-radius: 0.85rem;
+  border: 1px solid var(--ir-hairline);
+  border-radius: 10px;
   color: var(--ifm-font-color-base);
   display: flex;
   flex-direction: column;
-  gap: 0.8rem;
-  padding: 1.1rem;
-  transition: border-color 150ms ease, transform 150ms ease;
+  gap: 0.7rem;
+  padding: 1.5rem;
+  transition: border-color 140ms ease;
 }
 
 .pluginCard:hover {
   border-color: var(--ifm-color-primary);
+  color: var(--ifm-font-color-base);
   text-decoration: none;
-  transform: translateY(-3px);
 }
 
 .pluginCard code {
-  color: var(--ifm-color-primary-darkest);
-  font-size: 0.78rem;
+  background: transparent;
+  border: 0;
+  color: var(--ifm-color-primary);
+  font-size: 0.8rem;
+  padding: 0;
 }
 
 .pluginCard span {
-  font-size: 0.9rem;
+  font-size: 0.92rem;
+  line-height: 1.55;
 }
 
 @media screen and (max-width: 996px) {
@@ -180,7 +235,7 @@
 
   .heroInner {
     gap: 2rem;
-    grid-template-columns: 180px 1fr;
+    grid-template-columns: minmax(0, 1fr) 170px;
   }
 
   .featureGrid,
@@ -198,8 +253,7 @@
   }
 
   .heroLogo {
-    margin: 0 auto;
-    max-width: 180px;
+    display: none;
   }
 
   .sectionHeadingRow {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -30,7 +30,13 @@ const features = [
   },
   {
     title: 'Reproducible',
-    body: 'Every run yields an immutable, schema-versioned EvalLog with the resolved config, git revision, and package versions. It is re-readable across releases and re-scorable offline.',
+    body: (
+      <>
+        Every run yields an immutable, schema-versioned <code>EvalLog</code>{' '}
+        with the resolved config, git revision, and package versions. It is
+        re-readable across releases and re-scorable offline.
+      </>
+    ),
   },
   {
     title: 'Light core',
@@ -42,42 +48,81 @@ const features = [
   },
   {
     title: 'Rerun visualization',
-    body: 'Stream camera images, 3D poses, joint and action time-series, and success markers to a .rrd recording. Logging is non-blocking: a slow viewer connection drops camera frames first instead of delaying the robot control loop.',
+    body: (
+      <>
+        Stream camera images, 3D poses, joint and action time-series, and
+        success markers to a <code>.rrd</code> recording. Logging is
+        non-blocking: a slow viewer connection drops camera frames first
+        instead of delaying the robot control loop.
+      </>
+    ),
   },
   {
     title: 'Pluggable',
-    body: 'Backends ship as separate packages: the first-party plugins below, and rig plugins like inspect-robots-yam. Entry points make them appear in inspect-robots list automatically.',
+    body: (
+      <>
+        Backends ship as separate packages: the first-party plugins below, and
+        rig plugins like <code>inspect-robots-yam</code>. Entry points make
+        them appear in <code>inspect-robots list</code> automatically.
+      </>
+    ),
   },
 ];
 
 const plugins = [
   {
     name: 'ros',
-    description:
-      'Run evals on ROS 1 or ROS 2 arms through rosbridge, with no ROS installation on the eval machine (--embodiment ros).',
+    description: (
+      <>
+        Run evals on ROS 1 or ROS 2 arms through rosbridge, with no ROS
+        installation on the eval machine (<code>--embodiment ros</code>).
+      </>
+    ),
     href: 'https://github.com/robocurve/inspect-robots/tree/main/plugins/inspect-robots-ros',
   },
   {
     name: 'isaacsim',
-    description: 'Run evals against an Isaac Lab simulation (--embodiment isaacsim).',
+    description: (
+      <>
+        Run evals against an Isaac Lab simulation (
+        <code>--embodiment isaacsim</code>).
+      </>
+    ),
     href: 'https://github.com/robocurve/inspect-robots/tree/main/plugins/inspect-robots-isaacsim',
   },
   {
     name: 'xpolicylab',
-    description:
-      'Drive any XPolicyLab-served policy. One adapter puts its zoo of 40+ VLAs (π0/π0.5, GR00T, OpenVLA-OFT, RDT-1B, SmolVLA, ACT, …) behind --policy xpolicylab -P url=ws://gpu-box:19000.',
+    description: (
+      <>
+        Drive any XPolicyLab-served policy. One adapter puts its zoo of 40+
+        VLAs (π0/π0.5, GR00T, OpenVLA-OFT, RDT-1B, SmolVLA, ACT, …) behind{' '}
+        <code>--policy xpolicylab -P url=ws://gpu-box:19000</code>.
+      </>
+    ),
     href: 'https://github.com/robocurve/inspect-robots/tree/main/plugins/inspect-robots-xpolicylab',
   },
   {
     name: 'agent',
-    description:
-      'Let a frontier LLM (Claude, GPT, anything behind an OpenAI-compatible API) drive any embodiment through tool calls, as a first-class policy. The same --policy agent runs ad-hoc instructions and scores on registered tasks next to fine-tuned VLAs.',
+    description: (
+      <>
+        Let a frontier LLM (Claude, GPT, anything behind an OpenAI-compatible
+        API) drive any embodiment through tool calls, as a first-class policy.
+        The same <code>--policy agent</code> runs ad-hoc instructions and
+        scores on registered tasks next to fine-tuned VLAs.
+      </>
+    ),
     href: 'https://github.com/robocurve/inspect-robots/tree/main/plugins/inspect-robots-agent',
   },
   {
     name: 'capx',
-    description:
-      'Evaluate CaP-X-style code-as-policy agents against a joint-space embodiment. Model-generated Python calls separately served SAM3, Contact-GraspNet, and Pyroki helpers, then queues approver-checked joint targets behind --policy capx.',
+    description: (
+      <>
+        Evaluate CaP-X-style code-as-policy agents against a joint-space
+        embodiment. Model-generated Python calls separately served SAM3,
+        Contact-GraspNet, and Pyroki helpers, then queues approver-checked
+        joint targets behind <code>--policy capx</code>.
+      </>
+    ),
     href: 'https://github.com/robocurve/inspect-robots/tree/main/plugins/inspect-robots-capx',
   },
 ];

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -86,11 +86,6 @@ function Hero(): ReactNode {
   return (
     <header className={styles.hero}>
       <div className={`container ${styles.heroInner}`}>
-        <img
-          className={styles.heroLogo}
-          src="/img/inspect-robots-logo.svg"
-          alt="Inspect Robots logo, a robot inspecting a dot through a magnifying lens"
-        />
         <div>
           <Heading as="h1" className={styles.heroTitle}>
             Inspect Robots
@@ -105,16 +100,19 @@ function Hero(): ReactNode {
             reproducible logs and first-class Rerun visualization.
           </p>
           <div className={styles.heroActions}>
-            <Link className="button button--primary button--lg" to="/guide/quickstart/">
+            <Link className={styles.ctaPrimary} to="/guide/quickstart/">
               Get started
             </Link>
-            <Link
-              className={`button button--outline button--lg ${styles.heroOutlineButton}`}
-              to="/guide/concepts/">
+            <Link className={styles.ctaOutline} to="/guide/concepts/">
               Concepts
             </Link>
           </div>
         </div>
+        <img
+          className={styles.heroLogo}
+          src="/img/inspect-robots-logo.svg"
+          alt="Inspect Robots logo, a robot inspecting a dot through a magnifying lens"
+        />
       </div>
     </header>
   );
@@ -126,9 +124,10 @@ export default function Home(): ReactNode {
       title="Inspect Robots"
       description="An open-source evaluation framework for benchmarking AI and robots in the physical world">
       <Hero />
-      <main>
+      <main className={styles.landing}>
         <section className={styles.section}>
           <div className="container">
+            <p className={styles.eyebrow}>The framework</p>
             <Heading as="h2">One framework, two swappable inputs</Heading>
             <p className={styles.sectionLead}>
               LLM evals have a single swappable input: the model. Robotics evals
@@ -162,10 +161,11 @@ export default function Home(): ReactNode {
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.creamSection}`}>
+        <section className={styles.section}>
           <div className="container">
             <div className={styles.sectionHeadingRow}>
               <div>
+                <p className={styles.eyebrow}>Try it</p>
                 <Heading as="h2">Quickstart</Heading>
                 <p>No hardware or simulator required. The CubePick mock world exercises the whole stack.</p>
               </div>
@@ -177,6 +177,7 @@ export default function Home(): ReactNode {
 
         <section className={styles.section}>
           <div className="container">
+            <p className={styles.eyebrow}>Design</p>
             <Heading as="h2">Why Inspect Robots</Heading>
             <div className={styles.featureGrid}>
               {features.map((feature) => (
@@ -189,8 +190,9 @@ export default function Home(): ReactNode {
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.creamSection}`}>
+        <section className={styles.section}>
           <div className="container">
+            <p className={styles.eyebrow}>For Inspect AI users</p>
             <Heading as="h2">How it maps to Inspect AI</Heading>
             <p>
               If you know{' '}
@@ -220,6 +222,7 @@ export default function Home(): ReactNode {
 
         <section className={styles.section}>
           <div className="container">
+            <p className={styles.eyebrow}>Ecosystem</p>
             <Heading as="h2">First-party plugins</Heading>
             <p className={styles.sectionLead}>
               Both halves of an eval, the body and the brain, have ready-made


### PR DESCRIPTION
Closes #156. Plan: `plans/0025-landing-style-and-quickstart-refresh.md` (two critique rounds, no blockers remaining).

## Landing page
- Adopts robocurve.org's editorial style, from its shipped design tokens: Space Grotesk + IBM Plex Mono (self-hosted via @fontsource, no external requests), cream `#FFFAED` page, near-black headings, white hairline-border cards, mono uppercase eyebrows, teal `#005f73` kept as accent only. Gradients, drop shadows, and the dark filled cards are gone.
- All light-mode values are scoped under `[data-theme='light']` (Infima defines several of these variables only on `:root`, so a bare override would leak into dark mode); literal light values in the CSS module get explicit `[data-theme='dark']` overrides. Verified by light+dark screenshots.
- Plugin strip goes from five skinny columns to three.

## Quickstart guide
Catches up with the README rewrite (#147): real-rig setup wizard flow (yam example, policy-server caveat), driving the robot with an LLM (`--policy agent`, plus the no-hardware `--embodiment cubepick` variant), CaP-X code-as-policy, `--sim`, and the `view`/`video` commands. New CLI blocks are verbatim from the README; prose follows the docs style rules.

## cli.md carve-outs
- Documents the existing `inspect --transcript` flag (the quickstart now references it).
- Replaces the half-fictional component names (`molmoact2-yam`/`yam-bimanual`, the implausible `checkpoint` arg for a server-client policy) with the real YAM names and a real `server_url` arg, consistently across the config example and the `--sim` example.

Verified: `npm run typecheck` and `npm run build` green locally (build is strict on links/anchors); light+dark screenshots of `/` and `/guide/quickstart/` reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)