### PR TITLE
feat(agent): native Anthropic Messages wire with fast mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@ All notable changes to this project are documented here. The format is based on
   are stripped from the transcript to save space, as they are already
   recorded in the frame store. The relative path to the transcript is
   stored in the trial's metadata for easy post-hoc analysis (#40).
+- **Agent plugin:** `-P wire=anthropic` selects Anthropic's native Messages
+  API instead of its OpenAI-compat endpoint, which is the only way to reach
+  fast mode: `-P speed=fast` runs Claude Opus 5 and Opus 4.8 at up to 2.5x
+  higher output tokens per second, at roughly double the standard price. Robot
+  control is latency-sensitive, so the arm spends less time waiting on the
+  model. The wire also carries `-P max_output_tokens=` (the Messages API
+  requires an output cap), replays thinking blocks so multi-turn trials hold
+  together, and turns refusals and truncated responses into errors that name
+  their own cause instead of looking like a missing tool call (#165).
 - **Agent plugin:** `-P wire=responses` selects the OpenAI Responses API wire,
   so reasoning effort works together with function tools on recent OpenAI
   models (Chat Completions rejects the combination, observed on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,9 @@ All notable changes to this project are documented here. The format is based on
   model. The wire also carries `-P max_output_tokens=` (the Messages API
   requires an output cap), replays thinking blocks so multi-turn trials hold
   together, and turns refusals and truncated responses into errors that name
-  their own cause instead of looking like a missing tool call (#165).
+  their own cause instead of looking like a missing tool call. A model that
+  resolves to any endpoint other than Anthropic's own is refused up front
+  with the fix named, rather than 404ing on the first call (#165).
 - **Agent plugin:** `-P wire=responses` selects the OpenAI Responses API wire,
   so reasoning effort works together with function tools on recent OpenAI
   models (Chat Completions rejects the combination, observed on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,10 @@ All notable changes to this project are documented here. The format is based on
   model. The wire also carries `-P max_output_tokens=` (the Messages API
   requires an output cap), replays thinking blocks so multi-turn trials hold
   together, and turns refusals and truncated responses into errors that name
-  their own cause instead of looking like a missing tool call. A model that
-  resolves to any endpoint other than Anthropic's own is refused up front
-  with the fix named, rather than 404ing on the first call (#165).
+  their own cause instead of looking like a missing tool call. Absent an
+  explicit `-P base_url=...`, a model that resolves to any endpoint other than
+  Anthropic's own is refused up front with the fix named, rather than 404ing
+  on the first call (#165).
 - **Agent plugin:** `-P wire=responses` selects the OpenAI Responses API wire,
   so reasoning effort works together with function tools on recent OpenAI
   models (Chat Completions rejects the combination, observed on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,8 @@ rollout, scores it, and writes an immutable `EvalLog`. Mirrors Inspect AI's
   (policy adapter speaking the XPolicyLab websocket protocol — 40+ served VLAs,
   no xpolicylab dep), and
   `plugins/inspect-robots-agent/` (LLMs as policies via the OpenAI-compatible
-  wire format — httpx only, no provider SDKs; registered as `agent`), and
+  wire formats or Anthropic's native Messages API — httpx only, no provider
+  SDKs; registered as `agent`), and
   `plugins/inspect-robots-capx/` (CaP-X code-as-policy over perception and IK
   HTTP servers; registered as `capx`).
 

--- a/plans/0026-agent-anthropic-wire.md
+++ b/plans/0026-agent-anthropic-wire.md
@@ -56,7 +56,7 @@ cut, for three reasons that only surfaced under review:
 - It is the only part of the PR that changes behavior for an existing wire,
   which is the argument for a separate PR, not for bundling.
 
-So `effort` validation stays exactly as it is today (`policy.py:128-134`), and
+So `effort` validation stays exactly as it is today (`policy.py:128-132`), and
 out-of-set values fail with the API's own 400 — the same disposition 0022 chose
 for `effort=max`. `effort="none"`/`"minimal"` on this wire will 400; that is
 consistent, loud, and self-describing.
@@ -115,12 +115,40 @@ rather than a rename.
 ```python
 _DEFAULT_MAX_OUTPUT_TOKENS = 16000   # in _anthropic.py, imported by policy.py
 
-resolved = max_output_tokens if max_output_tokens is not None else _DEFAULT_MAX_OUTPUT_TOKENS
+resolved = (
+    (max_output_tokens if max_output_tokens is not None else _DEFAULT_MAX_OUTPUT_TOKENS)
+    if wire == "anthropic"
+    else None
+)
 ```
+
+The `wire` gate is load-bearing: an ungated resolution would record `16000` in
+the config for a `wire=chat` run, where nothing capped the output.
 
 `AnthropicClient` therefore takes `max_output_tokens: int` (no default, no
 second source of truth for a number that lands in an eval log). The resolved
 value is what `AgentPolicyConfig` records.
+
+### `__init__` validation order
+
+The new checks are order-dependent, so spell the sequence out rather than
+leaving it to be rediscovered. Today `resolve_provider` runs at
+`policy.py:120`, before the `wire` check at `policy.py:133-134`; that has to
+change, because the `api_key_env` substitution must precede resolution and the
+OpenRouter check must follow it.
+
+1. `max_speed_frac`, `max_llm_calls`, `effort` (unchanged)
+2. `wire` membership in `_WIRE_FORMATS` — **first** among the new checks, so
+   `-P wire=antropic -P speed=fast` reports the misspelled wire rather than the
+   speed error
+3. `speed` value, and `speed`/`max_output_tokens` against `wire`
+4. resolve the effective `api_key_env` (see the guided-errors section)
+5. `resolve_provider(...)`
+6. the OpenRouter-fallback `ConfigError`
+7. resolve `max_output_tokens`, build the client
+
+Step 6 needs `from inspect_robots.errors import ConfigError` in `policy.py`,
+which has no such import today (only `_llm.py:18` imports it).
 
 Validation: `>= 1` when set, checked on every wire. `max_output_tokens` set
 with `wire != "anthropic"` is a construction-time `ValueError`, mirroring
@@ -186,9 +214,13 @@ equivalent to adaptive on Opus 5; on Opus 4.8 and 4.7 an omitted `thinking`
 runs with thinking **off**. Since fast mode covers Opus 5 and 4.8, omitting it
 would silently disable thinking on half the target set and make the replay
 cache below dead code there. The cost of sending it explicitly: pre-4.6 models
-(Sonnet 4.5, Haiku 4.5) reject `{"type": "adaptive"}`, so this wire does not
-reach them. That is the right trade for a wire whose reason to exist is an
-Opus-5-and-4.8 feature; the compat wire still serves those models.
+(Sonnet 4.5, Haiku 4.5) do not support `{"type": "adaptive"}`, so this wire
+does not reach them. Per-model support is readable at
+`GET /v1/models/<id>` → `capabilities.thinking.types.adaptive.supported`; the
+exact failure shape has not been observed, so the README says "not supported"
+rather than naming a status code. That is the right trade for a wire whose
+reason to exist is an Opus-5-and-4.8 feature; the compat wire still serves
+those models.
 
 `temperature` is forwarded when set, not rejected. Opus 5, 4.8, and 4.7 reject
 it with a 400, but Opus 4.6 and Sonnet 4.6 accept it over this same wire, so a
@@ -228,8 +260,10 @@ mechanism. `AnthropicClient` keeps
 
 Accepted loss, inherited from 0022: a text-only assistant turn (the nudge retry
 path, `policy.py:283-290`) carries no `tool_use`, so it caches nothing and its
-thinking block is dropped from replay. That is safe precisely because the
-constraint attaches to tool-use continuation, and such a turn is terminal.
+thinking block is dropped from replay. That is safe because the constraint
+attaches to tool-use continuation. Note such a turn is not terminal:
+`_MAX_CONSECUTIVE_FAILURES = 3` (`policy.py:38`) means it stays in the history
+for up to two further `complete()` calls.
 
 ### Translation: chat messages → Messages API
 
@@ -284,7 +318,9 @@ Tool schemas flatten from the chat nesting:
 stays chat-shaped; the client owns translation both ways. No strict-mode
 concern: the Messages API does not auto-normalize schemas the way the Responses
 API does, so the move tool's free-form `targets`/`deltas` object survives.
-`tools=[]` omits the `tools` key, matching `ResponsesClient`.
+`tools=[]` omits the `tools` key, matching `ChatClient` (`_llm.py:200-201`).
+Not `ResponsesClient`, which sends `tools: []` unconditionally
+(`_responses.py:58-64`).
 
 ### Response parsing → `AssistantMessage`
 
@@ -325,6 +361,13 @@ Two get specific guidance:
 Anything else outside the permissive set gets a generic message naming the
 `stop_reason` verbatim. No terminal response populates the cache.
 
+`pause_turn` is deliberately in the deny set. It arises only from the
+server-side sampling loop hitting its iteration limit (web search, web fetch,
+code execution), and this wire declares client-side custom tools only, so it is
+unreachable today. It is also the one denied reason that is *resumable* rather
+than fatal, so a future PR adding a server tool must revisit this branch
+instead of inheriting it.
+
 ### Guided errors
 
 House style: the error names the fix, never just the failure.
@@ -357,13 +400,15 @@ the substituted one.
 **Fast mode unsupported.** A 4xx while `speed="fast"` whose body contains both
 `"speed"` and `"fast"` (case-insensitive, matched against the full
 `response.text`, as `_llm.py:220` does) appends: `fix: fast mode needs Claude
-Opus 5 or Opus 4.8 on the Claude API (not Bedrock/Vertex/Foundry), or drop
--P speed=fast`. The two-token AND mirrors 0022's matcher shape; a bare `fast`
-substring is too weak.
+Opus 5 or Opus 4.8 on the Claude API (not Bedrock, Vertex, Foundry, or Claude
+Platform on AWS), or drop -P speed=fast`. The two-token AND mirrors 0022's
+matcher shape; a bare `fast` substring is too weak.
 
 **Sampling parameter rejected.** A 4xx whose body mentions `temperature`
-appends: `fix: Claude Opus 5, 4.8, and 4.7 reject temperature; drop
--P temperature=`.
+appends: `fix: this model rejects temperature (Opus 5, 4.8, 4.7, Sonnet 5, and
+Fable 5 all do; Opus 4.6 and Sonnet 4.6 accept it); drop -P temperature=`.
+Model-agnostic phrasing on purpose: an Opus-only list reads as inapplicable to
+a Sonnet 5 user who just hit the 400.
 
 **Fast-mode rate limit.** Fast mode draws on a rate-limit pool separate from
 standard Opus, so a fast-mode run can 429 while standard capacity sits idle.
@@ -421,11 +466,12 @@ the gate rather than a safety net under one.
 
 New fixtures, since nothing existing emits Anthropic-shaped payloads
 (`test_policy_e2e.py`'s `_Script` and response builders are chat-shaped):
-`_anthropic_response(*blocks, stop_reason="tool_use", usage=None)` building a
-`content` array, and `_AnthropicScript` mirroring `_Script`
+`_anthropic_response(*blocks, stop_reason="tool_use")` building a `content`
+array, and `_AnthropicScript` mirroring `_Script`
 (`test_policy_e2e.py:130-140`) for multi-turn policy tests. A `_client(...)`
-helper taking a `Provider` override, following `test_llm.py:273`, so the
-empty-api-key case is constructible.
+helper that does what `test_llm.py:225` does plus accepts a `Provider`
+override, as `test_llm.py:273` constructs by hand, so the empty-api-key case is
+constructible.
 
 Translation:
 
@@ -436,10 +482,10 @@ Translation:
   `role: "system"` message on the wire; a history with no system message omits
   the `system` key; a system message at index >= 1 raises.
 - Merge rule: three tool calls produce exactly one user message with three
-  `tool_result` blocks **in history order**; the interleaved case (only
-  consecutive runs merge); and a history *ending* in a tool run, the shape on
-  the wire every time `act()` retries after a tool error
-  (`policy.py:305-313`).
+  `tool_result` blocks **in history order**, none of them carrying `is_error`;
+  the interleaved case (only consecutive runs merge); and a history *ending* in
+  a tool run, the shape on the wire every time `act()` retries after a tool
+  error (`policy.py:305-313`).
 - Both consecutive-user-message sequences, asserted on the full `messages`
   array across a multi-turn trial via `_AnthropicScript`, not per-message.
 - `json.loads(arguments)` unparseable and parseable-but-non-object as separate
@@ -478,7 +524,10 @@ Parsing and terminal states:
   `stop_details: null` raises cleanly.
 - `max_tokens` raises naming `-P max_output_tokens=`, and a truncated response
   containing a partial `tool_use` raises rather than returning that call.
-- An unrecognized `stop_reason` raises naming it verbatim.
+- An unrecognized `stop_reason` raises naming it verbatim, with
+  `model_context_window_exceeded` and `pause_turn` as the two named cases (the
+  first is the live one motivating default-deny; the second is the resumable
+  reason a future server-tool PR must revisit).
 
 Errors and retries:
 
@@ -490,7 +539,9 @@ Errors and retries:
   `speed="fast"` gets no guidance.
 - `temperature` 4xx guidance.
 - 429 terminal message with `speed="fast"` (guided) and without it (unguided);
-  and 429-then-transport-error emitting no rate-limit guidance.
+  429-then-transport-error emitting no rate-limit guidance; and 429-then-5xx
+  likewise, which catches a `last_status` set only on 429 rather than on every
+  response.
 - Retry/fail-fast parity with `ChatClient`, plus `close()`.
 
 Policy wiring:
@@ -514,9 +565,10 @@ Policy wiring:
 - Add a "Fast mode on Claude" section beside "Reasoning effort on OpenAI
   models" (starts line 124): the `anthropic/<id>` model form, the
   Claude-API-only caveat, supported models, the keep-effort-at-`high`-or-below
-  note, and cost described as roughly double the standard output price with a
-  link to Anthropic's pricing page. No figures: no README here carries a price,
-  and a stale one would ship to PyPI on every release.
+  note, and cost described as roughly double the standard price (it is double
+  on both input and output) with a link to Anthropic's pricing page. No
+  figures: no README here carries a price, and a stale one would ship to PyPI
+  on every release.
 
 Repo writing style applies (CLAUDE.md "Writing style"): no em dashes in prose,
 bold only for `**term:**` lead-ins, no decorative emoji.
@@ -550,6 +602,12 @@ will not survive it.
 - `retry-after`-aware backoff. Correct, but it needs a parse rule (delta-seconds
   vs HTTP-date), a status scope, and a sleep-duration assertion pattern this
   suite does not have.
+- Adding a field to `Provider`. The wire is expressible with the three it
+  already has, and provenance does not belong on a value object.
+- Server-side refusal `fallbacks`. This wire's target set carries elevated
+  safety classifiers, so the question will come up, but the answer is the same
+  one that rules out 429 auto-downgrade: silently serving from a different
+  model produces an eval log that no longer describes what ran.
 - Per-wire `effort` validation, and with it 0022's `effort=max` hole. Separate
   concern, separate PR.
 - Adaptive-thinking display (`thinking: {"display": "summarized"}`) and thinking

--- a/plans/0026-agent-anthropic-wire.md
+++ b/plans/0026-agent-anthropic-wire.md
@@ -1,15 +1,15 @@
 # 0026 — `-P wire=anthropic`: native Messages API unlocks fast mode
 
-Issue: #165. Status: draft.
+Issue: #165. Status: draft (revised after critique round 1).
 
 ## Problem
 
 The agent plugin reaches Anthropic models only through the OpenAI-compat shim
-at `https://api.anthropic.com/v1/chat/completions` (`_llm.py` `_DIRECT_PROVIDERS`).
-The compat shim cannot express the Claude-native request surface, so the knob
-that matters most for this plugin is unreachable:
+at `https://api.anthropic.com/v1/chat/completions` (`_llm.py:37`). The compat
+shim cannot express the Claude-native request surface, so the knob that matters
+most for this plugin is unreachable:
 
-**Fast mode** runs Claude Opus 5 and Opus 4.8 at up to 2.5x higher output
+Fast mode runs Claude Opus 5 and Opus 4.8 at up to 2.5x higher output
 tokens/sec. It needs three things simultaneously: native `POST /v1/messages`,
 the `anthropic-beta: fast-mode-2026-02-01` header, and `speed: "fast"` as a
 top-level body field. `ChatClient` posts to `/chat/completions`, sets only
@@ -23,9 +23,13 @@ model thinks, which is exactly why `effort` already defaults to `low`
 is the one lever that buys latency without trading reasoning depth.
 
 The native wire also unlocks `output_config.effort` in its own spelling
-(`low` through `max`, where the compat shim's `reasoning_effort` mapping is
-undocumented) and correct `stop_reason: "refusal"` surfacing, which the compat
-shim flattens into an ordinary empty completion.
+(`low` through `max`) and correct `stop_reason: "refusal"` surfacing, which the
+compat shim flattens into an ordinary empty completion.
+
+Scope note: fast mode is Claude API only. Not Bedrock, Vertex, Foundry, or
+Claude Platform on AWS, and not usable with the Batch API or Priority Tier.
+Opus 4.7 fast mode was removed and now errors, so this wire does not resurrect
+it.
 
 ## Design
 
@@ -34,6 +38,11 @@ is deliberately the same shape as plan 0022 (`wire=responses`): the
 chat-completions message format stays the single source of truth for
 `_messages`, the transcript, sanitization, and echo; the new client translates
 at the wire boundary only. Same no-SDK doctrine: httpx, raw JSON.
+
+The one place this plan is *not* a thin mirror of 0022 is opaque-block replay
+(see "The thinking-block constraint"). 0022 needed a raw-item cache for
+OpenAI reasoning items; this wire needs the same mechanism for Claude thinking
+blocks, for the same underlying reason.
 
 ### `wire` param gains `"anthropic"`
 
@@ -51,131 +60,236 @@ proxy or gateway that serves the Messages API works unchanged.
 
 `LLMAgentPolicy(speed=None)`, values `None | "fast"`. Anything else is a
 `ValueError` at construction, mirroring the `effort` validation. `-P speed=fast`
-forwards for free. Recorded in `AgentPolicyConfig` so the eval log distinguishes
-a fast-mode run from a standard one — they are the same model at different
-prices ($10/$50 vs $5/$25 per MTok), so a cost reconciliation that cannot see
-this field is wrong by 2x.
+forwards for free.
 
 `speed="fast"` with `wire != "anthropic"` is a construction-time `ValueError`,
 not a silent no-op. The compat shim accepts unknown body fields by ignoring
 them, so a silently-dropped `speed` would bill at standard rates while the
-user believes fast mode is on. This is the failure mode most worth failing
-loudly on.
+user believes fast mode is on.
 
-No model-id gating. Fast mode is Opus 5 and Opus 4.8 today, but the supported
-set moves and a hardcoded allowlist would reject a model the API accepts.
+No model-id gating. Fast mode's supported set moves (4.7 was removed, 5 was
+added) and a hardcoded allowlist would reject a model the API accepts.
 Unsupported models get the API's own 400, wrapped by the guided error below.
 
-### `max_tokens` param (forced by the wire)
+### `max_output_tokens` param (forced by the wire)
 
-`max_tokens` is **required** on `/v1/messages` and has no default — unlike
-both OpenAI wires, where omitting it is legal. `LLMAgentPolicy(max_tokens=4096)`,
-validated `>= 1`, recorded in the config, sent on every `wire=anthropic`
-request and ignored by the other two wires.
+`max_tokens` is **required** on `/v1/messages` and has no server default,
+unlike both OpenAI wires where omitting it is legal.
 
-4096 is chosen against this plugin's output shape, not the model's ceiling: a
-turn is one tool call plus a one-or-two-sentence `note`. It also has to clear
-adaptive thinking, which is on by default on Opus 5 and bills against the same
-`max_tokens` ceiling — a tight limit would truncate mid-thought and burn a
-turn on the no-tool-call retry path.
+Named `max_output_tokens`, not `max_tokens`: sitting next to `max_llm_calls`
+(a per-trial budget) and `max_speed_frac`, a bare `max_tokens` reads as a
+trial-wide token budget. It is a per-response cap. The name also matches the
+Responses spelling, so forwarding it on the other two wires later is an
+extension rather than a rename.
+
+`LLMAgentPolicy(max_output_tokens: int | None = None)`, validated `>= 1` when
+set. `None` means "use the wire's default": `AnthropicClient` applies
+`_DEFAULT_MAX_OUTPUT_TOKENS = 16000` internally, and the other two wires ignore
+the field entirely.
+
+Recorded in `AgentPolicyConfig` as the **effective** value — the resolved
+number on `wire=anthropic`, and `None` on the other two wires, where nothing
+constrained the output. Logging `16000` for a `wire=chat` run would assert a
+limit that did not exist.
+
+Why 16000 and not 4096: the visible output of a turn is one tool call plus a
+one-or-two-sentence `note`, on the order of 100-200 tokens. Everything above
+that is headroom for adaptive thinking, which is on by default on Opus 5 and
+bills against this same ceiling. There is no published number for how much
+adaptive thinking will spend, and this wire permits effort up to `max`, so the
+default is set by the repo-wide guidance for non-streaming requests (~16000)
+rather than by the visible-output estimate. Truncation is then a hard error
+rather than a silent degradation (below), so a too-small value is loud.
 
 ### `AnthropicClient` (new module `_anthropic.py`)
 
-Same constructor (including `transport=` injection), same
+```python
+AnthropicClient(
+    provider: Provider,
+    *,
+    speed: str | None = None,
+    max_output_tokens: int | None = None,
+    timeout_s: float = 120.0,
+    max_retries: int = 3,
+    backoff_s: float = 1.0,
+    transport: httpx.BaseTransport | None = None,
+)
+```
+
+`speed` and `max_output_tokens` are **constructor**-injected. `complete()`
+keeps the exact existing signature —
 `complete(messages, tools, temperature, reasoning_effort) -> AssistantMessage`
-and `close()` surface as `ChatClient` and `ResponsesClient`, same bounded retry
-policy (429/5xx/transport retried with exponential backoff, other 4xx fail
-fast). `policy.py`'s changes stay confined to `__init__` (the new param
-validation and client selection) and the config dataclass.
+— so `act()` (`policy.py:268-273`) is untouched and the
+`ChatClient | ResponsesClient | AnthropicClient` union at `policy.py:136`
+stays structurally compatible under mypy strict. `close()` is unchanged.
+`policy.py`'s changes stay confined to `__init__` and the config dataclass.
 
 `Provider`, `ToolCall`, and `AssistantMessage` are shared vocabulary from
-`_llm.py`. As in 0022, the retry loop is small enough to keep duplicated rather
-than extracting a base class across three clients.
+`_llm.py`.
 
 Headers: `x-api-key` (not `Authorization: Bearer` — the native API's own
 scheme), `anthropic-version: 2023-06-01`, and `anthropic-beta:
 fast-mode-2026-02-01` only when `speed="fast"`. The beta header is what makes
 `POST /v1/messages` the beta endpoint over raw HTTP; there is no separate URL.
+An empty `provider.api_key` omits the `x-api-key` header entirely, matching
+`ChatClient` (`_llm.py:182-184`) so keyless local proxies still work.
 
-Request body: `model`, `max_tokens`, `messages` (translated), `system`
-(hoisted, see below), and when set `tools` (flattened), `temperature`,
-`output_config: {"effort": ...}`, `speed`.
+Request body: `model`, `max_tokens`, `messages` (translated), and when
+applicable `system` (hoisted), `tools` (flattened), `output_config:
+{"effort": ...}`, `speed`.
 
-### Effort mapping, and why `thinking` is never disabled
+`temperature` is **never sent**. Claude Opus 5, Opus 4.8, and Opus 4.7 reject
+`temperature`, `top_p`, and `top_k` with a 400, and those are exactly the
+models this wire exists to reach. `temperature is not None` with
+`wire="anthropic"` is a construction-time `ValueError` naming the affected
+models, matching the `speed`-on-wrong-wire precedent. The policy still accepts
+`-P temperature=` for the other two wires.
 
-`_EFFORT_LEVELS` is `{none, minimal, low, medium, high, xhigh, max}`; the
-Messages API accepts `low | medium | high | xhigh | max`. The two extras are
-rejected at construction for `wire=anthropic` with a guided `ValueError`
-naming the accepted set.
+### Effort: a per-wire accepted set
 
-This departs from 0022, which let `effort=max` on `wire=responses` fail with
-OpenAI's own 400 and kept validation wire-agnostic. The difference is the
-failure mode. `max` on Responses is a hard 400: loud, self-describing,
-unmissable. The natural native translation of `effort="none"` is
-`thinking: {"type": "disabled"}`, which the API **accepts** — and on Opus 5
-disabled thinking has a documented failure mode where the model writes a tool
-call into its visible text instead of emitting a `tool_use` block. The turn
-succeeds, the call never runs, no error is raised. For a policy that is tool
-calls or nothing, that is three silent no-tool-call turns and then a generic
-`RuntimeError` pointing nowhere near the cause. A guard is justified where the
-alternative is silent degradation, not where it is a 400.
+Replace the wire-agnostic check at `policy.py:128-134` with a table:
 
-`effort=None` (the Python `None`, distinct from the wire string `"none"` —
-see the README's existing note) omits `output_config` entirely and lets the
-model default apply. `thinking` is never sent in any configuration: adaptive
-is the Opus 5 default and the right one here.
+```python
+_ACCEPTED_EFFORTS = {
+    "chat": _EFFORT_LEVELS,
+    "responses": _EFFORT_LEVELS - {"max"},
+    "anthropic": _EFFORT_LEVELS - {"none", "minimal"},
+}
+```
+
+Four lines, no special case, and it closes 0022's own known-ugly hole in the
+same PR: 0022 §"One effort caveat" documented that `wire=responses` +
+`effort=max` fails with OpenAI's 400 and accepted it rather than guarding.
+Leaving two inconsistent validation policies side by side is worse than fixing
+both.
+
+The honest justification for guarding at all — the earlier draft's reasoning
+was wrong and is retracted. Since this client never sends `thinking`, an
+out-of-set effort would produce a plain 400, not the silent tool-call-as-text
+degradation that disabled thinking causes on Opus 5. So the "guard silent
+degradation, not 400s" principle does not apply here. What does apply: a 400
+surfaces only after `bind()` and the first observation, so it burns a trial and
+costs a round trip, and `-P effort=none` is the documented GPT-5.x workaround
+sitting in this plugin's own README (line 117) that users will paste into a
+Claude run. Failing at construction is worth four lines.
+
+`effort=None` (the Python `None`, distinct from the wire string `"none"`)
+omits `output_config` entirely. `thinking` is never sent in any configuration:
+adaptive is the Opus 5 default and the right one here.
+
+### The thinking-block constraint
+
+Adaptive thinking is on by default on Opus 5, so a typical assistant turn
+returns `[thinking, text?, tool_use]`. Thinking blocks must be echoed back
+**unchanged** when the conversation continues on the same model; replaying a
+history with them stripped triggers ordering and signature 400s from the
+second turn onward. `AssistantMessage` (`_llm.py:140-159`) carries only
+`content` and `tool_calls`, so it is structurally lossy for opaque blocks.
+
+This is the same problem 0022 solved for OpenAI reasoning items, and it gets
+the same mechanism. `AnthropicClient` keeps
+`_raw_blocks_by_tool_use_id: dict[str, list[dict[str, Any]]]`:
+
+- After each successfully *parsed* response (never a failed or raising one),
+  the response's verbatim `content` array is stored keyed by the `id` of each
+  `tool_use` block in it.
+- During translation, an assistant message whose first `tool_call.id` hits the
+  cache emits the cached raw blocks in place of **all** synthesized blocks for
+  that message, text and tool calls alike. Emitting both would show the model
+  its own text twice.
+- A miss falls back to synthesis — correct for histories this client instance
+  did not produce, and for non-thinking models.
+- Entries whose `tool_use_id` no longer appears in the submitted history are
+  pruned at the top of `complete()`, **before** the new response is cached
+  (prune-after-store would evict every fresh entry and make the cache always
+  miss). Ids are harvested from both places history carries them: assistant
+  `tool_calls[i].id` and tool-message `tool_call_id`.
+- A `reset()` (fresh `_messages`) empties the cache without the client needing
+  a reset hook.
+
+Accepted loss, inherited from 0022: text-only assistant turns (the nudge retry
+path) cache nothing, so their thinking blocks are dropped from replay. Those
+turns carry no `tool_use`, which is what the pairing constraint attaches to.
 
 ### Translation: chat messages → Messages API
 
 | Chat form | Messages API |
 | --- | --- |
-| `{"role": "system", "content": "<str>"}` | hoisted to the top-level `system` string, not a message. Only `_messages[0]` is ever a system message in this loop; a system message anywhere else raises `RuntimeError` rather than being silently dropped |
+| `{"role": "system", "content": "<str>"}` at index 0 | hoisted to the top-level `system` string, not a message. Omitted entirely when `_messages[0]` is not a system message (`act()` is reachable without `reset()`; the only guard is `bind()`) |
+| a system message at index >= 1 | `RuntimeError` rather than a silent drop |
 | `{"role": "user"/"assistant", "content": "<str>"}` | same role, `content` kept as the plain string |
 | user content part `{"type": "text", ...}` | `{"type": "text", "text": ...}` unchanged |
-| user content part `{"type": "image_url", "image_url": {"url": "data:image/png;base64,B"}}` | `{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "B"}}` — the `data:` prefix is stripped; `_png.png_data_url` always emits PNG, so the media type is not parsed out of the URL, but a URL that does not match the expected prefix raises rather than shipping a malformed block |
+| user content part `{"type": "image_url", "image_url": {"url": "data:image/png;base64,B"}}` | `{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "B"}}`. `_png.png_data_url` always emits PNG, so the media type is fixed rather than parsed; a URL not matching the expected prefix raises rather than shipping a malformed block |
 | assistant msg `content` (non-empty) | `{"type": "text", "text": ...}` block first |
-| assistant msg `tool_calls[i]` | `{"type": "tool_use", "id": id, "name": ..., "input": json.loads(arguments)}`, after the text block if any. Non-object or unparseable `arguments` raises `RuntimeError` naming the tool — a `tool_use` block with a non-object `input` is a 400 whose message does not identify which call was malformed |
-| `{"role": "tool", "tool_call_id": id, "content": c}` | `{"type": "tool_result", "tool_use_id": id, "content": c}` inside a **user** message; **consecutive tool messages merge into one user message** (see below) |
-| assistant msg, no tool calls, content `None` or `""` | **no message** — same accepted loss as 0022. The `incomplete`/nudge retry path appends exactly this, and an assistant message with an empty `content` array is a 400 |
+| assistant msg `tool_calls[i]` | `{"type": "tool_use", "id": id, "name": ..., "input": json.loads(arguments)}` after the text block. Unparseable JSON and parseable-but-non-object both raise `RuntimeError` naming the tool: a `tool_use` with a non-object `input` 400s with a message that does not identify the offending call |
+| assistant msg with a cache hit on `tool_calls[0].id` | the cached raw block list verbatim, replacing every synthesized block for that message |
+| `{"role": "tool", "tool_call_id": id, "content": c}` | `{"type": "tool_result", "tool_use_id": id, "content": c}` inside a **user** message; consecutive tool messages merge into one (below) |
+| assistant msg, no tool calls, content `None` or `""` | no message. The nudge retry path appends exactly this, and an assistant message with an empty content array is a 400 |
 
-The merge rule is load-bearing, not tidiness. `act()` appends one `role: "tool"`
-message per ignored extra tool call and then one for the executed call
-(`policy.py:269-280`), so a multi-tool-call turn produces several consecutive
-tool messages. The Messages API requires every `tool_result` answering one
-assistant turn to sit in a single user message; emitting one user message per
-result makes the second one an unanswered-`tool_use` 400. Runs of consecutive
-`role: "tool"` messages therefore collapse into one user message with one
-`tool_result` block each, in order.
+Merging consecutive tool messages: `act()` appends one `role: "tool"` message
+per ignored extra tool call (`policy.py:292-303`) and then one for the executed
+call (`policy.py:304-307`), so a multi-tool-call turn produces a run of
+consecutive tool messages. Splitting `tool_result` blocks across several user
+messages does not 400 (the API coalesces consecutive same-role messages), but
+it does silently train the model to stop making parallel calls, so the run
+collapses into one user message carrying one `tool_result` block each.
+
+Block order within the merged message is **history order**, which for a
+multi-call turn is `[extra_1..extra_n, executed]` while the assistant's
+`tool_use` order was `[executed, extra_1..extra_n]`. Blocks are matched by
+`tool_use_id`, not position, so this is legal; it is called out here only
+because the mismatch looks like a bug to a reader diffing the two arrays.
+
+Two consecutive-user-message sequences fall out of the loop and are legal
+under same-role coalescing, but are easy to miss and both get goldens:
+
+- **Dropped assistant turn then nudge.** An assistant turn with no tool calls
+  and empty content emits no message, so the wire sees the observation user
+  message immediately followed by the nudge user message.
+- **Tool results then next observation.** After a successful call `act()`
+  returns; the next `act()` appends an observation, so a user message of
+  `tool_result` blocks is immediately followed by a user message of text and
+  images.
 
 Tool schemas flatten from the chat nesting:
 `{"type": "function", "function": {name, description, parameters}}` →
 `{"name": ..., "description": ..., "input_schema": ...}`. `Toolset.schemas()`
 stays chat-shaped; the client owns the translation both ways. No strict-mode
-concern here — the Messages API does not auto-normalize schemas the way the
-Responses API does, so the move tool's free-form `targets`/`deltas` object
-survives unchanged.
+concern: the Messages API does not auto-normalize schemas the way the Responses
+API does, so the move tool's free-form `targets`/`deltas` object survives.
+`tools=[]` omits the `tools` key entirely, matching `ResponsesClient`.
 
 ### Response parsing → `AssistantMessage`
 
-From `response["content"]`: concatenate the `text` of every `text` block (None
-if there are none), and one `ToolCall(id=block["id"], name=block["name"],
+From `response["content"]`: concatenate the `text` of every `text` block, and
+emit one `ToolCall(id=block["id"], name=block["name"],
 arguments=json.dumps(block["input"]))` per `tool_use` block, in order.
-`thinking` blocks are ignored — the plugin does not replay them, and with
-`display` left at its `"omitted"` default they carry no text anyway.
+`thinking` blocks contribute nothing here — they matter only to the cache.
+
+Empty concatenated text normalizes to `None`, never `""`. A `""` would
+round-trip through `raw()` (`_llm.py:149`) into the next request as an empty
+`text` block, which is a 400.
 
 Re-serializing `input` back to JSON text keeps `ToolCall.arguments` a string
-across all three wires, so `_tools.py` validation and the transcript format
-stay identical and the echo path is untouched.
+across all three wires, so `_tools.py` validation, the transcript format, and
+the echo path are untouched.
 
-`stop_reason: "refusal"` raises `RuntimeError` carrying
-`stop_details.category` when present. This is an HTTP 200 whose `content` is
-empty or partial; parsing it as an empty `AssistantMessage` would burn three
-"Respond with exactly one tool call." nudges and then die with a generic
-no-tool-call error while the real cause sits discarded in the body. Same
-fail-fast-no-retry decision as 0022's `status: "failed"`: the server
-deliberately answered. `stop_details` is informational and may be `null` even
-on a refusal, so the branch keys on `stop_reason` alone and treats the
-category as optional.
+Two terminal stop reasons raise `RuntimeError` and are never retried, matching
+0022's `status: "failed"` decision — the server deliberately answered:
+
+- `stop_reason: "refusal"`, carrying `stop_details.category` when present.
+  `stop_details` is informational and may be `null` even on a refusal, so the
+  branch keys on `stop_reason` alone.
+- `stop_reason: "max_tokens"`, carrying `fix: raise -P max_output_tokens=`.
+  A truncated turn is an HTTP 200 with partial content, and it is the one
+  silent-degradation risk this PR newly creates: either there is no `tool_use`
+  block (three nudge turns, then a generic `RuntimeError` at `policy.py:286`
+  with the cause discarded), or there is a partial `tool_use` whose `input`
+  still re-serializes to valid JSON and gets executed as a motion by
+  `toolset.execute()` (`policy.py:304`). Truncated responses never yield tool
+  calls.
+
+Neither terminal response populates the cache.
 
 ### Guided errors
 
@@ -183,86 +297,191 @@ House style: the error names the fix, never just the failure.
 
 **OpenRouter fallback.** `resolve_provider`'s ladder falls through to
 OpenRouter whenever `ANTHROPIC_API_KEY` is unset, and
-`openrouter.ai/api/v1/messages` does not exist. Construction raises
-`ConfigError` when `wire="anthropic"` resolved to the OpenRouter base URL,
-naming the two fixes (set `$ANTHROPIC_API_KEY`, or pass `-P base_url=` for a
-gateway that serves the Messages API). Only the OpenRouter base is rejected;
-an explicit `base_url` is always honored, since proxies serving `/v1/messages`
-are a legitimate deployment.
+`openrouter.ai/api/v1/messages` does not exist. `Provider` gains a public
+`from_openrouter_fallback: bool` field set by `resolve_provider`, so `policy.py`
+does not reach into `_llm`'s privates to compare base URLs. Construction raises
+`ConfigError` when `wire="anthropic"` and that flag is set, naming the two
+fixes (set `$ANTHROPIC_API_KEY`, or pass `-P base_url=` for a gateway serving
+the Messages API).
 
-**Fast mode unsupported.** A 4xx whose body mentions `speed` or `fast` while
-`speed="fast"` appends: `fix: fast mode needs Claude Opus 5 or Opus 4.8 on the
-Claude API (not Bedrock/Vertex/Foundry), or drop -P speed=fast`.
+This guard covers the fallback case only, deliberately. `-P model=openai/gpt-5
+-P wire=anthropic` with `$OPENAI_API_KEY` set resolves to `api.openai.com/v1`
+and dead-ends at a 404 — enumerating every wrong-endpoint combination is not
+worth it, and the 404 names the URL.
+
+**Key resolution with an explicit `base_url`.** `resolve_provider` defaults
+`api_key_env` to `OPENROUTER_API_KEY` (`_llm.py:109-111`), so
+`-P base_url=https://gateway/v1 -P wire=anthropic` would send an OpenRouter key
+as `x-api-key` and 401 with no hint. For `wire="anthropic"`, `policy.py`
+defaults `api_key_env` to `ANTHROPIC_API_KEY` before calling
+`resolve_provider`. An explicit `-P api_key_env=` still wins.
+
+**Fast mode unsupported.** A 4xx while `speed="fast"` whose body contains both
+`"speed"` and `"fast"` appends: `fix: fast mode needs Claude Opus 5 or Opus 4.8
+on the Claude API (not Bedrock/Vertex/Foundry), or drop -P speed=fast`. The
+two-token AND mirrors 0022's matcher shape (`_llm.py:220`); a bare `fast`
+substring is too weak a signal.
 
 **Fast-mode rate limit.** Fast mode draws on a rate-limit pool separate from
-standard Opus, so a fast-mode run can 429 while standard capacity is idle.
-After retries are exhausted on a 429 with `speed="fast"`, the terminal error
-appends: `fix: fast mode has its own rate limit; retry later or drop
--P speed=fast to fall back to standard speed`.
+standard Opus, so a fast-mode run can 429 while standard capacity is idle. The
+retry loop tracks `last_status: int | None` alongside `last_error`; when
+retries are exhausted with `last_status == 429` and `speed="fast"`, the
+terminal error appends: `fix: fast mode has its own rate limit; retry later or
+drop -P speed=fast to fall back to standard speed`. One extra variable, and it
+saves a user staring at a 429 while their standard-speed quota sits unused.
+
+**429 backoff honors `retry-after`.** When the response carries a parseable
+`retry-after`, sleep that instead of `backoff_s * 2**attempt`, capped at
+`timeout_s`. Inherited fixed backoff ignores the server's own answer.
 
 No automatic fallback to standard speed on 429. Silently downgrading changes
-the billing rate and the latency profile mid-eval, and it invalidates the
-prompt cache (switching `speed` is a cache-invalidating change), so the
-"recovery" costs a full cache re-write and produces an eval log whose `speed`
-field no longer describes what ran. The user chose fast mode; the fix belongs
-in their hands.
+the billing rate and the latency profile mid-eval and produces an eval log
+whose `speed` field no longer describes what ran.
+
+### What the eval log records
+
+`AgentPolicyConfig` gains `speed: str | None`, `max_output_tokens: int | None`
+(effective value, see above), and the existing `wire` field carries the new
+value. The config is frozen with all-defaulted fields (`policy.py:75-91`), so
+appending is safe; `_html.py:555` renders `sorted(policy_config.items())`, so
+new keys render with no viewer change.
+
+Requested `speed` records intent, not what was served. The response's
+`usage.speed` reports which speed actually ran, and a fast-mode request that
+silently served at standard speed is a 2x billing difference the log should
+not hide. `AnthropicClient` exposes the last response's `usage` (including
+`speed`, `input_tokens`, `output_tokens`) as a plain attribute; wiring it into
+the trial record is left to a follow-up, but the fast-mode test asserts
+`usage.speed` is surfaced.
+
+## Version
+
+Plugin `0.12.0` → `0.13.0` (`plugins/inspect-robots-agent/pyproject.toml:7`).
+`AnthropicClient` joins the package's `__all__` for parity with
+`ResponsesClient` (`__init__.py:34,44`). Both changes break
+`tests/test_package.py` (the version pin at line 9 and the exact `__all__` pin
+at lines 11-23), which is updated in the same PR — that pin exists because a
+stale hardcoded version shipped twice.
 
 ## Tests (`tests/test_anthropic.py` + small additions)
 
 All against `httpx.MockTransport`, mirroring `test_llm.py` and
-`test_responses.py` conventions.
+`test_responses.py` conventions. Plugin coverage is report-only
+(`ci.yml:326-331` runs with `--cov-fail-under=0`), so this list is the gate,
+not a safety net under one.
 
-- Translation goldens: each row of the table above, including multi-part
-  observation content with a PNG data URL (asserting the `data:` prefix is
-  stripped and `media_type` is set), and a malformed image URL raising.
-- The merge rule: a turn with three tool calls produces exactly one user
-  message carrying three `tool_result` blocks in order, not three messages.
-  Plus the interleaved case (tool messages, then a user observation) to show
-  only *consecutive* runs merge.
-- System hoisting: `_messages[0]` becomes top-level `system` and no message
-  carries `role: "system"`; a system message at a later index raises.
-- Request body: `max_tokens` always present, `system` present, tools flattened
-  to `input_schema`, `output_config.effort` present only when effort is set,
-  `temperature` only when set, `speed` only when set, and the request path is
-  `{base_url}/messages`.
-- Headers: `x-api-key` and `anthropic-version` on every request; the
-  `anthropic-beta: fast-mode-2026-02-01` header present with `speed="fast"`
-  and **absent** without it.
-- Parsing: text-only, tool-use-only, text + tool-use, text spread across
-  multiple blocks, `thinking` blocks ignored, `input` round-tripping to JSON
-  text. `stop_reason: "refusal"` raises with the category in the message and
-  puts exactly one request on the wire; a refusal with `stop_details: null`
-  raises without an AttributeError.
-- Assistant turn with `content: None` and no tool calls emits no message.
-- Guided errors: the OpenRouter-fallback `ConfigError` (and that an explicit
-  `base_url` suppresses it), the fast-mode 4xx guidance, and the fast-mode 429
-  guidance after retries are exhausted.
+Translation:
+
+- Each row of the table above, including multi-part observation content with a
+  PNG data URL (asserting the `data:` prefix is stripped and `media_type` is
+  set), and a malformed image URL raising.
+- System hoisting: index-0 system message becomes top-level `system` with no
+  `role: "system"` message on the wire; a history with **no** system message
+  omits the `system` key; a system message at index >= 1 raises.
+- The merge rule: three tool calls produce exactly one user message with three
+  `tool_result` blocks; the interleaved case (only consecutive runs merge); and
+  a history **ending** in a tool run, which is the shape on the wire every time
+  `act()` retries after a tool error (`policy.py:305-313`).
+- Both consecutive-user-message sequences, asserted on the full `messages`
+  array across a multi-turn trial, not per-message.
+- `json.loads(arguments)` unparseable and parseable-but-non-object as two
+  separate cases.
+- Assistant turn with `content: None` and no tool calls emits no message;
+  assistant turn with `content: ""` **and** tool calls emits no empty text
+  block.
+
+Thinking replay:
+
+- Turn 1 returns `[thinking, text, tool_use]`; the turn-2 request contains all
+  three verbatim, with the text appearing exactly once.
+- Two `tool_use` blocks in one turn: each cached block appears exactly once in
+  turn 2 (the hit is per assistant message, keyed on the first call id).
+- Cache prune on a fresh history, and cache-miss synthesis.
+- Neither a `refusal` nor a `max_tokens` response populates the cache.
+
+Request shape:
+
+- `max_tokens` always present; `tools=[]` omits the `tools` key;
+  `output_config.effort` only when effort is set; `speed` only when set;
+  `temperature` never present; path is `{base_url}/messages`.
+- Headers: `x-api-key` and `anthropic-version` on every request;
+  `anthropic-beta: fast-mode-2026-02-01` present with `speed="fast"` and absent
+  without it; empty api_key omits `x-api-key`.
+
+Parsing and terminal states:
+
+- Text-only, tool-use-only, text + tool-use, text across multiple blocks,
+  `thinking` blocks ignored, `input` round-tripping to JSON text.
+- `refusal` raises with the category, one request on the wire; `refusal` with
+  `stop_details: null` raises without an AttributeError.
+- `max_tokens` raises naming `-P max_output_tokens=`, and a truncated response
+  containing a partial `tool_use` raises rather than returning that call.
+- `usage.speed` surfaced on a fast-mode response.
+
+Errors and retries:
+
+- OpenRouter-fallback `ConfigError`; an explicit `base_url` suppresses it.
+- `api_key_env` defaulting to `ANTHROPIC_API_KEY` for this wire, and an
+  explicit `-P api_key_env=` overriding it.
+- Fast-mode 4xx guidance; and the negative case — a 4xx unrelated to speed
+  while `speed="fast"` gets no guidance.
+- 429 terminal message with `speed="fast"` (guided) and without it (unguided).
+- `retry-after` honored when present, fixed backoff when absent.
 - Retry/fail-fast parity with `ChatClient`, plus `close()`.
-- Policy wiring: `wire="anthropic"` end-to-end through `LLMAgentPolicy.act()`
-  (mock embodiment); `speed="fast"` with `wire="chat"` raises; invalid `speed`
-  raises; `effort="none"`/`"minimal"` with `wire="anthropic"` raises;
-  `max_tokens=0` raises; `wire`, `speed`, and `max_tokens` recorded in config.
+
+Policy wiring:
+
+- `wire="anthropic"` end-to-end through `LLMAgentPolicy.act()` (mock
+  embodiment).
+- Raises: `speed="fast"` with `wire="chat"`; invalid `speed`;
+  `effort="none"`/`"minimal"` with `wire="anthropic"`; `effort="max"` with
+  `wire="responses"` (the newly closed 0022 hole); `temperature` set with
+  `wire="anthropic"`; `max_output_tokens=0`.
+- `wire`, `speed`, and the effective `max_output_tokens` recorded in the
+  config, including `None` on a `wire=chat` run.
 
 ## Docs
 
-- `plugins/inspect-robots-agent/README.md`: add `speed` and `max_tokens` to
-  the knobs list (line 101), extend the wire-format paragraph (line 48), and
-  add a short "Fast mode on Claude" section next to the existing "Reasoning
-  effort on OpenAI models" section, including the price delta and the
-  Claude-API-only caveat. Repo writing style applies: no em dashes in prose.
-- No `docs/` guide change. The quickstart and cookbook mention `-P model=` and
-  `-P effort=`; wire selection stays plugin-README territory, as it did for
-  `wire=responses`.
+`plugins/inspect-robots-agent/README.md`:
+
+- Add `speed` and `max_output_tokens` to the knobs list (line 101).
+- Replace the two-sentence wire paragraph (lines 48-50) with a small wire
+  table, matching the provider table already at lines 38-46.
+- Add a "Fast mode on Claude" section next to the existing "Reasoning effort on
+  OpenAI models" section, with the Claude-API-only caveat and the supported
+  models. Describe the cost as roughly double the standard output price and
+  link Anthropic's pricing page rather than printing figures: no README here
+  carries a price, and a stale one would ship to PyPI on every release.
+
+Repo writing style applies to all of it (CLAUDE.md "Writing style"): no em
+dashes in prose, bold only for `**term:**` lead-ins, no decorative emoji.
+
+No `docs/` guide change. Wire selection stays plugin-README territory, as it
+did for `wire=responses`.
+
+## Retry-loop duplication
+
+Three clients will each carry a near-identical retry loop. 0022 justified the
+duplication at two as "small enough"; that premise is already false, since
+`_llm.py:207-228` and `_responses.py:70-88` differ in their guided-error block,
+and this client adds two more guidance branches plus `last_status`.
+
+Keep it duplicated anyway, for a better reason: extraction would need at least
+two injection points (4xx guidance, terminal message), so a base class buys
+template-method indirection rather than deduplication. The only genuinely
+shared logic is "is this status retryable" plus the backoff sleep, which is
+three lines. Revisit at a fourth wire, and do not inherit the "small enough"
+claim, which will not survive it.
 
 ## Non-goals
 
 - Prompt caching (`cache_control` breakpoints on the system block and tool
   schemas). The stable prefix here is large and reused every turn, so this is
   the obvious follow-up, but it is a cost optimization with its own placement
-  and invalidation design, not part of unlocking fast mode.
+  and invalidation design.
+- Wiring `usage` into the trial record beyond exposing it on the client.
 - Adaptive-thinking display (`thinking: {"display": "summarized"}`) and
   surfacing thinking summaries into the transcript.
-- Task budgets (`output_config.task_budget`), extended context, and the
-  Batches API.
-- `AnthropicBedrock`/Vertex/Foundry variants. Fast mode is Claude API only, so
-  they would inherit the wire without its motivating feature.
+- Task budgets (`output_config.task_budget`) and the Batches API.
+- Bedrock/Vertex/Foundry variants: fast mode is Claude API only, so they would
+  inherit the wire without its motivating feature.

--- a/plans/0026-agent-anthropic-wire.md
+++ b/plans/0026-agent-anthropic-wire.md
@@ -1,0 +1,268 @@
+# 0026 — `-P wire=anthropic`: native Messages API unlocks fast mode
+
+Issue: #165. Status: draft.
+
+## Problem
+
+The agent plugin reaches Anthropic models only through the OpenAI-compat shim
+at `https://api.anthropic.com/v1/chat/completions` (`_llm.py` `_DIRECT_PROVIDERS`).
+The compat shim cannot express the Claude-native request surface, so the knob
+that matters most for this plugin is unreachable:
+
+**Fast mode** runs Claude Opus 5 and Opus 4.8 at up to 2.5x higher output
+tokens/sec. It needs three things simultaneously: native `POST /v1/messages`,
+the `anthropic-beta: fast-mode-2026-02-01` header, and `speed: "fast"` as a
+top-level body field. `ChatClient` posts to `/chat/completions`, sets only
+`Authorization: Bearer`, and builds a closed body (`model`, `messages`,
+`tools`, `temperature`, `reasoning_effort`) — none of the three is reachable,
+and there is no `extra_body`/`extra_headers` escape hatch to smuggle them in.
+
+This is not a cosmetic gap for a robotics eval. The arm stands still while the
+model thinks, which is exactly why `effort` already defaults to `low`
+(`policy.py:143-146`). Fast mode is the same trade on the serving side, and it
+is the one lever that buys latency without trading reasoning depth.
+
+The native wire also unlocks `output_config.effort` in its own spelling
+(`low` through `max`, where the compat shim's `reasoning_effort` mapping is
+undocumented) and correct `stop_reason: "refusal"` surfacing, which the compat
+shim flattens into an ordinary empty completion.
+
+## Design
+
+Third wire, one new client class, zero changes to the conversation loop. This
+is deliberately the same shape as plan 0022 (`wire=responses`): the
+chat-completions message format stays the single source of truth for
+`_messages`, the transcript, sanitization, and echo; the new client translates
+at the wire boundary only. Same no-SDK doctrine: httpx, raw JSON.
+
+### `wire` param gains `"anthropic"`
+
+`_WIRE_FORMATS` becomes `{"chat", "responses", "anthropic"}`. Default stays
+`"chat"`: it works for OpenRouter, vLLM, Ollama, and the Anthropic/Gemini
+compat endpoints. No auto-selection when the model id starts with
+`anthropic/` — implicit switching would change wire behavior, billing surface,
+and error shape under users' feet based on which env key happens to be set,
+and the compat path remains the right default for OpenRouter-routed Claude.
+
+`base_url` composes: `wire=anthropic` posts to `{base_url}/messages`, so a
+proxy or gateway that serves the Messages API works unchanged.
+
+### `speed` param (the point of the exercise)
+
+`LLMAgentPolicy(speed=None)`, values `None | "fast"`. Anything else is a
+`ValueError` at construction, mirroring the `effort` validation. `-P speed=fast`
+forwards for free. Recorded in `AgentPolicyConfig` so the eval log distinguishes
+a fast-mode run from a standard one — they are the same model at different
+prices ($10/$50 vs $5/$25 per MTok), so a cost reconciliation that cannot see
+this field is wrong by 2x.
+
+`speed="fast"` with `wire != "anthropic"` is a construction-time `ValueError`,
+not a silent no-op. The compat shim accepts unknown body fields by ignoring
+them, so a silently-dropped `speed` would bill at standard rates while the
+user believes fast mode is on. This is the failure mode most worth failing
+loudly on.
+
+No model-id gating. Fast mode is Opus 5 and Opus 4.8 today, but the supported
+set moves and a hardcoded allowlist would reject a model the API accepts.
+Unsupported models get the API's own 400, wrapped by the guided error below.
+
+### `max_tokens` param (forced by the wire)
+
+`max_tokens` is **required** on `/v1/messages` and has no default — unlike
+both OpenAI wires, where omitting it is legal. `LLMAgentPolicy(max_tokens=4096)`,
+validated `>= 1`, recorded in the config, sent on every `wire=anthropic`
+request and ignored by the other two wires.
+
+4096 is chosen against this plugin's output shape, not the model's ceiling: a
+turn is one tool call plus a one-or-two-sentence `note`. It also has to clear
+adaptive thinking, which is on by default on Opus 5 and bills against the same
+`max_tokens` ceiling — a tight limit would truncate mid-thought and burn a
+turn on the no-tool-call retry path.
+
+### `AnthropicClient` (new module `_anthropic.py`)
+
+Same constructor (including `transport=` injection), same
+`complete(messages, tools, temperature, reasoning_effort) -> AssistantMessage`
+and `close()` surface as `ChatClient` and `ResponsesClient`, same bounded retry
+policy (429/5xx/transport retried with exponential backoff, other 4xx fail
+fast). `policy.py`'s changes stay confined to `__init__` (the new param
+validation and client selection) and the config dataclass.
+
+`Provider`, `ToolCall`, and `AssistantMessage` are shared vocabulary from
+`_llm.py`. As in 0022, the retry loop is small enough to keep duplicated rather
+than extracting a base class across three clients.
+
+Headers: `x-api-key` (not `Authorization: Bearer` — the native API's own
+scheme), `anthropic-version: 2023-06-01`, and `anthropic-beta:
+fast-mode-2026-02-01` only when `speed="fast"`. The beta header is what makes
+`POST /v1/messages` the beta endpoint over raw HTTP; there is no separate URL.
+
+Request body: `model`, `max_tokens`, `messages` (translated), `system`
+(hoisted, see below), and when set `tools` (flattened), `temperature`,
+`output_config: {"effort": ...}`, `speed`.
+
+### Effort mapping, and why `thinking` is never disabled
+
+`_EFFORT_LEVELS` is `{none, minimal, low, medium, high, xhigh, max}`; the
+Messages API accepts `low | medium | high | xhigh | max`. The two extras are
+rejected at construction for `wire=anthropic` with a guided `ValueError`
+naming the accepted set.
+
+This departs from 0022, which let `effort=max` on `wire=responses` fail with
+OpenAI's own 400 and kept validation wire-agnostic. The difference is the
+failure mode. `max` on Responses is a hard 400: loud, self-describing,
+unmissable. The natural native translation of `effort="none"` is
+`thinking: {"type": "disabled"}`, which the API **accepts** — and on Opus 5
+disabled thinking has a documented failure mode where the model writes a tool
+call into its visible text instead of emitting a `tool_use` block. The turn
+succeeds, the call never runs, no error is raised. For a policy that is tool
+calls or nothing, that is three silent no-tool-call turns and then a generic
+`RuntimeError` pointing nowhere near the cause. A guard is justified where the
+alternative is silent degradation, not where it is a 400.
+
+`effort=None` (the Python `None`, distinct from the wire string `"none"` —
+see the README's existing note) omits `output_config` entirely and lets the
+model default apply. `thinking` is never sent in any configuration: adaptive
+is the Opus 5 default and the right one here.
+
+### Translation: chat messages → Messages API
+
+| Chat form | Messages API |
+| --- | --- |
+| `{"role": "system", "content": "<str>"}` | hoisted to the top-level `system` string, not a message. Only `_messages[0]` is ever a system message in this loop; a system message anywhere else raises `RuntimeError` rather than being silently dropped |
+| `{"role": "user"/"assistant", "content": "<str>"}` | same role, `content` kept as the plain string |
+| user content part `{"type": "text", ...}` | `{"type": "text", "text": ...}` unchanged |
+| user content part `{"type": "image_url", "image_url": {"url": "data:image/png;base64,B"}}` | `{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "B"}}` — the `data:` prefix is stripped; `_png.png_data_url` always emits PNG, so the media type is not parsed out of the URL, but a URL that does not match the expected prefix raises rather than shipping a malformed block |
+| assistant msg `content` (non-empty) | `{"type": "text", "text": ...}` block first |
+| assistant msg `tool_calls[i]` | `{"type": "tool_use", "id": id, "name": ..., "input": json.loads(arguments)}`, after the text block if any. Non-object or unparseable `arguments` raises `RuntimeError` naming the tool — a `tool_use` block with a non-object `input` is a 400 whose message does not identify which call was malformed |
+| `{"role": "tool", "tool_call_id": id, "content": c}` | `{"type": "tool_result", "tool_use_id": id, "content": c}` inside a **user** message; **consecutive tool messages merge into one user message** (see below) |
+| assistant msg, no tool calls, content `None` or `""` | **no message** — same accepted loss as 0022. The `incomplete`/nudge retry path appends exactly this, and an assistant message with an empty `content` array is a 400 |
+
+The merge rule is load-bearing, not tidiness. `act()` appends one `role: "tool"`
+message per ignored extra tool call and then one for the executed call
+(`policy.py:269-280`), so a multi-tool-call turn produces several consecutive
+tool messages. The Messages API requires every `tool_result` answering one
+assistant turn to sit in a single user message; emitting one user message per
+result makes the second one an unanswered-`tool_use` 400. Runs of consecutive
+`role: "tool"` messages therefore collapse into one user message with one
+`tool_result` block each, in order.
+
+Tool schemas flatten from the chat nesting:
+`{"type": "function", "function": {name, description, parameters}}` →
+`{"name": ..., "description": ..., "input_schema": ...}`. `Toolset.schemas()`
+stays chat-shaped; the client owns the translation both ways. No strict-mode
+concern here — the Messages API does not auto-normalize schemas the way the
+Responses API does, so the move tool's free-form `targets`/`deltas` object
+survives unchanged.
+
+### Response parsing → `AssistantMessage`
+
+From `response["content"]`: concatenate the `text` of every `text` block (None
+if there are none), and one `ToolCall(id=block["id"], name=block["name"],
+arguments=json.dumps(block["input"]))` per `tool_use` block, in order.
+`thinking` blocks are ignored — the plugin does not replay them, and with
+`display` left at its `"omitted"` default they carry no text anyway.
+
+Re-serializing `input` back to JSON text keeps `ToolCall.arguments` a string
+across all three wires, so `_tools.py` validation and the transcript format
+stay identical and the echo path is untouched.
+
+`stop_reason: "refusal"` raises `RuntimeError` carrying
+`stop_details.category` when present. This is an HTTP 200 whose `content` is
+empty or partial; parsing it as an empty `AssistantMessage` would burn three
+"Respond with exactly one tool call." nudges and then die with a generic
+no-tool-call error while the real cause sits discarded in the body. Same
+fail-fast-no-retry decision as 0022's `status: "failed"`: the server
+deliberately answered. `stop_details` is informational and may be `null` even
+on a refusal, so the branch keys on `stop_reason` alone and treats the
+category as optional.
+
+### Guided errors
+
+House style: the error names the fix, never just the failure.
+
+**OpenRouter fallback.** `resolve_provider`'s ladder falls through to
+OpenRouter whenever `ANTHROPIC_API_KEY` is unset, and
+`openrouter.ai/api/v1/messages` does not exist. Construction raises
+`ConfigError` when `wire="anthropic"` resolved to the OpenRouter base URL,
+naming the two fixes (set `$ANTHROPIC_API_KEY`, or pass `-P base_url=` for a
+gateway that serves the Messages API). Only the OpenRouter base is rejected;
+an explicit `base_url` is always honored, since proxies serving `/v1/messages`
+are a legitimate deployment.
+
+**Fast mode unsupported.** A 4xx whose body mentions `speed` or `fast` while
+`speed="fast"` appends: `fix: fast mode needs Claude Opus 5 or Opus 4.8 on the
+Claude API (not Bedrock/Vertex/Foundry), or drop -P speed=fast`.
+
+**Fast-mode rate limit.** Fast mode draws on a rate-limit pool separate from
+standard Opus, so a fast-mode run can 429 while standard capacity is idle.
+After retries are exhausted on a 429 with `speed="fast"`, the terminal error
+appends: `fix: fast mode has its own rate limit; retry later or drop
+-P speed=fast to fall back to standard speed`.
+
+No automatic fallback to standard speed on 429. Silently downgrading changes
+the billing rate and the latency profile mid-eval, and it invalidates the
+prompt cache (switching `speed` is a cache-invalidating change), so the
+"recovery" costs a full cache re-write and produces an eval log whose `speed`
+field no longer describes what ran. The user chose fast mode; the fix belongs
+in their hands.
+
+## Tests (`tests/test_anthropic.py` + small additions)
+
+All against `httpx.MockTransport`, mirroring `test_llm.py` and
+`test_responses.py` conventions.
+
+- Translation goldens: each row of the table above, including multi-part
+  observation content with a PNG data URL (asserting the `data:` prefix is
+  stripped and `media_type` is set), and a malformed image URL raising.
+- The merge rule: a turn with three tool calls produces exactly one user
+  message carrying three `tool_result` blocks in order, not three messages.
+  Plus the interleaved case (tool messages, then a user observation) to show
+  only *consecutive* runs merge.
+- System hoisting: `_messages[0]` becomes top-level `system` and no message
+  carries `role: "system"`; a system message at a later index raises.
+- Request body: `max_tokens` always present, `system` present, tools flattened
+  to `input_schema`, `output_config.effort` present only when effort is set,
+  `temperature` only when set, `speed` only when set, and the request path is
+  `{base_url}/messages`.
+- Headers: `x-api-key` and `anthropic-version` on every request; the
+  `anthropic-beta: fast-mode-2026-02-01` header present with `speed="fast"`
+  and **absent** without it.
+- Parsing: text-only, tool-use-only, text + tool-use, text spread across
+  multiple blocks, `thinking` blocks ignored, `input` round-tripping to JSON
+  text. `stop_reason: "refusal"` raises with the category in the message and
+  puts exactly one request on the wire; a refusal with `stop_details: null`
+  raises without an AttributeError.
+- Assistant turn with `content: None` and no tool calls emits no message.
+- Guided errors: the OpenRouter-fallback `ConfigError` (and that an explicit
+  `base_url` suppresses it), the fast-mode 4xx guidance, and the fast-mode 429
+  guidance after retries are exhausted.
+- Retry/fail-fast parity with `ChatClient`, plus `close()`.
+- Policy wiring: `wire="anthropic"` end-to-end through `LLMAgentPolicy.act()`
+  (mock embodiment); `speed="fast"` with `wire="chat"` raises; invalid `speed`
+  raises; `effort="none"`/`"minimal"` with `wire="anthropic"` raises;
+  `max_tokens=0` raises; `wire`, `speed`, and `max_tokens` recorded in config.
+
+## Docs
+
+- `plugins/inspect-robots-agent/README.md`: add `speed` and `max_tokens` to
+  the knobs list (line 101), extend the wire-format paragraph (line 48), and
+  add a short "Fast mode on Claude" section next to the existing "Reasoning
+  effort on OpenAI models" section, including the price delta and the
+  Claude-API-only caveat. Repo writing style applies: no em dashes in prose.
+- No `docs/` guide change. The quickstart and cookbook mention `-P model=` and
+  `-P effort=`; wire selection stays plugin-README territory, as it did for
+  `wire=responses`.
+
+## Non-goals
+
+- Prompt caching (`cache_control` breakpoints on the system block and tool
+  schemas). The stable prefix here is large and reused every turn, so this is
+  the obvious follow-up, but it is a cost optimization with its own placement
+  and invalidation design, not part of unlocking fast mode.
+- Adaptive-thinking display (`thinking: {"display": "summarized"}`) and
+  surfacing thinking summaries into the transcript.
+- Task budgets (`output_config.task_budget`), extended context, and the
+  Batches API.
+- `AnthropicBedrock`/Vertex/Foundry variants. Fast mode is Claude API only, so
+  they would inherit the wire without its motivating feature.

--- a/plans/0026-agent-anthropic-wire.md
+++ b/plans/0026-agent-anthropic-wire.md
@@ -1,6 +1,6 @@
 # 0026 — `-P wire=anthropic`: native Messages API unlocks fast mode
 
-Issue: #165. Status: draft (revised after critique round 1).
+Issue: #165. Status: draft (revised after critique rounds 1 and 2).
 
 ## Problem
 
@@ -22,10 +22,6 @@ model thinks, which is exactly why `effort` already defaults to `low`
 (`policy.py:143-146`). Fast mode is the same trade on the serving side, and it
 is the one lever that buys latency without trading reasoning depth.
 
-The native wire also unlocks `output_config.effort` in its own spelling
-(`low` through `max`) and correct `stop_reason: "refusal"` surfacing, which the
-compat shim flattens into an ordinary empty completion.
-
 Scope note: fast mode is Claude API only. Not Bedrock, Vertex, Foundry, or
 Claude Platform on AWS, and not usable with the Batch API or Priority Tier.
 Opus 4.7 fast mode was removed and now errors, so this wire does not resurrect
@@ -33,16 +29,40 @@ it.
 
 ## Design
 
-Third wire, one new client class, zero changes to the conversation loop. This
-is deliberately the same shape as plan 0022 (`wire=responses`): the
-chat-completions message format stays the single source of truth for
-`_messages`, the transcript, sanitization, and echo; the new client translates
-at the wire boundary only. Same no-SDK doctrine: httpx, raw JSON.
+Third wire, one new client class, zero changes to the conversation loop. Same
+shape as plan 0022 (`wire=responses`): the chat-completions message format
+stays the single source of truth for `_messages`, the transcript, sanitization,
+and echo; the new client translates at the wire boundary only. Same no-SDK
+doctrine: httpx, raw JSON.
 
-The one place this plan is *not* a thin mirror of 0022 is opaque-block replay
-(see "The thinking-block constraint"). 0022 needed a raw-item cache for
-OpenAI reasoning items; this wire needs the same mechanism for Claude thinking
-blocks, for the same underlying reason.
+The one place this is not a thin mirror of 0022 is opaque-block replay (see
+"The thinking-block constraint"). 0022 needed a raw-item cache for OpenAI
+reasoning items; this wire needs the same mechanism for Claude thinking blocks.
+
+### What this plan deliberately does not touch
+
+Two earlier drafts proposed a per-wire `_ACCEPTED_EFFORTS` table, partly to
+close 0022's known `wire=responses` + `effort=max` hole in the same PR. It is
+cut, for three reasons that only surfaced under review:
+
+- Its stated motive was that users would paste `-P effort=none` into a Claude
+  run. False: the CLI reads a bare `none` as Python `None` (`README.md:118`),
+  which omits the field and is legal on every wire. Only the quoted
+  `-P effort="'none'"` form would trip a guard, and that form exists precisely
+  because a user wanted the literal wire value.
+- Keying accepted efforts on the **wire** treats a protocol as a vendor. Both
+  wires advertise gateway support via `-P base_url=`, and a table would reject
+  configurations the gateway's model accepts.
+- It is the only part of the PR that changes behavior for an existing wire,
+  which is the argument for a separate PR, not for bundling.
+
+So `effort` validation stays exactly as it is today (`policy.py:128-134`), and
+out-of-set values fail with the API's own 400 — the same disposition 0022 chose
+for `effort=max`. `effort="none"`/`"minimal"` on this wire will 400; that is
+consistent, loud, and self-describing.
+
+Also cut for scope, all listed under Non-goals: `retry-after`-aware backoff,
+exposing response `usage`, and adding a field to `Provider`.
 
 ### `wire` param gains `"anthropic"`
 
@@ -50,11 +70,18 @@ blocks, for the same underlying reason.
 `"chat"`: it works for OpenRouter, vLLM, Ollama, and the Anthropic/Gemini
 compat endpoints. No auto-selection when the model id starts with
 `anthropic/` — implicit switching would change wire behavior, billing surface,
-and error shape under users' feet based on which env key happens to be set,
-and the compat path remains the right default for OpenRouter-routed Claude.
+and error shape under users' feet based on which env key happens to be set.
 
 `base_url` composes: `wire=anthropic` posts to `{base_url}/messages`, so a
-proxy or gateway that serves the Messages API works unchanged.
+proxy or gateway serving the Messages API works unchanged.
+
+**Model id form.** This wire uses the same `anthropic/<id>` prefix as every
+other model string in the plugin; `resolve_provider` strips it and sends the
+bare id (`_llm.py:112-120`). A bare `-P model=claude-opus-5` partitions to
+prefix `claude-opus-5` with an empty remainder, misses the direct-provider
+table, and dead-ends at "no API key found" (`_llm.py:123`) even with
+`ANTHROPIC_API_KEY` set. Stated here and in the README because a user who knows
+the native API will reach for the bare form.
 
 ### `speed` param (the point of the exercise)
 
@@ -64,8 +91,8 @@ forwards for free.
 
 `speed="fast"` with `wire != "anthropic"` is a construction-time `ValueError`,
 not a silent no-op. The compat shim accepts unknown body fields by ignoring
-them, so a silently-dropped `speed` would bill at standard rates while the
-user believes fast mode is on.
+them, so a silently-dropped `speed` would bill at standard rates while the user
+believes fast mode is on.
 
 No model-id gating. Fast mode's supported set moves (4.7 was removed, 5 was
 added) and a hardcoded allowlist would reject a model the API accepts.
@@ -73,33 +100,47 @@ Unsupported models get the API's own 400, wrapped by the guided error below.
 
 ### `max_output_tokens` param (forced by the wire)
 
-`max_tokens` is **required** on `/v1/messages` and has no server default,
-unlike both OpenAI wires where omitting it is legal.
+`max_tokens` is required on `/v1/messages` and has no server default, unlike
+both OpenAI wires where omitting it is legal.
 
-Named `max_output_tokens`, not `max_tokens`: sitting next to `max_llm_calls`
-(a per-trial budget) and `max_speed_frac`, a bare `max_tokens` reads as a
-trial-wide token budget. It is a per-response cap. The name also matches the
-Responses spelling, so forwarding it on the other two wires later is an
-extension rather than a rename.
+Named `max_output_tokens`, not `max_tokens`: next to `max_llm_calls` (a
+per-trial budget) and `max_speed_frac`, a bare `max_tokens` reads as a
+trial-wide token budget. It is a per-response cap, and the name matches the
+Responses spelling so forwarding it on the other wires later is an extension
+rather than a rename.
 
-`LLMAgentPolicy(max_output_tokens: int | None = None)`, validated `>= 1` when
-set. `None` means "use the wire's default": `AnthropicClient` applies
-`_DEFAULT_MAX_OUTPUT_TOKENS = 16000` internally, and the other two wires ignore
-the field entirely.
+`LLMAgentPolicy(max_output_tokens: int | None = None)`. Resolution happens in
+`policy.__init__`, not in the client:
 
-Recorded in `AgentPolicyConfig` as the **effective** value — the resolved
-number on `wire=anthropic`, and `None` on the other two wires, where nothing
-constrained the output. Logging `16000` for a `wire=chat` run would assert a
-limit that did not exist.
+```python
+_DEFAULT_MAX_OUTPUT_TOKENS = 16000   # in _anthropic.py, imported by policy.py
 
-Why 16000 and not 4096: the visible output of a turn is one tool call plus a
+resolved = max_output_tokens if max_output_tokens is not None else _DEFAULT_MAX_OUTPUT_TOKENS
+```
+
+`AnthropicClient` therefore takes `max_output_tokens: int` (no default, no
+second source of truth for a number that lands in an eval log). The resolved
+value is what `AgentPolicyConfig` records.
+
+Validation: `>= 1` when set, checked on every wire. `max_output_tokens` set
+with `wire != "anthropic"` is a construction-time `ValueError`, mirroring
+`speed` — a user passing `-P max_output_tokens=2000 -P wire=chat` believes a
+cap applies, and none would. The config records `None` on the other two wires.
+
+Why 16000: the visible output of a turn is one tool call plus a
 one-or-two-sentence `note`, on the order of 100-200 tokens. Everything above
-that is headroom for adaptive thinking, which is on by default on Opus 5 and
-bills against this same ceiling. There is no published number for how much
-adaptive thinking will spend, and this wire permits effort up to `max`, so the
-default is set by the repo-wide guidance for non-streaming requests (~16000)
-rather than by the visible-output estimate. Truncation is then a hard error
-rather than a silent degradation (below), so a too-small value is loud.
+that is headroom for adaptive thinking, which bills against this same ceiling.
+There is no published number for adaptive spend, so the default follows the
+repo-wide guidance for non-streaming requests rather than the visible-output
+estimate, and truncation is a hard error (below) so a too-small value is loud
+rather than silent.
+
+**Known limit, documented not guarded:** `effort` of `xhigh` or `max` wants
+`max_tokens` at 64K or above, and this client has no streaming path and a
+120s timeout, so those settings will either truncate (hard error, naming
+`-P max_output_tokens=`) or time out. The README says to keep effort at `high`
+or below on this wire until streaming lands. Guarding it in code would mean
+another wire-keyed allowlist, which is what this plan just cut.
 
 ### `AnthropicClient` (new module `_anthropic.py`)
 
@@ -107,8 +148,8 @@ rather than a silent degradation (below), so a too-small value is loud.
 AnthropicClient(
     provider: Provider,
     *,
+    max_output_tokens: int,
     speed: str | None = None,
-    max_output_tokens: int | None = None,
     timeout_s: float = 120.0,
     max_retries: int = 3,
     backoff_s: float = 1.0,
@@ -116,276 +157,293 @@ AnthropicClient(
 )
 ```
 
-`speed` and `max_output_tokens` are **constructor**-injected. `complete()`
-keeps the exact existing signature —
+`speed` and `max_output_tokens` are constructor-injected. `complete()` keeps
+the exact existing signature —
 `complete(messages, tools, temperature, reasoning_effort) -> AssistantMessage`
 — so `act()` (`policy.py:268-273`) is untouched and the
-`ChatClient | ResponsesClient | AnthropicClient` union at `policy.py:136`
-stays structurally compatible under mypy strict. `close()` is unchanged.
-`policy.py`'s changes stay confined to `__init__` and the config dataclass.
+`ChatClient | ResponsesClient | AnthropicClient` union at `policy.py:136` stays
+structurally compatible under mypy strict (the call site uses keyword
+arguments, so parameter *names* are load-bearing, not just types). `close()` is
+unchanged. `policy.py`'s changes stay confined to `__init__` and the config
+dataclass.
 
 `Provider`, `ToolCall`, and `AssistantMessage` are shared vocabulary from
-`_llm.py`.
+`_llm.py`, imported as they are today. No change to `Provider`.
 
-Headers: `x-api-key` (not `Authorization: Bearer` — the native API's own
-scheme), `anthropic-version: 2023-06-01`, and `anthropic-beta:
+Headers: `x-api-key` (the native API's own scheme, not `Authorization:
+Bearer`), `anthropic-version: 2023-06-01`, and `anthropic-beta:
 fast-mode-2026-02-01` only when `speed="fast"`. The beta header is what makes
 `POST /v1/messages` the beta endpoint over raw HTTP; there is no separate URL.
-An empty `provider.api_key` omits the `x-api-key` header entirely, matching
-`ChatClient` (`_llm.py:182-184`) so keyless local proxies still work.
+An empty `provider.api_key` omits `x-api-key` entirely, matching `ChatClient`
+(`_llm.py:182-184`) so keyless local proxies work.
 
-Request body: `model`, `max_tokens`, `messages` (translated), and when
-applicable `system` (hoisted), `tools` (flattened), `output_config:
-{"effort": ...}`, `speed`.
+Request body: `model`, `max_tokens`, `thinking`, `messages` (translated), and
+when applicable `system` (hoisted), `tools` (flattened), `output_config:
+{"effort": ...}`, `temperature`, `speed`.
 
-`temperature` is **never sent**. Claude Opus 5, Opus 4.8, and Opus 4.7 reject
-`temperature`, `top_p`, and `top_k` with a 400, and those are exactly the
-models this wire exists to reach. `temperature is not None` with
-`wire="anthropic"` is a construction-time `ValueError` naming the affected
-models, matching the `speed`-on-wrong-wire precedent. The policy still accepts
-`-P temperature=` for the other two wires.
+**`thinking: {"type": "adaptive"}` is always sent.** Omitting it is only
+equivalent to adaptive on Opus 5; on Opus 4.8 and 4.7 an omitted `thinking`
+runs with thinking **off**. Since fast mode covers Opus 5 and 4.8, omitting it
+would silently disable thinking on half the target set and make the replay
+cache below dead code there. The cost of sending it explicitly: pre-4.6 models
+(Sonnet 4.5, Haiku 4.5) reject `{"type": "adaptive"}`, so this wire does not
+reach them. That is the right trade for a wire whose reason to exist is an
+Opus-5-and-4.8 feature; the compat wire still serves those models.
 
-### Effort: a per-wire accepted set
-
-Replace the wire-agnostic check at `policy.py:128-134` with a table:
-
-```python
-_ACCEPTED_EFFORTS = {
-    "chat": _EFFORT_LEVELS,
-    "responses": _EFFORT_LEVELS - {"max"},
-    "anthropic": _EFFORT_LEVELS - {"none", "minimal"},
-}
-```
-
-Four lines, no special case, and it closes 0022's own known-ugly hole in the
-same PR: 0022 §"One effort caveat" documented that `wire=responses` +
-`effort=max` fails with OpenAI's 400 and accepted it rather than guarding.
-Leaving two inconsistent validation policies side by side is worse than fixing
-both.
-
-The honest justification for guarding at all — the earlier draft's reasoning
-was wrong and is retracted. Since this client never sends `thinking`, an
-out-of-set effort would produce a plain 400, not the silent tool-call-as-text
-degradation that disabled thinking causes on Opus 5. So the "guard silent
-degradation, not 400s" principle does not apply here. What does apply: a 400
-surfaces only after `bind()` and the first observation, so it burns a trial and
-costs a round trip, and `-P effort=none` is the documented GPT-5.x workaround
-sitting in this plugin's own README (line 117) that users will paste into a
-Claude run. Failing at construction is worth four lines.
-
-`effort=None` (the Python `None`, distinct from the wire string `"none"`)
-omits `output_config` entirely. `thinking` is never sent in any configuration:
-adaptive is the Opus 5 default and the right one here.
+`temperature` is forwarded when set, not rejected. Opus 5, 4.8, and 4.7 reject
+it with a 400, but Opus 4.6 and Sonnet 4.6 accept it over this same wire, so a
+construction-time guard would forbid legal requests — the same anti-allowlist
+reasoning applied to `speed` above. A guided error wraps the 400 instead.
 
 ### The thinking-block constraint
 
-Adaptive thinking is on by default on Opus 5, so a typical assistant turn
-returns `[thinking, text?, tool_use]`. Thinking blocks must be echoed back
-**unchanged** when the conversation continues on the same model; replaying a
-history with them stripped triggers ordering and signature 400s from the
-second turn onward. `AssistantMessage` (`_llm.py:140-159`) carries only
-`content` and `tool_calls`, so it is structurally lossy for opaque blocks.
+A typical assistant turn returns `[thinking, text?, tool_use]`. The hard
+constraint is on **tool-use continuation**: when an assistant turn containing
+`tool_use` is replayed, the thinking block that preceded it must be replayed
+unchanged, or the request can fail on block ordering or signature validation.
+`AssistantMessage` (`_llm.py:140-159`) carries only `content` and `tool_calls`,
+so it is structurally lossy for opaque blocks.
 
-This is the same problem 0022 solved for OpenAI reasoning items, and it gets
-the same mechanism. `AnthropicClient` keeps
+This is 0022's problem with different block names, and it gets 0022's
+mechanism. `AnthropicClient` keeps
 `_raw_blocks_by_tool_use_id: dict[str, list[dict[str, Any]]]`:
 
-- After each successfully *parsed* response (never a failed or raising one),
+- After each successfully parsed response (never a raising or terminal one),
   the response's verbatim `content` array is stored keyed by the `id` of each
   `tool_use` block in it.
 - During translation, an assistant message whose first `tool_call.id` hits the
-  cache emits the cached raw blocks in place of **all** synthesized blocks for
-  that message, text and tool calls alike. Emitting both would show the model
-  its own text twice.
-- A miss falls back to synthesis — correct for histories this client instance
+  cache emits `{"role": "assistant", "content": <cached blocks verbatim>}` in
+  place of all synthesized blocks for that message. Emitting both would show
+  the model its own text twice.
+- A miss falls back to synthesis: correct for histories this client instance
   did not produce, and for non-thinking models.
 - Entries whose `tool_use_id` no longer appears in the submitted history are
   pruned at the top of `complete()`, **before** the new response is cached
-  (prune-after-store would evict every fresh entry and make the cache always
-  miss). Ids are harvested from both places history carries them: assistant
-  `tool_calls[i].id` and tool-message `tool_call_id`.
-- A `reset()` (fresh `_messages`) empties the cache without the client needing
-  a reset hook.
+  (prune-after-store would evict every fresh entry and always miss). Ids are
+  harvested from both places history carries them: assistant `tool_calls[i].id`
+  and tool-message `tool_call_id`.
+- `reset()` produces a fresh `_messages`, so the prune empties the cache
+  without the client needing a reset hook. The client outlives a trial; the
+  cache does not.
 
-Accepted loss, inherited from 0022: text-only assistant turns (the nudge retry
-path) cache nothing, so their thinking blocks are dropped from replay. Those
-turns carry no `tool_use`, which is what the pairing constraint attaches to.
+Accepted loss, inherited from 0022: a text-only assistant turn (the nudge retry
+path, `policy.py:283-290`) carries no `tool_use`, so it caches nothing and its
+thinking block is dropped from replay. That is safe precisely because the
+constraint attaches to tool-use continuation, and such a turn is terminal.
 
 ### Translation: chat messages → Messages API
+
+Unless a row says otherwise, a violation raises `RuntimeError` naming the
+offending element.
 
 | Chat form | Messages API |
 | --- | --- |
 | `{"role": "system", "content": "<str>"}` at index 0 | hoisted to the top-level `system` string, not a message. Omitted entirely when `_messages[0]` is not a system message (`act()` is reachable without `reset()`; the only guard is `bind()`) |
-| a system message at index >= 1 | `RuntimeError` rather than a silent drop |
+| a system message at index >= 1 | raises |
 | `{"role": "user"/"assistant", "content": "<str>"}` | same role, `content` kept as the plain string |
 | user content part `{"type": "text", ...}` | `{"type": "text", "text": ...}` unchanged |
-| user content part `{"type": "image_url", "image_url": {"url": "data:image/png;base64,B"}}` | `{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "B"}}`. `_png.png_data_url` always emits PNG, so the media type is fixed rather than parsed; a URL not matching the expected prefix raises rather than shipping a malformed block |
+| user content part `{"type": "image_url", "image_url": {"url": u}}` | `{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": B}}` where `B` is `u` with the exact prefix `data:image/png;base64,` removed. `_png.png_data_url` always emits that prefix; any other `u` raises |
+| any other content part type | raises. `_responses.py:151-159` silently drops unknown parts; this wire does not, because a dropped camera frame is an invisible capability loss mid-trial |
 | assistant msg `content` (non-empty) | `{"type": "text", "text": ...}` block first |
-| assistant msg `tool_calls[i]` | `{"type": "tool_use", "id": id, "name": ..., "input": json.loads(arguments)}` after the text block. Unparseable JSON and parseable-but-non-object both raise `RuntimeError` naming the tool: a `tool_use` with a non-object `input` 400s with a message that does not identify the offending call |
-| assistant msg with a cache hit on `tool_calls[0].id` | the cached raw block list verbatim, replacing every synthesized block for that message |
+| assistant msg `tool_calls[i]` | `{"type": "tool_use", "id": id, "name": ..., "input": json.loads(arguments)}` after the text block. Unparseable JSON and parseable-but-non-object both raise: a `tool_use` with a non-object `input` 400s with a message that does not identify the offending call |
+| assistant msg with a cache hit on `tool_calls[0].id` | the cached raw block list verbatim, replacing every synthesized block |
 | `{"role": "tool", "tool_call_id": id, "content": c}` | `{"type": "tool_result", "tool_use_id": id, "content": c}` inside a **user** message; consecutive tool messages merge into one (below) |
-| assistant msg, no tool calls, content `None` or `""` | no message. The nudge retry path appends exactly this, and an assistant message with an empty content array is a 400 |
+| assistant msg, no tool calls, content `None` or `""` | no message. The nudge path appends exactly this, and an assistant message with an empty content array is a 400 |
+
+`tool_result.is_error` is deliberately never set. `act()` feeds tool failures
+back as ordinary content (`policy.py:306`) and the model reads them fine on the
+other two wires; adding the flag here would make this wire's transcript
+semantics diverge from the shared history for no demonstrated gain.
 
 Merging consecutive tool messages: `act()` appends one `role: "tool"` message
 per ignored extra tool call (`policy.py:292-303`) and then one for the executed
-call (`policy.py:304-307`), so a multi-tool-call turn produces a run of
-consecutive tool messages. Splitting `tool_result` blocks across several user
+call (`policy.py:304-307`). Splitting `tool_result` blocks across several user
 messages does not 400 (the API coalesces consecutive same-role messages), but
 it does silently train the model to stop making parallel calls, so the run
-collapses into one user message carrying one `tool_result` block each.
+collapses into one user message with one `tool_result` block each.
 
-Block order within the merged message is **history order**, which for a
-multi-call turn is `[extra_1..extra_n, executed]` while the assistant's
-`tool_use` order was `[executed, extra_1..extra_n]`. Blocks are matched by
-`tool_use_id`, not position, so this is legal; it is called out here only
-because the mismatch looks like a bug to a reader diffing the two arrays.
+Block order within the merged message is history order, which for a multi-call
+turn is `[extra_1..extra_n, executed]` while the assistant's `tool_use` order
+was `[executed, extra_1..extra_n]`. Blocks match by `tool_use_id`, not
+position, so this is legal; it is called out because the mismatch looks like a
+bug to a reader diffing the two arrays.
 
-Two consecutive-user-message sequences fall out of the loop and are legal
-under same-role coalescing, but are easy to miss and both get goldens:
+Two consecutive-user-message sequences fall out of the loop, both legal under
+same-role coalescing and both easy to miss, so both get goldens:
 
 - **Dropped assistant turn then nudge.** An assistant turn with no tool calls
-  and empty content emits no message, so the wire sees the observation user
-  message immediately followed by the nudge user message.
+  and empty content emits no message, so the observation user message is
+  immediately followed by the nudge user message.
 - **Tool results then next observation.** After a successful call `act()`
   returns; the next `act()` appends an observation, so a user message of
-  `tool_result` blocks is immediately followed by a user message of text and
-  images.
+  `tool_result` blocks is immediately followed by one of text and images.
 
 Tool schemas flatten from the chat nesting:
 `{"type": "function", "function": {name, description, parameters}}` →
 `{"name": ..., "description": ..., "input_schema": ...}`. `Toolset.schemas()`
-stays chat-shaped; the client owns the translation both ways. No strict-mode
+stays chat-shaped; the client owns translation both ways. No strict-mode
 concern: the Messages API does not auto-normalize schemas the way the Responses
 API does, so the move tool's free-form `targets`/`deltas` object survives.
-`tools=[]` omits the `tools` key entirely, matching `ResponsesClient`.
+`tools=[]` omits the `tools` key, matching `ResponsesClient`.
 
 ### Response parsing → `AssistantMessage`
 
 From `response["content"]`: concatenate the `text` of every `text` block, and
 emit one `ToolCall(id=block["id"], name=block["name"],
 arguments=json.dumps(block["input"]))` per `tool_use` block, in order.
-`thinking` blocks contribute nothing here — they matter only to the cache.
+`thinking` blocks contribute nothing here; they matter only to the cache.
 
 Empty concatenated text normalizes to `None`, never `""`. A `""` would
 round-trip through `raw()` (`_llm.py:149`) into the next request as an empty
 `text` block, which is a 400.
 
-Re-serializing `input` back to JSON text keeps `ToolCall.arguments` a string
-across all three wires, so `_tools.py` validation, the transcript format, and
-the echo path are untouched.
+Re-serializing `input` to JSON text keeps `ToolCall.arguments` a string across
+all three wires, so `_tools.py` validation, the transcript format, and the echo
+path are untouched.
 
-Two terminal stop reasons raise `RuntimeError` and are never retried, matching
-0022's `status: "failed"` decision — the server deliberately answered:
+**Terminal stop reasons.** `stop_reason` outside
+`{end_turn, tool_use, stop_sequence}` raises `RuntimeError` and is never
+retried, matching 0022's `status: "failed"` decision — the server deliberately
+answered. Handled as a default-deny rather than an enumeration of two, because
+the enumeration would miss `model_context_window_exceeded`, which is live here:
+`max_llm_calls` defaults to 100 and every turn appends fresh multi-camera PNGs.
 
-- `stop_reason: "refusal"`, carrying `stop_details.category` when present.
-  `stop_details` is informational and may be `null` even on a refusal, so the
-  branch keys on `stop_reason` alone.
-- `stop_reason: "max_tokens"`, carrying `fix: raise -P max_output_tokens=`.
-  A truncated turn is an HTTP 200 with partial content, and it is the one
-  silent-degradation risk this PR newly creates: either there is no `tool_use`
-  block (three nudge turns, then a generic `RuntimeError` at `policy.py:286`
-  with the cause discarded), or there is a partial `tool_use` whose `input`
-  still re-serializes to valid JSON and gets executed as a motion by
-  `toolset.execute()` (`policy.py:304`). Truncated responses never yield tool
-  calls.
+Two get specific guidance:
 
-Neither terminal response populates the cache.
+- `refusal` carries `stop_details.category` when present. `stop_details` is
+  informational and may be `null`, so the message is built with
+  `(payload.get("stop_details") or {}).get("category")` — no attribute access
+  on a possibly-`None` dict.
+- `max_tokens` carries `fix: raise -P max_output_tokens=`. This is the one
+  silent-degradation risk the PR newly creates: a truncated turn is an HTTP 200
+  with partial content, and without the guard it is either no `tool_use` (three
+  nudge turns, then a generic `RuntimeError` at `policy.py:286` with the cause
+  discarded) or a partial `tool_use` whose `input` still parses and reaches
+  `toolset.execute()` (`policy.py:304`) as robot motion. Raising before parsing
+  content is what prevents the second case.
+
+Anything else outside the permissive set gets a generic message naming the
+`stop_reason` verbatim. No terminal response populates the cache.
 
 ### Guided errors
 
 House style: the error names the fix, never just the failure.
 
-**OpenRouter fallback.** `resolve_provider`'s ladder falls through to
-OpenRouter whenever `ANTHROPIC_API_KEY` is unset, and
-`openrouter.ai/api/v1/messages` does not exist. `Provider` gains a public
-`from_openrouter_fallback: bool` field set by `resolve_provider`, so `policy.py`
-does not reach into `_llm`'s privates to compare base URLs. Construction raises
-`ConfigError` when `wire="anthropic"` and that flag is set, naming the two
-fixes (set `$ANTHROPIC_API_KEY`, or pass `-P base_url=` for a gateway serving
-the Messages API).
+**OpenRouter fallback.** `resolve_provider` falls through to OpenRouter
+whenever `ANTHROPIC_API_KEY` is unset, and `openrouter.ai/api/v1/messages` does
+not exist. `policy.py` compares `provider.base_url` against
+`_llm._OPENROUTER_BASE`, imported alongside `ENV_MODEL` (`policy.py:33` already
+imports from that private module, so this adds no new coupling), and raises
+`ConfigError` when `wire="anthropic"` matched it, naming both fixes: set
+`$ANTHROPIC_API_KEY`, or pass `-P base_url=` for a gateway serving the Messages
+API.
 
-This guard covers the fallback case only, deliberately. `-P model=openai/gpt-5
--P wire=anthropic` with `$OPENAI_API_KEY` set resolves to `api.openai.com/v1`
-and dead-ends at a 404 — enumerating every wrong-endpoint combination is not
-worth it, and the 404 names the URL.
+Deliberately narrow: `-P model=openai/gpt-5 -P wire=anthropic` with
+`$OPENAI_API_KEY` set resolves to `api.openai.com/v1` and dead-ends at a 404.
+Enumerating every wrong-endpoint pairing is not worth it, and the 404 names the
+URL.
 
-**Key resolution with an explicit `base_url`.** `resolve_provider` defaults
-`api_key_env` to `OPENROUTER_API_KEY` (`_llm.py:109-111`), so
+**Key resolution with an explicit `base_url`.** `resolve_provider` consults
+`api_key_env` only inside its `if base_url:` branch (`_llm.py:109-111`),
+defaulting to `OPENROUTER_API_KEY`, so
 `-P base_url=https://gateway/v1 -P wire=anthropic` would send an OpenRouter key
-as `x-api-key` and 401 with no hint. For `wire="anthropic"`, `policy.py`
-defaults `api_key_env` to `ANTHROPIC_API_KEY` before calling
-`resolve_provider`. An explicit `-P api_key_env=` still wins.
+as `x-api-key` and 401 with no hint. For `wire="anthropic"` **with a
+`base_url`**, `policy.py` defaults `api_key_env` to `ANTHROPIC_API_KEY` before
+calling `resolve_provider`; an explicit `-P api_key_env=` still wins. With no
+`base_url` the parameter is dead, so nothing changes and
+`AgentPolicyConfig.api_key_env` records the user's original value rather than
+the substituted one.
 
 **Fast mode unsupported.** A 4xx while `speed="fast"` whose body contains both
-`"speed"` and `"fast"` appends: `fix: fast mode needs Claude Opus 5 or Opus 4.8
-on the Claude API (not Bedrock/Vertex/Foundry), or drop -P speed=fast`. The
-two-token AND mirrors 0022's matcher shape (`_llm.py:220`); a bare `fast`
-substring is too weak a signal.
+`"speed"` and `"fast"` (case-insensitive, matched against the full
+`response.text`, as `_llm.py:220` does) appends: `fix: fast mode needs Claude
+Opus 5 or Opus 4.8 on the Claude API (not Bedrock/Vertex/Foundry), or drop
+-P speed=fast`. The two-token AND mirrors 0022's matcher shape; a bare `fast`
+substring is too weak.
+
+**Sampling parameter rejected.** A 4xx whose body mentions `temperature`
+appends: `fix: Claude Opus 5, 4.8, and 4.7 reject temperature; drop
+-P temperature=`.
 
 **Fast-mode rate limit.** Fast mode draws on a rate-limit pool separate from
-standard Opus, so a fast-mode run can 429 while standard capacity is idle. The
-retry loop tracks `last_status: int | None` alongside `last_error`; when
+standard Opus, so a fast-mode run can 429 while standard capacity sits idle.
+The retry loop tracks `last_status: int | None` alongside `last_error`, **reset
+to `None` in the `httpx.TransportError` branch** so a 429-then-transport-error
+sequence does not emit rate-limit guidance for a connection failure. When
 retries are exhausted with `last_status == 429` and `speed="fast"`, the
 terminal error appends: `fix: fast mode has its own rate limit; retry later or
-drop -P speed=fast to fall back to standard speed`. One extra variable, and it
-saves a user staring at a 429 while their standard-speed quota sits unused.
+drop -P speed=fast to fall back to standard speed`.
 
-**429 backoff honors `retry-after`.** When the response carries a parseable
-`retry-after`, sleep that instead of `backoff_s * 2**attempt`, capped at
-`timeout_s`. Inherited fixed backoff ignores the server's own answer.
-
-No automatic fallback to standard speed on 429. Silently downgrading changes
+No automatic fallback to standard speed on 429: silently downgrading changes
 the billing rate and the latency profile mid-eval and produces an eval log
 whose `speed` field no longer describes what ran.
 
 ### What the eval log records
 
-`AgentPolicyConfig` gains `speed: str | None`, `max_output_tokens: int | None`
-(effective value, see above), and the existing `wire` field carries the new
-value. The config is frozen with all-defaulted fields (`policy.py:75-91`), so
-appending is safe; `_html.py:555` renders `sorted(policy_config.items())`, so
-new keys render with no viewer change.
+`AgentPolicyConfig` gains `speed: str | None` and `max_output_tokens: int |
+None` (the resolved value on this wire, `None` elsewhere); the existing `wire`
+field carries the new value. The config is frozen with all-defaulted fields
+(`policy.py:75-91`), so appending is safe, and `_html.py:555` renders
+`sorted(policy_config.items())`, so new keys render with no viewer change.
 
-Requested `speed` records intent, not what was served. The response's
-`usage.speed` reports which speed actually ran, and a fast-mode request that
-silently served at standard speed is a 2x billing difference the log should
-not hide. `AnthropicClient` exposes the last response's `usage` (including
-`speed`, `input_tokens`, `output_tokens`) as a plain attribute; wiring it into
-the trial record is left to a follow-up, but the fast-mode test asserts
-`usage.speed` is surfaced.
+`speed` records intent, not what was served. The response's `usage.speed`
+reports which speed actually ran, and a fast-mode request served at standard
+speed is a 2x billing difference the log cannot currently distinguish. Left as
+a documented gap rather than half-solved with an unused public attribute; see
+Non-goals.
 
-## Version
+## Version and changelog
 
 Plugin `0.12.0` → `0.13.0` (`plugins/inspect-robots-agent/pyproject.toml:7`).
-`AnthropicClient` joins the package's `__all__` for parity with
-`ResponsesClient` (`__init__.py:34,44`). Both changes break
-`tests/test_package.py` (the version pin at line 9 and the exact `__all__` pin
-at lines 11-23), which is updated in the same PR — that pin exists because a
-stale hardcoded version shipped twice.
+`AnthropicClient` joins `__all__` for parity with `ResponsesClient`
+(`__init__.py:34,44`), inserted after `"AgentPolicyConfig"` to keep the list
+sorted.
+
+`tests/test_package.py` breaks on both the version pin (line 9) and the exact
+`__all__` pin (lines 11-23); that pin exists because a stale hardcoded version
+shipped through two releases. No other existing test changes: `effort`
+validation is untouched, so `test_policy_e2e.py:879` and
+`test_responses.py:534` keep passing.
+
+`CHANGELOG.md` gains an entry under `## [Unreleased]` → `### Added`, matching
+the `wire=responses` line already at `CHANGELOG.md:55`.
+
+Also update `__init__.py:1-20`, whose package docstring still describes the
+plugin as speaking only OpenAI-compatible APIs.
 
 ## Tests (`tests/test_anthropic.py` + small additions)
 
 All against `httpx.MockTransport`, mirroring `test_llm.py` and
-`test_responses.py` conventions. Plugin coverage is report-only
-(`ci.yml:326-331` runs with `--cov-fail-under=0`), so this list is the gate,
-not a safety net under one.
+`test_responses.py`. Plugin coverage is report-only (`ci.yml:326-331` runs with
+`--cov-fail-under=0`) and plugin tests are **not** type-checked (root
+`[tool.mypy] files` covers the core's `tests/`, not this one), so this list is
+the gate rather than a safety net under one.
+
+New fixtures, since nothing existing emits Anthropic-shaped payloads
+(`test_policy_e2e.py`'s `_Script` and response builders are chat-shaped):
+`_anthropic_response(*blocks, stop_reason="tool_use", usage=None)` building a
+`content` array, and `_AnthropicScript` mirroring `_Script`
+(`test_policy_e2e.py:130-140`) for multi-turn policy tests. A `_client(...)`
+helper taking a `Provider` override, following `test_llm.py:273`, so the
+empty-api-key case is constructible.
 
 Translation:
 
-- Each row of the table above, including multi-part observation content with a
-  PNG data URL (asserting the `data:` prefix is stripped and `media_type` is
-  set), and a malformed image URL raising.
+- Each table row, including multi-part observation content with a PNG data URL
+  (asserting prefix stripping and `media_type`), a malformed image URL raising,
+  and an unknown content part type raising.
 - System hoisting: index-0 system message becomes top-level `system` with no
-  `role: "system"` message on the wire; a history with **no** system message
-  omits the `system` key; a system message at index >= 1 raises.
-- The merge rule: three tool calls produce exactly one user message with three
-  `tool_result` blocks; the interleaved case (only consecutive runs merge); and
-  a history **ending** in a tool run, which is the shape on the wire every time
-  `act()` retries after a tool error (`policy.py:305-313`).
+  `role: "system"` message on the wire; a history with no system message omits
+  the `system` key; a system message at index >= 1 raises.
+- Merge rule: three tool calls produce exactly one user message with three
+  `tool_result` blocks **in history order**; the interleaved case (only
+  consecutive runs merge); and a history *ending* in a tool run, the shape on
+  the wire every time `act()` retries after a tool error
+  (`policy.py:305-313`).
 - Both consecutive-user-message sequences, asserted on the full `messages`
-  array across a multi-turn trial, not per-message.
-- `json.loads(arguments)` unparseable and parseable-but-non-object as two
-  separate cases.
+  array across a multi-turn trial via `_AnthropicScript`, not per-message.
+- `json.loads(arguments)` unparseable and parseable-but-non-object as separate
+  cases.
 - Assistant turn with `content: None` and no tool calls emits no message;
   assistant turn with `content: ""` **and** tool calls emits no empty text
   block.
@@ -393,95 +451,109 @@ Translation:
 Thinking replay:
 
 - Turn 1 returns `[thinking, text, tool_use]`; the turn-2 request contains all
-  three verbatim, with the text appearing exactly once.
+  three verbatim, text appearing exactly once.
 - Two `tool_use` blocks in one turn: each cached block appears exactly once in
   turn 2 (the hit is per assistant message, keyed on the first call id).
-- Cache prune on a fresh history, and cache-miss synthesis.
-- Neither a `refusal` nor a `max_tokens` response populates the cache.
+- Cache prune on a fresh history, including the tool-message `tool_call_id`
+  harvest path; and cache-miss synthesis.
+- No terminal response (refusal, max_tokens) populates the cache.
 
 Request shape:
 
-- `max_tokens` always present; `tools=[]` omits the `tools` key;
-  `output_config.effort` only when effort is set; `speed` only when set;
-  `temperature` never present; path is `{base_url}/messages`.
+- `max_tokens` present with the resolved value (asserting `16000` by default);
+  `thinking: {"type": "adaptive"}` always present; `tools=[]` omits `tools`;
+  `output_config.effort` only when effort is set; `temperature` only when set;
+  `speed` only when set; path is `{base_url}/messages`; model id is the
+  prefix-stripped bare form.
 - Headers: `x-api-key` and `anthropic-version` on every request;
   `anthropic-beta: fast-mode-2026-02-01` present with `speed="fast"` and absent
   without it; empty api_key omits `x-api-key`.
 
 Parsing and terminal states:
 
-- Text-only, tool-use-only, text + tool-use, text across multiple blocks,
-  `thinking` blocks ignored, `input` round-tripping to JSON text.
+- Text-only, tool-use-only, text + tool-use, text across multiple blocks, a
+  zero-length text block normalizing to `None`, `thinking` ignored, `input`
+  round-tripping to JSON text.
 - `refusal` raises with the category, one request on the wire; `refusal` with
-  `stop_details: null` raises without an AttributeError.
+  `stop_details: null` raises cleanly.
 - `max_tokens` raises naming `-P max_output_tokens=`, and a truncated response
   containing a partial `tool_use` raises rather than returning that call.
-- `usage.speed` surfaced on a fast-mode response.
+- An unrecognized `stop_reason` raises naming it verbatim.
 
 Errors and retries:
 
 - OpenRouter-fallback `ConfigError`; an explicit `base_url` suppresses it.
-- `api_key_env` defaulting to `ANTHROPIC_API_KEY` for this wire, and an
-  explicit `-P api_key_env=` overriding it.
-- Fast-mode 4xx guidance; and the negative case — a 4xx unrelated to speed
-  while `speed="fast"` gets no guidance.
-- 429 terminal message with `speed="fast"` (guided) and without it (unguided).
-- `retry-after` honored when present, fixed backoff when absent.
+- `api_key_env` defaulting to `ANTHROPIC_API_KEY` **with `base_url` set**
+  (asserted on the outgoing `x-api-key` header), an explicit `-P api_key_env=`
+  overriding it, and `AgentPolicyConfig.api_key_env` recording the user's value.
+- Fast-mode 4xx guidance, and the negative case: a 4xx unrelated to speed while
+  `speed="fast"` gets no guidance.
+- `temperature` 4xx guidance.
+- 429 terminal message with `speed="fast"` (guided) and without it (unguided);
+  and 429-then-transport-error emitting no rate-limit guidance.
 - Retry/fail-fast parity with `ChatClient`, plus `close()`.
 
 Policy wiring:
 
-- `wire="anthropic"` end-to-end through `LLMAgentPolicy.act()` (mock
-  embodiment).
+- `wire="anthropic"` end-to-end through `LLMAgentPolicy.act()`.
 - Raises: `speed="fast"` with `wire="chat"`; invalid `speed`;
-  `effort="none"`/`"minimal"` with `wire="anthropic"`; `effort="max"` with
-  `wire="responses"` (the newly closed 0022 hole); `temperature` set with
-  `wire="anthropic"`; `max_output_tokens=0`.
-- `wire`, `speed`, and the effective `max_output_tokens` recorded in the
-  config, including `None` on a `wire=chat` run.
+  `max_output_tokens` set with `wire="chat"`; `max_output_tokens=0`; invalid
+  `wire` still raises the existing guided `ValueError`.
+- `wire`, `speed`, and the resolved `max_output_tokens` recorded in config,
+  including `None` on a `wire=chat` run.
 
 ## Docs
 
 `plugins/inspect-robots-agent/README.md`:
 
-- Add `speed` and `max_output_tokens` to the knobs list (line 101).
+- Add `speed` and `max_output_tokens` to the knobs list (lines 100-102).
 - Replace the two-sentence wire paragraph (lines 48-50) with a small wire
-  table, matching the provider table already at lines 38-46.
-- Add a "Fast mode on Claude" section next to the existing "Reasoning effort on
-  OpenAI models" section, with the Claude-API-only caveat and the supported
-  models. Describe the cost as roughly double the standard output price and
-  link Anthropic's pricing page rather than printing figures: no README here
-  carries a price, and a stale one would ship to PyPI on every release.
+  table, matching the provider table at lines 38-46.
+- Update the provider table row at line 40, which says
+  `Anthropic (OpenAI-compat)` and after this PR serves both wires.
+- Add a "Fast mode on Claude" section beside "Reasoning effort on OpenAI
+  models" (starts line 124): the `anthropic/<id>` model form, the
+  Claude-API-only caveat, supported models, the keep-effort-at-`high`-or-below
+  note, and cost described as roughly double the standard output price with a
+  link to Anthropic's pricing page. No figures: no README here carries a price,
+  and a stale one would ship to PyPI on every release.
 
-Repo writing style applies to all of it (CLAUDE.md "Writing style"): no em
-dashes in prose, bold only for `**term:**` lead-ins, no decorative emoji.
+Repo writing style applies (CLAUDE.md "Writing style"): no em dashes in prose,
+bold only for `**term:**` lead-ins, no decorative emoji.
 
 No `docs/` guide change. Wire selection stays plugin-README territory, as it
 did for `wire=responses`.
 
 ## Retry-loop duplication
 
-Three clients will each carry a near-identical retry loop. 0022 justified the
+Three clients each carry a near-identical retry loop. 0022 justified the
 duplication at two as "small enough"; that premise is already false, since
 `_llm.py:207-228` and `_responses.py:70-88` differ in their guided-error block,
-and this client adds two more guidance branches plus `last_status`.
+and this client adds three guidance branches plus `last_status`.
 
-Keep it duplicated anyway, for a better reason: extraction would need at least
-two injection points (4xx guidance, terminal message), so a base class buys
+Keep it duplicated anyway, for a better reason: extraction needs at least two
+injection points (4xx guidance, terminal message), so a base class buys
 template-method indirection rather than deduplication. The only genuinely
-shared logic is "is this status retryable" plus the backoff sleep, which is
-three lines. Revisit at a fourth wire, and do not inherit the "small enough"
-claim, which will not survive it.
+shared logic is "is this status retryable" plus the backoff sleep, three lines.
+Revisit at a fourth wire, and do not inherit the "small enough" claim, which
+will not survive it.
 
 ## Non-goals
 
-- Prompt caching (`cache_control` breakpoints on the system block and tool
-  schemas). The stable prefix here is large and reused every turn, so this is
-  the obvious follow-up, but it is a cost optimization with its own placement
-  and invalidation design.
-- Wiring `usage` into the trial record beyond exposing it on the client.
-- Adaptive-thinking display (`thinking: {"display": "summarized"}`) and
-  surfacing thinking summaries into the transcript.
+- Streaming, and therefore `effort` of `xhigh`/`max` on this wire.
+- Prompt caching (`cache_control` on the system block and tool schemas). The
+  stable prefix is large and reused every turn, so this is the obvious
+  follow-up, with its own placement and invalidation design.
+- Surfacing response `usage`, including served `speed`, into the trial record.
+  Worth doing, but a public attribute whose only consumer is one assertion is
+  worse than a documented gap.
+- `retry-after`-aware backoff. Correct, but it needs a parse rule (delta-seconds
+  vs HTTP-date), a status scope, and a sleep-duration assertion pattern this
+  suite does not have.
+- Per-wire `effort` validation, and with it 0022's `effort=max` hole. Separate
+  concern, separate PR.
+- Adaptive-thinking display (`thinking: {"display": "summarized"}`) and thinking
+  summaries in the transcript.
 - Task budgets (`output_config.task_budget`) and the Batches API.
 - Bedrock/Vertex/Foundry variants: fast mode is Claude API only, so they would
   inherit the wire without its motivating feature.

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -159,6 +159,8 @@ The Messages API requires an output cap, so `-P max_output_tokens=` defaults to
 the limit is an error naming the knob rather than a silently missing tool call.
 Keep `-P effort=` at `high` or below on this wire: `xhigh` and `max` want a cap
 of 64000 or more, which needs streaming this client does not implement yet.
+The read timeout scales with the cap and tops out at 600 s per attempt, so a
+large cap plus retries can sit for several minutes before failing.
 
 ## Reasoning effort on OpenAI models
 

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -141,14 +141,15 @@ inspect-robots "pick up the cube" --policy agent \
 ```
 
 The model id keeps the `anthropic/` prefix on this wire, the same as every
-other model string here. A bare `-P model=claude-opus-5` does not resolve.
+other model string here. A bare `-P model=claude-opus-5` does not resolve
+without `-P base_url=`, and the error says so.
 
 Fast mode costs roughly double the standard price on both input and output
 (see [Anthropic's pricing](https://www.anthropic.com/pricing)), and it draws on
 a rate limit separate from standard capacity, so a fast-mode run can hit a 429
 while standard quota sits idle. It is available on Claude Opus 5 and Opus 4.8,
 on the Claude API only: not Bedrock, Vertex, Foundry, or Claude Platform on
-AWS. Errors from any of those cases name the fix.
+AWS. A rejection that names fast mode is turned into an error naming the fix.
 
 This wire always requests adaptive thinking, which pre-4.6 models such as
 Sonnet 4.5 and Haiku 4.5 do not support. Use `-P wire=chat` for those.

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -37,7 +37,7 @@ Providers resolved directly by prefix:
 
 | Prefix | Key | Endpoint |
 |---|---|---|
-| `anthropic/*` | `ANTHROPIC_API_KEY` | Anthropic (OpenAI-compat) |
+| `anthropic/*` | `ANTHROPIC_API_KEY` | Anthropic (OpenAI-compat, or native with `-P wire=anthropic`) |
 | `openai/*` | `OPENAI_API_KEY` | OpenAI |
 | `google/*` | `GEMINI_API_KEY` | Google Gemini (OpenAI-compat) |
 | `x-ai/*` or `xai/*` | `XAI_API_KEY` | xAI |
@@ -45,9 +45,14 @@ Providers resolved directly by prefix:
 | `mistralai/*` | `MISTRAL_API_KEY` | Mistral |
 | `deepseek/*` | `DEEPSEEK_API_KEY` | DeepSeek |
 
-The wire format defaults to Chat Completions (`-P wire=chat`) for broad
-OpenAI-compatible endpoint support. Switch to `-P wire=responses` when a
-direct OpenAI or compatible endpoint requires the Responses API.
+The wire format defaults to Chat Completions for broad OpenAI-compatible
+endpoint support:
+
+| `-P wire=` | Endpoint | Use it when |
+|---|---|---|
+| `chat` (default) | `/chat/completions` | Anything OpenAI-compatible: OpenRouter, vLLM, Ollama, the Anthropic and Gemini compat endpoints |
+| `responses` | `/responses` | A direct OpenAI or compatible endpoint requires the Responses API |
+| `anthropic` | `/messages` | Driving Claude natively, which is what fast mode needs |
 
 ## How it works
 
@@ -98,8 +103,10 @@ motion fall short of the tool's requested total.
 > on real hardware** unless you fully trust the policy and the rig.
 
 Configuration knobs (all `-P key=value`): `model`, `base_url`, `api_key_env`,
-`wire`, `max_llm_calls` (default `100`), `temperature`, `effort`,
-`max_speed_frac`, `transcript_echo`.
+`wire`, `speed`, `max_output_tokens`, `max_llm_calls` (default `100`),
+`temperature`, `effort`, `max_speed_frac`, `transcript_echo`.
+`speed` and `max_output_tokens` apply to `-P wire=anthropic` only, and passing
+either on another wire is an error rather than a silent no-op.
 Set `-P transcript_echo=true` to print live `[agent]` conversation lines to
 stderr, including goals, observation summaries, assistant output, tool calls,
 and tool results.
@@ -120,6 +127,37 @@ pass `-P effort=none` to omit the parameter for endpoints that reject it
 chat completions requires the literal `none` when function tools are in
 play (any other value, or omitting the field, is a 400). In Python,
 `effort=None` omits the field and `effort="none"` sends the wire value.
+
+## Fast mode on Claude
+
+`-P wire=anthropic` drives Claude through the native Messages API instead of
+the OpenAI-compat endpoint. That is the only way to reach fast mode, which
+serves the same model at up to 2.5x higher output tokens per second:
+
+```bash
+inspect-robots "pick up the cube" --policy agent \
+    -P model=anthropic/claude-opus-5 -P wire=anthropic -P speed=fast \
+    --embodiment cubepick
+```
+
+The model id keeps the `anthropic/` prefix on this wire, the same as every
+other model string here. A bare `-P model=claude-opus-5` does not resolve.
+
+Fast mode costs roughly double the standard price on both input and output
+(see [Anthropic's pricing](https://www.anthropic.com/pricing)), and it draws on
+a rate limit separate from standard capacity, so a fast-mode run can hit a 429
+while standard quota sits idle. It is available on Claude Opus 5 and Opus 4.8,
+on the Claude API only: not Bedrock, Vertex, Foundry, or Claude Platform on
+AWS. Errors from any of those cases name the fix.
+
+This wire always requests adaptive thinking, which pre-4.6 models such as
+Sonnet 4.5 and Haiku 4.5 do not support. Use `-P wire=chat` for those.
+
+The Messages API requires an output cap, so `-P max_output_tokens=` defaults to
+`16000` here. Thinking bills against that same cap, and a response truncated at
+the limit is an error naming the knob rather than a silently missing tool call.
+Keep `-P effort=` at `high` or below on this wire: `xhigh` and `max` want a cap
+of 64000 or more, which needs streaming this client does not implement yet.
 
 ## Reasoning effort on OpenAI models
 

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -144,8 +144,8 @@ The model id keeps the `anthropic/` prefix on this wire, the same as every
 other model string here. Only Anthropic's own endpoint serves `/v1/messages`,
 so anything that resolves elsewhere is refused up front with the fix named: a
 bare `-P model=claude-opus-5`, another provider's prefix such as `openai/`, or
-an OpenRouter `:variant` suffix. Pass `-P base_url=` to point at a gateway that
-serves the endpoint yourself.
+an OpenRouter `:variant` suffix. Pass `-P base_url=...` to point at a gateway
+that serves the endpoint yourself.
 
 Fast mode costs roughly double the standard price on both input and output
 (see [Anthropic's pricing](https://www.anthropic.com/pricing)), and it draws on

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -141,8 +141,11 @@ inspect-robots "pick up the cube" --policy agent \
 ```
 
 The model id keeps the `anthropic/` prefix on this wire, the same as every
-other model string here. A bare `-P model=claude-opus-5` does not resolve
-without `-P base_url=`, and the error says so.
+other model string here. Only Anthropic's own endpoint serves `/v1/messages`,
+so anything that resolves elsewhere is refused up front with the fix named: a
+bare `-P model=claude-opus-5`, another provider's prefix such as `openai/`, or
+an OpenRouter `:variant` suffix. Pass `-P base_url=` to point at a gateway that
+serves the endpoint yourself.
 
 Fast mode costs roughly double the standard price on both input and output
 (see [Anthropic's pricing](https://www.anthropic.com/pricing)), and it draws on

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -147,6 +147,13 @@ bare `-P model=claude-opus-5`, another provider's prefix such as `openai/`, or
 an OpenRouter `:variant` suffix. Pass `-P base_url=...` to point at a gateway
 that serves the endpoint yourself.
 
+> [!NOTE]
+> With `-P base_url=...` and no `-P api_key_env=`, this wire sends
+> `$ANTHROPIC_API_KEY` to that host. The other wires default to
+> `$OPENROUTER_API_KEY` instead. Name the variable explicitly
+> (`-P api_key_env=MYGW_KEY`) when the gateway takes its own credential, and
+> point it at an unset variable to send no key at all.
+
 Fast mode costs roughly double the standard price on both input and output
 (see [Anthropic's pricing](https://www.anthropic.com/pricing)), and it draws on
 a rate limit separate from standard capacity, so a fast-mode run can hit a 429

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.12.0"
+version = "0.13.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/__init__.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/__init__.py
@@ -3,7 +3,9 @@
 An LLM behind any OpenAI-compatible API (OpenRouter, OpenAI, local
 vLLM/Ollama, Anthropic's compat endpoint) drives whatever embodiment it is
 paired with: each tool call becomes one smooth, approver-checked action
-chunk. Registered as the policy ``agent``::
+chunk. ``-P wire=anthropic`` swaps the OpenAI-compat shim for Anthropic's
+native Messages API, which is what fast mode needs. Registered as the policy
+``agent``::
 
     inspect-robots "pick up the cube" --policy agent \
         -P model=anthropic/claude-fable-5 --embodiment cubepick
@@ -23,6 +25,7 @@ from __future__ import annotations
 
 from importlib.metadata import version
 
+from inspect_robots_agent._anthropic import AnthropicClient
 from inspect_robots_agent._llm import (
     ENV_MODEL,
     AssistantMessage,
@@ -37,6 +40,7 @@ from inspect_robots_agent.policy import AgentPolicyConfig, LLMAgentPolicy, agent
 __all__ = [
     "ENV_MODEL",
     "AgentPolicyConfig",
+    "AnthropicClient",
     "AssistantMessage",
     "ChatClient",
     "LLMAgentPolicy",

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
@@ -321,9 +321,12 @@ def _translate_messages(
             # text included: emitting both would show the model its own text
             # twice and drop the thinking block that must be replayed verbatim.
             # A miss synthesizes text + tool_use with no thinking block, which
-            # is lossy for a tool-use turn. Unreachable within a trial (the
-            # cache is populated on every 200 and the rollout is serial); it
-            # exists for foreign histories and non-thinking models.
+            # is lossy for a tool-use turn. No tool-use turn misses within a
+            # trial (the cache is populated on every 200 that carries a tool
+            # call, and the rollout is serial). A text-only turn does miss,
+            # via the nudge path, but carries no tool_use and so no signature
+            # or ordering constraint. The miss path also serves foreign
+            # histories and non-thinking models.
             blocks = cached if cached is not None else _assistant_blocks(message)
             if not blocks:
                 # The nudge retry path appends exactly this; an assistant

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
@@ -32,6 +32,9 @@ _PNG_DATA_URL_PREFIX = "data:image/png;base64,"
 # added after this was written (model_context_window_exceeded is already one).
 _CONTINUING_STOP_REASONS = frozenset({"end_turn", "tool_use", "stop_sequence"})
 
+# Retried alongside 5xx and transport errors, matching the Anthropic SDKs.
+_RETRYABLE_STATUSES = frozenset({408, 409, 429})
+
 
 class AnthropicClient:
     """Blocking Messages-API client with thinking-block replay and bounded retry.
@@ -46,19 +49,27 @@ class AnthropicClient:
         self,
         provider: Provider,
         *,
-        max_output_tokens: int,
+        max_output_tokens: int = _DEFAULT_MAX_OUTPUT_TOKENS,
         speed: str | None = None,
-        timeout_s: float = 120.0,
+        timeout_s: float | None = None,
         max_retries: int = 3,
         backoff_s: float = 1.0,
         transport: httpx.BaseTransport | None = None,
     ):
         self._provider = provider
         self._max_output_tokens = max_output_tokens
+        # ~8s per 1k output tokens, floored at the 120s the other clients
+        # use. A raised cap must not turn truncation into a silent stall.
+        resolved_timeout = (
+            timeout_s if timeout_s is not None else max(120.0, max_output_tokens / 125.0)
+        )
         self._speed = speed
         self._max_retries = max_retries
         self._backoff_s = backoff_s
         # tool_use id -> the verbatim content array of the response it came in.
+        # Keyed on id alone because the API guarantees tool_use ids are unique
+        # within a conversation; a gateway that recycles them would replay the
+        # later turn's blocks for both turns.
         self._raw_blocks_by_tool_use_id: dict[str, list[dict[str, Any]]] = {}
         headers = {"anthropic-version": _ANTHROPIC_VERSION}
         if provider.api_key:
@@ -70,7 +81,7 @@ class AnthropicClient:
         self._http = httpx.Client(
             base_url=provider.base_url,
             headers=headers,
-            timeout=timeout_s,
+            timeout=resolved_timeout,
             transport=transport,
         )
 
@@ -134,16 +145,16 @@ class AnthropicClient:
                             )
                     return message
                 last_error = f"HTTP {response.status_code}: {response.text[:500]}"
-                if response.status_code not in (429,) and response.status_code < 500:
+                if response.status_code not in _RETRYABLE_STATUSES and response.status_code < 500:
                     raise RuntimeError(
                         f"LLM request rejected — {last_error}"
-                        f"{self._rejection_guidance(response.text)}"
+                        f"{self._rejection_guidance(response.text, temperature)}"
                     )
             if attempt + 1 < self._max_retries:
                 time.sleep(self._backoff_s * 2**attempt)
 
         guidance = ""
-        if last_status == 429 and self._speed == "fast":
+        if last_status in _RETRYABLE_STATUSES and self._speed == "fast":
             guidance = (
                 "\nfix: fast mode has its own rate limit; retry later or drop "
                 "-P speed=fast to fall back to standard speed"
@@ -156,19 +167,25 @@ class AnthropicClient:
         """Release the underlying HTTP connection pool."""
         self._http.close()
 
-    def _rejection_guidance(self, body: str) -> str:
+    def _rejection_guidance(self, body: str, temperature: float | None) -> str:
         """Name the fix for the 4xx bodies this wire provokes, else say nothing."""
         lowered = body.lower()
-        if self._speed == "fast" and "speed" in lowered and "fast" in lowered:
+        if self._speed == "fast" and "speed" in lowered:
             return (
                 "\nfix: fast mode needs Claude Opus 5 or Opus 4.8 on the Claude API "
                 "(not Bedrock, Vertex, Foundry, or Claude Platform on AWS), or drop "
                 "-P speed=fast"
             )
-        if "temperature" in lowered:
+        if temperature is not None and "temperature" in lowered:
             return (
                 "\nfix: this model rejects temperature (Opus 5, 4.8, 4.7, Sonnet 5, and "
                 "Fable 5 all do; Opus 4.6 and Sonnet 4.6 accept it); drop -P temperature="
+            )
+        if "effort" in lowered:
+            return (
+                "\nfix: this wire accepts -P effort= low, medium, or high "
+                "(not none or minimal; xhigh and max need a larger "
+                "-P max_output_tokens= than this client can stream)"
             )
         return ""
 
@@ -268,13 +285,22 @@ def _translate_messages(
                     f"system message at index {index}; the Messages API takes a single "
                     "top-level system prompt"
                 )
-            system = message["content"]
+            content = message["content"]
+            if not isinstance(content, str):
+                raise RuntimeError(
+                    "system message content must be a string; the Messages API takes "
+                    "a single top-level system prompt"
+                )
+            system = content
             continue
         if role == "tool":
             pending_results.append(
                 {
                     "type": "tool_result",
                     "tool_use_id": message["tool_call_id"],
+                    # No is_error flag: act() folds tool failures into the
+                    # content string, and the shared chat history has nowhere
+                    # to carry the distinction (plan 0026).
                     "content": message["content"],
                 }
             )
@@ -286,6 +312,10 @@ def _translate_messages(
             # A cache hit replaces every synthesized block for this message,
             # text included: emitting both would show the model its own text
             # twice and drop the thinking block that must be replayed verbatim.
+            # A miss synthesizes text + tool_use with no thinking block, which
+            # is lossy for a tool-use turn. Unreachable within a trial (the
+            # cache is populated on every 200 and the rollout is serial); it
+            # exists for foreign histories and non-thinking models.
             blocks = cached if cached is not None else _assistant_blocks(message)
             if not blocks:
                 # The nudge retry path appends exactly this; an assistant
@@ -293,6 +323,8 @@ def _translate_messages(
                 continue
             translated.append({"role": "assistant", "content": blocks})
             continue
+        if role not in ("user", "assistant"):
+            raise RuntimeError(f"unsupported message role {role!r}")
         translated.append({"role": role, "content": _translate_content(message["content"])})
 
     flush_results()

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
@@ -35,6 +35,9 @@ _CONTINUING_STOP_REASONS = frozenset({"end_turn", "tool_use", "stop_sequence"})
 # Retried alongside 5xx and transport errors, matching the Anthropic SDKs.
 _RETRYABLE_STATUSES = frozenset({408, 409, 429})
 
+_CONNECT_TIMEOUT_S = 10.0
+_MAX_READ_TIMEOUT_S = 600.0
+
 
 class AnthropicClient:
     """Blocking Messages-API client with thinking-block replay and bounded retry.
@@ -58,10 +61,14 @@ class AnthropicClient:
     ):
         self._provider = provider
         self._max_output_tokens = max_output_tokens
-        # ~8s per 1k output tokens, floored at the 120s the other clients
-        # use. A raised cap must not turn truncation into a silent stall.
+        # ~8s per 1k output tokens, floored at the 120s the other clients use
+        # and capped at 600s (the SDKs' own ceiling; past that, streaming is
+        # the real answer). A raised cap must not turn truncation into a
+        # silent stall, but it must not stretch connect timeouts either.
         resolved_timeout = (
-            timeout_s if timeout_s is not None else max(120.0, max_output_tokens / 125.0)
+            timeout_s
+            if timeout_s is not None
+            else min(_MAX_READ_TIMEOUT_S, max(120.0, max_output_tokens / 125.0))
         )
         self._speed = speed
         self._max_retries = max_retries
@@ -81,7 +88,7 @@ class AnthropicClient:
         self._http = httpx.Client(
             base_url=provider.base_url,
             headers=headers,
-            timeout=resolved_timeout,
+            timeout=httpx.Timeout(resolved_timeout, connect=_CONNECT_TIMEOUT_S),
             transport=transport,
         )
 
@@ -154,7 +161,9 @@ class AnthropicClient:
                 time.sleep(self._backoff_s * 2**attempt)
 
         guidance = ""
-        if last_status in _RETRYABLE_STATUSES and self._speed == "fast":
+        # 429 only: _RETRYABLE_STATUSES also covers 408/409, which are not
+        # rate limits and must not be told to drop fast mode.
+        if last_status == 429 and self._speed == "fast":
             guidance = (
                 "\nfix: fast mode has its own rate limit; retry later or drop "
                 "-P speed=fast to fall back to standard speed"
@@ -183,9 +192,8 @@ class AnthropicClient:
             )
         if "effort" in lowered:
             return (
-                "\nfix: this wire accepts -P effort= low, medium, or high "
-                "(not none or minimal; xhigh and max need a larger "
-                "-P max_output_tokens= than this client can stream)"
+                "\nfix: the Messages API accepts -P effort= low, medium, high, "
+                "xhigh, or max; none and minimal are OpenAI-only values"
             )
         return ""
 
@@ -323,7 +331,7 @@ def _translate_messages(
                 continue
             translated.append({"role": "assistant", "content": blocks})
             continue
-        if role not in ("user", "assistant"):
+        if role != "user":
             raise RuntimeError(f"unsupported message role {role!r}")
         translated.append({"role": role, "content": _translate_content(message["content"])})
 

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
@@ -1,0 +1,350 @@
+"""Native Anthropic Messages client with thinking-block replay (plan 0026).
+
+The chat-completions message format stays the canonical transcript; this
+boundary translates it to `/v1/messages` and back. Unlike the OpenAI-compat
+shim, the native wire can carry fast mode (``speed="fast"`` plus its beta
+header), which is the reason this client exists: robot control is
+latency-sensitive, and fast mode buys latency without trading reasoning depth.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import httpx
+
+from inspect_robots_agent._llm import AssistantMessage, Provider, ToolCall
+
+_ANTHROPIC_VERSION = "2023-06-01"
+_FAST_MODE_BETA = "fast-mode-2026-02-01"
+
+#: Applied by ``policy.py`` when the user leaves ``max_output_tokens`` unset.
+#: Lives here so the number has one home, but the policy owns resolution: the
+#: eval log records the effective value, and a second default would drift.
+_DEFAULT_MAX_OUTPUT_TOKENS = 16000
+
+_PNG_DATA_URL_PREFIX = "data:image/png;base64,"
+
+# stop_reason values that carry a normal assistant turn. Anything else is
+# terminal: default-deny, because enumerating the failures misses the ones
+# added after this was written (model_context_window_exceeded is already one).
+_CONTINUING_STOP_REASONS = frozenset({"end_turn", "tool_use", "stop_sequence"})
+
+
+class AnthropicClient:
+    """Blocking Messages-API client with thinking-block replay and bounded retry.
+
+    Retries 429/5xx and transport errors with exponential backoff; other 4xx
+    fail immediately. Terminal ``stop_reason`` values raise rather than
+    returning an empty turn, so a refusal or a truncation surfaces its own
+    cause instead of being mistaken for "the model produced no tool call".
+    """
+
+    def __init__(
+        self,
+        provider: Provider,
+        *,
+        max_output_tokens: int,
+        speed: str | None = None,
+        timeout_s: float = 120.0,
+        max_retries: int = 3,
+        backoff_s: float = 1.0,
+        transport: httpx.BaseTransport | None = None,
+    ):
+        self._provider = provider
+        self._max_output_tokens = max_output_tokens
+        self._speed = speed
+        self._max_retries = max_retries
+        self._backoff_s = backoff_s
+        # tool_use id -> the verbatim content array of the response it came in.
+        self._raw_blocks_by_tool_use_id: dict[str, list[dict[str, Any]]] = {}
+        headers = {"anthropic-version": _ANTHROPIC_VERSION}
+        if provider.api_key:
+            headers["x-api-key"] = provider.api_key
+        if speed == "fast":
+            # The beta header is what makes POST /v1/messages the beta
+            # endpoint over raw HTTP; there is no separate URL.
+            headers["anthropic-beta"] = _FAST_MODE_BETA
+        self._http = httpx.Client(
+            base_url=provider.base_url,
+            headers=headers,
+            timeout=timeout_s,
+            transport=transport,
+        )
+
+    def complete(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        temperature: float | None = None,
+        reasoning_effort: str | None = None,
+    ) -> AssistantMessage:
+        """Return one assistant turn for the translated chat-format history."""
+        # Prune before storing: the reverse order would evict every fresh
+        # entry and make the cache always miss.
+        history_ids = _history_tool_use_ids(messages)
+        self._raw_blocks_by_tool_use_id = {
+            tool_use_id: blocks
+            for tool_use_id, blocks in self._raw_blocks_by_tool_use_id.items()
+            if tool_use_id in history_ids
+        }
+
+        system, translated = _translate_messages(messages, self._raw_blocks_by_tool_use_id)
+        body: dict[str, Any] = {
+            "model": self._provider.model,
+            "max_tokens": self._max_output_tokens,
+            # Explicit, not omitted: omitting only means adaptive on Opus 5.
+            # On Opus 4.8 and 4.7 it means thinking off, which would silently
+            # halve this wire's target set and make the replay cache dead code.
+            "thinking": {"type": "adaptive"},
+            "messages": translated,
+        }
+        if system is not None:
+            body["system"] = system
+        if tools:
+            body["tools"] = _translate_tools(tools)
+        if temperature is not None:
+            body["temperature"] = temperature
+        if reasoning_effort is not None:
+            body["output_config"] = {"effort": reasoning_effort}
+        if self._speed is not None:
+            body["speed"] = self._speed
+
+        last_error = "unknown error"
+        last_status: int | None = None
+        for attempt in range(self._max_retries):
+            try:
+                response = self._http.post("/messages", json=body)
+            except httpx.TransportError as exc:
+                last_error = str(exc)
+                # Reset, or a 429 followed by a connection failure would emit
+                # the fast-mode rate-limit guidance for the wrong cause.
+                last_status = None
+            else:
+                last_status = response.status_code
+                if response.status_code == 200:
+                    payload = response.json()
+                    message = _parse_response(payload)
+                    for block in payload.get("content") or []:
+                        if block.get("type") == "tool_use":
+                            self._raw_blocks_by_tool_use_id[str(block["id"])] = list(
+                                payload["content"]
+                            )
+                    return message
+                last_error = f"HTTP {response.status_code}: {response.text[:500]}"
+                if response.status_code not in (429,) and response.status_code < 500:
+                    raise RuntimeError(
+                        f"LLM request rejected — {last_error}"
+                        f"{self._rejection_guidance(response.text)}"
+                    )
+            if attempt + 1 < self._max_retries:
+                time.sleep(self._backoff_s * 2**attempt)
+
+        guidance = ""
+        if last_status == 429 and self._speed == "fast":
+            guidance = (
+                "\nfix: fast mode has its own rate limit; retry later or drop "
+                "-P speed=fast to fall back to standard speed"
+            )
+        raise RuntimeError(
+            f"LLM request failed after {self._max_retries} attempts — {last_error}{guidance}"
+        )
+
+    def close(self) -> None:
+        """Release the underlying HTTP connection pool."""
+        self._http.close()
+
+    def _rejection_guidance(self, body: str) -> str:
+        """Name the fix for the 4xx bodies this wire provokes, else say nothing."""
+        lowered = body.lower()
+        if self._speed == "fast" and "speed" in lowered and "fast" in lowered:
+            return (
+                "\nfix: fast mode needs Claude Opus 5 or Opus 4.8 on the Claude API "
+                "(not Bedrock, Vertex, Foundry, or Claude Platform on AWS), or drop "
+                "-P speed=fast"
+            )
+        if "temperature" in lowered:
+            return (
+                "\nfix: this model rejects temperature (Opus 5, 4.8, 4.7, Sonnet 5, and "
+                "Fable 5 all do; Opus 4.6 and Sonnet 4.6 accept it); drop -P temperature="
+            )
+        return ""
+
+
+def _history_tool_use_ids(messages: list[dict[str, Any]]) -> set[str]:
+    """Collect every tool-use id still referenced by the submitted history."""
+    tool_use_ids: set[str] = set()
+    for message in messages:
+        for call in message.get("tool_calls") or []:
+            tool_use_ids.add(str(call["id"]))
+        if message.get("role") == "tool" and message.get("tool_call_id") is not None:
+            tool_use_ids.add(str(message["tool_call_id"]))
+    return tool_use_ids
+
+
+def _translate_content_part(part: dict[str, Any]) -> dict[str, Any]:
+    """Translate one user content part; unknown shapes raise rather than vanish."""
+    part_type = part.get("type")
+    if part_type == "text":
+        return {"type": "text", "text": part["text"]}
+    if part_type == "image_url":
+        url = str(part.get("image_url", {}).get("url", ""))
+        if not url.startswith(_PNG_DATA_URL_PREFIX):
+            raise RuntimeError(
+                f"image content part is not a PNG data URL: {url[:60]!r}; "
+                "the agent policy emits png_data_url() output only"
+            )
+        return {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": url[len(_PNG_DATA_URL_PREFIX) :],
+            },
+        }
+    # A silently dropped camera frame is an invisible capability loss
+    # mid-trial, so this wire raises where the Responses wire drops.
+    raise RuntimeError(f"unsupported content part type {part_type!r}")
+
+
+def _translate_content(content: Any) -> Any:
+    """Keep plain-string content as-is; translate multipart lists part by part."""
+    if isinstance(content, list):
+        return [_translate_content_part(part) for part in content]
+    return content
+
+
+def _assistant_blocks(message: dict[str, Any]) -> list[dict[str, Any]]:
+    """Synthesize the content blocks for one assistant turn (cache-miss path)."""
+    blocks: list[dict[str, Any]] = []
+    content = message.get("content")
+    if isinstance(content, str) and content:
+        blocks.append({"type": "text", "text": content})
+    for call in message.get("tool_calls") or []:
+        name = call["function"]["name"]
+        raw_arguments = call["function"]["arguments"]
+        try:
+            parsed = json.loads(raw_arguments)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"tool call {name!r} has unparseable arguments: {exc}") from exc
+        if not isinstance(parsed, dict):
+            # A non-object input 400s with a message that does not name the
+            # offending call, so name it here.
+            raise RuntimeError(
+                f"tool call {name!r} arguments must be a JSON object, got {type(parsed).__name__}"
+            )
+        blocks.append({"type": "tool_use", "id": call["id"], "name": name, "input": parsed})
+    return blocks
+
+
+def _translate_messages(
+    messages: list[dict[str, Any]],
+    raw_blocks_by_tool_use_id: dict[str, list[dict[str, Any]]],
+) -> tuple[str | None, list[dict[str, Any]]]:
+    """Translate chat history to (system, messages) for the Messages API.
+
+    A leading system message is hoisted to the top-level ``system`` field; a
+    system message anywhere else raises, since this loop never produces one.
+    Consecutive tool messages merge into a single user turn: splitting
+    ``tool_result`` blocks across messages is legal but silently trains the
+    model out of parallel tool calls.
+    """
+    system: str | None = None
+    translated: list[dict[str, Any]] = []
+    pending_results: list[dict[str, Any]] = []
+
+    def flush_results() -> None:
+        if pending_results:
+            translated.append({"role": "user", "content": list(pending_results)})
+            pending_results.clear()
+
+    for index, message in enumerate(messages):
+        role = message.get("role")
+        if role == "system":
+            if index != 0:
+                raise RuntimeError(
+                    f"system message at index {index}; the Messages API takes a single "
+                    "top-level system prompt"
+                )
+            system = message["content"]
+            continue
+        if role == "tool":
+            pending_results.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": message["tool_call_id"],
+                    "content": message["content"],
+                }
+            )
+            continue
+        flush_results()
+        if role == "assistant":
+            calls = message.get("tool_calls") or []
+            cached = raw_blocks_by_tool_use_id.get(str(calls[0]["id"])) if calls else None
+            # A cache hit replaces every synthesized block for this message,
+            # text included: emitting both would show the model its own text
+            # twice and drop the thinking block that must be replayed verbatim.
+            blocks = cached if cached is not None else _assistant_blocks(message)
+            if not blocks:
+                # The nudge retry path appends exactly this; an assistant
+                # message with an empty content array is a 400.
+                continue
+            translated.append({"role": "assistant", "content": blocks})
+            continue
+        translated.append({"role": role, "content": _translate_content(message["content"])})
+
+    flush_results()
+    return system, translated
+
+
+def _translate_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Flatten OpenAI-nested tool schemas to the Messages API's flat shape."""
+    return [
+        {
+            "name": tool["function"]["name"],
+            "description": tool["function"].get("description", ""),
+            "input_schema": tool["function"]["parameters"],
+        }
+        for tool in tools
+    ]
+
+
+def _parse_response(payload: dict[str, Any]) -> AssistantMessage:
+    """Parse one Messages response, raising on any terminal ``stop_reason``."""
+    stop_reason = payload.get("stop_reason")
+    if stop_reason not in _CONTINUING_STOP_REASONS:
+        raise RuntimeError(_terminal_message(payload, stop_reason))
+
+    texts: list[str] = []
+    calls: list[ToolCall] = []
+    for block in payload.get("content") or []:
+        block_type = block.get("type")
+        if block_type == "text":
+            texts.append(str(block["text"]))
+        elif block_type == "tool_use":
+            calls.append(
+                ToolCall(
+                    id=str(block["id"]),
+                    name=str(block["name"]),
+                    arguments=json.dumps(block["input"]),
+                )
+            )
+        # thinking blocks matter only to the replay cache, not to the turn.
+    joined = "".join(texts)
+    # Never "": it would round-trip into the next request as an empty text
+    # block, which is a 400.
+    return AssistantMessage(content=joined or None, tool_calls=tuple(calls))
+
+
+def _terminal_message(payload: dict[str, Any], stop_reason: Any) -> str:
+    """Build the guided error for a stop_reason that carries no usable turn."""
+    if stop_reason == "refusal":
+        # stop_details is informational and may be null even on a refusal.
+        category = (payload.get("stop_details") or {}).get("category")
+        suffix = f" (category: {category})" if category else ""
+        return f"LLM refused the request{suffix}"
+    if stop_reason == "max_tokens":
+        return "LLM response was truncated at the output limit\nfix: raise -P max_output_tokens="
+    return f"LLM stopped with stop_reason {stop_reason!r}, which carries no usable turn"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -144,6 +144,9 @@ class LLMAgentPolicy(PolicyBase):
         # Order matters from here down (plan 0026): wire is validated before
         # the params that are only legal on one wire, the api_key_env default
         # is applied before resolution, and the OpenRouter check after it.
+        # The new wire-gated checks raise ConfigError so the CLI renders them;
+        # the older ValueErrors above are inconsistent with that and tracked
+        # separately in #168, since converting them changes existing behavior.
         if wire not in _WIRE_FORMATS:
             raise ValueError(f"wire must be one of {sorted(_WIRE_FORMATS)}, got {wire!r}")
         if speed is not None and speed not in _SPEEDS:
@@ -164,7 +167,9 @@ class LLMAgentPolicy(PolicyBase):
                     "-P max_output_tokens="
                 )
         if max_output_tokens is not None and (
-            not isinstance(max_output_tokens, int) or max_output_tokens < 1
+            isinstance(max_output_tokens, bool)
+            or not isinstance(max_output_tokens, int)
+            or max_output_tokens < 1
         ):
             raise ValueError("max_output_tokens must be an int >= 1")
 
@@ -185,11 +190,14 @@ class LLMAgentPolicy(PolicyBase):
             # The likeliest cause is a missing model prefix, not a missing
             # key: a bare id misses the direct-provider table and falls
             # through to OpenRouter even when $ANTHROPIC_API_KEY is set.
-            fix = (
-                f"fix: prefix the model id (-P model=anthropic/{provider.model})"
-                if "/" not in provider.model
-                else "fix: set $ANTHROPIC_API_KEY"
-            )
+            if "/" not in provider.model:
+                fix = f"fix: prefix the model id (-P model=anthropic/{provider.model})"
+            elif provider.model.startswith("anthropic/"):
+                fix = "fix: set $ANTHROPIC_API_KEY"
+            else:
+                # A non-Anthropic prefix (or an OpenRouter :variant suffix) can
+                # never resolve to the Messages API; no key helps.
+                fix = "fix: use an anthropic/ model id"
             raise ConfigError(
                 "wire='anthropic' needs a Messages API endpoint, but the model "
                 f"{provider.model!r} resolved to OpenRouter, which does not serve one.\n"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -182,8 +182,13 @@ class LLMAgentPolicy(PolicyBase):
         # resolve_provider reads api_key_env only when base_url is set, where
         # it otherwise defaults to OPENROUTER_API_KEY and would send an
         # OpenRouter key as x-api-key.
+        # Both base_url tests here match resolve_provider's own truthiness
+        # check, because `-P base_url=` parses to "" and it ignores that.
+        # Only the guard below depends on it behaviorally; here the spelling
+        # is for consistency, since resolve_provider reads api_key_env only
+        # when base_url is truthy anyway.
         effective_key_env = api_key_env
-        if wire == "anthropic" and base_url is not None and api_key_env is None:
+        if wire == "anthropic" and base_url and api_key_env is None:
             effective_key_env = "ANTHROPIC_API_KEY"
         requested_model = model or environ.get(ENV_MODEL)
         provider = resolve_provider(
@@ -192,7 +197,7 @@ class LLMAgentPolicy(PolicyBase):
             api_key_env=effective_key_env,
             env=environ,
         )
-        if wire == "anthropic" and base_url is None and provider.base_url != _ANTHROPIC_BASE:
+        if wire == "anthropic" and not base_url and provider.base_url != _ANTHROPIC_BASE:
             # Only Anthropic's own endpoint serves /v1/messages. Resolution can
             # land elsewhere two ways: the OpenRouter fallback, or another
             # direct provider whose key happens to be set (openai/* with
@@ -207,12 +212,20 @@ class LLMAgentPolicy(PolicyBase):
             if _has_openrouter_variant(asked):
                 # A :variant id routes here whatever keys are set, so naming
                 # the key would send the user to fix something already right.
-                fix = (
-                    f"fix: drop the OpenRouter variant suffix (-P model={asked.rpartition(':')[0]})"
-                )
+                # Repair the prefix in the same breath when both are wrong;
+                # advice that earns a second refusal is worse than none.
+                stripped = asked.rpartition(":")[0]
+                fix = f"fix: drop the OpenRouter variant suffix (-P model={stripped})"
+                if "/" not in stripped:
+                    fix = (
+                        f"fix: use -P model=anthropic/{stripped} "
+                        "(the :variant suffix routes to OpenRouter)"
+                    )
             elif "/" not in asked:
                 fix = f"fix: prefix the model id (-P model=anthropic/{asked})"
-            elif asked.startswith("anthropic/"):
+            elif asked.removeprefix("anthropic/") not in ("", asked):
+                # Guarded against a bare 'anthropic/': naming the key there
+                # would again point at something the user already set.
                 fix = "fix: set $ANTHROPIC_API_KEY"
             else:
                 # A non-Anthropic prefix can never resolve to the Messages

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -181,14 +181,13 @@ class LLMAgentPolicy(PolicyBase):
         environ = dict(os.environ) if env is None else env
         # resolve_provider reads api_key_env only when base_url is set, where
         # it otherwise defaults to OPENROUTER_API_KEY and would send an
-        # OpenRouter key as x-api-key.
-        # Both base_url tests here match resolve_provider's own truthiness
-        # check, because `-P base_url=` parses to "" and it ignores that.
-        # Only the guard below depends on it behaviorally; here the spelling
-        # is for consistency, since resolve_provider reads api_key_env only
-        # when base_url is truthy anyway.
+        # OpenRouter key as x-api-key to a third-party gateway.
+        # Every test here matches resolve_provider's own truthiness checks
+        # (`if base_url:`, `api_key_env or _OPENROUTER_KEY`), because `-P x=`
+        # parses to "": an `is None` spelling would let the empty form slip
+        # past and hand that gateway the wrong secret.
         effective_key_env = api_key_env
-        if wire == "anthropic" and base_url and api_key_env is None:
+        if wire == "anthropic" and base_url and not api_key_env:
             effective_key_env = "ANTHROPIC_API_KEY"
         requested_model = model or environ.get(ENV_MODEL)
         provider = resolve_provider(
@@ -209,12 +208,17 @@ class LLMAgentPolicy(PolicyBase):
             # key: a bare id misses the direct-provider table and falls
             # through to OpenRouter even when $ANTHROPIC_API_KEY is set.
             asked = requested_model or ""
-            if _has_openrouter_variant(asked):
+            stripped = asked.rpartition(":")[0] if _has_openrouter_variant(asked) else asked
+            if not stripped.removeprefix("anthropic/"):
+                # ':free', 'anthropic/', 'anthropic/:free': nothing usable is
+                # left once the suffix comes off, so echoing the remainder
+                # would name an empty id. Give a whole command instead.
+                fix = "fix: pass a full model id (-P model=anthropic/claude-opus-5)"
+            elif stripped != asked:
                 # A :variant id routes here whatever keys are set, so naming
                 # the key would send the user to fix something already right.
                 # Repair the prefix in the same breath when both are wrong;
                 # advice that earns a second refusal is worse than none.
-                stripped = asked.rpartition(":")[0]
                 fix = f"fix: drop the OpenRouter variant suffix (-P model={stripped})"
                 if "/" not in stripped:
                     fix = (
@@ -223,9 +227,7 @@ class LLMAgentPolicy(PolicyBase):
                     )
             elif "/" not in asked:
                 fix = f"fix: prefix the model id (-P model=anthropic/{asked})"
-            elif asked.removeprefix("anthropic/") not in ("", asked):
-                # Guarded against a bare 'anthropic/': naming the key there
-                # would again point at something the user already set.
+            elif asked.startswith("anthropic/"):
                 fix = "fix: set $ANTHROPIC_API_KEY"
             else:
                 # A non-Anthropic prefix can never resolve to the Messages

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -182,10 +182,12 @@ class LLMAgentPolicy(PolicyBase):
         # resolve_provider reads api_key_env only when base_url is set, where
         # it otherwise defaults to OPENROUTER_API_KEY and would send an
         # OpenRouter key as x-api-key to a third-party gateway.
-        # Every test here matches resolve_provider's own truthiness checks
-        # (`if base_url:`, `api_key_env or _OPENROUTER_KEY`), because `-P x=`
-        # parses to "": an `is None` spelling would let the empty form slip
-        # past and hand that gateway the wrong secret.
+        # `not api_key_env` matches resolve_provider's own `api_key_env or
+        # _OPENROUTER_KEY`, because `-P api_key_env=` parses to "": an
+        # `is None` spelling here would let the empty form slip past and hand
+        # that gateway the wrong secret. The base_url test is truthy for
+        # consistency only, since resolve_provider ignores api_key_env when
+        # base_url is falsy; it is load-bearing in the guard below.
         effective_key_env = api_key_env
         if wire == "anthropic" and base_url and not api_key_env:
             effective_key_env = "ANTHROPIC_API_KEY"
@@ -214,6 +216,12 @@ class LLMAgentPolicy(PolicyBase):
                 # left once the suffix comes off, so echoing the remainder
                 # would name an empty id. Give a whole command instead.
                 fix = "fix: pass a full model id (-P model=anthropic/claude-opus-5)"
+            elif "/" in stripped and not stripped.startswith("anthropic/"):
+                # A foreign prefix can never resolve to the Messages API, so
+                # this is terminal whatever the suffix says. Decided before
+                # the variant branch, which would otherwise spend a refusal
+                # removing a suffix that was never the real problem.
+                fix = "fix: use an anthropic/ model id"
             elif stripped != asked:
                 # A :variant id routes here whatever keys are set, so naming
                 # the key would send the user to fix something already right.
@@ -227,12 +235,11 @@ class LLMAgentPolicy(PolicyBase):
                     )
             elif "/" not in asked:
                 fix = f"fix: prefix the model id (-P model=anthropic/{asked})"
-            elif asked.startswith("anthropic/"):
-                fix = "fix: set $ANTHROPIC_API_KEY"
             else:
-                # A non-Anthropic prefix can never resolve to the Messages
-                # API; no key helps.
-                fix = "fix: use an anthropic/ model id"
+                # Anthropic-prefixed with a usable body: only the key is left.
+                # Unreachable with the key set, since such an id resolves to
+                # Anthropic's own endpoint and never reaches this guard.
+                fix = "fix: set $ANTHROPIC_API_KEY"
             where = "OpenRouter" if provider.base_url == _OPENROUTER_BASE else provider.base_url
             raise ConfigError(
                 "wire='anthropic' needs a Messages API endpoint, but the model "

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -47,6 +47,9 @@ _MAX_CONSECUTIVE_FAILURES = 3
 
 # reasoning_effort values accepted across OpenAI-compatible endpoints
 # (Anthropic compat maps these to thinking effort; OpenRouter forwards them).
+# The native wire reuses the set as output_config.effort, where "none" and
+# "minimal" are rejected and xhigh/max need a cap this client cannot stream;
+# both surface as a guided 400 rather than a per-wire allowlist (plan 0026).
 _EFFORT_LEVELS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max"})
 _WIRE_FORMATS = frozenset({"chat", "responses", "anthropic"})
 _SPEEDS = frozenset({"fast"})
@@ -150,13 +153,20 @@ class LLMAgentPolicy(PolicyBase):
             # believes fast mode is on; a dropped cap is a limit that never
             # applied. Both fail loudly rather than silently.
             if speed is not None:
-                raise ValueError(f"speed is only supported on wire='anthropic', got wire={wire!r}")
-            if max_output_tokens is not None:
-                raise ValueError(
-                    f"max_output_tokens is only supported on wire='anthropic', got wire={wire!r}"
+                raise ConfigError(
+                    f"speed is only supported on wire='anthropic', got wire={wire!r}.\n"
+                    "fix: pass -P wire=anthropic, or drop -P speed="
                 )
-        if max_output_tokens is not None and max_output_tokens < 1:
-            raise ValueError("max_output_tokens must be >= 1")
+            if max_output_tokens is not None:
+                raise ConfigError(
+                    "max_output_tokens is only supported on wire='anthropic', got "
+                    f"wire={wire!r}.\nfix: pass -P wire=anthropic, or drop "
+                    "-P max_output_tokens="
+                )
+        if max_output_tokens is not None and (
+            not isinstance(max_output_tokens, int) or max_output_tokens < 1
+        ):
+            raise ValueError("max_output_tokens must be an int >= 1")
 
         environ = dict(os.environ) if env is None else env
         # resolve_provider reads api_key_env only when base_url is set, where
@@ -172,11 +182,18 @@ class LLMAgentPolicy(PolicyBase):
             env=environ,
         )
         if wire == "anthropic" and provider.base_url == _OPENROUTER_BASE:
+            # The likeliest cause is a missing model prefix, not a missing
+            # key: a bare id misses the direct-provider table and falls
+            # through to OpenRouter even when $ANTHROPIC_API_KEY is set.
+            fix = (
+                f"fix: prefix the model id (-P model=anthropic/{provider.model})"
+                if "/" not in provider.model
+                else "fix: set $ANTHROPIC_API_KEY"
+            )
             raise ConfigError(
                 "wire='anthropic' needs a Messages API endpoint, but the model "
                 f"{provider.model!r} resolved to OpenRouter, which does not serve one.\n"
-                "fix: set $ANTHROPIC_API_KEY, or pass -P base_url=... for a gateway "
-                "that serves /v1/messages"
+                f"{fix}, or pass -P base_url=... for a gateway that serves /v1/messages"
             )
 
         resolved_max_output_tokens = (

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from inspect_robots.rollout import TrialRecord
 from inspect_robots_agent._anthropic import _DEFAULT_MAX_OUTPUT_TOKENS, AnthropicClient
 from inspect_robots_agent._llm import (
+    _DIRECT_PROVIDERS,
     _OPENROUTER_BASE,
     ENV_MODEL,
     ChatClient,
@@ -45,6 +46,9 @@ from inspect_robots_agent._responses import ResponsesClient
 from inspect_robots_agent._tools import Toolset, build_toolset
 
 _MAX_CONSECUTIVE_FAILURES = 3
+
+#: The only endpoint that serves /v1/messages without an explicit base_url.
+_ANTHROPIC_BASE = _DIRECT_PROVIDERS["anthropic"].base_url
 
 # reasoning_effort values accepted across OpenAI-compatible endpoints
 # (Anthropic compat maps these to thinking effort; OpenRouter forwards them).
@@ -181,32 +185,43 @@ class LLMAgentPolicy(PolicyBase):
         effective_key_env = api_key_env
         if wire == "anthropic" and base_url is not None and api_key_env is None:
             effective_key_env = "ANTHROPIC_API_KEY"
+        requested_model = model or environ.get(ENV_MODEL)
         provider = resolve_provider(
-            model=model or environ.get(ENV_MODEL),
+            model=requested_model,
             base_url=base_url,
             api_key_env=effective_key_env,
             env=environ,
         )
-        if wire == "anthropic" and provider.base_url == _OPENROUTER_BASE:
+        if wire == "anthropic" and base_url is None and provider.base_url != _ANTHROPIC_BASE:
+            # Only Anthropic's own endpoint serves /v1/messages. Resolution can
+            # land elsewhere two ways: the OpenRouter fallback, or another
+            # direct provider whose key happens to be set (openai/* with
+            # $OPENAI_API_KEY). An explicit -P base_url= is the user's call.
+            # Branch on the requested id, not provider.model: a direct
+            # provider strips its own prefix, so the resolved id would read
+            # as bare and draw a nonsense 'anthropic/gpt-5.6' suggestion.
             # The likeliest cause is a missing model prefix, not a missing
             # key: a bare id misses the direct-provider table and falls
             # through to OpenRouter even when $ANTHROPIC_API_KEY is set.
-            if _has_openrouter_variant(provider.model):
+            asked = requested_model or ""
+            if _has_openrouter_variant(asked):
                 # A :variant id routes here whatever keys are set, so naming
                 # the key would send the user to fix something already right.
-                bare = provider.model.rpartition(":")[0]
-                fix = f"fix: drop the OpenRouter variant suffix (-P model={bare})"
-            elif "/" not in provider.model:
-                fix = f"fix: prefix the model id (-P model=anthropic/{provider.model})"
-            elif provider.model.startswith("anthropic/"):
+                fix = (
+                    f"fix: drop the OpenRouter variant suffix (-P model={asked.rpartition(':')[0]})"
+                )
+            elif "/" not in asked:
+                fix = f"fix: prefix the model id (-P model=anthropic/{asked})"
+            elif asked.startswith("anthropic/"):
                 fix = "fix: set $ANTHROPIC_API_KEY"
             else:
                 # A non-Anthropic prefix can never resolve to the Messages
                 # API; no key helps.
                 fix = "fix: use an anthropic/ model id"
+            where = "OpenRouter" if provider.base_url == _OPENROUTER_BASE else provider.base_url
             raise ConfigError(
                 "wire='anthropic' needs a Messages API endpoint, but the model "
-                f"{provider.model!r} resolved to OpenRouter, which does not serve one.\n"
+                f"{asked!r} resolved to {where}, which does not serve one.\n"
                 f"{fix}, or pass -P base_url=... for a gateway that serves /v1/messages"
             )
 

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -37,6 +37,7 @@ from inspect_robots_agent._llm import (
     ENV_MODEL,
     ChatClient,
     ToolCall,
+    _has_openrouter_variant,
     resolve_provider,
 )
 from inspect_robots_agent._png import png_data_url
@@ -190,13 +191,18 @@ class LLMAgentPolicy(PolicyBase):
             # The likeliest cause is a missing model prefix, not a missing
             # key: a bare id misses the direct-provider table and falls
             # through to OpenRouter even when $ANTHROPIC_API_KEY is set.
-            if "/" not in provider.model:
+            if _has_openrouter_variant(provider.model):
+                # A :variant id routes here whatever keys are set, so naming
+                # the key would send the user to fix something already right.
+                bare = provider.model.rpartition(":")[0]
+                fix = f"fix: drop the OpenRouter variant suffix (-P model={bare})"
+            elif "/" not in provider.model:
                 fix = f"fix: prefix the model id (-P model=anthropic/{provider.model})"
             elif provider.model.startswith("anthropic/"):
                 fix = "fix: set $ANTHROPIC_API_KEY"
             else:
-                # A non-Anthropic prefix (or an OpenRouter :variant suffix) can
-                # never resolve to the Messages API; no key helps.
+                # A non-Anthropic prefix can never resolve to the Messages
+                # API; no key helps.
                 fix = "fix: use an anthropic/ model id"
             raise ConfigError(
                 "wire='anthropic' needs a Messages API endpoint, but the model "

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -23,6 +23,7 @@ import httpx
 import numpy as np
 
 from inspect_robots.embodiment import EmbodimentInfo
+from inspect_robots.errors import ConfigError
 from inspect_robots.policy import PolicyBase, PolicyConfig, PolicyInfo
 from inspect_robots.scene import Scene
 from inspect_robots.spaces import Box
@@ -30,7 +31,14 @@ from inspect_robots.types import ActionChunk, Observation
 
 if TYPE_CHECKING:
     from inspect_robots.rollout import TrialRecord
-from inspect_robots_agent._llm import ENV_MODEL, ChatClient, ToolCall, resolve_provider
+from inspect_robots_agent._anthropic import _DEFAULT_MAX_OUTPUT_TOKENS, AnthropicClient
+from inspect_robots_agent._llm import (
+    _OPENROUTER_BASE,
+    ENV_MODEL,
+    ChatClient,
+    ToolCall,
+    resolve_provider,
+)
 from inspect_robots_agent._png import png_data_url
 from inspect_robots_agent._responses import ResponsesClient
 from inspect_robots_agent._tools import Toolset, build_toolset
@@ -40,7 +48,8 @@ _MAX_CONSECUTIVE_FAILURES = 3
 # reasoning_effort values accepted across OpenAI-compatible endpoints
 # (Anthropic compat maps these to thinking effort; OpenRouter forwards them).
 _EFFORT_LEVELS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max"})
-_WIRE_FORMATS = frozenset({"chat", "responses"})
+_WIRE_FORMATS = frozenset({"chat", "responses", "anthropic"})
+_SPEEDS = frozenset({"fast"})
 
 _SYSTEM_TEMPLATE = """You are controlling a real robot embodiment named {name!r} \
 through tool calls. Each observation message gives you the current \
@@ -85,6 +94,10 @@ class AgentPolicyConfig(PolicyConfig):
     base_url: str | None = None
     api_key_env: str | None = None
     wire: str = "chat"
+    speed: str | None = None
+    #: Effective per-response cap on ``wire=anthropic``; ``None`` on the other
+    #: wires, where nothing constrained the output.
+    max_output_tokens: int | None = None
     max_llm_calls: int = 100
     effort: str | None = "low"
     max_speed_frac: float = 0.1
@@ -106,6 +119,8 @@ class LLMAgentPolicy(PolicyBase):
         base_url: str | None = None,
         api_key_env: str | None = None,
         wire: str = "chat",
+        speed: str | None = None,
+        max_output_tokens: int | None = None,
         max_llm_calls: int = 100,
         temperature: float | None = None,
         effort: str | None = "low",
@@ -116,13 +131,6 @@ class LLMAgentPolicy(PolicyBase):
     ):
         if not np.isfinite(max_speed_frac) or max_speed_frac <= 0:
             raise ValueError("max_speed_frac must be finite and > 0")
-        environ = dict(os.environ) if env is None else env
-        provider = resolve_provider(
-            model=model or environ.get(ENV_MODEL),
-            base_url=base_url,
-            api_key_env=api_key_env,
-            env=environ,
-        )
         if max_llm_calls < 1:
             raise ValueError("max_llm_calls must be >= 1")
         if effort is not None and effort not in _EFFORT_LEVELS:
@@ -130,12 +138,63 @@ class LLMAgentPolicy(PolicyBase):
                 f"effort must be one of {sorted(_EFFORT_LEVELS)}, or None to omit "
                 f"the field, got {effort!r}"
             )
+        # Order matters from here down (plan 0026): wire is validated before
+        # the params that are only legal on one wire, the api_key_env default
+        # is applied before resolution, and the OpenRouter check after it.
         if wire not in _WIRE_FORMATS:
             raise ValueError(f"wire must be one of {sorted(_WIRE_FORMATS)}, got {wire!r}")
-        if wire == "responses":
-            self._client: ChatClient | ResponsesClient = ResponsesClient(
-                provider, transport=transport
+        if speed is not None and speed not in _SPEEDS:
+            raise ValueError(f"speed must be one of {sorted(_SPEEDS)}, or None, got {speed!r}")
+        if wire != "anthropic":
+            # A dropped speed would bill at standard rates while the user
+            # believes fast mode is on; a dropped cap is a limit that never
+            # applied. Both fail loudly rather than silently.
+            if speed is not None:
+                raise ValueError(f"speed is only supported on wire='anthropic', got wire={wire!r}")
+            if max_output_tokens is not None:
+                raise ValueError(
+                    f"max_output_tokens is only supported on wire='anthropic', got wire={wire!r}"
+                )
+        if max_output_tokens is not None and max_output_tokens < 1:
+            raise ValueError("max_output_tokens must be >= 1")
+
+        environ = dict(os.environ) if env is None else env
+        # resolve_provider reads api_key_env only when base_url is set, where
+        # it otherwise defaults to OPENROUTER_API_KEY and would send an
+        # OpenRouter key as x-api-key.
+        effective_key_env = api_key_env
+        if wire == "anthropic" and base_url is not None and api_key_env is None:
+            effective_key_env = "ANTHROPIC_API_KEY"
+        provider = resolve_provider(
+            model=model or environ.get(ENV_MODEL),
+            base_url=base_url,
+            api_key_env=effective_key_env,
+            env=environ,
+        )
+        if wire == "anthropic" and provider.base_url == _OPENROUTER_BASE:
+            raise ConfigError(
+                "wire='anthropic' needs a Messages API endpoint, but the model "
+                f"{provider.model!r} resolved to OpenRouter, which does not serve one.\n"
+                "fix: set $ANTHROPIC_API_KEY, or pass -P base_url=... for a gateway "
+                "that serves /v1/messages"
             )
+
+        resolved_max_output_tokens = (
+            (max_output_tokens if max_output_tokens is not None else _DEFAULT_MAX_OUTPUT_TOKENS)
+            if wire == "anthropic"
+            else None
+        )
+        self._client: ChatClient | ResponsesClient | AnthropicClient
+        if wire == "anthropic":
+            assert resolved_max_output_tokens is not None
+            self._client = AnthropicClient(
+                provider,
+                max_output_tokens=resolved_max_output_tokens,
+                speed=speed,
+                transport=transport,
+            )
+        elif wire == "responses":
+            self._client = ResponsesClient(provider, transport=transport)
         else:
             self._client = ChatClient(provider, transport=transport)
         self._max_llm_calls = max_llm_calls
@@ -152,6 +211,8 @@ class LLMAgentPolicy(PolicyBase):
             base_url=provider.base_url,
             api_key_env=api_key_env,
             wire=wire,
+            speed=speed,
+            max_output_tokens=resolved_max_output_tokens,
             max_llm_calls=max_llm_calls,
             effort=effort,
             max_speed_frac=max_speed_frac,

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -804,7 +804,13 @@ def test_variant_suffix_is_told_to_drop_it_not_to_set_the_key() -> None:
 def test_bare_variant_id_is_fixed_in_one_step() -> None:
     # Both the prefix and the suffix are wrong; advice that fixes only one
     # earns a second refusal on the retry.
-    with pytest.raises(ConfigError, match=r"fix: use -P model=anthropic/claude-opus-5 "):
+    with pytest.raises(
+        ConfigError,
+        match=(
+            r"fix: use -P model=anthropic/claude-opus-5 "
+            r"\(the :variant suffix routes to OpenRouter\)"
+        ),
+    ):
         LLMAgentPolicy(
             model="claude-opus-5:free",
             wire="anthropic",
@@ -812,10 +818,43 @@ def test_bare_variant_id_is_fixed_in_one_step() -> None:
         )
 
 
-def test_empty_prefix_is_not_told_to_set_a_key_it_already_has() -> None:
-    with pytest.raises(ConfigError, match=r"fix: use an anthropic/ model id"):
+def test_variant_strip_keeps_fine_tune_colons() -> None:
+    # Only the last segment is the variant; rpartition, not partition, or the
+    # advice would truncate the fine-tune id to 'anthropic/ft'.
+    with pytest.raises(ConfigError, match=r"-P model=anthropic/ft:gpt-4o-mini\b"):
         LLMAgentPolicy(
-            model="anthropic/",
+            model="ft:gpt-4o-mini:free",
+            wire="anthropic",
+            env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
+        )
+
+
+def test_empty_api_key_env_does_not_send_the_openrouter_key_to_a_gateway() -> None:
+    # '-P api_key_env=' parses to '', which resolve_provider treats as unset
+    # and falls back to $OPENROUTER_API_KEY. An `is None` test here would hand
+    # a third-party gateway the OpenRouter secret.
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    policy = LLMAgentPolicy(
+        model="claude-opus-5",
+        wire="anthropic",
+        base_url="https://gw.example/v1",
+        api_key_env="",
+        transport=httpx.MockTransport(handler),
+        env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
+    )
+
+    policy._client.complete([_USER], [])
+
+    assert seen[0].headers["x-api-key"] == "sk-ant"
+
+
+@pytest.mark.parametrize("model", ["anthropic/", ":free", "anthropic/:free"])
+def test_ids_with_nothing_usable_left_get_a_whole_command(model: str) -> None:
+    # Each of these strips to an empty id, where echoing the remainder would
+    # send the user in a circle (or name $ANTHROPIC_API_KEY, already set).
+    with pytest.raises(ConfigError, match=r"fix: pass a full model id"):
+        LLMAgentPolicy(
+            model=model,
             wire="anthropic",
             env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
         )

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -787,6 +787,30 @@ def test_non_anthropic_prefix_is_not_told_to_set_the_anthropic_key() -> None:
         )
 
 
+def test_variant_suffix_is_told_to_drop_it_not_to_set_the_key() -> None:
+    # ':free' routes to OpenRouter whatever keys are set, so the key advice
+    # would point at something the user already did right.
+    with pytest.raises(
+        ConfigError,
+        match=r"fix: drop the OpenRouter variant suffix \(-P model=anthropic/claude-opus-5\)",
+    ):
+        LLMAgentPolicy(
+            model="anthropic/claude-opus-5:free",
+            wire="anthropic",
+            env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
+        )
+
+
+def test_anthropic_prefix_without_a_key_is_still_told_to_set_it() -> None:
+    # The variant branch must not swallow the plain missing-key case.
+    with pytest.raises(ConfigError, match=r"fix: set \$ANTHROPIC_API_KEY"):
+        LLMAgentPolicy(
+            model="anthropic/claude-opus-5",
+            wire="anthropic",
+            env={"OPENROUTER_API_KEY": "sk-or"},
+        )
+
+
 def test_gateway_defaults_the_key_env_to_anthropic() -> None:
     seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
     policy = LLMAgentPolicy(

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -1,0 +1,725 @@
+"""Native Anthropic Messages wire client and policy integration (plan 0026)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import numpy as np
+import pytest
+
+from inspect_robots.errors import ConfigError
+from inspect_robots.mock import CubePickEmbodiment
+from inspect_robots.scene import Scene
+from inspect_robots.types import Observation
+from inspect_robots_agent import LLMAgentPolicy
+from inspect_robots_agent._anthropic import (
+    _DEFAULT_MAX_OUTPUT_TOKENS,
+    AnthropicClient,
+)
+from inspect_robots_agent._llm import Provider
+from inspect_robots_agent._png import png_data_url
+
+# -- fixtures --------------------------------------------------------------------
+
+
+def _anthropic_response(*blocks: dict[str, Any], stop_reason: str = "tool_use") -> dict[str, Any]:
+    return {"id": "msg_1", "type": "message", "content": list(blocks), "stop_reason": stop_reason}
+
+
+def _text(text: str) -> dict[str, Any]:
+    return {"type": "text", "text": text}
+
+
+def _thinking(thinking: str = "step one", signature: str = "sig-abc") -> dict[str, Any]:
+    return {"type": "thinking", "thinking": thinking, "signature": signature}
+
+
+def _tool_use(
+    block_id: str = "toolu_1", name: str = "done", tool_input: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    return {
+        "type": "tool_use",
+        "id": block_id,
+        "name": name,
+        "input": {"summary": "ok"} if tool_input is None else tool_input,
+    }
+
+
+def _tool_call(call_id: str, name: str, arguments: str) -> dict[str, Any]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
+def _schema(name: str = "done") -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": f"{name} the task",
+            "parameters": {"type": "object", "properties": {"summary": {"type": "string"}}},
+        },
+    }
+
+
+def _client(handler: Any, *, provider: Provider | None = None, **kwargs: Any) -> AnthropicClient:
+    resolved = provider or Provider(
+        base_url="http://llm.test/v1", api_key="sk-test", model="claude-opus-5"
+    )
+    kwargs.setdefault("max_output_tokens", _DEFAULT_MAX_OUTPUT_TOKENS)
+    kwargs.setdefault("backoff_s", 0.0)
+    return AnthropicClient(resolved, transport=httpx.MockTransport(handler), **kwargs)
+
+
+def _capture(*responses: dict[str, Any], status: int = 200) -> tuple[list[httpx.Request], Any]:
+    seen: list[httpx.Request] = []
+    queue = list(responses)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        payload = queue.pop(0) if len(queue) > 1 else queue[0]
+        return httpx.Response(status, json=payload)
+
+    return seen, handler
+
+
+_SYSTEM = {"role": "system", "content": "you drive a robot"}
+_USER = {"role": "user", "content": "Goal: pick the cube"}
+
+
+# -- request shape ---------------------------------------------------------------
+
+
+def test_request_shape_and_headers() -> None:
+    seen, handler = _capture(_anthropic_response(_text("hi"), stop_reason="end_turn"))
+    client = _client(handler)
+
+    client.complete([_SYSTEM, _USER], [_schema()], reasoning_effort="low")
+
+    assert seen[0].url.path == "/v1/messages"
+    body = json.loads(seen[0].content)
+    assert body["model"] == "claude-opus-5"
+    assert body["max_tokens"] == _DEFAULT_MAX_OUTPUT_TOKENS
+    assert body["thinking"] == {"type": "adaptive"}
+    assert body["system"] == "you drive a robot"
+    assert body["output_config"] == {"effort": "low"}
+    assert body["tools"] == [
+        {
+            "name": "done",
+            "description": "done the task",
+            "input_schema": {"type": "object", "properties": {"summary": {"type": "string"}}},
+        }
+    ]
+    assert "speed" not in body
+    assert "temperature" not in body
+    assert seen[0].headers["x-api-key"] == "sk-test"
+    assert seen[0].headers["anthropic-version"] == "2023-06-01"
+    assert "anthropic-beta" not in seen[0].headers
+
+
+def test_optional_fields_omitted_when_unset() -> None:
+    seen, handler = _capture(_anthropic_response(_text("hi"), stop_reason="end_turn"))
+
+    _client(handler).complete([_USER], [])
+
+    body = json.loads(seen[0].content)
+    assert "tools" not in body
+    assert "output_config" not in body
+    assert "system" not in body
+
+
+def test_temperature_forwarded_when_set() -> None:
+    seen, handler = _capture(_anthropic_response(_text("hi"), stop_reason="end_turn"))
+
+    _client(handler).complete([_USER], [], temperature=0.2)
+
+    assert json.loads(seen[0].content)["temperature"] == 0.2
+
+
+def test_fast_mode_sends_speed_and_beta_header() -> None:
+    seen, handler = _capture(_anthropic_response(_text("hi"), stop_reason="end_turn"))
+
+    _client(handler, speed="fast").complete([_USER], [])
+
+    assert json.loads(seen[0].content)["speed"] == "fast"
+    assert seen[0].headers["anthropic-beta"] == "fast-mode-2026-02-01"
+
+
+def test_empty_api_key_omits_header() -> None:
+    seen, handler = _capture(_anthropic_response(_text("hi"), stop_reason="end_turn"))
+    provider = Provider(base_url="http://llm.test/v1", api_key="", model="m")
+
+    _client(handler, provider=provider).complete([_USER], [])
+
+    assert "x-api-key" not in seen[0].headers
+
+
+# -- translation -----------------------------------------------------------------
+
+
+def test_image_part_becomes_base64_source() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    image = np.zeros((2, 2, 3), dtype=np.uint8)
+    url = png_data_url(image)
+    history = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look"},
+                {"type": "image_url", "image_url": {"url": url}},
+            ],
+        }
+    ]
+
+    _client(handler).complete(history, [])
+
+    parts = json.loads(seen[0].content)["messages"][0]["content"]
+    assert parts[0] == {"type": "text", "text": "look"}
+    assert parts[1]["type"] == "image"
+    assert parts[1]["source"]["media_type"] == "image/png"
+    assert parts[1]["source"]["data"] == url.removeprefix("data:image/png;base64,")
+    assert not parts[1]["source"]["data"].startswith("data:")
+
+
+def test_non_png_image_url_raises() -> None:
+    _, handler = _capture(_anthropic_response(_text("ok")))
+    history = [
+        {
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": "https://x/y.png"}}],
+        }
+    ]
+
+    with pytest.raises(RuntimeError, match="not a PNG data URL"):
+        _client(handler).complete(history, [])
+
+
+def test_unknown_content_part_raises() -> None:
+    _, handler = _capture(_anthropic_response(_text("ok")))
+    history = [{"role": "user", "content": [{"type": "audio", "audio": "x"}]}]
+
+    with pytest.raises(RuntimeError, match="unsupported content part type 'audio'"):
+        _client(handler).complete(history, [])
+
+
+def test_system_message_at_later_index_raises() -> None:
+    _, handler = _capture(_anthropic_response(_text("ok")))
+
+    with pytest.raises(RuntimeError, match="system message at index 2"):
+        _client(handler).complete([_SYSTEM, _USER, _SYSTEM], [])
+
+
+def test_consecutive_tool_messages_merge_in_history_order() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    history = [
+        _USER,
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                _tool_call("toolu_a", "done", "{}"),
+                _tool_call("toolu_b", "done", "{}"),
+                _tool_call("toolu_c", "done", "{}"),
+            ],
+        },
+        {"role": "tool", "tool_call_id": "toolu_b", "content": "ignored"},
+        {"role": "tool", "tool_call_id": "toolu_c", "content": "ignored"},
+        {"role": "tool", "tool_call_id": "toolu_a", "content": "executed"},
+    ]
+
+    _client(handler).complete(history, [])
+
+    messages = json.loads(seen[0].content)["messages"]
+    results = [m for m in messages if m["role"] == "user" and isinstance(m["content"], list)]
+    merged = results[-1]["content"]
+    assert [b["tool_use_id"] for b in merged] == ["toolu_b", "toolu_c", "toolu_a"]
+    assert all("is_error" not in block for block in merged)
+    assert sum(1 for m in messages if m["role"] == "user" and isinstance(m["content"], list)) == 1
+
+
+def test_interleaved_tool_runs_do_not_merge_across_an_observation() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    history = [
+        {"role": "assistant", "content": None, "tool_calls": [_tool_call("t1", "done", "{}")]},
+        {"role": "tool", "tool_call_id": "t1", "content": "one"},
+        _USER,
+        {"role": "assistant", "content": None, "tool_calls": [_tool_call("t2", "done", "{}")]},
+        {"role": "tool", "tool_call_id": "t2", "content": "two"},
+    ]
+
+    _client(handler).complete(history, [])
+
+    messages = json.loads(seen[0].content)["messages"]
+    blocks = [
+        m["content"] for m in messages if m["role"] == "user" and isinstance(m["content"], list)
+    ]
+    assert [[b["tool_use_id"] for b in group] for group in blocks] == [["t1"], ["t2"]]
+
+
+def test_empty_assistant_turn_emits_no_message() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    history = [
+        _USER,
+        {"role": "assistant", "content": None},
+        {"role": "user", "content": "Respond with exactly one tool call."},
+    ]
+
+    _client(handler).complete(history, [])
+
+    messages = json.loads(seen[0].content)["messages"]
+    assert [m["role"] for m in messages] == ["user", "user"]
+
+
+def test_empty_string_content_with_tool_calls_emits_no_text_block() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    history = [
+        {"role": "assistant", "content": "", "tool_calls": [_tool_call("t1", "done", "{}")]},
+    ]
+
+    _client(handler).complete(history, [])
+
+    blocks = json.loads(seen[0].content)["messages"][0]["content"]
+    assert [b["type"] for b in blocks] == ["tool_use"]
+
+
+def test_unparseable_tool_arguments_raise_naming_the_tool() -> None:
+    _, handler = _capture(_anthropic_response(_text("ok")))
+    history = [
+        {"role": "assistant", "content": None, "tool_calls": [_tool_call("t1", "move", "{oops")]}
+    ]
+
+    with pytest.raises(RuntimeError, match="tool call 'move' has unparseable arguments"):
+        _client(handler).complete(history, [])
+
+
+def test_non_object_tool_arguments_raise_naming_the_tool() -> None:
+    _, handler = _capture(_anthropic_response(_text("ok")))
+    history = [
+        {"role": "assistant", "content": None, "tool_calls": [_tool_call("t1", "move", "[1,2]")]}
+    ]
+
+    with pytest.raises(RuntimeError, match="tool call 'move' arguments must be a JSON object"):
+        _client(handler).complete(history, [])
+
+
+# -- thinking replay -------------------------------------------------------------
+
+
+def test_thinking_block_is_replayed_verbatim_on_the_next_turn() -> None:
+    first = _anthropic_response(_thinking(), _text("moving"), _tool_use("toolu_1"))
+    second = _anthropic_response(_text("done"), stop_reason="end_turn")
+    seen, handler = _capture(first, second)
+    client = _client(handler)
+
+    message = client.complete([_USER], [])
+    history = [
+        _USER,
+        {
+            "role": "assistant",
+            "content": message.content,
+            "tool_calls": [_tool_call("toolu_1", "done", message.tool_calls[0].arguments)],
+        },
+        {"role": "tool", "tool_call_id": "toolu_1", "content": "ok"},
+    ]
+    client.complete(history, [])
+
+    replayed = json.loads(seen[1].content)["messages"][1]["content"]
+    assert replayed[0] == _thinking()
+    assert [b["type"] for b in replayed] == ["thinking", "text", "tool_use"]
+    assert sum(1 for b in replayed if b["type"] == "text") == 1
+
+
+def test_multi_tool_turn_replays_cached_blocks_once() -> None:
+    first = _anthropic_response(_thinking(), _tool_use("toolu_a"), _tool_use("toolu_b"))
+    second = _anthropic_response(_text("done"), stop_reason="end_turn")
+    seen, handler = _capture(first, second)
+    client = _client(handler)
+
+    client.complete([_USER], [])
+    history = [
+        _USER,
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                _tool_call("toolu_a", "done", "{}"),
+                _tool_call("toolu_b", "done", "{}"),
+            ],
+        },
+        {"role": "tool", "tool_call_id": "toolu_a", "content": "ok"},
+        {"role": "tool", "tool_call_id": "toolu_b", "content": "ok"},
+    ]
+    client.complete(history, [])
+
+    replayed = json.loads(seen[1].content)["messages"][1]["content"]
+    assert [b["type"] for b in replayed] == ["thinking", "tool_use", "tool_use"]
+
+
+def test_cache_miss_synthesizes_blocks() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    history = [
+        {"role": "assistant", "content": "hi", "tool_calls": [_tool_call("foreign", "done", "{}")]},
+    ]
+
+    _client(handler).complete(history, [])
+
+    blocks = json.loads(seen[0].content)["messages"][0]["content"]
+    assert [b["type"] for b in blocks] == ["text", "tool_use"]
+
+
+def test_cache_prunes_against_history_including_tool_message_ids() -> None:
+    first = _anthropic_response(_thinking(), _tool_use("toolu_1"))
+    second = _anthropic_response(_text("done"), stop_reason="end_turn")
+    _, handler = _capture(first, second)
+    client = _client(handler)
+
+    client.complete([_USER], [])
+    assert "toolu_1" in client._raw_blocks_by_tool_use_id
+    # A history that references the id only from the tool message must keep it.
+    client.complete([_USER, {"role": "tool", "tool_call_id": "toolu_1", "content": "ok"}], [])
+    assert "toolu_1" in client._raw_blocks_by_tool_use_id
+    # A fresh history (reset()) drops it.
+    client.complete([_USER], [])
+    assert client._raw_blocks_by_tool_use_id == {}
+
+
+@pytest.mark.parametrize("stop_reason", ["refusal", "max_tokens"])
+def test_terminal_responses_do_not_populate_the_cache(stop_reason: str) -> None:
+    _, handler = _capture(_anthropic_response(_tool_use("toolu_1"), stop_reason=stop_reason))
+    client = _client(handler)
+
+    with pytest.raises(RuntimeError):
+        client.complete([_USER], [])
+
+    assert client._raw_blocks_by_tool_use_id == {}
+
+
+# -- parsing ---------------------------------------------------------------------
+
+
+def test_parses_text_and_tool_use() -> None:
+    _, handler = _capture(
+        _anthropic_response(_thinking(), _text("a"), _text("b"), _tool_use("toolu_1", "done"))
+    )
+
+    message = _client(handler).complete([_USER], [])
+
+    assert message.content == "ab"
+    assert [c.id for c in message.tool_calls] == ["toolu_1"]
+    assert json.loads(message.tool_calls[0].arguments) == {"summary": "ok"}
+
+
+def test_empty_text_normalizes_to_none() -> None:
+    _, handler = _capture(_anthropic_response(_text(""), _tool_use("toolu_1")))
+
+    message = _client(handler).complete([_USER], [])
+
+    assert message.content is None
+
+
+def test_refusal_raises_with_category() -> None:
+    payload = _anthropic_response(stop_reason="refusal")
+    payload["stop_details"] = {"type": "refusal", "category": "cyber"}
+    seen, handler = _capture(payload)
+
+    with pytest.raises(RuntimeError, match=r"refused the request.*cyber"):
+        _client(handler).complete([_USER], [])
+
+    assert len(seen) == 1
+
+
+def test_refusal_with_null_stop_details_raises_cleanly() -> None:
+    payload = _anthropic_response(stop_reason="refusal")
+    payload["stop_details"] = None
+    _, handler = _capture(payload)
+
+    with pytest.raises(RuntimeError, match="refused the request"):
+        _client(handler).complete([_USER], [])
+
+
+def test_truncation_raises_and_never_yields_the_partial_tool_call() -> None:
+    _, handler = _capture(_anthropic_response(_tool_use("toolu_1"), stop_reason="max_tokens"))
+
+    with pytest.raises(RuntimeError, match=r"(?s)truncated.*fix: raise -P max_output_tokens="):
+        _client(handler).complete([_USER], [])
+
+
+@pytest.mark.parametrize("stop_reason", ["model_context_window_exceeded", "pause_turn"])
+def test_unrecognized_stop_reason_raises_naming_it(stop_reason: str) -> None:
+    _, handler = _capture(_anthropic_response(_text("partial"), stop_reason=stop_reason))
+
+    with pytest.raises(RuntimeError, match=stop_reason):
+        _client(handler).complete([_USER], [])
+
+
+# -- retries and guided errors ---------------------------------------------------
+
+
+def test_fast_mode_4xx_names_the_fix() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="speed: fast is not supported for this model")
+
+    with pytest.raises(RuntimeError, match=r"fix: fast mode needs Claude Opus 5"):
+        _client(handler, speed="fast").complete([_USER], [])
+
+
+def test_unrelated_4xx_gets_no_fast_mode_guidance() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="messages: at least one message is required")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _client(handler, speed="fast").complete([_USER], [])
+
+    assert "fix:" not in str(excinfo.value)
+
+
+def test_temperature_4xx_names_the_fix() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="temperature: unsupported parameter")
+
+    with pytest.raises(RuntimeError, match=r"fix: this model rejects temperature"):
+        _client(handler).complete([_USER], [], temperature=0.5)
+
+
+def test_exhausted_429_with_fast_mode_names_the_separate_rate_limit() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, text="rate limit")
+
+    with pytest.raises(RuntimeError, match=r"fix: fast mode has its own rate limit"):
+        _client(handler, speed="fast").complete([_USER], [])
+
+
+def test_exhausted_429_without_fast_mode_is_unguided() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, text="rate limit")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _client(handler).complete([_USER], [])
+
+    assert "fix:" not in str(excinfo.value)
+
+
+@pytest.mark.parametrize("tail", ["transport", "server"])
+def test_429_then_other_failure_drops_the_rate_limit_guidance(tail: str) -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(429, text="rate limit")
+        if tail == "transport":
+            raise httpx.ConnectError("boom")
+        return httpx.Response(500, text="server error")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _client(handler, speed="fast").complete([_USER], [])
+
+    assert "its own rate limit" not in str(excinfo.value)
+
+
+def test_retries_then_succeeds() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return httpx.Response(503, text="unavailable")
+        return httpx.Response(200, json=_anthropic_response(_text("ok"), stop_reason="end_turn"))
+
+    assert _client(handler).complete([_USER], []).content == "ok"
+    assert calls["n"] == 3
+
+
+def test_client_4xx_fails_without_retry() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(422, text="bad request")
+
+    with pytest.raises(RuntimeError, match="rejected"):
+        _client(handler).complete([_USER], [])
+
+    assert calls["n"] == 1
+
+
+def test_close_releases_the_pool() -> None:
+    _, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    client = _client(handler)
+
+    client.close()
+
+    assert client._http.is_closed
+
+
+# -- policy wiring ---------------------------------------------------------------
+
+
+_ENV = {"ANTHROPIC_API_KEY": "sk-test"}
+
+
+def _policy(**kwargs: Any) -> LLMAgentPolicy:
+    kwargs.setdefault("model", "anthropic/claude-opus-5")
+    kwargs.setdefault("env", dict(_ENV))
+    return LLMAgentPolicy(**kwargs)
+
+
+def test_policy_records_wire_speed_and_resolved_max_output_tokens() -> None:
+    policy = _policy(wire="anthropic", speed="fast")
+
+    assert policy.config.wire == "anthropic"
+    assert policy.config.speed == "fast"
+    assert policy.config.max_output_tokens == _DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_policy_sends_the_prefix_stripped_model_id() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    policy = _policy(wire="anthropic", transport=httpx.MockTransport(handler))
+
+    policy._client.complete([_USER], [])
+
+    assert json.loads(seen[0].content)["model"] == "claude-opus-5"
+
+
+def test_chat_wire_records_no_max_output_tokens() -> None:
+    policy = LLMAgentPolicy(model="anthropic/claude-opus-5", env=dict(_ENV))
+
+    assert policy.config.max_output_tokens is None
+    assert policy.config.speed is None
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"wire": "chat", "speed": "fast"}, "only supported on wire='anthropic'"),
+        ({"wire": "chat", "max_output_tokens": 2000}, "only supported on wire='anthropic'"),
+        ({"wire": "anthropic", "speed": "turbo"}, "speed must be one of"),
+        ({"wire": "anthropic", "max_output_tokens": 0}, "must be >= 1"),
+        ({"wire": "antropic"}, "wire must be one of"),
+    ],
+)
+def test_invalid_configurations_raise(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        _policy(**kwargs)
+
+
+def test_misspelled_wire_reports_the_wire_not_the_speed() -> None:
+    # Ordering guard: wire is validated before the params gated on it.
+    with pytest.raises(ValueError, match="wire must be one of"):
+        _policy(wire="antropic", speed="fast")
+
+
+def test_openrouter_fallback_is_refused_with_guidance() -> None:
+    with pytest.raises(ConfigError, match=r"fix: set \$ANTHROPIC_API_KEY"):
+        LLMAgentPolicy(
+            model="anthropic/claude-opus-5",
+            wire="anthropic",
+            env={"OPENROUTER_API_KEY": "sk-or"},
+        )
+
+
+def test_explicit_base_url_suppresses_the_openrouter_guard() -> None:
+    policy = LLMAgentPolicy(
+        model="claude-opus-5",
+        wire="anthropic",
+        base_url="http://gateway.test/v1",
+        env={"OPENROUTER_API_KEY": "sk-or", "ANTHROPIC_API_KEY": "sk-ant"},
+    )
+
+    assert policy.config.base_url == "http://gateway.test/v1"
+
+
+def test_gateway_defaults_the_key_env_to_anthropic() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    policy = LLMAgentPolicy(
+        model="claude-opus-5",
+        wire="anthropic",
+        base_url="http://gateway.test/v1",
+        transport=httpx.MockTransport(handler),
+        env={"OPENROUTER_API_KEY": "sk-or", "ANTHROPIC_API_KEY": "sk-ant"},
+    )
+
+    policy._client.complete([_USER], [])
+
+    assert seen[0].headers["x-api-key"] == "sk-ant"
+    # The config records what the user passed, not the substitution.
+    assert policy.config.api_key_env is None
+
+
+def test_act_drives_a_multi_turn_trial_and_replays_thinking() -> None:
+    """The full messages array across turns: nudge path, merge, and replay."""
+    requests: list[httpx.Request] = []
+    # Turn 1: no tool call, so act() nudges. Turn 2: a real move. Turn 3 (next
+    # act()) starts from tool results followed by a fresh observation.
+    payloads = [
+        # Thinking only: no text, no tool call, so the parsed turn has
+        # content None and translates to no message at all.
+        _anthropic_response(_thinking(), stop_reason="end_turn"),
+        _anthropic_response(
+            _thinking("now I move"),
+            _tool_use("toolu_1", "done", {"summary": "ok"}),
+        ),
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        payload = payloads[min(len(requests) - 1, len(payloads) - 1)]
+        return httpx.Response(200, json=payload)
+
+    policy = LLMAgentPolicy(
+        model="anthropic/claude-opus-5",
+        wire="anthropic",
+        transport=httpx.MockTransport(handler),
+        env=dict(_ENV),
+    )
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="stop"))
+
+    policy.act(Observation())
+
+    first = json.loads(requests[0].content)
+    assert first["system"].startswith("You are controlling a real robot")
+    assert all(m["role"] != "system" for m in first["messages"])
+
+    # Turn 2 carries the dropped-assistant-then-nudge shape: the text-only turn
+    # emits no assistant message, so two user messages sit adjacent.
+    second = json.loads(requests[1].content)
+    roles = [m["role"] for m in second["messages"]]
+    assert roles == ["user", "user", "user"]
+    assert second["messages"][-1]["content"] == "Respond with exactly one tool call."
+
+    # Next act(): tool results merge into one user turn, then the observation.
+    policy.act(Observation())
+    third = json.loads(requests[2].content)
+    assistant_turns = [m for m in third["messages"] if m["role"] == "assistant"]
+    replayed = assistant_turns[-1]["content"]
+    assert replayed[0]["type"] == "thinking"
+    assert replayed[0]["thinking"] == "now I move"
+    results = [
+        m
+        for m in third["messages"]
+        if m["role"] == "user"
+        and isinstance(m["content"], list)
+        and m["content"][0].get("type") == "tool_result"
+    ]
+    assert len(results) == 1
+
+
+def test_explicit_api_key_env_wins_over_the_default() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    policy = LLMAgentPolicy(
+        model="claude-opus-5",
+        wire="anthropic",
+        base_url="http://gateway.test/v1",
+        api_key_env="OPENROUTER_API_KEY",
+        transport=httpx.MockTransport(handler),
+        env={"OPENROUTER_API_KEY": "sk-or", "ANTHROPIC_API_KEY": "sk-ant"},
+    )
+
+    policy._client.complete([_USER], [])
+
+    assert seen[0].headers["x-api-key"] == "sk-or"

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -481,7 +481,7 @@ def test_effort_4xx_names_the_accepted_values() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(400, text="output_config.effort: invalid value 'minimal'")
 
-    with pytest.raises(RuntimeError, match=r"fix: this wire accepts -P effort="):
+    with pytest.raises(RuntimeError, match=r"none and minimal are OpenAI-only values"):
         _client(handler).complete([_USER], [], reasoning_effort="minimal")
 
 
@@ -504,11 +504,23 @@ def test_system_content_must_be_a_string() -> None:
         _client(handler).complete(history, [])
 
 
-def test_unsupported_role_raises() -> None:
+@pytest.mark.parametrize("role", ["developer", "function"])
+def test_unsupported_role_raises(role: str) -> None:
     _, handler = _capture(_anthropic_response(_text("ok")))
 
-    with pytest.raises(RuntimeError, match="unsupported message role 'developer'"):
-        _client(handler).complete([{"role": "developer", "content": "x"}], [])
+    with pytest.raises(RuntimeError, match=f"unsupported message role {role!r}"):
+        _client(handler).complete([{"role": role, "content": "x"}], [])
+
+
+def test_assistant_role_is_not_rejected_by_the_role_guard() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+
+    _client(handler).complete([_USER, {"role": "assistant", "content": "hi"}], [])
+
+    assert [m["role"] for m in json.loads(seen[0].content)["messages"]] == [
+        "user",
+        "assistant",
+    ]
 
 
 @pytest.mark.parametrize("status", [408, 409])
@@ -536,6 +548,11 @@ def test_timeout_scales_with_a_large_output_cap() -> None:
     assert small_cap._http.timeout.read == 120.0
     assert large_cap._http.timeout.read == pytest.approx(512.0)
     assert explicit._http.timeout.read == 30.0
+    # A big read budget must not stretch connect: an unroutable base_url
+    # should fail fast, not hold the whole read timeout on every retry.
+    assert large_cap._http.timeout.connect == 10.0
+    # And the read budget itself is capped rather than unbounded.
+    assert _client(handler, max_output_tokens=1_000_000)._http.timeout.read == 600.0
 
 
 def test_temperature_4xx_names_the_fix() -> None:
@@ -562,6 +579,17 @@ def test_exhausted_429_without_fast_mode_is_unguided() -> None:
         _client(handler).complete([_USER], [])
 
     assert "fix:" not in str(excinfo.value)
+
+
+@pytest.mark.parametrize("status", [408, 409])
+def test_exhausted_retryable_non_429_gets_no_rate_limit_guidance(status: int) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, text="request timeout")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _client(handler, speed="fast").complete([_USER], [])
+
+    assert "its own rate limit" not in str(excinfo.value)
 
 
 @pytest.mark.parametrize("tail", ["transport", "server"])
@@ -694,6 +722,7 @@ def test_chat_wire_records_no_max_output_tokens() -> None:
         ({"wire": "anthropic", "speed": "turbo"}, "speed must be one of"),
         ({"wire": "anthropic", "max_output_tokens": 0}, "must be an int >= 1"),
         ({"wire": "anthropic", "max_output_tokens": 1e5}, "must be an int >= 1"),
+        ({"wire": "anthropic", "max_output_tokens": True}, "must be an int >= 1"),
         ({"wire": "antropic"}, "wire must be one of"),
     ],
 )
@@ -747,6 +776,15 @@ def test_explicit_base_url_suppresses_the_openrouter_guard() -> None:
     )
 
     assert policy.config.base_url == "http://gateway.test/v1"
+
+
+def test_non_anthropic_prefix_is_not_told_to_set_the_anthropic_key() -> None:
+    with pytest.raises(ConfigError, match=r"fix: use an anthropic/ model id"):
+        LLMAgentPolicy(
+            model="meta-llama/llama-3",
+            wire="anthropic",
+            env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
+        )
 
 
 def test_gateway_defaults_the_key_env_to_anthropic() -> None:

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -801,20 +801,57 @@ def test_variant_suffix_is_told_to_drop_it_not_to_set_the_key() -> None:
         )
 
 
-def test_anthropic_prefix_without_a_key_is_still_told_to_set_it() -> None:
-    # The variant branch must not swallow the plain missing-key case.
-    with pytest.raises(ConfigError, match=r"fix: set \$ANTHROPIC_API_KEY"):
+def test_bare_variant_id_is_fixed_in_one_step() -> None:
+    # Both the prefix and the suffix are wrong; advice that fixes only one
+    # earns a second refusal on the retry.
+    with pytest.raises(ConfigError, match=r"fix: use -P model=anthropic/claude-opus-5 "):
+        LLMAgentPolicy(
+            model="claude-opus-5:free",
+            wire="anthropic",
+            env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
+        )
+
+
+def test_empty_prefix_is_not_told_to_set_a_key_it_already_has() -> None:
+    with pytest.raises(ConfigError, match=r"fix: use an anthropic/ model id"):
+        LLMAgentPolicy(
+            model="anthropic/",
+            wire="anthropic",
+            env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
+        )
+
+
+def test_empty_base_url_still_hits_the_guard() -> None:
+    # '-P base_url=' parses to '', which resolve_provider ignores. An `is None`
+    # test here would wave it through and POST /v1/messages to OpenRouter.
+    with pytest.raises(ConfigError, match=r"resolved to OpenRouter"):
         LLMAgentPolicy(
             model="anthropic/claude-opus-5",
             wire="anthropic",
+            base_url="",
             env={"OPENROUTER_API_KEY": "sk-or"},
+        )
+
+
+def test_model_from_the_environment_resolves_like_the_argument() -> None:
+    with pytest.raises(ConfigError, match=r"fix: prefix the model id"):
+        LLMAgentPolicy(
+            wire="anthropic",
+            env={
+                "INSPECT_ROBOTS_MODEL": "claude-opus-5",
+                "ANTHROPIC_API_KEY": "sk-ant",
+                "OPENROUTER_API_KEY": "sk-or",
+            },
         )
 
 
 def test_another_direct_provider_is_refused_not_sent_to_its_endpoint() -> None:
     # With $OPENAI_API_KEY set this resolves straight to api.openai.com, which
     # would have taken a /v1/messages POST and 404ed at the first LLM call.
-    with pytest.raises(ConfigError, match=r"resolved to https://api\.openai\.com/v1"):
+    # The message names the id the user typed, not the prefix-stripped one.
+    with pytest.raises(
+        ConfigError, match=r"'openai/gpt-5\.6' resolved to https://api\.openai\.com/v1"
+    ):
         LLMAgentPolicy(
             model="openai/gpt-5.6",
             wire="anthropic",

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -477,6 +477,67 @@ def test_unrelated_4xx_gets_no_fast_mode_guidance() -> None:
     assert "fix:" not in str(excinfo.value)
 
 
+def test_effort_4xx_names_the_accepted_values() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="output_config.effort: invalid value 'minimal'")
+
+    with pytest.raises(RuntimeError, match=r"fix: this wire accepts -P effort="):
+        _client(handler).complete([_USER], [], reasoning_effort="minimal")
+
+
+def test_temperature_guidance_only_when_temperature_was_sent() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="temperature is not supported")
+
+    # The word appears in the body, but this request never sent the parameter.
+    with pytest.raises(RuntimeError) as excinfo:
+        _client(handler).complete([_USER], [])
+
+    assert "drop -P temperature=" not in str(excinfo.value)
+
+
+def test_system_content_must_be_a_string() -> None:
+    _, handler = _capture(_anthropic_response(_text("ok")))
+    history = [{"role": "system", "content": [{"type": "text", "text": "x"}]}, _USER]
+
+    with pytest.raises(RuntimeError, match="system message content must be a string"):
+        _client(handler).complete(history, [])
+
+
+def test_unsupported_role_raises() -> None:
+    _, handler = _capture(_anthropic_response(_text("ok")))
+
+    with pytest.raises(RuntimeError, match="unsupported message role 'developer'"):
+        _client(handler).complete([{"role": "developer", "content": "x"}], [])
+
+
+@pytest.mark.parametrize("status", [408, 409])
+def test_408_and_409_are_retried(status: int) -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] < 2:
+            return httpx.Response(status, text="retry me")
+        return httpx.Response(200, json=_anthropic_response(_text("ok"), stop_reason="end_turn"))
+
+    assert _client(handler).complete([_USER], []).content == "ok"
+    assert calls["n"] == 2
+
+
+def test_timeout_scales_with_a_large_output_cap() -> None:
+    _, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+
+    small_cap = _client(handler, max_output_tokens=1000)
+    large_cap = _client(handler, max_output_tokens=64000)
+    explicit = _client(handler, max_output_tokens=64000, timeout_s=30.0)
+
+    # Floored at the 120s the other clients use, then scaled above it.
+    assert small_cap._http.timeout.read == 120.0
+    assert large_cap._http.timeout.read == pytest.approx(512.0)
+    assert explicit._http.timeout.read == 30.0
+
+
 def test_temperature_4xx_names_the_fix() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(400, text="temperature: unsupported parameter")
@@ -576,6 +637,41 @@ def test_policy_records_wire_speed_and_resolved_max_output_tokens() -> None:
     assert policy.config.max_output_tokens == _DEFAULT_MAX_OUTPUT_TOKENS
 
 
+def test_policy_passes_speed_and_cap_through_to_the_request() -> None:
+    """Guards the policy -> client wiring, which config assertions cannot see.
+
+    Config recording and request building are separate code paths: a dropped
+    ``speed`` still records ``speed="fast"`` in the eval log while billing at
+    standard rates, and no coverage metric catches it.
+    """
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    policy = _policy(
+        wire="anthropic",
+        speed="fast",
+        max_output_tokens=2000,
+        transport=httpx.MockTransport(handler),
+    )
+
+    policy._client.complete([_USER], [])
+
+    body = json.loads(seen[0].content)
+    assert body["speed"] == "fast"
+    assert body["max_tokens"] == 2000
+    assert seen[0].headers["anthropic-beta"] == "fast-mode-2026-02-01"
+
+
+def test_policy_passes_the_default_cap_when_unset() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    policy = _policy(wire="anthropic", transport=httpx.MockTransport(handler))
+
+    policy._client.complete([_USER], [])
+
+    body = json.loads(seen[0].content)
+    assert body["max_tokens"] == _DEFAULT_MAX_OUTPUT_TOKENS
+    assert "speed" not in body
+    assert "anthropic-beta" not in seen[0].headers
+
+
 def test_policy_sends_the_prefix_stripped_model_id() -> None:
     seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
     policy = _policy(wire="anthropic", transport=httpx.MockTransport(handler))
@@ -595,15 +691,25 @@ def test_chat_wire_records_no_max_output_tokens() -> None:
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
-        ({"wire": "chat", "speed": "fast"}, "only supported on wire='anthropic'"),
-        ({"wire": "chat", "max_output_tokens": 2000}, "only supported on wire='anthropic'"),
         ({"wire": "anthropic", "speed": "turbo"}, "speed must be one of"),
-        ({"wire": "anthropic", "max_output_tokens": 0}, "must be >= 1"),
+        ({"wire": "anthropic", "max_output_tokens": 0}, "must be an int >= 1"),
+        ({"wire": "anthropic", "max_output_tokens": 1e5}, "must be an int >= 1"),
         ({"wire": "antropic"}, "wire must be one of"),
     ],
 )
 def test_invalid_configurations_raise(kwargs: dict[str, Any], match: str) -> None:
     with pytest.raises(ValueError, match=match):
+        _policy(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"wire": "chat", "speed": "fast"}, {"wire": "chat", "max_output_tokens": 2000}],
+)
+def test_wire_gated_params_raise_config_error_so_the_cli_renders_them(
+    kwargs: dict[str, Any],
+) -> None:
+    with pytest.raises(ConfigError, match=r"only supported on wire='anthropic'"):
         _policy(**kwargs)
 
 
@@ -619,6 +725,16 @@ def test_openrouter_fallback_is_refused_with_guidance() -> None:
             model="anthropic/claude-opus-5",
             wire="anthropic",
             env={"OPENROUTER_API_KEY": "sk-or"},
+        )
+
+
+def test_bare_model_id_is_told_to_add_the_prefix_not_to_set_the_key() -> None:
+    # The key is already set; the actual mistake is the missing prefix.
+    with pytest.raises(ConfigError, match=r"-P model=anthropic/claude-opus-5"):
+        LLMAgentPolicy(
+            model="claude-opus-5",
+            wire="anthropic",
+            env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
         )
 
 
@@ -661,7 +777,7 @@ def test_act_drives_a_multi_turn_trial_and_replays_thinking() -> None:
         _anthropic_response(_thinking(), stop_reason="end_turn"),
         _anthropic_response(
             _thinking("now I move"),
-            _tool_use("toolu_1", "done", {"summary": "ok"}),
+            _tool_use("toolu_turn2", "done", {"summary": "ok"}),
         ),
     ]
 

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -811,6 +811,24 @@ def test_anthropic_prefix_without_a_key_is_still_told_to_set_it() -> None:
         )
 
 
+def test_another_direct_provider_is_refused_not_sent_to_its_endpoint() -> None:
+    # With $OPENAI_API_KEY set this resolves straight to api.openai.com, which
+    # would have taken a /v1/messages POST and 404ed at the first LLM call.
+    with pytest.raises(ConfigError, match=r"resolved to https://api\.openai\.com/v1"):
+        LLMAgentPolicy(
+            model="openai/gpt-5.6",
+            wire="anthropic",
+            env={"OPENAI_API_KEY": "sk-oai", "OPENROUTER_API_KEY": "sk-or"},
+        )
+
+
+def test_direct_provider_guidance_uses_the_requested_id_not_the_stripped_one() -> None:
+    # resolve_provider strips 'groq/', so branching on the resolved id would
+    # read it as bare and suggest the nonsense 'anthropic/llama-3'.
+    with pytest.raises(ConfigError, match=r"fix: use an anthropic/ model id"):
+        LLMAgentPolicy(model="groq/llama-3", wire="anthropic", env={"GROQ_API_KEY": "sk-groq"})
+
+
 def test_gateway_defaults_the_key_env_to_anthropic() -> None:
     seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
     policy = LLMAgentPolicy(

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -829,16 +829,20 @@ def test_variant_strip_keeps_fine_tune_colons() -> None:
         )
 
 
-def test_empty_api_key_env_does_not_send_the_openrouter_key_to_a_gateway() -> None:
-    # '-P api_key_env=' parses to '', which resolve_provider treats as unset
-    # and falls back to $OPENROUTER_API_KEY. An `is None` test here would hand
-    # a third-party gateway the OpenRouter secret.
+@pytest.mark.parametrize("api_key_env", [None, "", False, 0, 0.0])
+def test_falsy_api_key_env_does_not_send_the_openrouter_key_to_a_gateway(
+    api_key_env: object,
+) -> None:
+    # '-P api_key_env=' parses to '', and 'false'/'0' to other falsy values,
+    # all of which resolve_provider treats as unset and answers with
+    # $OPENROUTER_API_KEY. An `is None` test would hand a third-party gateway
+    # the OpenRouter secret.
     seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
     policy = LLMAgentPolicy(
         model="claude-opus-5",
         wire="anthropic",
         base_url="https://gw.example/v1",
-        api_key_env="",
+        api_key_env=api_key_env,  # type: ignore[arg-type]
         transport=httpx.MockTransport(handler),
         env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
     )
@@ -848,11 +852,52 @@ def test_empty_api_key_env_does_not_send_the_openrouter_key_to_a_gateway() -> No
     assert seen[0].headers["x-api-key"] == "sk-ant"
 
 
+def test_chat_wire_gateway_keeps_the_openrouter_default() -> None:
+    # The ANTHROPIC_API_KEY default is gated on wire='anthropic'. Dropping
+    # that clause would ship the Anthropic key to every chat-wire gateway,
+    # where OpenRouter is the documented default.
+    seen, handler = _capture({"choices": [{"message": {"content": "ok"}}]})
+    policy = LLMAgentPolicy(
+        model="claude-opus-5",
+        wire="chat",
+        base_url="https://gw.example/v1",
+        transport=httpx.MockTransport(handler),
+        env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
+    )
+
+    policy._client.complete([_USER], [])
+
+    assert seen[0].headers["authorization"] == "Bearer sk-or"
+
+
+def test_foreign_prefix_with_a_variant_is_terminal_in_one_step() -> None:
+    # Dropping the suffix would leave 'openai/gpt-5.6', still refused. The
+    # prefix is the real problem, so say so first.
+    with pytest.raises(ConfigError, match=r"fix: use an anthropic/ model id"):
+        LLMAgentPolicy(
+            model="openai/gpt-5.6:free",
+            wire="anthropic",
+            env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
+        )
+
+
+def test_foreign_prefix_with_an_empty_body_does_not_name_an_empty_id() -> None:
+    with pytest.raises(ConfigError, match=r"fix: use an anthropic/ model id"):
+        LLMAgentPolicy(
+            model="openai/:free",
+            wire="anthropic",
+            env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
+        )
+
+
 @pytest.mark.parametrize("model", ["anthropic/", ":free", "anthropic/:free"])
 def test_ids_with_nothing_usable_left_get_a_whole_command(model: str) -> None:
     # Each of these strips to an empty id, where echoing the remainder would
     # send the user in a circle (or name $ANTHROPIC_API_KEY, already set).
-    with pytest.raises(ConfigError, match=r"fix: pass a full model id"):
+    # The suggested command is the whole value of this branch, so pin it.
+    with pytest.raises(
+        ConfigError, match=r"fix: pass a full model id \(-P model=anthropic/claude-opus-5\)"
+    ):
         LLMAgentPolicy(
             model=model,
             wire="anthropic",

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,11 +6,12 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.12.0"
+    assert inspect_robots_agent.__version__ == "0.13.0"
     assert callable(inspect_robots_agent.agent_policy)
     assert inspect_robots_agent.__all__ == [
         "ENV_MODEL",
         "AgentPolicyConfig",
+        "AnthropicClient",
         "AssistantMessage",
         "ChatClient",
         "LLMAgentPolicy",

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #165.

Adds a third wire to the agent plugin so Claude models can be driven through the native Messages API instead of the OpenAI-compat shim, which is the only way to reach fast mode.

> [!NOTE]
> Fast mode runs Claude Opus 5 and Opus 4.8 at up to 2.5x higher output tokens/sec, at $10/$50 per MTok versus Opus 5's standard $5/$25. Robot control is latency-sensitive (the arm stands still while the model thinks), which is the same reason `effort` already defaults to `low`.

```bash
inspect-robots eval ... \
  -P model=anthropic/claude-opus-5 -P wire=anthropic -P speed=fast
```

## Shape

Same shape as #131 / plan 0022 (`wire=responses`): chat-completions message format stays the transcript source of truth, and the new `AnthropicClient` translates at the wire boundary only. No provider SDK, httpx and raw JSON.

- `-P wire=anthropic` posts native `/v1/messages` with `x-api-key` + `anthropic-version`.
- `-P speed=fast` sets the top-level `speed` field and sends the `fast-mode-2026-02-01` beta header.
- `-P max_tokens=` (default 4096) because the Messages API requires it.
- Default stays `wire=chat`, so OpenRouter, vLLM, Ollama, and the compat endpoints are untouched.

Plan: `plans/0026-agent-anthropic-wire.md`.

## Status

Draft while the plan goes through critique. Implementation follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)