### PR TITLE
docs(landing): hero CTA links GitHub instead of Concepts

### DIFF
--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -74,11 +74,13 @@
 }
 
 .ctaOutline {
+  align-items: center;
   background: transparent;
   border: 1px solid var(--ir-hairline-strong);
   border-radius: 6px;
   color: var(--ifm-heading-color);
   display: inline-flex;
+  gap: 0.55rem;
   font-size: 1rem;
   font-weight: 600;
   letter-spacing: -0.01em;

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -127,6 +127,19 @@ const plugins = [
   },
 ];
 
+function GitHubMark(): ReactNode {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width="18"
+      height="18"
+      aria-hidden="true"
+      fill="currentColor">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+    </svg>
+  );
+}
+
 function Hero(): ReactNode {
   return (
     <header className={styles.hero}>
@@ -148,8 +161,10 @@ function Hero(): ReactNode {
             <Link className={styles.ctaPrimary} to="/guide/quickstart/">
               Get started
             </Link>
-            <Link className={styles.ctaOutline} to="/guide/concepts/">
-              Concepts
+            <Link
+              className={styles.ctaOutline}
+              href="https://github.com/robocurve/inspect-robots">
+              <GitHubMark /> GitHub
             </Link>
           </div>
         </div>


### PR DESCRIPTION
Swaps the hero's secondary CTA from Concepts to GitHub, with the octocat mark inline (currentColor, so it adapts to both themes). Concepts stays one click away via Docs.

Verified: typecheck + build green, hero screenshot reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)