### PR TITLE
feat(agent): on-demand camera capture and chained tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- **Agent plugin:** tool results in `images=always` mode now follow the model's
+  tool-call order. Extra calls remain answered with
+  `ignored: one tool call per turn` and are not executed; only their result
+  ordering relative to the executed call changes (#173).
 - **Docs site migrated from MkDocs Material to Docusaurus.** The site at
   inspectrobots.org now builds from `website/` (Docusaurus 3) while the
   Markdown source stays in `docs/`; every existing URL, `llms.txt`, and
@@ -44,6 +48,13 @@ All notable changes to this project are documented here. The format is based on
   pays a single keypress. Notes reach the JSON log and the HTML report, a note
   is kept even on a trial the grader answered `skip`, and no note ever moves a
   score (#174).
+- **Agent plugin:** `-P images=on_demand` lets the model request camera frames
+  with `take_pic` instead of attaching every frame to every observation. A
+  capture may follow one motion in the same assistant turn and is delivered
+  from the post-motion observation; its narration reports observed playout,
+  any missing cameras, and the measured remaining offset from absolute targets
+  when proprioception is available. `images=always` remains the default
+  (#173).
 - **Policy lifecycle hook: `on_trial_end`** — policies can now hook into
   the end of a trial to persist state or artifacts. The orchestrator calls
   `policy.on_trial_end(record, log_dir, run_id)` and any metadata the policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- **Agent plugin:** runtime camera dropouts in `images=on_demand` now reject
+  `take_pic` without treating a well-formed call as a tool error, so a single
+  dropout no longer errors the trial. The first world-state rejection in one
+  `act()` is free and later rejections escalate to the three-strike guard,
+  bounding repeated capture refusals (#173).
 - **Agent plugin:** tool results in `images=always` mode now follow the model's
   tool-call order. Extra calls remain answered with
   `ignored: one tool call per turn` and are not executed; only their result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,12 @@ All notable changes to this project are documented here. The format is based on
   `act()` is free and later rejections escalate to the three-strike guard,
   bounding repeated capture refusals (#173).
 - **Agent plugin:** tool results in `images=always` mode now follow the model's
-  tool-call order. Extra calls remain answered with
-  `ignored: one tool call per turn` and are not executed; only their result
-  ordering relative to the executed call changes (#173).
+  tool-call order, and extra calls are still never executed. Two things change:
+  their result ordering relative to the executed call, and the reason string
+  when the executed call itself failed, which is now
+  `ignored: an earlier call in this turn failed` rather than
+  `ignored: one tool call per turn`. Extras behind a successful call keep the
+  original wording (#173).
 - **Docs site migrated from MkDocs Material to Docusaurus.** The site at
   inspectrobots.org now builds from `website/` (Docusaurus 3) while the
   Markdown source stays in `docs/`; every existing URL, `llms.txt`, and

--- a/plans/0027-agent-on-demand-vision.md
+++ b/plans/0027-agent-on-demand-vision.md
@@ -1,0 +1,242 @@
+# 0027 — Agent on-demand camera capture and chained tool calls
+
+Closes #173.
+
+## 1. Problem
+
+The agent policy attaches every camera frame to every observation message
+(`_observation_content`). Two costs follow.
+
+**Token cost.** On a 60-step trial with two cameras the frames dominate the
+bill, and the model has no way to say "the state vector is enough right now".
+
+**Round-trip cost.** `act()` executes the first tool call of an assistant turn
+and answers every extra with `ignored: one tool call per turn`. The natural
+loop for a model that controls its own perception is "move, then look at where
+that got me". Without chaining that costs a whole extra LLM call after the
+motion has already finished playing.
+
+Chaining a capture onto a motion is only correct if the frames come from the
+observation delivered *after* the speed-limited chunk has played out. The move
+tools synthesize an N-step interpolation whose length depends on
+`max_speed_frac`, `control_hz`, and the distance travelled; a capture that
+resolved against the pre-motion observation would hand the model a picture of
+where the arm *was* while telling it the motion is done.
+
+## 2. Scope
+
+In scope, all inside `plugins/inspect-robots-agent`:
+
+- A policy-level `images` mode selecting force-fed frames (today's behavior) or
+  on-demand capture.
+- A `take_pic` tool, exposed only in on-demand mode.
+- Chained tool calls: a motion plus a trailing `take_pic` in one assistant
+  turn, with the capture resolved against the post-motion observation.
+- Arrival accounting so a motion cut short by early replanning or termination
+  is reported as such rather than silently labelled post-arrival.
+
+Out of scope: changes to the core rollout, controller, or approvers; video or
+multi-frame capture; chaining two motions; a `take_pic` equivalent for state
+(state text is cheap and stays force-fed).
+
+## 3. Design
+
+### 3a. `images` mode
+
+`LLMAgentPolicy.__init__` gains `images: str = "always"`, validated against
+`{"always", "on_demand"}` and recorded on `AgentPolicyConfig` so the eval log
+carries it. The default preserves today's behavior exactly, so existing
+benchmark numbers stay comparable and no CLI invocation changes meaning.
+
+`"always"`: `_observation_content` behaves as it does today, and `take_pic` is
+not in `schemas()`. Nothing in this plan is reachable.
+
+`"on_demand"`: observation messages carry the state text plus one line naming
+the cameras that `take_pic` can reach. No image parts.
+
+### 3b. `take_pic`
+
+Exposed by `Toolset.schemas()` only in on-demand mode:
+
+```
+take_pic(cameras?: string[], note: string)
+```
+
+`cameras` omitted means every camera. `note` is required, matching the move
+tools: the note stream is the human-readable narration the user follows live,
+and a capture is a decision worth narrating ("I cannot tell whether the gripper
+cleared the rim, so I am looking before descending").
+
+Validation lives in `Toolset.execute` because it holds the observation:
+
+- unknown camera name → error naming the valid names
+- `cameras` present but not a list of strings, or empty → structured error
+- the observation carries no images at all → error saying so
+
+`build_toolset` refuses `on_demand` at bind time when
+`observation_space.cameras` is empty, with a message naming the fix (drop
+`-P images=on_demand`). Failing at bind rather than mid-trial matches how every
+other unsupported configuration in this module behaves, and an embodiment that
+serves frames without declaring them is already outside the compatibility
+contract.
+
+`take_pic` yields neither a chunk nor an error. `ToolResult` gains
+`capture: tuple[str, ...] | None` holding the resolved camera names. The policy,
+not the toolset, decides whether that capture resolves now or after a motion,
+and writes the tool-result text accordingly, because that decision depends on
+loop position rather than on the observation.
+
+### 3c. Immediate capture
+
+A `take_pic` that is the turn's only call, or precedes the motion in the turn,
+resolves against the current observation. The policy appends:
+
+1. a `tool` message: `captured 2 frame(s): 'top', 'wrist'`
+2. a `user` message whose parts are the labelled image parts, built by the same
+   helper `_observation_content` uses so the `camera 'top' (step 480):` join key
+   into stored frames stays identical
+
+and then loops for another LLM call. The capture spends one `max_llm_calls`
+unit; budget exhaustion already forces `give_up`.
+
+Two `user` messages in a row (tool results, then frames) is the shape the
+Anthropic wire already produces today between turns, so no wire client changes.
+
+**Repeat guard.** Frames cannot change without stepping the robot, so within
+one `act()` each camera is revealed at most once. The policy tracks the
+revealed set for the current observation; a request for cameras already shown
+returns `error: camera 'top' was already captured for this observation and
+cannot change until the robot moves`. A request mixing new and already-shown
+cameras succeeds for the new ones and says which were skipped.
+
+### 3d. Chained capture
+
+`act()` stops answering extra tool calls with a blanket `ignored` and instead
+walks the turn's calls in order:
+
+- calls before the first chunk-producing call: `take_pic` executes immediately
+  (3c); anything else is answered `ignored: only one motion per turn`
+- the first chunk-producing call (a move, `done`, or `give_up`) is executed as
+  today
+- calls after it: a `take_pic` is **queued** and answered
+  `queued: frames arrive with the next observation, after the motion completes`;
+  anything else is answered `ignored: only one motion per turn`. After `done` or
+  `give_up` a queued capture can never be delivered, so it is answered
+  `ignored: the trial ends with this call` instead
+
+Every `tool_call_id` still gets exactly one answer before the next assistant
+turn, which is what the wire requires.
+
+The queue holds one `_PendingCapture(cameras, issued_step, chunk_len)`. A
+second queued `take_pic` in the same turn merges its camera names into it.
+
+### 3e. Arrival accounting
+
+`_PendingCapture` records `issued_step` (`observation.extra["env_step"]` when
+the motion was issued) and `chunk_len` (the number of actions in the emitted
+chunk). At the top of the next `act()`, the policy compares the new
+`env_step` against `issued_step + chunk_len`:
+
+- advanced by `chunk_len` or more: frames are labelled
+  `camera 'top' (step 42, after the motion completed)`
+- advanced by fewer steps: frames are still attached, and the observation
+  message carries a line
+  `the motion was interrupted after 3 of 12 steps; this is not the requested
+  target position`. A short advance means the controller replanned mid-chunk
+  (`DefaultController(replan_interval=k)`) or the embodiment terminated, both of
+  which are outside the policy's control and neither of which may be reported as
+  arrival.
+- `env_step` missing or not an `int` on either observation (a direct
+  `policy.act()` call outside `rollout()`): fall back to the neutral label
+  `camera 'top' (after the motion)` with no step arithmetic, matching how
+  `_step_label` already degrades.
+
+The guarantee this buys is exactly the one the issue asks for: the frames come
+from the observation the rollout produced after playing every action of the
+speed-limited chunk, so a slow embodiment or a long interpolation delays the
+picture rather than taking it early.
+
+A pending capture is consumed by the next `act()` whatever happens, so it can
+never leak into a later observation. `reset()` clears it along with the
+revealed set.
+
+### 3f. System prompt
+
+The on-demand mode swaps two sentences of `_SYSTEM_TEMPLATE`:
+
+- perception: cameras are not attached automatically; call `take_pic` to see
+  them
+- turn shape: exactly one motion per turn, and `take_pic` may be chained in the
+  same turn — placed after a motion it returns frames once the motion has
+  finished, placed alone it looks before deciding
+
+The `always` mode keeps today's text verbatim.
+
+### 3g. Echo and transcript
+
+`transcript_echo` gains lines for captures (`[agent] -- captured 2 frame(s)`,
+`[agent] -- queued capture: 'top'`). `_sanitize` already replaces image parts
+with omission markers, so persisted transcripts and the Rerun stream need no
+change.
+
+## 4. Files
+
+```
+plugins/inspect-robots-agent/
+├── src/inspect_robots_agent/
+│   ├── _tools.py          # take_pic schema + validation, ToolResult.capture,
+│   │                      # build_toolset(images=...) bind-time refusal
+│   └── policy.py          # images knob, capture bookkeeping, chained-call walk,
+│                          # arrival accounting, on-demand system prompt
+│   README.md              # images mode, take_pic, chaining, arrival semantics
+└── tests/
+    ├── test_tools_motion.py   # schema exposure, argument validation, bind refusal
+    └── test_policy_e2e.py     # on-demand flow, chaining, arrival vs interruption
+plans/0027-agent-on-demand-vision.md
+CHANGELOG.md
+```
+
+## 5. Testing
+
+Unit (`test_tools_motion.py`):
+
+- `take_pic` absent from `schemas()` in `always` mode, present in `on_demand`
+- `build_toolset(images="on_demand")` raises `ToolsetError` naming the fix when
+  the observation space declares no cameras
+- unknown camera name, non-list `cameras`, empty `cameras`, missing `note`,
+  and an imageless observation each return a structured error, not a raise
+- omitted `cameras` resolves to every camera in the observation
+
+End-to-end (`test_policy_e2e.py`, fake transports as today):
+
+- on-demand observation message carries no image parts and names the cameras
+- immediate `take_pic` appends the tool result and a user message whose parts
+  are image parts, and the loop continues to a second LLM call
+- a second `take_pic` for the same camera in the same `act()` errors
+- a move chained with `take_pic` returns the chunk from `act()`, answers both
+  tool calls, and attaches frames to the *next* observation message
+- the chained capture labels frames post-arrival when the next `env_step` has
+  advanced by the full chunk length, and reports interruption when it has not
+- a `take_pic` chained after `done` is answered as ignored and never delivered
+- `always` mode is byte-identical to today's message stream (regression guard)
+- `images` appears in `AgentPolicyConfig` and an invalid value raises
+
+Gates: `ruff check`, `ruff format --check`, `mypy --strict` over
+`plugins/inspect-robots-agent/src/inspect_robots_agent`, and the plugin test
+suite. Core coverage is untouched; plugin coverage stays report-only.
+
+## 6. Risks
+
+**A blind model.** In on-demand mode a model that never calls `take_pic` drives
+on proprioception alone and will score worse. This is the point of the knob and
+the reason `always` stays the default; the on-demand system prompt says plainly
+that images exist and how to get them.
+
+**Capture spam.** A model could burn its budget looking. The per-observation
+repeat guard removes the only *useless* case (the same camera twice with no
+motion between), and `max_llm_calls` bounds the rest.
+
+**Consecutive failures.** A capture is a success but does not reset the
+`_MAX_CONSECUTIVE_FAILURES` counter, so an alternating error/capture loop still
+ends the trial after three errors. That is the intended reading: the errors are
+what is persistent.

--- a/plans/0027-agent-on-demand-vision.md
+++ b/plans/0027-agent-on-demand-vision.md
@@ -313,16 +313,16 @@ The leading text part gains one narration line. With
 `advanced = new_env_step - issued_step`:
 
 - both steps are `int` and `advanced > 0`:
-  - `advanced >= chunk_len` → `the motion finished playing (12 of 12 steps).`
-  - otherwise → `the motion played 3 of 12 steps before this observation; it
+  - `advanced >= chunk_len` → `The motion finished playing (12 of 12 steps).`
+  - otherwise → `The motion played 3 of 12 steps before this observation; it
     did not run to the end.`
-- `env_step` missing, not an `int`, or `advanced <= 0` → `these frames follow
+- `env_step` missing, not an `int`, or `advanced <= 0` → `These frames follow
   the motion.` with no arithmetic. The `<= 0` case is the direct-`policy.act()`
   pattern the existing suite uses (`test_policy_e2e.py:436`), where every call
   passes `env_step=0`.
 
 When `target` is set **and** `Toolset.residual` returns a value, a second
-sentence follows: `largest remaining offset from the requested target is 0.004
+sentence follows: `Largest remaining offset from the requested target is 0.004
 on j3.` The magnitude is formatted `:.4g`, matching `bounds_text`
 (`_tools.py:493-497`). When residual returns `None` the sentence is omitted
 entirely and the playout line stands alone. This is

--- a/plans/0027-agent-on-demand-vision.md
+++ b/plans/0027-agent-on-demand-vision.md
@@ -66,8 +66,9 @@ the cameras that `take_pic` can reach. No image parts. That line names the
 cameras present in `observation.images`, **not** the declared ones, and when
 the observation carries no frames it says so. Advertising a declared camera
 that did not arrive would invite a call that can only return the "no images"
-error, and three of those inside one `act()` would kill a trial over a dropped
-frame — the condition §3e goes out of its way to survive on the delivery path.
+rejection. That runtime dropout is not a model mistake: the first rejection in
+one `act()` is free, and only repeated rejections escalate toward the guard
+that bounds the loop (§3c-§3d).
 
 Every capture branch in the walk is gated on `images == "on_demand"`, not on
 the schema. Tool names come from the model, so a stray `take_pic` in `always`
@@ -99,16 +100,19 @@ unknown-name error listing the names actually present:
 - unknown or absent camera name → error naming the cameras present now
 - `cameras` present but not a list of strings, or empty → structured error
 - `note` missing or blank → structured error, worded like the move tools'
-- the observation carries no images at all → error saying so
+- the observation carries no images at all → rejection saying
+  `no camera images are available in this observation`
 
 An omitted `cameras` is resolved by the **policy**, not the toolset. On the
 immediate path it resolves against the current observation's revealed set
 (§3d). On the queued path it is stored verbatim — `None` for the omitted form,
 the named tuple otherwise — with **no subtraction at queue time**, and is
 resolved at delivery against the arriving observation, whose revealed set is
-empty (§3e). Subtracting at queue time would reject exactly the flow this
-feature exists for: look at observation *N*, then chain a capture onto a motion
-in the same observation, whose frames belong to *N+1*.
+empty (§3e). An empty tuple is reserved for an observation with no images and
+is rejected on either path rather than stored. Subtracting at queue time would
+reject exactly the flow this feature exists for: look at observation *N*, then
+chain a capture onto a motion in the same observation, whose frames belong to
+*N+1*.
 
 `build_toolset` refuses `on_demand` at bind time when
 `observation_space.cameras` is empty, with a message naming the fix (drop
@@ -116,13 +120,14 @@ in the same observation, whose frames belong to *N+1*.
 other unsupported configuration in this module, and an embodiment that serves
 frames without declaring them is already outside the compatibility contract.
 
-A *successful* `take_pic` yields neither a chunk nor an error; the validation
+A well-formed `take_pic` yields neither a chunk nor an error; the validation
 failures above still come back as `ToolResult.error` like any other tool's.
 `ToolResult` becomes
 `@dataclass(frozen=True, eq=False)` and gains two fields:
 
-- `capture: tuple[str, ...] | None` — resolved camera names, or `None` when
-  `cameras` was omitted, which the policy then resolves itself
+- `capture: tuple[str, ...] | None` — `None` when `cameras` was omitted and the
+  policy must resolve all available cameras, `()` when a well-formed request
+  found no images in the observation, or a non-empty tuple of named cameras
 - `target: npt.NDArray[np.float64] | None` — the clipped absolute target vector
   a successful `_move_absolute` computed (§3e). `None` for displacement modes,
   stops, and captures.
@@ -182,10 +187,13 @@ error loop into a fatal `PolicyError` (`rollout.py:225`).
 - an on-demand `take_pic` closes the walk **whatever its outcome**. On success
   it is an *immediate* capture (§3d): the model asked to look before acting, so
   it re-decides with the frames in hand rather than executing a motion it chose
-  blind. On a `toolset.execute` error it is answered with the error text and
-  increments `failures`. On a revealed-set rejection it is answered with the
-  rejection text and leaves `failures` alone (§3d). All three close, so a move
-  behind a rejected `take_pic` is answered `ignored`, not executed.
+  blind. A malformed-call error is answered with the error text and increments
+  `failures`. A well-formed call refused by world state — either an empty-images
+  dropout or a revealed-set rejection — is answered with the rejection text;
+  the first rejection within one `act()` is free, and every subsequent
+  rejection increments `failures` and becomes `last_error` (§3d). Frames,
+  rejection, and error all close, so a move behind a rejected `take_pic` is
+  answered `ignored`, not executed.
 - every other call — including an unknown tool name, and including `take_pic`
   in `always` mode — goes to `toolset.execute` exactly as today. A chunk closes
   the walk. An error is answered with its text, increments `failures`, and
@@ -199,9 +207,10 @@ guarantees a next observation and a `chunk_len` to count against:
 - on-demand `take_pic`, walk closed by a motion chunk: still passed to
   `toolset.execute` for argument and camera-name validation. On success it is
   *queued* (§3e) and answered `queued: frames arrive with the next observation,
-  once the motion has finished playing`. On error it is answered with the error
-  text, nothing is queued, the queue slot stays free for a later valid
-  `take_pic` in the same turn, and `failures` is untouched — `act()` is
+  after the motion plays`. On error it is answered with the error text. An
+  empty-images `capture=()` is answered with the dropout rejection text.
+  Neither outcome queues anything, so the queue slot stays free for a later
+  valid `take_pic` in the same turn, and neither touches `failures` — `act()` is
   returning the chunk regardless, so counting it would leak into the next
   observation's budget. Only one capture is queued per turn; once the slot is
   filled a second `take_pic` is answered `ignored: one tool call per turn`.
@@ -210,13 +219,15 @@ guarantees a next observation and a `chunk_len` to count against:
   policy recognises a stop by reading `chunk.actions[0].meta.get("request_stop")`,
   which `_stop` already sets (`_tools.py:216-219`), rather than forking the
   `("done", "give_up")` literal out of `_tools.py:200`.
-- on-demand `take_pic`, walk closed **without a chunk** (an immediate capture, a
-  revealed-set rejection, or an error): answered `ignored: one tool call per
-  turn`. No motion was emitted, so "once the motion has finished playing" would
-  be false and `chunk_len` would be undefined. `[take_pic, take_pic]` resolves
+- on-demand `take_pic`, walk closed by a successful **immediate capture**:
+  answered `ignored: one tool call per turn`. `[take_pic, take_pic]` resolves
   here.
-- everything else is answered `ignored: one tool call per turn`, the string
-  used today.
+- any call dropped after an error or rejection closed the walk without a chunk:
+  answered `ignored: an earlier call in this turn failed`. The second valid
+  call in `[take_pic(cameras=["nope"]), take_pic(cameras=["top"])]` is not
+  mislabelled as a surplus call.
+- every other call dropped after a chunk is answered `ignored: one tool call
+  per turn`, the string used today.
 
 Nothing after a chunk can cancel it. An error there comes from a call that
 never ran, and discarding the chunk would leave the move's own tool result
@@ -227,10 +238,12 @@ that never reached the embodiment.
 continues the `while True` loop for another LLM turn — the same path a
 no-tool-call turn already takes. That covers an immediate capture, a
 revealed-set rejection, an errored call, and a turn of nothing but `ignored`.
-Only an error increments `failures`; an immediate capture resets it to `0`; a
-revealed-set rejection leaves it untouched (§3d). `max_llm_calls` bounds every
-one of these paths, since each loop iteration calls `complete()` and increments
-`_calls_used`.
+An error increments `failures`; an immediate capture resets it to `0`; the
+first rejection in the `act()` is free, while every subsequent rejection
+increments `failures` and records its text as `last_error` (§3d). The rejection
+count is local beside `failures` and resets for each `act()`. This escalation
+lets the three-strike guard stop a model that repeats a world-state refusal
+before it can consume the whole `max_llm_calls` budget inside one `act()`.
 
 **This changes `always` mode too, in one respect: ordering.** Today every
 extra's `ignored` result is appended *before* the executed call's result
@@ -272,19 +285,25 @@ If the remainder is non-empty, those frames are revealed and the tool result is
 `captured 1 frame(s): 'wrist' (already shown: 'top')`, with the parenthetical
 omitted when nothing was skipped. If the remainder is empty, the result is
 `already shown for this observation: 'top'; the view cannot change until the
-robot moves` — and **that rejection does not increment `failures`**. It is a
-refusal of a well-formed call, not a malformed call, and counting it would let
-three bare `take_pic()` calls error a trial that is otherwise healthy. The
-on-demand system prompt states the rule so the model can avoid it in the first
-place.
+robot moves`. An empty-images `capture=()` is the other rejection and renders
+`no camera images are available in this observation`. Both are refusals of
+well-formed calls rather than malformed-call errors. The first rejection
+within an `act()` leaves `failures` alone; every subsequent rejection
+increments it and sets `last_error` to the rejection text. That one free
+correction preserves tolerance for a transient refusal while the existing
+three-strike guard bounds a model that repeats it. The on-demand system prompt
+states the revealed-set rule so the model can avoid that rejection in the
+first place.
 
 This subtraction applies only here. The queued path (§3e) stores the request
 unresolved.
 
-**Failure counter.** A successful immediate capture resets `failures` to `0`.
+**Failure counters.** A successful immediate capture resets `failures` to `0`.
 Without that, the counter initialised once per `act()` (`policy.py:393`) stops
 meaning "consecutive" the moment a success stops returning, and the two
-messages that call it consecutive (`policy.py:415`, `:441`) become wrong.
+messages that call it consecutive (`policy.py:415`, `:441`) become wrong. The
+separate rejection count does not reset after frames: its contract is first
+rejection per `act()`, not first consecutive rejection.
 
 ### 3e. Queued capture, playout, and measured residual
 
@@ -363,8 +382,9 @@ On-demand mode swaps two sentences of `_SYSTEM_TEMPLATE`:
   see them, and a camera already shown for the current observation cannot be
   re-taken until the robot moves
 - turn shape: exactly one motion per turn, and `take_pic` may be chained in the
-  same turn — placed after a motion it returns frames once the motion has
-  finished playing, placed alone it looks before deciding
+  same turn — placed after a motion its frames arrive with the next observation
+  after the controller has played the motion, and the narration reports how
+  much actually played; placed alone it looks before deciding
 
 The no-tool-call nudge (`policy.py:417-418`, `"Respond with exactly one tool
 call."`) becomes mode-dependent for the same reason; in on-demand mode it must
@@ -428,8 +448,8 @@ Unit (`test_tools_motion.py`):
 - `build_toolset(images="on_demand")` raises `ToolsetError` naming the fix when
   the observation space declares no cameras
 - unknown name, declared-but-absent name, non-list `cameras`, empty `cameras`,
-  blank `note`, and an imageless observation each return a structured error
-  rather than raising
+  and blank `note` return a structured error rather than raising; an imageless
+  observation returns `capture=()` as a rejection outcome
 - a successful `_move_absolute` carries the clipped `target`; `residual` returns
   the labelled largest offset, and `None` when there is no matching state field
 
@@ -456,11 +476,16 @@ End-to-end (`test_policy_e2e.py`, scripted `httpx.MockTransport` as today):
 - an erroring `take_pic` *after* a move leaves the chunk intact and returns it,
   queues nothing, and leaves the slot free: `[move, take_pic(invalid),
   take_pic(valid)]` still queues the third call's capture
+- an imageless `take_pic` is rejected rather than errored, does not end the
+  trial, and behind a move queues nothing while leaving the slot free
 - `[take_pic, take_pic]` captures once; the second is answered `ignored: one
   tool call per turn` and no second image message is appended
 - the unknown-tool error's `available:` list names `take_pic` in on-demand mode
-- a bare repeat `take_pic()` is rejected without incrementing the failure
-  counter: three in a row do not error the trial
+- three consecutive immediate-capture validation errors raise, while the first
+  rejection in one `act()` is free and subsequent rejections escalate; a model
+  repeating a rejected capture is stopped after a bounded number of LLM calls
+- a valid capture dropped after an earlier error is answered `ignored: an
+  earlier call in this turn failed`
 - with two cameras, a `take_pic` naming both after one was already shown reveals
   only the unshown one and says so
 - a move chained with `take_pic` returns the chunk, answers both calls in order,

--- a/plans/0027-agent-on-demand-vision.md
+++ b/plans/0027-agent-on-demand-vision.md
@@ -32,8 +32,8 @@ In scope, all inside `plugins/inspect-robots-agent`:
 - A `take_pic` tool, exposed only in on-demand mode.
 - Chained tool calls: a motion plus a trailing `take_pic` in one assistant
   turn, with the capture resolved against the post-motion observation.
-- Playout accounting so a chunk cut short by early replanning or termination is
-  reported with its step count rather than presented as a finished motion.
+- Playout accounting, plus a **measured** residual against the requested target
+  so a motion the approvers truncated is reported as short rather than done.
 
 Out of scope: changes to the core rollout, controller, approvers, or
 `_html.py`; video or multi-frame capture; chaining two motions; a `take_pic`
@@ -59,10 +59,15 @@ The default preserves today's behavior, so existing benchmark numbers stay
 comparable and no CLI invocation changes meaning.
 
 `"always"`: `_observation_content` behaves as it does today and `take_pic` is
-not in `schemas()`, so nothing in §3b-§3e is reachable.
+not in `schemas()`.
 
 `"on_demand"`: observation messages carry the state text plus one line naming
 the cameras that `take_pic` can reach. No image parts.
+
+Every capture branch in the walk is gated on `images == "on_demand"`, not on
+the schema. Tool names come from the model, so a stray `take_pic` in `always`
+mode must still fall through to the existing structured unknown-tool error
+(`_tools.py:202-205`).
 
 ### 3b. `take_pic`
 
@@ -72,8 +77,7 @@ Exposed by `Toolset.schemas()` only in on-demand mode:
 take_pic(cameras?: string[], note: string)
 ```
 
-`cameras` omitted means every camera in the current observation. The schema
-description enumerates the cameras the embodiment *declares*
+The schema description enumerates the cameras the embodiment *declares*
 (`ObservationSpace.cameras`), since that is all the toolset knows at build
 time. `note` is required, matching the move tools: the note stream is the
 human-readable narration the user follows live, and a capture is a decision
@@ -90,22 +94,34 @@ unknown-name error listing the names actually present:
 - `note` missing or blank → structured error, worded like the move tools'
 - the observation carries no images at all → error saying so
 
+An omitted `cameras` is resolved by the **policy**, not the toolset, to the
+cameras of the current observation that have not been revealed yet (§3d).
+
 `build_toolset` refuses `on_demand` at bind time when
 `observation_space.cameras` is empty, with a message naming the fix (drop
 `-P images=on_demand`). Failing at bind rather than mid-trial matches every
 other unsupported configuration in this module, and an embodiment that serves
 frames without declaring them is already outside the compatibility contract.
 
-`take_pic` yields neither a chunk nor an error. `ToolResult` gains
-`capture: tuple[str, ...] | None` holding the resolved camera names, and its
-class docstring must stop claiming that exactly one of `chunk`/`error` is set.
-The two `assert result.chunk is not None` sites (`policy.py:443`, and inside
-`_forced_give_up`) are narrowed to the branches that produced a chunk, so
-`mypy --strict` still follows the invariant where it holds.
+`take_pic` yields neither a chunk nor an error. `ToolResult` gains two fields:
 
-The policy, not the toolset, decides whether a capture resolves now or after a
-motion, and writes the tool-result text accordingly, because that decision
-depends on position within the turn rather than on the observation.
+- `capture: tuple[str, ...] | None` — resolved camera names, or `None` when
+  `cameras` was omitted, which the policy then resolves itself
+- `target: npt.NDArray[np.float64] | None` — the clipped absolute target vector
+  a successful `_move_absolute` computed (§3e). `None` for displacement modes,
+  stops, and captures.
+
+`ToolResult`'s class docstring must stop claiming that exactly one of
+`chunk`/`error` is set. The two `assert result.chunk is not None` sites
+(`policy.py:443`, and inside `_forced_give_up`) are narrowed to the branches
+that produced a chunk, so `mypy --strict` still follows the invariant where it
+holds.
+
+`Toolset` also gains `residual(target, observation) -> tuple[str, float] | None`
+returning the dimension label and magnitude of the largest absolute difference
+between `target` and the observation's proprioceptive state. It lives on the
+toolset because the toolset owns `_state_key` and `_labels`; it returns `None`
+when there is no state key or the shape does not match.
 
 ### 3c. The call walk
 
@@ -117,26 +133,31 @@ not in the very next message, and `_translate_messages` flushes its pending
 results the moment any non-tool message arrives. Slipping an image message
 between two tool results is a 400, not a style question.
 
-The walk:
+The walk collects results for every call and only then decides what `act()`
+does. Let *chunked* mean "some earlier call in this turn produced a chunk".
 
-1. A `take_pic` seen **before** any chunk-producing call is an *immediate*
-   capture (§3d). It short-circuits the turn: every remaining call is answered
-   `ignored: one tool call per turn` and no motion executes. The model asked to
-   look before acting, so it re-decides with the frames in hand rather than
-   executing a motion it chose blind.
-2. Otherwise the first chunk-producing call (a move, `done`, or `give_up`)
-   executes as it does today.
-3. A `take_pic` **after** that call is *queued* (§3e) and answered
-   `queued: frames arrive with the next observation, once the motion has
-   finished playing`. Only one capture is queued per turn; a second is answered
-   `ignored: one tool call per turn`. After `done` or `give_up` there is no next
-   observation, so a queued capture there is answered
-   `ignored: the trial ends with this call`.
-4. Every other extra is answered `ignored: one tool call per turn`, the string
-   used today.
-5. A call that returns an error is answered with the error and ends the walk;
-   remaining calls are answered `ignored: one tool call per turn` and the loop
-   asks for a new turn, as today.
+1. Not chunked, `take_pic` → *immediate* capture (§3d). It short-circuits: every
+   remaining call is answered `ignored: one tool call per turn` and no motion
+   executes. The model asked to look before acting, so it re-decides with the
+   frames in hand rather than executing a motion it chose blind.
+2. Not chunked, a move / `done` / `give_up` → executed as today; the walk
+   continues so the remaining ids get answered.
+3. Chunked, `take_pic` → *queued* (§3e), answered `queued: frames arrive with
+   the next observation, once the motion has finished playing`. Only one capture
+   is queued per turn; a second is answered `ignored: one tool call per turn`.
+   After `done` or `give_up` there is no next observation, so a queued capture
+   there is answered `ignored: the trial ends with this call`.
+4. Anything else, chunked or not, is answered `ignored: one tool call per turn`
+   — the string used today.
+5. An error is answered with the error text. **If a chunk was already produced,
+   the error is reported in its own tool result and nothing else happens: the
+   motion is not cancelled, no capture is queued, `failures` is untouched, and
+   `act()` still returns the chunk.** Discarding the chunk there would leave the
+   move's own tool result (`executing move_joints over 12 steps`) in the
+   transcript describing a motion that never reached the embodiment. If no
+   chunk has been produced, the error ends the walk as today: remaining calls
+   are answered `ignored: one tool call per turn`, `failures` increments, and
+   the loop asks for a new turn.
 
 **This changes `always` mode too, in one respect: ordering.** Today every
 extra's `ignored` result is appended *before* the executed call's result
@@ -153,11 +174,10 @@ unchanged so only the order moves. CHANGELOG records it.
 After the walk, an immediate capture appends one `user` message whose parts are
 the labelled image parts, built by the same helper `_observation_content` uses
 so the `camera 'top_cam' (step 480):` label stays **byte-identical**. That
-label is not cosmetic: `_html.py` matches it with
-`_FRAME_LABEL_RE.fullmatch` to pair a transcript label with its stored frame in
-`inspect-robots view`, so any decoration inside the parentheses silently drops
-the frame from the report. Narration never goes in the label; it goes in a
-neighbouring text part.
+label is not cosmetic: `_html.py` matches it with `_FRAME_LABEL_RE.fullmatch`
+to pair a transcript label with its stored frame in `inspect-robots view`, so
+any decoration inside the parentheses silently drops the frame from the report.
+Narration never goes in the label; it goes in a neighbouring text part.
 
 The loop then asks for another LLM call. The capture spends one
 `max_llm_calls` unit; budget exhaustion already forces `give_up`.
@@ -165,65 +185,82 @@ The loop then asks for another LLM call. The capture spends one
 Two consecutive `user` messages (tool results, then frames) is the shape the
 Anthropic wire already produces between turns today, so no wire client changes.
 
-**Repeat guard.** Frames cannot change without stepping the robot, so within
-one `act()` each camera is revealed at most once. The policy tracks the
-revealed set for the current observation; a request naming any camera already
-shown returns a structured error naming those cameras and saying the view
-cannot change until the robot moves. No partial success: one branch, one error
-string.
+**Revealed-set resolution.** Frames cannot change without stepping the robot,
+so within one `act()` each camera is revealed at most once. The policy keeps
+the revealed set for the current observation and resolves the request against
+it:
+
+- `cameras` omitted → the observation's cameras minus the revealed set
+- `cameras` named → the named cameras minus the revealed set
+
+If the remainder is non-empty, those frames are revealed and the tool result
+names any request members that were skipped as already shown. If the remainder
+is empty, the result is a rejection naming them and saying the view cannot
+change until the robot moves — and **that rejection does not increment
+`failures`**. It is a refusal of a well-formed call, not a malformed call, and
+counting it would let three bare `take_pic()` calls error a trial that is
+otherwise healthy. The on-demand system prompt states the rule so the model can
+avoid it in the first place.
 
 **Failure counter.** A successful immediate capture resets `failures` to `0`.
 Without that, the counter initialised once per `act()` (`policy.py:393`) stops
 meaning "consecutive" the moment a success stops returning, and the two
-messages that call it consecutive (`policy.py:415`, `:441`) become wrong. With
-the reset, three scattered typos across a long capture sequence no longer kill
-the trial and the messages stay true.
+messages that call it consecutive (`policy.py:415`, `:441`) become wrong.
 
-### 3e. Queued capture and playout accounting
+### 3e. Queued capture, playout, and measured residual
 
-`_PendingCapture` records the resolved camera names, `issued_step`
-(`observation.extra["env_step"]` when the motion was issued), and `chunk_len`
-(the number of actions in the emitted chunk).
+`_PendingCapture` records the requested camera names (or `None` for "all"),
+`issued_step` (`observation.extra["env_step"]` when the motion was issued),
+`chunk_len` (the number of actions in the emitted chunk), and `target` (the
+`ToolResult.target` vector, `None` outside absolute modes).
 
-At the top of the next `act()` the policy consumes it: the resolved cameras'
-image parts are appended **into the observation message itself**, via
-`_observation_content(observation, state_labels, reveal=cameras)`, and those
-cameras are entered into the new observation's revealed set so the model cannot
-immediately re-request them. Keeping the frames inside the observation message
-holds the message count and delta-stream shape identical to `always` mode, and
-is semantically right: the frames *are* that observation's.
+At the top of the next `act()` the policy consumes it. Requested names are
+**intersected with the new observation's `images`**: present cameras are
+revealed, absent ones are named in the narration, and nothing raises — a
+dropped frame between the request and the arrival must not kill the trial via
+`PolicyError`. The revealed cameras are entered into the new observation's
+revealed set so the model cannot immediately re-request them.
 
-The leading text part of that message gains one narration line derived from
-`env_step` arithmetic (`advanced = new_env_step - issued_step`):
+The image parts go **into the observation message itself**, via
+`_observation_content(observation, state_labels, reveal=cameras)`. That holds
+the message count and delta-stream shape identical to `always` mode, and is
+semantically right: the frames *are* that observation's.
 
-- `advanced >= chunk_len` → `the motion finished playing (12 of 12 steps).`
-- `advanced < chunk_len` → `the motion played 3 of 12 steps before this
-  observation; it did not run to the end.`
-- `env_step` missing or not an `int` on either observation (a direct
-  `policy.act()` call outside `rollout()`) → `these frames follow the motion.`,
-  with no step arithmetic, matching how `_step_label` already degrades.
+The leading text part gains one narration line. With
+`advanced = new_env_step - issued_step`:
 
-**What this does and does not guarantee.** It guarantees the frames come from
-the observation the rollout produced after playing the chunk's actions, so a
-slow embodiment or a long interpolation delays the picture instead of taking it
-early. It does **not** guarantee the arm is at the requested target, and no
-wording may imply that. The rollout hands each action to the approver chain and
-never tells the policy about a rewrite (`rollout.py:267-278`); the CLI wires
-Clamp and DeltaLimit by default, and the plugin README already documents that a
-tight `--max-action-delta` truncates absolute interpolants. `SmoothingController`
-EMA-blends every action, so the final commanded value is never the
-interpolant's endpoint. The report is about playout, which the policy can
-observe, not arrival, which it cannot.
+- both steps are `int` and `advanced > 0`:
+  - `advanced >= chunk_len` → `the motion finished playing (12 of 12 steps).`
+  - otherwise → `the motion played 3 of 12 steps before this observation; it
+    did not run to the end.`
+- `env_step` missing, not an `int`, or `advanced <= 0` → `these frames follow
+  the motion.` with no arithmetic. The `<= 0` case is the direct-`policy.act()`
+  pattern the existing suite uses (`test_policy_e2e.py:436`), where every call
+  passes `env_step=0`.
+
+When `target` is set, `Toolset.residual` appends a second sentence:
+`largest remaining offset from the requested target is 0.004 on j3.` This is
+what actually answers the user's requirement, and it is a measurement rather
+than a promise. The policy cannot make the rollout wait for arrival — the
+rollout owns the loop — but it can tell the model how far off the arm ended up.
+That matters precisely where step counting is blind: `rollout.py:267-278` hands
+every action to the approver chain and never reports a rewrite, the CLI wires
+Clamp and DeltaLimit by default, a tight `--max-action-delta` truncates
+absolute interpolants, and `SmoothingController` EMA-blends every action so the
+commanded value is never the interpolant's endpoint. In all of those a step
+count reads as success while the residual reads as short.
+
+Displacement modes have no state-space target, so they keep the playout-only
+line.
 
 **Degradation under other controllers, stated plainly in the README.**
-`DefaultController` buffers `list(chunk.actions)[:replan_interval]`, so with any
-`replan_interval` shorter than a typical interpolation the advance is always
-`replan_interval` and every chained capture reports a partial playout.
-`EnsemblingController` re-queries every control step, so the advance is always
-`1` (and it rebuilds actions from chunk meta, so `done`/`give_up` do not
-terminate there either — an existing limitation noted in `rollout.py:259-263`).
-Reporting the observed numbers rather than a binary verdict is what keeps these
-cases honest.
+`DefaultController` buffers `list(chunk.actions)[:replan_interval]`, so the
+advance is `min(replan_interval, chunk_len)`: a `replan_interval` shorter than
+the interpolation reports a partial playout every time, while a chunk shorter
+than the interval still reports finished. `EnsemblingController` re-queries
+every control step, so the advance is always `1` (and it rebuilds actions from
+chunk meta, so `done`/`give_up` do not terminate there either — an existing
+limitation noted in `rollout.py:259-263`).
 
 **A trial that ends drops the queued capture.** `rollout()` breaks on
 `terminated`, `truncated`, or a policy-requested stop, and the `while/else`
@@ -237,7 +274,8 @@ clearing the queue and the revealed set, not by the consume path.
 On-demand mode swaps two sentences of `_SYSTEM_TEMPLATE`:
 
 - perception: camera images are not attached automatically; call `take_pic` to
-  see them
+  see them, and a camera already shown for the current observation cannot be
+  re-taken until the robot moves
 - turn shape: exactly one motion per turn, and `take_pic` may be chained in the
   same turn — placed after a motion it returns frames once the motion has
   finished playing, placed alone it looks before deciding
@@ -247,50 +285,70 @@ call."`) becomes mode-dependent for the same reason; in on-demand mode it must
 not contradict the turn shape the system prompt just taught. `always` mode
 keeps both strings verbatim.
 
-### 3g. Echo and transcript
+### 3g. Echo, state, and transcript
 
 `transcript_echo` gains lines for captures (`[agent] -- captured 2 frame(s)`,
-`[agent] -- queued capture: 'top_cam'`). `_sanitize` and `transcript_delta`
-need no change: the new image parts are `image_url` dicts inside list content,
-which `_sanitize` already replaces with omission markers, and the rollout pulls
-the delta once per inference.
+`[agent] -- queued capture: 'top_cam'`). The observation echo summary
+(`policy.py:384`, `f"{len(observation.images)} camera(s)"`) becomes
+`"1 camera(s) available"` in on-demand mode so it stops implying frames were
+sent.
+
+`_pending` and the revealed set are initialised in `__init__` next to
+`self._calls_used = 0` as well as in `reset()`: `act()` is reachable without
+`reset()` (`policy.py:373` guards only `bind()`), and `mypy --strict` requires
+the attributes to exist.
+
+`_sanitize` and `transcript_delta` need no change: the new image parts are
+`image_url` dicts inside list content, which `_sanitize` already replaces with
+omission markers, and the rollout pulls the delta once per inference.
 
 ## 4. Files
 
 ```
 plugins/inspect-robots-agent/
 ├── pyproject.toml         # version 0.13.0 -> 0.14.0
-├── README.md              # images mode, take_pic, chaining, playout semantics,
-│                          # controller degradation, the -P knob list
+├── README.md              # images mode, take_pic, chaining, playout + residual
+│                          # semantics, controller degradation, the -P knob list
 ├── src/inspect_robots_agent/
 │   ├── _tools.py          # take_pic schema + validation, ToolResult.capture and
-│   │                      # its docstring, build_toolset(images=...) bind refusal
-│   └── policy.py          # images knob, call walk, capture bookkeeping,
-│                          # playout accounting, on-demand prompt and nudge
+│   │                      # .target and its docstring, Toolset.residual,
+│   │                      # build_toolset(images=...) bind refusal
+│   └── policy.py          # images knob, call walk, revealed-set resolution,
+│                          # _PendingCapture, playout + residual narration,
+│                          # on-demand prompt, nudge, and echo
 └── tests/
     ├── test_package.py    # pinned __version__
-    ├── test_tools_motion.py   # schema exposure, argument validation, bind refusal
-    └── test_policy_e2e.py     # on-demand flow, chaining, playout reporting,
-                               # the two reordered extras tests
+    ├── test_tools_motion.py   # schema exposure, validation, bind refusal, residual
+    ├── test_policy_e2e.py     # on-demand flow, chaining, narration,
+    │                          # the two reordered extras tests
+    ├── test_anthropic.py      # translated Messages body for a capture history
+    └── test_responses.py      # item order for a capture history
 plans/0027-agent-on-demand-vision.md
 CHANGELOG.md
 ```
 
 `inspect_robots_agent.__all__` and the core `tests/test_api_snapshot.py` are
 unchanged: `_PendingCapture` and the `take_pic` plumbing are private and no
-core API moves.
+core API moves. `__version__` reads `importlib.metadata`, so bumping the plugin
+pyproject alone is enough.
 
 ## 5. Testing
 
 Unit (`test_tools_motion.py`):
 
-- `take_pic` absent from `schemas()` in `always` mode, present in `on_demand`
+- `take_pic` absent from `schemas()` in `always` mode, present in `on_demand`;
+  a `take_pic` call in `always` mode returns the unknown-tool error
 - `build_toolset(images="on_demand")` raises `ToolsetError` naming the fix when
   the observation space declares no cameras
 - unknown name, declared-but-absent name, non-list `cameras`, empty `cameras`,
   blank `note`, and an imageless observation each return a structured error
   rather than raising
-- omitted `cameras` resolves to every camera in the observation
+- a successful `_move_absolute` carries the clipped `target`; `residual` returns
+  the labelled largest offset, and `None` when there is no matching state field
+
+Multi-camera cases need a two-camera fixture: `CubePickEmbodiment` declares one
+camera (`mock/cubepick.py:57`), so these build a custom `EmbodimentInfo` and
+`Observation` the way `test_policy_e2e.py` already does elsewhere.
 
 End-to-end (`test_policy_e2e.py`, scripted `httpx.MockTransport` as today):
 
@@ -300,22 +358,35 @@ End-to-end (`test_policy_e2e.py`, scripted `httpx.MockTransport` as today):
 - `take_pic` before a move short-circuits: the move is answered `ignored`, no
   chunk is returned from that turn, and every `tool_call_id` is answered exactly
   once with the results contiguous
-- a repeat `take_pic` for an already-revealed camera errors, and a later
-  successful capture has reset the failure counter
+- an erroring `take_pic` *after* a move leaves the chunk intact and returns it
+- a bare repeat `take_pic()` is rejected without incrementing the failure
+  counter: three in a row do not error the trial
+- with two cameras, a `take_pic` naming both after one was already shown reveals
+  only the unshown one and says so
 - a move chained with `take_pic` returns the chunk, answers both calls in order,
-  and attaches the frames to the *next* observation message with a
-  byte-identical `camera 'x' (step N):` label
-- the narration line reads "finished playing" when `env_step` advanced by the
-  full chunk length and reports the observed counts when it did not
-  (`DefaultController(replan_interval=1)` drives the short case)
+  and attaches frames to the *next* observation message with a byte-identical
+  `camera 'x' (step N):` label
+- the narration reads "finished playing" at full advance, reports observed
+  counts under `DefaultController(replan_interval=1)`, degrades to the neutral
+  sentence when `advanced <= 0`, and appends the residual sentence in an
+  absolute mode
+- a camera that disappears between request and arrival is named as missing and
+  does not raise
 - a capture queued behind a chunk on a step that terminates the trial is never
   delivered and leaves no residue in the next trial
 - `take_pic` chained after `done` is answered `ignored: the trial ends with this
   call`
-- `always` mode still emits no `take_pic` schema, and the two reordered extras
-  tests assert the new call-order results
+- the two reordered extras tests assert the new call-order results
 - `images` appears in `AgentPolicyConfig`; an invalid value raises `ConfigError`
   carrying a `fix:` line
+
+Wire tests (`test_anthropic.py`, `test_responses.py`): the e2e suite runs the
+chat wire, which passes `self._messages` through verbatim (`_llm.py:199`) and
+so proves nothing about the adjacency constraint §3c is built around. Add one
+test per wire feeding a capture history (assistant with two tool calls, both
+results, then the image user message) and asserting the translated body keeps
+the `tool_result` blocks contiguous in the message immediately following the
+assistant turn, and one `function_call_output` per `function_call` in order.
 
 Gates: `ruff check`, `ruff format --check`, `mypy --strict` over
 `plugins/inspect-robots-agent/src/inspect_robots_agent`, and the plugin test
@@ -328,12 +399,13 @@ on proprioception alone and will score worse. This is the point of the knob and
 the reason `always` stays the default; the on-demand system prompt says plainly
 that images exist and how to get them.
 
-**Capture spam.** A model could burn its budget looking. The per-observation
-repeat guard removes the only useless case (the same camera twice with no
-motion between), and `max_llm_calls` bounds the rest.
+**Capture spam.** A model could burn its budget looking. The revealed-set
+resolution removes the only useless case (the same camera twice with no motion
+between) without erroring the trial, and `max_llm_calls` bounds the rest.
 
 **Chaining is a latency win, not a correctness win.** It saves one LLM
 round-trip per look-after-move; it does not make the motion more accurate, and
 under `replan_interval` or ensembling it degrades to reporting a partial
-playout. The README says so rather than leaving users to infer it from a
+playout. The residual sentence is what keeps the transcript honest in those
+cases, and the README says so rather than leaving users to infer it from a
 surprising transcript.

--- a/plans/0027-agent-on-demand-vision.md
+++ b/plans/0027-agent-on-demand-vision.md
@@ -67,7 +67,9 @@ the cameras that `take_pic` can reach. No image parts.
 Every capture branch in the walk is gated on `images == "on_demand"`, not on
 the schema. Tool names come from the model, so a stray `take_pic` in `always`
 mode must still fall through to the existing structured unknown-tool error
-(`_tools.py:202-205`).
+(`_tools.py:202-205`). That error's `available:` list becomes mode-dependent so
+it names `take_pic` in on-demand mode and omits it in `always` mode — a stale
+list is worst precisely where the model is guessing tool names.
 
 ### 3b. `take_pic`
 
@@ -109,7 +111,9 @@ in the same observation, whose frames belong to *N+1*.
 other unsupported configuration in this module, and an embodiment that serves
 frames without declaring them is already outside the compatibility contract.
 
-`take_pic` yields neither a chunk nor an error. `ToolResult` becomes
+A *successful* `take_pic` yields neither a chunk nor an error; the validation
+failures above still come back as `ToolResult.error` like any other tool's.
+`ToolResult` becomes
 `@dataclass(frozen=True, eq=False)` and gains two fields:
 
 - `capture: tuple[str, ...] | None` — resolved camera names, or `None` when
@@ -159,34 +163,54 @@ The walk collects results for every call and only then decides what `act()`
 does. It is a two-state machine, not a list of cases. The state is *open* until
 some call produces a chunk or an immediate capture, and *closed* after.
 
+Every call reaches `toolset.execute` for validation, open or closed. What
+changes with the state is what is *done* with the result.
+
 **While open**, each call is dispatched normally:
 
-- an on-demand `take_pic` becomes an *immediate* capture (§3d) and closes the
-  walk. The model asked to look before acting, so it re-decides with the frames
-  in hand rather than executing a motion it chose blind.
+- an on-demand `take_pic` closes the walk **whatever its outcome**. On success
+  it is an *immediate* capture (§3d): the model asked to look before acting, so
+  it re-decides with the frames in hand rather than executing a motion it chose
+  blind. On a `toolset.execute` error it is answered with the error text and
+  increments `failures`. On a revealed-set rejection it is answered with the
+  rejection text and leaves `failures` alone (§3d). All three close, so a move
+  behind a rejected `take_pic` is answered `ignored`, not executed.
 - every other call — including an unknown tool name, and including `take_pic`
   in `always` mode — goes to `toolset.execute` exactly as today. A chunk closes
   the walk. An error is answered with its text, increments `failures`, and
   closes the walk with no chunk.
 
-**Once closed**, no further call executes:
+**Once closed**, nothing further reaches the embodiment and no further chunk is
+produced. The one remaining live path is queuing, and it exists only when the
+walk was closed by a **non-stop motion chunk** — that is the only close that
+guarantees a next observation and a `chunk_len` to count against:
 
-- an on-demand `take_pic` is *queued* (§3e), answered `queued: frames arrive
-  with the next observation, once the motion has finished playing`. Only one
-  capture is queued per turn; a second is answered `ignored: one tool call per
-  turn`. When the chunk that closed the walk was a stop there is no next
-  observation, so the capture is answered `ignored: the trial ends with this
-  call` instead. The policy recognises a stop by reading
-  `chunk.actions[0].meta.get("request_stop")`, which `_stop` already sets
-  (`_tools.py:216-219`), rather than forking the `("done", "give_up")` literal
-  out of `_tools.py:200`.
+- on-demand `take_pic`, walk closed by a motion chunk: still passed to
+  `toolset.execute` for argument and camera-name validation. On success it is
+  *queued* (§3e) and answered `queued: frames arrive with the next observation,
+  once the motion has finished playing`. On error it is answered with the error
+  text, nothing is queued, the queue slot stays free for a later valid
+  `take_pic` in the same turn, and `failures` is untouched — `act()` is
+  returning the chunk regardless, so counting it would leak into the next
+  observation's budget. Only one capture is queued per turn; once the slot is
+  filled a second `take_pic` is answered `ignored: one tool call per turn`.
+- on-demand `take_pic`, walk closed by a **stop** chunk: answered `ignored: the
+  trial ends with this call`. There is no next observation to deliver into. The
+  policy recognises a stop by reading `chunk.actions[0].meta.get("request_stop")`,
+  which `_stop` already sets (`_tools.py:216-219`), rather than forking the
+  `("done", "give_up")` literal out of `_tools.py:200`.
+- on-demand `take_pic`, walk closed **without a chunk** (an immediate capture, a
+  revealed-set rejection, or an error): answered `ignored: one tool call per
+  turn`. No motion was emitted, so "once the motion has finished playing" would
+  be false and `chunk_len` would be undefined. `[take_pic, take_pic]` resolves
+  here.
 - everything else is answered `ignored: one tool call per turn`, the string
   used today.
 
-Nothing after a chunk can cancel it. An error would have had to come from a
-call that never ran, and discarding the chunk would leave the move's own tool
-result (`executing move_joints over 12 steps`) in the transcript describing a
-motion that never reached the embodiment.
+Nothing after a chunk can cancel it. An error there comes from a call that
+never ran, and discarding the chunk would leave the move's own tool result
+(`executing move_joints over 12 steps`) in the transcript describing a motion
+that never reached the embodiment.
 
 **After the walk**, `act()` returns the chunk if one was produced. Otherwise it
 continues the `while True` loop for another LLM turn — the same path a
@@ -204,7 +228,7 @@ the correct mirror of the request and keeps a single dispatch path rather than
 two divergent ones. Two existing tests pin the old order and must be updated:
 `test_transcript_echo_marks_extra_tool_calls_before_executed_result` and
 `test_extra_tool_calls_are_answered_but_not_executed` (`test_policy_e2e.py:417`
-and `:836`). The `ignored: one tool call per turn` wording is deliberately
+and `:832`). The `ignored: one tool call per turn` wording is deliberately
 unchanged so only the order moves. CHANGELOG records it.
 
 ### 3d. Immediate capture
@@ -267,9 +291,9 @@ revealed set so the model cannot immediately re-request them.
 
 The image parts go **into the observation message itself**, via
 `_observation_content(observation, state_labels, reveal=cameras)`. `reveal` is
-keyword-only and defaults to `None` meaning "every camera", so the six existing
+keyword-only and defaults to `None` meaning "every camera", so the existing
 call sites that pass one or two positional arguments
-(`test_policy_e2e.py:321-372`) keep rendering every frame; on-demand mode
+(`test_policy_e2e.py:321-370`) keep rendering every frame; on-demand mode
 passes an explicit empty tuple for an unrevealed observation. That holds
 the message count and delta-stream shape identical to `always` mode, and is
 semantically right: the frames *are* that observation's.

--- a/plans/0027-agent-on-demand-vision.md
+++ b/plans/0027-agent-on-demand-vision.md
@@ -252,8 +252,13 @@ the correct mirror of the request and keeps a single dispatch path rather than
 two divergent ones. Two existing tests pin the old order and must be updated:
 `test_transcript_echo_marks_extra_tool_calls_before_executed_result` and
 `test_extra_tool_calls_are_answered_but_not_executed` (`test_policy_e2e.py:417`
-and `:832`). The `ignored: one tool call per turn` wording is deliberately
-unchanged so only the order moves. CHANGELOG records it.
+and `:832`). Extras behind a *successful* call keep the
+`ignored: one tool call per turn` wording, so for them only the order moves.
+Extras behind a call that *failed* are answered
+`ignored: an earlier call in this turn failed`, which is not scoped to
+on-demand mode: the old wording blamed the model for a surplus call when the
+real cause was the earlier failure, and that is misleading in either mode.
+CHANGELOG records both.
 
 ### 3d. Immediate capture
 

--- a/plans/0027-agent-on-demand-vision.md
+++ b/plans/0027-agent-on-demand-vision.md
@@ -94,8 +94,14 @@ unknown-name error listing the names actually present:
 - `note` missing or blank → structured error, worded like the move tools'
 - the observation carries no images at all → error saying so
 
-An omitted `cameras` is resolved by the **policy**, not the toolset, to the
-cameras of the current observation that have not been revealed yet (§3d).
+An omitted `cameras` is resolved by the **policy**, not the toolset. On the
+immediate path it resolves against the current observation's revealed set
+(§3d). On the queued path it is stored verbatim — `None` for the omitted form,
+the named tuple otherwise — with **no subtraction at queue time**, and is
+resolved at delivery against the arriving observation, whose revealed set is
+empty (§3e). Subtracting at queue time would reject exactly the flow this
+feature exists for: look at observation *N*, then chain a capture onto a motion
+in the same observation, whose frames belong to *N+1*.
 
 `build_toolset` refuses `on_demand` at bind time when
 `observation_space.cameras` is empty, with a message naming the fix (drop
@@ -103,13 +109,19 @@ cameras of the current observation that have not been revealed yet (§3d).
 other unsupported configuration in this module, and an embodiment that serves
 frames without declaring them is already outside the compatibility contract.
 
-`take_pic` yields neither a chunk nor an error. `ToolResult` gains two fields:
+`take_pic` yields neither a chunk nor an error. `ToolResult` becomes
+`@dataclass(frozen=True, eq=False)` and gains two fields:
 
 - `capture: tuple[str, ...] | None` — resolved camera names, or `None` when
   `cameras` was omitted, which the policy then resolves itself
 - `target: npt.NDArray[np.float64] | None` — the clipped absolute target vector
   a successful `_move_absolute` computed (§3e). `None` for displacement modes,
   stops, and captures.
+
+`eq=False` is not optional: the default `eq=True` on a frozen dataclass
+generates `__eq__` and `__hash__` over the field tuple, and a NumPy field makes
+both raise. `types.py:7-9` documents the same convention for the core's
+array-carrying dataclasses.
 
 `ToolResult`'s class docstring must stop claiming that exactly one of
 `chunk`/`error` is set. The two `assert result.chunk is not None` sites
@@ -118,10 +130,20 @@ that produced a chunk, so `mypy --strict` still follows the invariant where it
 holds.
 
 `Toolset` also gains `residual(target, observation) -> tuple[str, float] | None`
-returning the dimension label and magnitude of the largest absolute difference
-between `target` and the observation's proprioceptive state. It lives on the
-toolset because the toolset owns `_state_key` and `_labels`; it returns `None`
-when there is no state key or the shape does not match.
+(with a `D102` docstring) returning the dimension label and magnitude of the
+largest absolute difference between `target` and the observation's
+proprioceptive state. It lives on the toolset because the toolset owns
+`_state_key` and `_labels`.
+
+It must never raise, because it runs on the delivery path where §3e forbids
+killing a trial over a degraded observation. It returns `None` when any of
+these hold: `self._state_key is None`; the key is absent from
+`observation.state`; the value does not coerce to a float array; its shape does
+not match `len(self._labels)`; or any element of `target - state` is
+non-finite. `_current_state` is not reusable here — it indexes
+`observation.state[...]` directly and would raise `KeyError` on a dropped
+field, which `rollout.py:225` turns into a `PolicyError`. A NaN state would
+otherwise print `nan on <first label>` as if it were a measurement.
 
 ### 3c. The call walk
 
@@ -134,30 +156,46 @@ results the moment any non-tool message arrives. Slipping an image message
 between two tool results is a 400, not a style question.
 
 The walk collects results for every call and only then decides what `act()`
-does. Let *chunked* mean "some earlier call in this turn produced a chunk".
+does. It is a two-state machine, not a list of cases. The state is *open* until
+some call produces a chunk or an immediate capture, and *closed* after.
 
-1. Not chunked, `take_pic` → *immediate* capture (§3d). It short-circuits: every
-   remaining call is answered `ignored: one tool call per turn` and no motion
-   executes. The model asked to look before acting, so it re-decides with the
-   frames in hand rather than executing a motion it chose blind.
-2. Not chunked, a move / `done` / `give_up` → executed as today; the walk
-   continues so the remaining ids get answered.
-3. Chunked, `take_pic` → *queued* (§3e), answered `queued: frames arrive with
-   the next observation, once the motion has finished playing`. Only one capture
-   is queued per turn; a second is answered `ignored: one tool call per turn`.
-   After `done` or `give_up` there is no next observation, so a queued capture
-   there is answered `ignored: the trial ends with this call`.
-4. Anything else, chunked or not, is answered `ignored: one tool call per turn`
-   — the string used today.
-5. An error is answered with the error text. **If a chunk was already produced,
-   the error is reported in its own tool result and nothing else happens: the
-   motion is not cancelled, no capture is queued, `failures` is untouched, and
-   `act()` still returns the chunk.** Discarding the chunk there would leave the
-   move's own tool result (`executing move_joints over 12 steps`) in the
-   transcript describing a motion that never reached the embodiment. If no
-   chunk has been produced, the error ends the walk as today: remaining calls
-   are answered `ignored: one tool call per turn`, `failures` increments, and
-   the loop asks for a new turn.
+**While open**, each call is dispatched normally:
+
+- an on-demand `take_pic` becomes an *immediate* capture (§3d) and closes the
+  walk. The model asked to look before acting, so it re-decides with the frames
+  in hand rather than executing a motion it chose blind.
+- every other call — including an unknown tool name, and including `take_pic`
+  in `always` mode — goes to `toolset.execute` exactly as today. A chunk closes
+  the walk. An error is answered with its text, increments `failures`, and
+  closes the walk with no chunk.
+
+**Once closed**, no further call executes:
+
+- an on-demand `take_pic` is *queued* (§3e), answered `queued: frames arrive
+  with the next observation, once the motion has finished playing`. Only one
+  capture is queued per turn; a second is answered `ignored: one tool call per
+  turn`. When the chunk that closed the walk was a stop there is no next
+  observation, so the capture is answered `ignored: the trial ends with this
+  call` instead. The policy recognises a stop by reading
+  `chunk.actions[0].meta.get("request_stop")`, which `_stop` already sets
+  (`_tools.py:216-219`), rather than forking the `("done", "give_up")` literal
+  out of `_tools.py:200`.
+- everything else is answered `ignored: one tool call per turn`, the string
+  used today.
+
+Nothing after a chunk can cancel it. An error would have had to come from a
+call that never ran, and discarding the chunk would leave the move's own tool
+result (`executing move_joints over 12 steps`) in the transcript describing a
+motion that never reached the embodiment.
+
+**After the walk**, `act()` returns the chunk if one was produced. Otherwise it
+continues the `while True` loop for another LLM turn — the same path a
+no-tool-call turn already takes. That covers an immediate capture, a
+revealed-set rejection, an errored call, and a turn of nothing but `ignored`.
+Only an error increments `failures`; an immediate capture resets it to `0`; a
+revealed-set rejection leaves it untouched (§3d). `max_llm_calls` bounds every
+one of these paths, since each loop iteration calls `complete()` and increments
+`_calls_used`.
 
 **This changes `always` mode too, in one respect: ordering.** Today every
 extra's `ignored` result is appended *before* the executed call's result
@@ -185,22 +223,28 @@ The loop then asks for another LLM call. The capture spends one
 Two consecutive `user` messages (tool results, then frames) is the shape the
 Anthropic wire already produces between turns today, so no wire client changes.
 
-**Revealed-set resolution.** Frames cannot change without stepping the robot,
-so within one `act()` each camera is revealed at most once. The policy keeps
-the revealed set for the current observation and resolves the request against
-it:
+**Revealed-set resolution (immediate path only).** Frames cannot change without
+stepping the robot, so each camera is revealed at most once per observation.
+The policy keeps a revealed set **scoped to the current observation**, cleared
+every time `act()` appends a new observation message — not just in `__init__`
+and `reset()`, or every camera would be one-shot for the whole trial. It
+resolves the request against that set:
 
 - `cameras` omitted → the observation's cameras minus the revealed set
 - `cameras` named → the named cameras minus the revealed set
 
-If the remainder is non-empty, those frames are revealed and the tool result
-names any request members that were skipped as already shown. If the remainder
-is empty, the result is a rejection naming them and saying the view cannot
-change until the robot moves — and **that rejection does not increment
-`failures`**. It is a refusal of a well-formed call, not a malformed call, and
-counting it would let three bare `take_pic()` calls error a trial that is
-otherwise healthy. The on-demand system prompt states the rule so the model can
-avoid it in the first place.
+If the remainder is non-empty, those frames are revealed and the tool result is
+`captured 1 frame(s): 'wrist' (already shown: 'top')`, with the parenthetical
+omitted when nothing was skipped. If the remainder is empty, the result is
+`already shown for this observation: 'top'; the view cannot change until the
+robot moves` — and **that rejection does not increment `failures`**. It is a
+refusal of a well-formed call, not a malformed call, and counting it would let
+three bare `take_pic()` calls error a trial that is otherwise healthy. The
+on-demand system prompt states the rule so the model can avoid it in the first
+place.
+
+This subtraction applies only here. The queued path (§3e) stores the request
+unresolved.
 
 **Failure counter.** A successful immediate capture resets `failures` to `0`.
 Without that, the counter initialised once per `act()` (`policy.py:393`) stops
@@ -222,7 +266,11 @@ dropped frame between the request and the arrival must not kill the trial via
 revealed set so the model cannot immediately re-request them.
 
 The image parts go **into the observation message itself**, via
-`_observation_content(observation, state_labels, reveal=cameras)`. That holds
+`_observation_content(observation, state_labels, reveal=cameras)`. `reveal` is
+keyword-only and defaults to `None` meaning "every camera", so the six existing
+call sites that pass one or two positional arguments
+(`test_policy_e2e.py:321-372`) keep rendering every frame; on-demand mode
+passes an explicit empty tuple for an unrevealed observation. That holds
 the message count and delta-stream shape identical to `always` mode, and is
 semantically right: the frames *are* that observation's.
 
@@ -238,8 +286,11 @@ The leading text part gains one narration line. With
   pattern the existing suite uses (`test_policy_e2e.py:436`), where every call
   passes `env_step=0`.
 
-When `target` is set, `Toolset.residual` appends a second sentence:
-`largest remaining offset from the requested target is 0.004 on j3.` This is
+When `target` is set **and** `Toolset.residual` returns a value, a second
+sentence follows: `largest remaining offset from the requested target is 0.004
+on j3.` The magnitude is formatted `:.4g`, matching `bounds_text`
+(`_tools.py:493-497`). When residual returns `None` the sentence is omitted
+entirely and the playout line stands alone. This is
 what actually answers the user's requirement, and it is a measurement rather
 than a promise. The policy cannot make the rollout wait for arrival — the
 rollout owns the loop — but it can tell the model how far off the arm ended up.
@@ -296,7 +347,8 @@ sent.
 `_pending` and the revealed set are initialised in `__init__` next to
 `self._calls_used = 0` as well as in `reset()`: `act()` is reachable without
 `reset()` (`policy.py:373` guards only `bind()`), and `mypy --strict` requires
-the attributes to exist.
+the attributes to exist. The revealed set is additionally cleared on every new
+observation message (§3d); `_pending` is cleared when consumed.
 
 `_sanitize` and `transcript_delta` need no change: the new image parts are
 `image_url` dicts inside list content, which `_sanitize` already replaces with
@@ -349,6 +401,14 @@ Unit (`test_tools_motion.py`):
 Multi-camera cases need a two-camera fixture: `CubePickEmbodiment` declares one
 camera (`mock/cubepick.py:57`), so these build a custom `EmbodimentInfo` and
 `Observation` the way `test_policy_e2e.py` already does elsewhere.
+
+**The e2e suite needs a new embodiment fixture, and neither existing one
+works.** `CubePickEmbodiment` is `eef_delta_pos`, so `state_key` stays `None`
+and `residual` can never fire. `_AbsoluteEmbodiment` (`test_policy_e2e.py:185`)
+is `joint_pos` but declares no `CameraSpec` and emits no images, so
+`build_toolset` refuses on-demand at bind. Add one modelled on
+`_AbsoluteEmbodiment`: `joint_pos` semantics, two `CameraSpec`s, and matching
+`images` on `reset()`/`step()`. Every on-demand e2e test below runs against it.
 
 End-to-end (`test_policy_e2e.py`, scripted `httpx.MockTransport` as today):
 

--- a/plans/0027-agent-on-demand-vision.md
+++ b/plans/0027-agent-on-demand-vision.md
@@ -16,7 +16,7 @@ loop for a model that controls its own perception is "move, then look at where
 that got me". Without chaining that costs a whole extra LLM call after the
 motion has already finished playing.
 
-Chaining a capture onto a motion is only correct if the frames come from the
+Chaining a capture onto a motion is only useful if the frames come from the
 observation delivered *after* the speed-limited chunk has played out. The move
 tools synthesize an N-step interpolation whose length depends on
 `max_speed_frac`, `control_hz`, and the distance travelled; a capture that
@@ -32,12 +32,17 @@ In scope, all inside `plugins/inspect-robots-agent`:
 - A `take_pic` tool, exposed only in on-demand mode.
 - Chained tool calls: a motion plus a trailing `take_pic` in one assistant
   turn, with the capture resolved against the post-motion observation.
-- Arrival accounting so a motion cut short by early replanning or termination
-  is reported as such rather than silently labelled post-arrival.
+- Playout accounting so a chunk cut short by early replanning or termination is
+  reported with its step count rather than presented as a finished motion.
 
-Out of scope: changes to the core rollout, controller, or approvers; video or
-multi-frame capture; chaining two motions; a `take_pic` equivalent for state
-(state text is cheap and stays force-fed).
+Out of scope: changes to the core rollout, controller, approvers, or
+`_html.py`; video or multi-frame capture; chaining two motions; a `take_pic`
+equivalent for state (state text is cheap and stays force-fed).
+
+No CLI change is required. `-P images=on_demand` reaches the policy through
+`_parse_kvs` → `parse_value` as a plain string, and `cameras` is a *tool*
+argument carried in the call's JSON, never a `-P` value. `parse_value` has no
+list syntax and must not grow one for this.
 
 ## 3. Design
 
@@ -45,11 +50,16 @@ multi-frame capture; chaining two motions; a `take_pic` equivalent for state
 
 `LLMAgentPolicy.__init__` gains `images: str = "always"`, validated against
 `{"always", "on_demand"}` and recorded on `AgentPolicyConfig` so the eval log
-carries it. The default preserves today's behavior exactly, so existing
-benchmark numbers stay comparable and no CLI invocation changes meaning.
+carries it. An invalid value raises `ConfigError` with a `fix:` line, matching
+the wire-gated checks at `policy.py:159-179` (the older `ValueError`s in that
+constructor are the inconsistency, tracked in #168, and are not the pattern to
+copy).
 
-`"always"`: `_observation_content` behaves as it does today, and `take_pic` is
-not in `schemas()`. Nothing in this plan is reachable.
+The default preserves today's behavior, so existing benchmark numbers stay
+comparable and no CLI invocation changes meaning.
+
+`"always"`: `_observation_content` behaves as it does today and `take_pic` is
+not in `schemas()`, so nothing in §3b-§3e is reachable.
 
 `"on_demand"`: observation messages carry the state text plus one line naming
 the cameras that `take_pic` can reach. No image parts.
@@ -62,139 +72,213 @@ Exposed by `Toolset.schemas()` only in on-demand mode:
 take_pic(cameras?: string[], note: string)
 ```
 
-`cameras` omitted means every camera. `note` is required, matching the move
-tools: the note stream is the human-readable narration the user follows live,
-and a capture is a decision worth narrating ("I cannot tell whether the gripper
-cleared the rim, so I am looking before descending").
+`cameras` omitted means every camera in the current observation. The schema
+description enumerates the cameras the embodiment *declares*
+(`ObservationSpace.cameras`), since that is all the toolset knows at build
+time. `note` is required, matching the move tools: the note stream is the
+human-readable narration the user follows live, and a capture is a decision
+worth narrating ("I cannot tell whether the gripper cleared the rim, so I am
+looking before descending").
 
-Validation lives in `Toolset.execute` because it holds the observation:
+Validation lives in `Toolset.execute`, which holds the observation, and
+resolves names against `observation.images` — the truth, not the declaration.
+A declared-but-absent camera (a dropped ROS frame) therefore returns the
+unknown-name error listing the names actually present:
 
-- unknown camera name → error naming the valid names
+- unknown or absent camera name → error naming the cameras present now
 - `cameras` present but not a list of strings, or empty → structured error
+- `note` missing or blank → structured error, worded like the move tools'
 - the observation carries no images at all → error saying so
 
 `build_toolset` refuses `on_demand` at bind time when
 `observation_space.cameras` is empty, with a message naming the fix (drop
-`-P images=on_demand`). Failing at bind rather than mid-trial matches how every
-other unsupported configuration in this module behaves, and an embodiment that
-serves frames without declaring them is already outside the compatibility
-contract.
+`-P images=on_demand`). Failing at bind rather than mid-trial matches every
+other unsupported configuration in this module, and an embodiment that serves
+frames without declaring them is already outside the compatibility contract.
 
 `take_pic` yields neither a chunk nor an error. `ToolResult` gains
-`capture: tuple[str, ...] | None` holding the resolved camera names. The policy,
-not the toolset, decides whether that capture resolves now or after a motion,
-and writes the tool-result text accordingly, because that decision depends on
-loop position rather than on the observation.
+`capture: tuple[str, ...] | None` holding the resolved camera names, and its
+class docstring must stop claiming that exactly one of `chunk`/`error` is set.
+The two `assert result.chunk is not None` sites (`policy.py:443`, and inside
+`_forced_give_up`) are narrowed to the branches that produced a chunk, so
+`mypy --strict` still follows the invariant where it holds.
 
-### 3c. Immediate capture
+The policy, not the toolset, decides whether a capture resolves now or after a
+motion, and writes the tool-result text accordingly, because that decision
+depends on position within the turn rather than on the observation.
 
-A `take_pic` that is the turn's only call, or precedes the motion in the turn,
-resolves against the current observation. The policy appends:
+### 3c. The call walk
 
-1. a `tool` message: `captured 2 frame(s): 'top', 'wrist'`
-2. a `user` message whose parts are the labelled image parts, built by the same
-   helper `_observation_content` uses so the `camera 'top' (step 480):` join key
-   into stored frames stays identical
+`act()` stops executing only the first tool call. It walks the turn's calls in
+order and appends **every** tool result before anything else, because both
+wires require the results to sit immediately after the assistant message that
+requested them: the Messages API rejects a `tool_use` whose `tool_result` is
+not in the very next message, and `_translate_messages` flushes its pending
+results the moment any non-tool message arrives. Slipping an image message
+between two tool results is a 400, not a style question.
 
-and then loops for another LLM call. The capture spends one `max_llm_calls`
-unit; budget exhaustion already forces `give_up`.
+The walk:
 
-Two `user` messages in a row (tool results, then frames) is the shape the
-Anthropic wire already produces today between turns, so no wire client changes.
+1. A `take_pic` seen **before** any chunk-producing call is an *immediate*
+   capture (§3d). It short-circuits the turn: every remaining call is answered
+   `ignored: one tool call per turn` and no motion executes. The model asked to
+   look before acting, so it re-decides with the frames in hand rather than
+   executing a motion it chose blind.
+2. Otherwise the first chunk-producing call (a move, `done`, or `give_up`)
+   executes as it does today.
+3. A `take_pic` **after** that call is *queued* (§3e) and answered
+   `queued: frames arrive with the next observation, once the motion has
+   finished playing`. Only one capture is queued per turn; a second is answered
+   `ignored: one tool call per turn`. After `done` or `give_up` there is no next
+   observation, so a queued capture there is answered
+   `ignored: the trial ends with this call`.
+4. Every other extra is answered `ignored: one tool call per turn`, the string
+   used today.
+5. A call that returns an error is answered with the error and ends the walk;
+   remaining calls are answered `ignored: one tool call per turn` and the loop
+   asks for a new turn, as today.
+
+**This changes `always` mode too, in one respect: ordering.** Today every
+extra's `ignored` result is appended *before* the executed call's result
+(`policy.py:421-436`). The walk emits results in call order instead, which is
+the correct mirror of the request and keeps a single dispatch path rather than
+two divergent ones. Two existing tests pin the old order and must be updated:
+`test_transcript_echo_marks_extra_tool_calls_before_executed_result` and
+`test_extra_tool_calls_are_answered_but_not_executed` (`test_policy_e2e.py:417`
+and `:836`). The `ignored: one tool call per turn` wording is deliberately
+unchanged so only the order moves. CHANGELOG records it.
+
+### 3d. Immediate capture
+
+After the walk, an immediate capture appends one `user` message whose parts are
+the labelled image parts, built by the same helper `_observation_content` uses
+so the `camera 'top_cam' (step 480):` label stays **byte-identical**. That
+label is not cosmetic: `_html.py` matches it with
+`_FRAME_LABEL_RE.fullmatch` to pair a transcript label with its stored frame in
+`inspect-robots view`, so any decoration inside the parentheses silently drops
+the frame from the report. Narration never goes in the label; it goes in a
+neighbouring text part.
+
+The loop then asks for another LLM call. The capture spends one
+`max_llm_calls` unit; budget exhaustion already forces `give_up`.
+
+Two consecutive `user` messages (tool results, then frames) is the shape the
+Anthropic wire already produces between turns today, so no wire client changes.
 
 **Repeat guard.** Frames cannot change without stepping the robot, so within
 one `act()` each camera is revealed at most once. The policy tracks the
-revealed set for the current observation; a request for cameras already shown
-returns `error: camera 'top' was already captured for this observation and
-cannot change until the robot moves`. A request mixing new and already-shown
-cameras succeeds for the new ones and says which were skipped.
+revealed set for the current observation; a request naming any camera already
+shown returns a structured error naming those cameras and saying the view
+cannot change until the robot moves. No partial success: one branch, one error
+string.
 
-### 3d. Chained capture
+**Failure counter.** A successful immediate capture resets `failures` to `0`.
+Without that, the counter initialised once per `act()` (`policy.py:393`) stops
+meaning "consecutive" the moment a success stops returning, and the two
+messages that call it consecutive (`policy.py:415`, `:441`) become wrong. With
+the reset, three scattered typos across a long capture sequence no longer kill
+the trial and the messages stay true.
 
-`act()` stops answering extra tool calls with a blanket `ignored` and instead
-walks the turn's calls in order:
+### 3e. Queued capture and playout accounting
 
-- calls before the first chunk-producing call: `take_pic` executes immediately
-  (3c); anything else is answered `ignored: only one motion per turn`
-- the first chunk-producing call (a move, `done`, or `give_up`) is executed as
-  today
-- calls after it: a `take_pic` is **queued** and answered
-  `queued: frames arrive with the next observation, after the motion completes`;
-  anything else is answered `ignored: only one motion per turn`. After `done` or
-  `give_up` a queued capture can never be delivered, so it is answered
-  `ignored: the trial ends with this call` instead
+`_PendingCapture` records the resolved camera names, `issued_step`
+(`observation.extra["env_step"]` when the motion was issued), and `chunk_len`
+(the number of actions in the emitted chunk).
 
-Every `tool_call_id` still gets exactly one answer before the next assistant
-turn, which is what the wire requires.
+At the top of the next `act()` the policy consumes it: the resolved cameras'
+image parts are appended **into the observation message itself**, via
+`_observation_content(observation, state_labels, reveal=cameras)`, and those
+cameras are entered into the new observation's revealed set so the model cannot
+immediately re-request them. Keeping the frames inside the observation message
+holds the message count and delta-stream shape identical to `always` mode, and
+is semantically right: the frames *are* that observation's.
 
-The queue holds one `_PendingCapture(cameras, issued_step, chunk_len)`. A
-second queued `take_pic` in the same turn merges its camera names into it.
+The leading text part of that message gains one narration line derived from
+`env_step` arithmetic (`advanced = new_env_step - issued_step`):
 
-### 3e. Arrival accounting
-
-`_PendingCapture` records `issued_step` (`observation.extra["env_step"]` when
-the motion was issued) and `chunk_len` (the number of actions in the emitted
-chunk). At the top of the next `act()`, the policy compares the new
-`env_step` against `issued_step + chunk_len`:
-
-- advanced by `chunk_len` or more: frames are labelled
-  `camera 'top' (step 42, after the motion completed)`
-- advanced by fewer steps: frames are still attached, and the observation
-  message carries a line
-  `the motion was interrupted after 3 of 12 steps; this is not the requested
-  target position`. A short advance means the controller replanned mid-chunk
-  (`DefaultController(replan_interval=k)`) or the embodiment terminated, both of
-  which are outside the policy's control and neither of which may be reported as
-  arrival.
+- `advanced >= chunk_len` → `the motion finished playing (12 of 12 steps).`
+- `advanced < chunk_len` → `the motion played 3 of 12 steps before this
+  observation; it did not run to the end.`
 - `env_step` missing or not an `int` on either observation (a direct
-  `policy.act()` call outside `rollout()`): fall back to the neutral label
-  `camera 'top' (after the motion)` with no step arithmetic, matching how
-  `_step_label` already degrades.
+  `policy.act()` call outside `rollout()`) → `these frames follow the motion.`,
+  with no step arithmetic, matching how `_step_label` already degrades.
 
-The guarantee this buys is exactly the one the issue asks for: the frames come
-from the observation the rollout produced after playing every action of the
-speed-limited chunk, so a slow embodiment or a long interpolation delays the
-picture rather than taking it early.
+**What this does and does not guarantee.** It guarantees the frames come from
+the observation the rollout produced after playing the chunk's actions, so a
+slow embodiment or a long interpolation delays the picture instead of taking it
+early. It does **not** guarantee the arm is at the requested target, and no
+wording may imply that. The rollout hands each action to the approver chain and
+never tells the policy about a rewrite (`rollout.py:267-278`); the CLI wires
+Clamp and DeltaLimit by default, and the plugin README already documents that a
+tight `--max-action-delta` truncates absolute interpolants. `SmoothingController`
+EMA-blends every action, so the final commanded value is never the
+interpolant's endpoint. The report is about playout, which the policy can
+observe, not arrival, which it cannot.
 
-A pending capture is consumed by the next `act()` whatever happens, so it can
-never leak into a later observation. `reset()` clears it along with the
-revealed set.
+**Degradation under other controllers, stated plainly in the README.**
+`DefaultController` buffers `list(chunk.actions)[:replan_interval]`, so with any
+`replan_interval` shorter than a typical interpolation the advance is always
+`replan_interval` and every chained capture reports a partial playout.
+`EnsemblingController` re-queries every control step, so the advance is always
+`1` (and it rebuilds actions from chunk meta, so `done`/`give_up` do not
+terminate there either — an existing limitation noted in `rollout.py:259-263`).
+Reporting the observed numbers rather than a binary verdict is what keeps these
+cases honest.
 
-### 3f. System prompt
+**A trial that ends drops the queued capture.** `rollout()` breaks on
+`terminated`, `truncated`, or a policy-requested stop, and the `while/else`
+ends on `max_steps`; in each case there is no next `act()`. The transcript's
+last tool message then reads `queued: ...` with nothing following it, which is
+accurate — the trial ended first. Cross-trial leakage is prevented by `reset()`
+clearing the queue and the revealed set, not by the consume path.
 
-The on-demand mode swaps two sentences of `_SYSTEM_TEMPLATE`:
+### 3f. System prompt and nudge
 
-- perception: cameras are not attached automatically; call `take_pic` to see
-  them
+On-demand mode swaps two sentences of `_SYSTEM_TEMPLATE`:
+
+- perception: camera images are not attached automatically; call `take_pic` to
+  see them
 - turn shape: exactly one motion per turn, and `take_pic` may be chained in the
   same turn — placed after a motion it returns frames once the motion has
-  finished, placed alone it looks before deciding
+  finished playing, placed alone it looks before deciding
 
-The `always` mode keeps today's text verbatim.
+The no-tool-call nudge (`policy.py:417-418`, `"Respond with exactly one tool
+call."`) becomes mode-dependent for the same reason; in on-demand mode it must
+not contradict the turn shape the system prompt just taught. `always` mode
+keeps both strings verbatim.
 
 ### 3g. Echo and transcript
 
 `transcript_echo` gains lines for captures (`[agent] -- captured 2 frame(s)`,
-`[agent] -- queued capture: 'top'`). `_sanitize` already replaces image parts
-with omission markers, so persisted transcripts and the Rerun stream need no
-change.
+`[agent] -- queued capture: 'top_cam'`). `_sanitize` and `transcript_delta`
+need no change: the new image parts are `image_url` dicts inside list content,
+which `_sanitize` already replaces with omission markers, and the rollout pulls
+the delta once per inference.
 
 ## 4. Files
 
 ```
 plugins/inspect-robots-agent/
+├── pyproject.toml         # version 0.13.0 -> 0.14.0
+├── README.md              # images mode, take_pic, chaining, playout semantics,
+│                          # controller degradation, the -P knob list
 ├── src/inspect_robots_agent/
-│   ├── _tools.py          # take_pic schema + validation, ToolResult.capture,
-│   │                      # build_toolset(images=...) bind-time refusal
-│   └── policy.py          # images knob, capture bookkeeping, chained-call walk,
-│                          # arrival accounting, on-demand system prompt
-│   README.md              # images mode, take_pic, chaining, arrival semantics
+│   ├── _tools.py          # take_pic schema + validation, ToolResult.capture and
+│   │                      # its docstring, build_toolset(images=...) bind refusal
+│   └── policy.py          # images knob, call walk, capture bookkeeping,
+│                          # playout accounting, on-demand prompt and nudge
 └── tests/
+    ├── test_package.py    # pinned __version__
     ├── test_tools_motion.py   # schema exposure, argument validation, bind refusal
-    └── test_policy_e2e.py     # on-demand flow, chaining, arrival vs interruption
+    └── test_policy_e2e.py     # on-demand flow, chaining, playout reporting,
+                               # the two reordered extras tests
 plans/0027-agent-on-demand-vision.md
 CHANGELOG.md
 ```
+
+`inspect_robots_agent.__all__` and the core `tests/test_api_snapshot.py` are
+unchanged: `_PendingCapture` and the `take_pic` plumbing are private and no
+core API moves.
 
 ## 5. Testing
 
@@ -203,23 +287,35 @@ Unit (`test_tools_motion.py`):
 - `take_pic` absent from `schemas()` in `always` mode, present in `on_demand`
 - `build_toolset(images="on_demand")` raises `ToolsetError` naming the fix when
   the observation space declares no cameras
-- unknown camera name, non-list `cameras`, empty `cameras`, missing `note`,
-  and an imageless observation each return a structured error, not a raise
+- unknown name, declared-but-absent name, non-list `cameras`, empty `cameras`,
+  blank `note`, and an imageless observation each return a structured error
+  rather than raising
 - omitted `cameras` resolves to every camera in the observation
 
-End-to-end (`test_policy_e2e.py`, fake transports as today):
+End-to-end (`test_policy_e2e.py`, scripted `httpx.MockTransport` as today):
 
-- on-demand observation message carries no image parts and names the cameras
-- immediate `take_pic` appends the tool result and a user message whose parts
-  are image parts, and the loop continues to a second LLM call
-- a second `take_pic` for the same camera in the same `act()` errors
-- a move chained with `take_pic` returns the chunk from `act()`, answers both
-  tool calls, and attaches frames to the *next* observation message
-- the chained capture labels frames post-arrival when the next `env_step` has
-  advanced by the full chunk length, and reports interruption when it has not
-- a `take_pic` chained after `done` is answered as ignored and never delivered
-- `always` mode is byte-identical to today's message stream (regression guard)
-- `images` appears in `AgentPolicyConfig` and an invalid value raises
+- on-demand observation messages carry no image parts and name the cameras
+- an immediate `take_pic` appends its tool result, then a user message of image
+  parts, and the loop continues to a second LLM call
+- `take_pic` before a move short-circuits: the move is answered `ignored`, no
+  chunk is returned from that turn, and every `tool_call_id` is answered exactly
+  once with the results contiguous
+- a repeat `take_pic` for an already-revealed camera errors, and a later
+  successful capture has reset the failure counter
+- a move chained with `take_pic` returns the chunk, answers both calls in order,
+  and attaches the frames to the *next* observation message with a
+  byte-identical `camera 'x' (step N):` label
+- the narration line reads "finished playing" when `env_step` advanced by the
+  full chunk length and reports the observed counts when it did not
+  (`DefaultController(replan_interval=1)` drives the short case)
+- a capture queued behind a chunk on a step that terminates the trial is never
+  delivered and leaves no residue in the next trial
+- `take_pic` chained after `done` is answered `ignored: the trial ends with this
+  call`
+- `always` mode still emits no `take_pic` schema, and the two reordered extras
+  tests assert the new call-order results
+- `images` appears in `AgentPolicyConfig`; an invalid value raises `ConfigError`
+  carrying a `fix:` line
 
 Gates: `ruff check`, `ruff format --check`, `mypy --strict` over
 `plugins/inspect-robots-agent/src/inspect_robots_agent`, and the plugin test
@@ -233,10 +329,11 @@ the reason `always` stays the default; the on-demand system prompt says plainly
 that images exist and how to get them.
 
 **Capture spam.** A model could burn its budget looking. The per-observation
-repeat guard removes the only *useless* case (the same camera twice with no
+repeat guard removes the only useless case (the same camera twice with no
 motion between), and `max_llm_calls` bounds the rest.
 
-**Consecutive failures.** A capture is a success but does not reset the
-`_MAX_CONSECUTIVE_FAILURES` counter, so an alternating error/capture loop still
-ends the trial after three errors. That is the intended reading: the errors are
-what is persistent.
+**Chaining is a latency win, not a correctness win.** It saves one LLM
+round-trip per look-after-move; it does not make the motion more accurate, and
+under `replan_interval` or ensembling it degrades to reporting a partial
+playout. The README says so rather than leaving users to infer it from a
+surprising transcript.

--- a/plans/0027-agent-on-demand-vision.md
+++ b/plans/0027-agent-on-demand-vision.md
@@ -62,7 +62,12 @@ comparable and no CLI invocation changes meaning.
 not in `schemas()`.
 
 `"on_demand"`: observation messages carry the state text plus one line naming
-the cameras that `take_pic` can reach. No image parts.
+the cameras that `take_pic` can reach. No image parts. That line names the
+cameras present in `observation.images`, **not** the declared ones, and when
+the observation carries no frames it says so. Advertising a declared camera
+that did not arrive would invite a call that can only return the "no images"
+error, and three of those inside one `act()` would kill a trial over a dropped
+frame — the condition §3e goes out of its way to survive on the delivery path.
 
 Every capture branch in the walk is gated on `images == "on_demand"`, not on
 the schema. Tool names come from the model, so a stray `take_pic` in `always`
@@ -163,8 +168,14 @@ The walk collects results for every call and only then decides what `act()`
 does. It is a two-state machine, not a list of cases. The state is *open* until
 some call produces a chunk or an immediate capture, and *closed* after.
 
-Every call reaches `toolset.execute` for validation, open or closed. What
-changes with the state is what is *done* with the result.
+Every call reaches `toolset.execute` **while the walk is open**. Once closed,
+the only call still dispatched is an on-demand `take_pic` behind a non-stop
+motion chunk, which needs argument and camera-name validation to queue.
+Anything answered `ignored` is never dispatched — `_move` raises on a
+non-finite proprioceptive reference (`_tools.py:232`) and both `_move` and
+`_stop` index `observation.state[...]` directly (`_tools.py:211`), so
+dispatching an extra on a degraded observation would turn today's correctable
+error loop into a fatal `PolicyError` (`rollout.py:225`).
 
 **While open**, each call is dispatched normally:
 
@@ -442,7 +453,12 @@ End-to-end (`test_policy_e2e.py`, scripted `httpx.MockTransport` as today):
 - `take_pic` before a move short-circuits: the move is answered `ignored`, no
   chunk is returned from that turn, and every `tool_call_id` is answered exactly
   once with the results contiguous
-- an erroring `take_pic` *after* a move leaves the chunk intact and returns it
+- an erroring `take_pic` *after* a move leaves the chunk intact and returns it,
+  queues nothing, and leaves the slot free: `[move, take_pic(invalid),
+  take_pic(valid)]` still queues the third call's capture
+- `[take_pic, take_pic]` captures once; the second is answered `ignored: one
+  tool call per turn` and no second image message is appended
+- the unknown-tool error's `available:` list names `take_pic` in on-demand mode
 - a bare repeat `take_pic()` is rejected without incrementing the failure
   counter: three in a row do not error the trial
 - with two cameras, a `take_pic` naming both after one was already shown reveals

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -107,8 +107,8 @@ the interpolation always reports partial playout; a chunk shorter than the
 interval reports finished. `EnsemblingController` re-queries every control
 step, so the observed advance is always one step. It also rebuilds actions
 from chunk metadata, which means `done` and `give_up` do not terminate under
-ensembling—an existing core limitation. A trial that terminates or reaches its
-step limit before the next policy call drops any queued capture.
+ensembling (an existing core limitation). A trial that terminates or reaches
+its step limit before the next policy call drops any queued capture.
 
 For displacement modes, `move_by` splits the requested total so every action
 fits the box side in that direction. The action box is the embodiment author's

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -73,6 +73,43 @@ describing the current observation and why the agent chose that motion. The
 user reads these notes live and in the saved transcript to follow what the
 agent sees and decides.
 
+Camera images are attached to every observation by default
+(`-P images=always`). Set `-P images=on_demand` to send state without image
+payloads and give the model a `take_pic` tool instead:
+
+```bash
+inspect-robots "pick up the cube" --policy agent \
+    -P model=anthropic/claude-fable-5 -P images=on_demand \
+    --embodiment cubepick
+```
+
+`take_pic` requires a human-readable `note` and accepts an optional `cameras`
+list. Omitting the list requests every camera available in that observation.
+A camera can be revealed only once per observation because its view cannot
+change until the robot moves. A standalone `take_pic` shows the current frame
+and lets the model decide again before moving. A `take_pic` placed after one
+motion in the same assistant turn is queued: the motion chunk is returned
+immediately, and the requested frames are attached to the next observation,
+after the controller has played the available part of the chunk. Two motions
+still cannot be chained.
+
+Queued-capture narration reports what the rollout actually observed. It says
+whether all requested chunk steps played or only a prefix did, names camera
+frames missing on arrival, and, for absolute control modes with matching
+proprioception, reports the largest measured offset from the requested target.
+The residual is the arrival check: a full step count alone does not prove the
+arm reached its target when an approver rewrote actions or a smoothing
+controller blended them.
+
+Controller choice affects that report. `DefaultController` buffers
+`min(replan_interval, chunk_len)` actions, so a `replan_interval` shorter than
+the interpolation always reports partial playout; a chunk shorter than the
+interval reports finished. `EnsemblingController` re-queries every control
+step, so the observed advance is always one step. It also rebuilds actions
+from chunk metadata, which means `done` and `give_up` do not terminate under
+ensembling—an existing core limitation. A trial that terminates or reaches its
+step limit before the next policy call drops any queued capture.
+
 For displacement modes, `move_by` splits the requested total so every action
 fits the box side in that direction. The action box is the embodiment author's
 per-step speed statement, so `max_speed_frac` does not apply to displacement
@@ -104,7 +141,8 @@ motion fall short of the tool's requested total.
 
 Configuration knobs (all `-P key=value`): `model`, `base_url`, `api_key_env`,
 `wire`, `speed`, `max_output_tokens`, `max_llm_calls` (default `100`),
-`temperature`, `effort`, `max_speed_frac`, `transcript_echo`.
+`temperature`, `effort`, `max_speed_frac`, `transcript_echo`, `images`
+(default `always`; use `on_demand` for model-requested frames).
 `speed` and `max_output_tokens` apply to `-P wire=anthropic` only, and passing
 either on another wire is an error rather than a silent no-op.
 Set `-P transcript_echo=true` to print live `[agent]` conversation lines to

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -86,12 +86,18 @@ inspect-robots "pick up the cube" --policy agent \
 `take_pic` requires a human-readable `note` and accepts an optional `cameras`
 list. Omitting the list requests every camera available in that observation.
 A camera can be revealed only once per observation because its view cannot
-change until the robot moves. A standalone `take_pic` shows the current frame
-and lets the model decide again before moving. A `take_pic` placed after one
-motion in the same assistant turn is queued: the motion chunk is returned
-immediately, and the requested frames are attached to the next observation,
-after the controller has played the available part of the chunk. Two motions
-still cannot be chained.
+change until the robot moves. If a runtime camera dropout leaves the
+observation with no images, the well-formed call is rejected with `no camera
+images are available in this observation` instead of counting as a malformed
+tool call. The first such world-state rejection in one policy decision is
+free; repeated rejections escalate to the normal three-strike guard.
+
+A standalone `take_pic` shows the current frame and lets the model decide
+again before moving. A `take_pic` placed after one motion in the same assistant
+turn is queued with `queued: frames arrive with the next observation, after
+the motion plays`: the motion chunk is returned immediately, and the requested
+frames are attached to the next observation after the controller has played
+the available part of the chunk. Two motions still cannot be chained.
 
 Queued-capture narration reports what the rollout actually observed. It says
 whether all requested chunk steps played or only a prefix did, names camera

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.13.0"
+version = "0.14.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -44,9 +44,12 @@ class ToolResult:
     """The policy-relevant effects of one validated tool call.
 
     ``note`` is the result confirmation text for a successful call, distinct
-    from the call's required ``note`` argument. A successful capture has only
-    ``capture`` set; motion targets are carried separately so their measured
-    residual can be reported after playout.
+    from the call's required ``note`` argument. ``capture`` encodes a
+    well-formed capture request: ``None`` means cameras were omitted and the
+    policy should resolve every available camera, ``()`` means the observation
+    had no images to show, and a non-empty tuple names the requested cameras.
+    Motion targets are carried separately so their measured residual can be
+    reported after playout.
     """
 
     chunk: ActionChunk | None = None
@@ -265,7 +268,7 @@ class Toolset:
             return None
         try:
             state = np.asarray(raw_state, dtype=np.float64)
-        except Exception:
+        except Exception:  # pragma: no cover
             # Delivery must survive third-party state containers whose array
             # coercion raises something less conventional than ValueError.
             return None
@@ -273,7 +276,7 @@ class Toolset:
             return None
         try:
             difference = np.abs(np.subtract(target, state))
-        except Exception:
+        except Exception:  # pragma: no cover
             return None
         if difference.shape != state.shape or not bool(np.all(np.isfinite(difference))):
             return None
@@ -303,11 +306,11 @@ class Toolset:
             return ToolResult(
                 error="note is required: describe what you observe and why you chose this capture"
             )
-        if not observation.images:
-            return ToolResult(error="no camera images are available in this observation")
 
         requested = arguments.get("cameras")
         if "cameras" not in arguments:
+            if not observation.images:
+                return ToolResult(capture=())
             return ToolResult(capture=None)
         if (
             not isinstance(requested, list)
@@ -315,6 +318,8 @@ class Toolset:
             or any(not isinstance(name, str) for name in requested)
         ):
             return ToolResult(error="cameras must be a non-empty list of strings when provided")
+        if not observation.images:
+            return ToolResult(capture=())
         present = tuple(observation.images)
         unknown = [name for name in requested if name not in observation.images]
         if unknown:

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -39,17 +39,21 @@ class ToolsetError(Exception):
     """An action space / observation space this toolset cannot drive."""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class ToolResult:
-    """One executed tool call: an action chunk to play, or an error for the LLM.
+    """The policy-relevant effects of one validated tool call.
 
-    Exactly one of ``chunk``/``error`` is set. ``note`` is the result confirmation
-    text for a successful call, distinct from the call's required ``note`` argument.
+    ``note`` is the result confirmation text for a successful call, distinct
+    from the call's required ``note`` argument. A successful capture has only
+    ``capture`` set; motion targets are carried separately so their measured
+    residual can be reported after playout.
     """
 
     chunk: ActionChunk | None = None
     error: str | None = None
     note: str = ""
+    capture: tuple[str, ...] | None = None
+    target: npt.NDArray[np.float64] | None = None
 
 
 class Toolset:
@@ -68,6 +72,8 @@ class Toolset:
         high: npt.NDArray[np.float64],
         step_limits: npt.NDArray[np.float64],
         pose: bool = False,
+        images: str = "always",
+        cameras: tuple[str, ...] = (),
     ):
         self._absolute = absolute
         self._pose = pose
@@ -88,6 +94,8 @@ class Toolset:
         self._low = low
         self._high = high
         self._step_limits = step_limits
+        self._images = images
+        self._cameras = cameras
         if absolute:
             self._positive_limits = np.zeros_like(high)
             self._negative_limits = np.zeros_like(low)
@@ -187,7 +195,45 @@ class Toolset:
                 },
             },
         }
-        return [move, done, give_up]
+        schemas = [move, done, give_up]
+        if self._images == "on_demand":
+            schemas.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "take_pic",
+                        "description": (
+                            "Capture the current frame from one or more cameras. "
+                            "Omit cameras to capture every available camera. "
+                            "Declared cameras: " + ", ".join(self._cameras) + "."
+                        ),
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "cameras": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "description": (
+                                        "Camera names to capture. Valid declared names: "
+                                        + ", ".join(self._cameras)
+                                    ),
+                                },
+                                "note": {
+                                    "type": "string",
+                                    "description": (
+                                        "What you need to inspect and why seeing a camera "
+                                        "frame is necessary before the next decision. The "
+                                        "user reads these notes live and in the saved "
+                                        "transcript."
+                                    ),
+                                },
+                            },
+                            "required": ["note"],
+                        },
+                    },
+                }
+            )
+        return schemas
 
     def execute(self, call: Any, observation: Observation) -> ToolResult:
         """Turn one tool call into an action chunk or an error string for the LLM."""
@@ -199,11 +245,40 @@ class Toolset:
             return ToolResult(error=f"arguments for {call.name} must be a JSON object")
         if call.name in ("done", "give_up"):
             return self._stop(call.name, arguments, observation)
+        if call.name == "take_pic" and self._images == "on_demand":
+            return self._take_pic(arguments, observation)
         if call.name != self._move_tool:
-            return ToolResult(
-                error=f"unknown tool {call.name!r}; available: {self._move_tool}, done, give_up"
-            )
+            available = f"{self._move_tool}, done, give_up"
+            if self._images == "on_demand":
+                available += ", take_pic"
+            return ToolResult(error=f"unknown tool {call.name!r}; available: {available}")
         return self._move(arguments, observation)
+
+    def residual(
+        self, target: npt.NDArray[np.float64], observation: Observation
+    ) -> tuple[str, float] | None:
+        """Return the largest finite target offset, or ``None`` when it cannot be measured."""
+        if self._state_key is None:
+            return None
+        raw_state = observation.state.get(self._state_key)
+        if raw_state is None:
+            return None
+        try:
+            state = np.asarray(raw_state, dtype=np.float64)
+        except Exception:
+            # Delivery must survive third-party state containers whose array
+            # coercion raises something less conventional than ValueError.
+            return None
+        if state.shape != (len(self._labels),):
+            return None
+        try:
+            difference = np.abs(np.subtract(target, state))
+        except Exception:
+            return None
+        if difference.shape != state.shape or not bool(np.all(np.isfinite(difference))):
+            return None
+        index = int(np.argmax(difference))
+        return self._labels[index], float(difference[index])
 
     def _current_state(self, observation: Observation) -> npt.NDArray[np.float64]:
         if self._state_key is None:
@@ -221,6 +296,35 @@ class Toolset:
             chunk=ActionChunk(actions=[action], control_hz=self._hz),
             note=f"{name}: {detail}",
         )
+
+    def _take_pic(self, arguments: dict[str, Any], observation: Observation) -> ToolResult:
+        call_note = arguments.get("note")
+        if not isinstance(call_note, str) or not call_note.strip():
+            return ToolResult(
+                error="note is required: describe what you observe and why you chose this capture"
+            )
+        if not observation.images:
+            return ToolResult(error="no camera images are available in this observation")
+
+        requested = arguments.get("cameras")
+        if "cameras" not in arguments:
+            return ToolResult(capture=None)
+        if (
+            not isinstance(requested, list)
+            or not requested
+            or any(not isinstance(name, str) for name in requested)
+        ):
+            return ToolResult(error="cameras must be a non-empty list of strings when provided")
+        present = tuple(observation.images)
+        unknown = [name for name in requested if name not in observation.images]
+        if unknown:
+            return ToolResult(
+                error=(
+                    f"unknown or unavailable camera {unknown[0]!r}; "
+                    f"available now: {', '.join(repr(name) for name in present)}"
+                )
+            )
+        return ToolResult(capture=tuple(requested))
 
     def _move(self, arguments: dict[str, Any], observation: Observation) -> ToolResult:
         current: npt.NDArray[np.float64] | None = None
@@ -312,7 +416,8 @@ class Toolset:
             for fraction in fractions
         ]
         actions[-1] = Action(data=np.clip(target.copy(), self._low, self._high))
-        return self._success(actions, steps)
+        clipped_target = np.clip(target.copy(), self._low, self._high)
+        return self._success(actions, steps, target=clipped_target)
 
     def _move_displacement(
         self,
@@ -358,13 +463,20 @@ class Toolset:
             )
         )
 
-    def _success(self, actions: list[Action], steps: int) -> ToolResult:
+    def _success(
+        self,
+        actions: list[Action],
+        steps: int,
+        *,
+        target: npt.NDArray[np.float64] | None = None,
+    ) -> ToolResult:
         note = f"executing {self._move_tool} over {steps} steps"
         if self._hz is not None:
             note += f" ({steps / self._hz:.1f}s)"
         return ToolResult(
             chunk=ActionChunk(actions=actions, control_hz=self._hz),
             note=note,
+            target=target,
         )
 
 
@@ -373,12 +485,18 @@ def build_toolset(
     observation_space: ObservationSpace,
     control_hz: float | None,
     max_speed_frac: float = 0.1,
+    images: str = "always",
 ) -> Toolset:
     """Validate an embodiment's spaces and build its agent-facing tools.
 
     Raises [`ToolsetError`][inspect_robots_agent._tools.ToolsetError] for
     configurations the motion layer cannot drive, before a trial begins.
     """
+    if images == "on_demand" and not observation_space.cameras:
+        raise ToolsetError(
+            "images='on_demand' needs at least one camera declared by the embodiment.\n"
+            "fix: drop -P images=on_demand"
+        )
     semantics = action_space.semantics
     if semantics is None:
         raise ToolsetError(
@@ -507,4 +625,6 @@ def build_toolset(
         high=high64,
         step_limits=step_limits,
         pose=mode in _POSE_MODES,
+        images=images,
+        cameras=tuple(camera.name for camera in observation_space.cameras),
     )

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -628,16 +628,16 @@ class LLMAgentPolicy(PolicyBase):
         ):
             if advanced >= pending.chunk_len:
                 narration = (
-                    f"the motion finished playing ({pending.chunk_len} of "
+                    f"The motion finished playing ({pending.chunk_len} of "
                     f"{pending.chunk_len} steps)."
                 )
             else:
                 narration = (
-                    f"the motion played {advanced} of {pending.chunk_len} steps before "
+                    f"The motion played {advanced} of {pending.chunk_len} steps before "
                     "this observation; it did not run to the end."
                 )
         else:
-            narration = "these frames follow the motion."
+            narration = "These frames follow the motion."
 
         toolset = self._toolset
         if pending.target is not None and toolset is not None:
@@ -645,11 +645,11 @@ class LLMAgentPolicy(PolicyBase):
             if residual is not None:
                 label, magnitude = residual
                 narration += (
-                    " largest remaining offset from the requested target is "
+                    " Largest remaining offset from the requested target is "
                     f"{magnitude:.4g} on {label}."
                 )
         if missing:
-            narration += f" missing camera(s) in this observation: {_quoted_names(missing)}."
+            narration += f" Missing camera(s) in this observation: {_quoted_names(missing)}."
         return narration
 
     def _echo(self, text: str) -> None:

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -1,12 +1,12 @@
 """LLMAgentPolicy — a frontier LLM as a first-class Inspect Robots policy.
 
 The conversation loop lives inside ``act()``: observation in (labeled state
-text + camera frames), one validated tool call out, synthesized into an
-open-loop ``ActionChunk`` by the motion layer. The LLM never sees raw
-actuation, and every emitted action still passes the rollout's approver
-chain — this module contains no safety-critical code path of its own
-(plan 0008 §4b). Chat-format history stays canonical while the selected
-client translates it to the configured API wire format.
+text, plus camera frames unless ``images=on_demand``), one validated tool call
+out, synthesized into an open-loop ``ActionChunk`` by the motion layer. The
+LLM never sees raw actuation, and every emitted action still passes the
+rollout's approver chain — this module contains no safety-critical code path
+of its own (plan 0008 §4b). Chat-format history stays canonical while the
+selected client translates it to the configured API wire format.
 """
 
 from __future__ import annotations
@@ -86,10 +86,11 @@ is watching these notes to see what you see and what you decide, so write them \
 for a human reader. \
 Safety approvers clamp out-of-bounds and too-fast actions below you. \
 Respond with exactly one motion tool call per turn; `take_pic` may be chained \
-in the same turn. Placed after a motion, it returns frames once the motion has \
-finished playing; placed alone, it looks before you decide what motion to make. \
-When the goal is achieved call done; if it cannot be achieved call give_up. You \
-have a budget of {budget} LLM calls for the whole trial."""
+in the same turn. Placed after a motion, its frames arrive with the next \
+observation, after the controller has played the motion; the narration reports \
+how much actually played. Placed alone, it looks before you decide what motion \
+to make. When the goal is achieved call done; if it cannot be achieved call \
+give_up. You have a budget of {budget} LLM calls for the whole trial."""
 
 _ON_DEMAND_NUDGE = (
     "Respond with one motion tool call, one motion followed by take_pic, or take_pic alone."
@@ -467,6 +468,7 @@ class LLMAgentPolicy(PolicyBase):
         else:
             self._echo(f"[agent] >> observation: {summary}")
         failures = 0
+        rejections = 0
         while True:
             if self._calls_used >= self._max_llm_calls:
                 return self._forced_give_up(toolset, observation, "LLM call budget exhausted")
@@ -505,6 +507,7 @@ class LLMAgentPolicy(PolicyBase):
             target: npt.NDArray[np.float64] | None = None
             immediate_frames: tuple[str, ...] = ()
             closed = False
+            closed_after_failure = False
             stopped = False
             last_error: str | None = None
             for call in message.tool_calls:
@@ -519,6 +522,14 @@ class LLMAgentPolicy(PolicyBase):
                             result_text = result.error
                             failures += 1
                             last_error = result.error
+                            closed_after_failure = True
+                        elif result.capture == ():
+                            result_text = "no camera images are available in this observation"
+                            rejections += 1
+                            if rejections > 1:
+                                failures += 1
+                                last_error = result_text
+                            closed_after_failure = True
                         else:
                             requested = (
                                 tuple(observation.images)
@@ -545,12 +556,18 @@ class LLMAgentPolicy(PolicyBase):
                                     f"{_quoted_names(skipped)}; the view cannot change until "
                                     "the robot moves"
                                 )
+                                rejections += 1
+                                if rejections > 1:
+                                    failures += 1
+                                    last_error = result_text
+                                closed_after_failure = True
                     else:
                         if result.error is not None:
                             result_text = result.error
                             failures += 1
                             last_error = result.error
                             closed = True
+                            closed_after_failure = True
                         else:
                             result_text = result.note
                             if result.chunk is not None:
@@ -565,6 +582,8 @@ class LLMAgentPolicy(PolicyBase):
                     result = toolset.execute(call, observation)
                     if result.error is not None:
                         result_text = result.error
+                    elif result.capture == ():
+                        result_text = "no camera images are available in this observation"
                     else:
                         self._pending = _PendingCapture(
                             requested=result.capture,
@@ -574,7 +593,7 @@ class LLMAgentPolicy(PolicyBase):
                         )
                         result_text = (
                             "queued: frames arrive with the next observation, "
-                            "once the motion has finished playing"
+                            "after the motion plays"
                         )
                         requested = (
                             tuple(observation.images) if result.capture is None else result.capture
@@ -582,6 +601,8 @@ class LLMAgentPolicy(PolicyBase):
                         echo_text = f"queued capture: {_quoted_names(requested)}"
                 elif is_capture and chunk is not None and stopped:
                     result_text = "ignored: the trial ends with this call"
+                elif closed_after_failure:
+                    result_text = "ignored: an earlier call in this turn failed"
                 else:
                     result_text = "ignored: one tool call per turn"
 
@@ -600,8 +621,9 @@ class LLMAgentPolicy(PolicyBase):
             if chunk is not None:
                 return chunk
             if failures >= _MAX_CONSECUTIVE_FAILURES:
-                assert last_error is not None
-                raise RuntimeError(f"LLM tool calls kept failing; last error: {last_error}")
+                raise RuntimeError(
+                    f"LLM tool calls kept failing; last error: {last_error or 'unknown'}"
+                )
 
     def _forced_give_up(self, toolset: Toolset, observation: Observation, why: str) -> ActionChunk:
         # Echoed but never appended to _messages: the synthetic call is not

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 import numpy as np
+import numpy.typing as npt
 
 from inspect_robots.embodiment import EmbodimentInfo
 from inspect_robots.errors import ConfigError
@@ -58,6 +59,7 @@ _ANTHROPIC_BASE = _DIRECT_PROVIDERS["anthropic"].base_url
 _EFFORT_LEVELS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max"})
 _WIRE_FORMATS = frozenset({"chat", "responses", "anthropic"})
 _SPEEDS = frozenset({"fast"})
+_IMAGE_MODES = frozenset({"always", "on_demand"})
 
 _SYSTEM_TEMPLATE = """You are controlling a real robot embodiment named {name!r} \
 through tool calls. Each observation message gives you the current \
@@ -71,6 +73,27 @@ Safety approvers clamp out-of-bounds and too-fast actions below you. \
 Respond with exactly one tool call per turn. When the goal is achieved call \
 done; if it cannot be achieved call give_up. You have a budget of \
 {budget} LLM calls for the whole trial."""
+
+_ON_DEMAND_SYSTEM_TEMPLATE = """You are controlling a real robot embodiment named {name!r} \
+through tool calls. Each observation message gives you the current \
+proprioceptive state. Camera images are not attached automatically; call \
+`take_pic` to see them. A camera already shown for the current observation \
+cannot be re-taken until the robot moves. Work toward the user's goal in \
+small, deliberate motions; re-check the observation after every motion. \
+Every move tool call must include a `note`: in one or two sentences, say what \
+you observe in the current observation and why you chose this motion. The user \
+is watching these notes to see what you see and what you decide, so write them \
+for a human reader. \
+Safety approvers clamp out-of-bounds and too-fast actions below you. \
+Respond with exactly one motion tool call per turn; `take_pic` may be chained \
+in the same turn. Placed after a motion, it returns frames once the motion has \
+finished playing; placed alone, it looks before you decide what motion to make. \
+When the goal is achieved call done; if it cannot be achieved call give_up. You \
+have a budget of {budget} LLM calls for the whole trial."""
+
+_ON_DEMAND_NUDGE = (
+    "Respond with one motion tool call, one motion followed by take_pic, or take_pic alone."
+)
 
 
 def _sanitize(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -110,6 +133,17 @@ class AgentPolicyConfig(PolicyConfig):
     effort: str | None = "low"
     max_speed_frac: float = 0.1
     transcript_echo: bool = False
+    images: str = "always"
+
+
+@dataclass(frozen=True, eq=False)
+class _PendingCapture:
+    """A capture request waiting for the observation produced after motion playout."""
+
+    requested: tuple[str, ...] | None
+    issued_step: object
+    chunk_len: int
+    target: npt.NDArray[np.float64] | None
 
 
 class LLMAgentPolicy(PolicyBase):
@@ -134,6 +168,7 @@ class LLMAgentPolicy(PolicyBase):
         effort: str | None = "low",
         max_speed_frac: float = 0.1,
         transcript_echo: bool = False,
+        images: str = "always",
         transport: httpx.BaseTransport | None = None,
         env: dict[str, str] | None = None,
     ):
@@ -156,6 +191,11 @@ class LLMAgentPolicy(PolicyBase):
             raise ValueError(f"wire must be one of {sorted(_WIRE_FORMATS)}, got {wire!r}")
         if speed is not None and speed not in _SPEEDS:
             raise ValueError(f"speed must be one of {sorted(_SPEEDS)}, or None, got {speed!r}")
+        if images not in _IMAGE_MODES:
+            raise ConfigError(
+                f"images must be one of {sorted(_IMAGE_MODES)}, got {images!r}.\n"
+                "fix: pass -P images=always or -P images=on_demand"
+            )
         if wire != "anthropic":
             # A dropped speed would bill at standard rates while the user
             # believes fast mode is on; a dropped cap is a limit that never
@@ -273,6 +313,7 @@ class LLMAgentPolicy(PolicyBase):
         self._effort = effort
         self._max_speed_frac = max_speed_frac
         self._transcript_echo = transcript_echo
+        self._images = images
         self.config = AgentPolicyConfig(
             temperature=temperature,
             model=provider.model,
@@ -285,6 +326,7 @@ class LLMAgentPolicy(PolicyBase):
             effort=effort,
             max_speed_frac=max_speed_frac,
             transcript_echo=transcript_echo,
+            images=images,
         )
         # Placeholder until bind(); eval() always binds before compat/rollout.
         self.info = PolicyInfo(name="agent", action_space=Box(shape=(1,)))
@@ -295,6 +337,8 @@ class LLMAgentPolicy(PolicyBase):
         self._messages: list[dict[str, Any]] = []
         self._delta_cursor = 0
         self._calls_used = 0
+        self._pending: _PendingCapture | None = None
+        self._revealed: set[str] = set()
 
     # -- lifecycle ---------------------------------------------------------------
 
@@ -305,6 +349,7 @@ class LLMAgentPolicy(PolicyBase):
             embodiment_info.observation_space,
             embodiment_info.control_hz,
             self._max_speed_frac,
+            images=self._images,
         )
         self._toolset = toolset
         self._state_labels = toolset.state_labels()
@@ -319,7 +364,8 @@ class LLMAgentPolicy(PolicyBase):
 
     def reset(self, scene: Scene) -> None:
         """Start a fresh per-trial conversation with the scene goal and call budget."""
-        formatted = _SYSTEM_TEMPLATE.format(name=self._embodiment_name, budget=self._max_llm_calls)
+        template = _ON_DEMAND_SYSTEM_TEMPLATE if self._images == "on_demand" else _SYSTEM_TEMPLATE
+        formatted = template.format(name=self._embodiment_name, budget=self._max_llm_calls)
         docs = self._embodiment_docs
         if docs is not None and docs.strip():
             formatted = formatted + "\n\nEmbodiment notes:\n" + docs.strip()
@@ -333,6 +379,8 @@ class LLMAgentPolicy(PolicyBase):
         self._echo(f"[agent] goal: {scene.instruction}")
         self._delta_cursor = 0
         self._calls_used = 0
+        self._pending = None
+        self._revealed.clear()
 
     def on_trial_end(self, record: TrialRecord, log_dir: str, run_id: str) -> None:
         """Persist the transcript at the end of the trial."""
@@ -375,13 +423,41 @@ class LLMAgentPolicy(PolicyBase):
                 "LLMAgentPolicy.act() before bind(); run it through eval() or call "
                 "policy.bind(embodiment.info) first"
             )
-        self._messages.append(
-            {
-                "role": "user",
-                "content": _observation_content(observation, self._state_labels),
-            }
+        self._revealed.clear()
+        reveal: tuple[str, ...] | None = None
+        narration: str | None = None
+        if self._images == "on_demand":
+            reveal = ()
+            pending = self._pending
+            self._pending = None
+            if pending is not None:
+                requested = (
+                    tuple(observation.images)
+                    if pending.requested is None
+                    else _unique_names(pending.requested)
+                )
+                reveal = tuple(name for name in requested if name in observation.images)
+                missing = tuple(name for name in requested if name not in observation.images)
+                self._revealed.update(reveal)
+                narration = self._pending_narration(pending, observation, missing)
+        observation_content = _observation_content(
+            observation,
+            self._state_labels,
+            reveal=reveal,
+            narration=narration,
         )
+        if self._images == "on_demand":
+            available = _quoted_names(tuple(observation.images))
+            camera_line = (
+                f"Cameras available to take_pic: {available}."
+                if available
+                else "No camera images are available to take_pic in this observation."
+            )
+            observation_content[0]["text"] += f"\n{camera_line}"
+        self._messages.append({"role": "user", "content": observation_content})
         summary = f"{len(observation.images)} camera(s)"
+        if self._images == "on_demand":
+            summary += " available"
         state_summary = " | ".join(_state_lines(observation, self._state_labels))
         if state_summary:
             summary = f"{summary}, {state_summary}"
@@ -414,34 +490,118 @@ class LLMAgentPolicy(PolicyBase):
                 if failures >= _MAX_CONSECUTIVE_FAILURES:
                     raise RuntimeError(f"LLM produced no tool call in {failures} consecutive turns")
                 self._messages.append(
-                    {"role": "user", "content": "Respond with exactly one tool call."}
+                    {
+                        "role": "user",
+                        "content": (
+                            _ON_DEMAND_NUDGE
+                            if self._images == "on_demand"
+                            else "Respond with exactly one tool call."
+                        ),
+                    }
                 )
                 continue
 
-            call, *extras = message.tool_calls
-            for extra in extras:
-                # Every tool_call id needs an answer on the wire; only the
-                # first call per turn is executed.
+            chunk: ActionChunk | None = None
+            target: npt.NDArray[np.float64] | None = None
+            immediate_frames: tuple[str, ...] = ()
+            closed = False
+            stopped = False
+            last_error: str | None = None
+            for call in message.tool_calls:
+                result_text: str
+                echo_text: str | None = None
+                is_capture = self._images == "on_demand" and call.name == "take_pic"
+                if not closed:
+                    result = toolset.execute(call, observation)
+                    if is_capture:
+                        closed = True
+                        if result.error is not None:
+                            result_text = result.error
+                            failures += 1
+                            last_error = result.error
+                        else:
+                            requested = (
+                                tuple(observation.images)
+                                if result.capture is None
+                                else _unique_names(result.capture)
+                            )
+                            skipped = tuple(name for name in requested if name in self._revealed)
+                            immediate_frames = tuple(
+                                name for name in requested if name not in self._revealed
+                            )
+                            if immediate_frames:
+                                self._revealed.update(immediate_frames)
+                                result_text = (
+                                    f"captured {len(immediate_frames)} frame(s): "
+                                    f"{_quoted_names(immediate_frames)}"
+                                )
+                                if skipped:
+                                    result_text += f" (already shown: {_quoted_names(skipped)})"
+                                failures = 0
+                                echo_text = f"captured {len(immediate_frames)} frame(s)"
+                            else:
+                                result_text = (
+                                    "already shown for this observation: "
+                                    f"{_quoted_names(skipped)}; the view cannot change until "
+                                    "the robot moves"
+                                )
+                    else:
+                        if result.error is not None:
+                            result_text = result.error
+                            failures += 1
+                            last_error = result.error
+                            closed = True
+                        else:
+                            result_text = result.note
+                            if result.chunk is not None:
+                                chunk = result.chunk
+                                target = result.target
+                                stopped = bool(chunk.actions[0].meta.get("request_stop"))
+                                closed = True
+                elif is_capture and chunk is not None and not stopped and self._pending is None:
+                    # The closed-state exception validates only the capture
+                    # that may ride behind a motion. A failed validation keeps
+                    # the queue slot open for a later call in this same turn.
+                    result = toolset.execute(call, observation)
+                    if result.error is not None:
+                        result_text = result.error
+                    else:
+                        self._pending = _PendingCapture(
+                            requested=result.capture,
+                            issued_step=observation.extra.get("env_step"),
+                            chunk_len=len(chunk),
+                            target=target,
+                        )
+                        result_text = (
+                            "queued: frames arrive with the next observation, "
+                            "once the motion has finished playing"
+                        )
+                        requested = (
+                            tuple(observation.images) if result.capture is None else result.capture
+                        )
+                        echo_text = f"queued capture: {_quoted_names(requested)}"
+                elif is_capture and chunk is not None and stopped:
+                    result_text = "ignored: the trial ends with this call"
+                else:
+                    result_text = "ignored: one tool call per turn"
+
+                self._messages.append(
+                    {"role": "tool", "tool_call_id": call.id, "content": result_text}
+                )
+                self._echo(f"[agent] -- {echo_text or result_text}")
+
+            if immediate_frames:
                 self._messages.append(
                     {
-                        "role": "tool",
-                        "tool_call_id": extra.id,
-                        "content": "ignored: one tool call per turn",
+                        "role": "user",
+                        "content": _image_parts(observation, reveal=immediate_frames),
                     }
                 )
-                self._echo("[agent] -- ignored: one tool call per turn")
-            result = toolset.execute(call, observation)
-            self._messages.append(
-                {"role": "tool", "tool_call_id": call.id, "content": result.error or result.note}
-            )
-            self._echo(f"[agent] -- {result.error or result.note}")
-            if result.error:
-                failures += 1
-                if failures >= _MAX_CONSECUTIVE_FAILURES:
-                    raise RuntimeError(f"LLM tool calls kept failing; last error: {result.error}")
-                continue
-            assert result.chunk is not None  # execute() sets exactly one of chunk/error
-            return result.chunk
+            if chunk is not None:
+                return chunk
+            if failures >= _MAX_CONSECUTIVE_FAILURES:
+                assert last_error is not None
+                raise RuntimeError(f"LLM tool calls kept failing; last error: {last_error}")
 
     def _forced_give_up(self, toolset: Toolset, observation: Observation, why: str) -> ActionChunk:
         # Echoed but never appended to _messages: the synthetic call is not
@@ -449,8 +609,48 @@ class LLMAgentPolicy(PolicyBase):
         self._echo(f"[agent] -- {why}; forcing give_up")
         synthetic = ToolCall(id="budget", name="give_up", arguments=json.dumps({"reason": why}))
         result = toolset.execute(synthetic, observation)
-        assert result.chunk is not None
+        if result.chunk is None:  # pragma: no cover - synthetic stop is structurally valid
+            raise RuntimeError(f"forced give_up failed: {result.error}")
         return result.chunk
+
+    def _pending_narration(
+        self,
+        pending: _PendingCapture,
+        observation: Observation,
+        missing: tuple[str, ...],
+    ) -> str:
+        """Describe observed playout, residual, and any cameras missing at delivery."""
+        arriving_step = observation.extra.get("env_step")
+        if (
+            isinstance(pending.issued_step, int)
+            and isinstance(arriving_step, int)
+            and (advanced := arriving_step - pending.issued_step) > 0
+        ):
+            if advanced >= pending.chunk_len:
+                narration = (
+                    f"the motion finished playing ({pending.chunk_len} of "
+                    f"{pending.chunk_len} steps)."
+                )
+            else:
+                narration = (
+                    f"the motion played {advanced} of {pending.chunk_len} steps before "
+                    "this observation; it did not run to the end."
+                )
+        else:
+            narration = "these frames follow the motion."
+
+        toolset = self._toolset
+        if pending.target is not None and toolset is not None:
+            residual = toolset.residual(pending.target, observation)
+            if residual is not None:
+                label, magnitude = residual
+                narration += (
+                    " largest remaining offset from the requested target is "
+                    f"{magnitude:.4g} on {label}."
+                )
+        if missing:
+            narration += f" missing camera(s) in this observation: {_quoted_names(missing)}."
+        return narration
 
     def _echo(self, text: str) -> None:
         if self._transcript_echo:
@@ -487,19 +687,49 @@ def _step_label(observation: Observation) -> str:
 def _observation_content(
     observation: Observation,
     state_labels: tuple[str, tuple[str, ...]] | None = None,
+    *,
+    reveal: tuple[str, ...] | None = None,
+    narration: str | None = None,
 ) -> list[dict[str, Any]]:
     """State as readable text plus camera frames as inline PNG data URLs."""
     lines = ["Current observation."]
     if observation.instruction:
         lines.append(f"Instruction: {observation.instruction}")
     lines.extend(_state_lines(observation, state_labels))
+    if narration is not None:
+        lines.append(narration)
     parts: list[dict[str, Any]] = [{"type": "text", "text": "\n".join(lines)}]
+    parts.extend(_image_parts(observation, reveal=reveal))
+    return parts
+
+
+def _image_parts(
+    observation: Observation,
+    *,
+    reveal: tuple[str, ...] | None = None,
+) -> list[dict[str, Any]]:
+    """Build frame labels and payloads without changing the report's label join key."""
+    parts: list[dict[str, Any]] = []
     step_label = _step_label(observation)
     suffix = f" ({step_label})" if step_label else ""
-    for name, image in observation.images.items():
+    names = tuple(observation.images) if reveal is None else reveal
+    for name in names:
+        image = observation.images.get(name)
+        if image is None:
+            continue
         parts.append({"type": "text", "text": f"camera {name!r}{suffix}:"})
         parts.append({"type": "image_url", "image_url": {"url": png_data_url(image)}})
     return parts
+
+
+def _quoted_names(names: tuple[str, ...]) -> str:
+    """Render camera names in stable request order for model-facing narration."""
+    return ", ".join(repr(name) for name in names)
+
+
+def _unique_names(names: tuple[str, ...]) -> tuple[str, ...]:
+    """Deduplicate requested cameras without changing their first-seen order."""
+    return tuple(dict.fromkeys(names))
 
 
 def agent_policy(**kwargs: Any) -> LLMAgentPolicy:

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -241,6 +241,47 @@ def test_consecutive_tool_messages_merge_in_history_order() -> None:
     assert sum(1 for m in messages if m["role"] == "user" and isinstance(m["content"], list)) == 1
 
 
+def test_capture_history_keeps_results_contiguous_before_the_image_message() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    url = png_data_url(np.zeros((1, 1, 3), dtype=np.uint8))
+    history = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                _tool_call("move", "move_joints", '{"targets":{"joint":0.2}}'),
+                _tool_call("pic", "take_pic", '{"note":"inspect"}'),
+            ],
+        },
+        {"role": "tool", "tool_call_id": "move", "content": "executing move"},
+        {"role": "tool", "tool_call_id": "pic", "content": "captured 1 frame(s): 'top'"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "camera 'top' (step 1):"},
+                {"type": "image_url", "image_url": {"url": url}},
+            ],
+        },
+    ]
+
+    _client(handler).complete(history, [])
+
+    messages = json.loads(seen[0].content)["messages"]
+    assert messages[1] == {
+        "role": "user",
+        "content": [
+            {"type": "tool_result", "tool_use_id": "move", "content": "executing move"},
+            {
+                "type": "tool_result",
+                "tool_use_id": "pic",
+                "content": "captured 1 frame(s): 'top'",
+            },
+        ],
+    }
+    assert messages[2]["role"] == "user"
+    assert [part["type"] for part in messages[2]["content"]] == ["text", "image"]
+
+
 def test_interleaved_tool_runs_do_not_merge_across_an_observation() -> None:
     seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
     history = [

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,7 +6,7 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.13.0"
+    assert inspect_robots_agent.__version__ == "0.14.0"
     assert callable(inspect_robots_agent.agent_policy)
     assert inspect_robots_agent.__all__ == [
         "ENV_MODEL",

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -994,6 +994,69 @@ def test_immediate_capture_appends_results_then_frames_and_redecides() -> None:
     assert frame_message["content"][1]["type"] == "image_url"
 
 
+def test_immediate_capture_validation_errors_increment_failures() -> None:
+    script = _Script([_tool_response("take_pic", {})])
+    policy = _policy(script, images="on_demand", max_llm_calls=50)
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="look"))
+
+    with pytest.raises(
+        RuntimeError,
+        match="last error: note is required",
+    ):
+        policy.act(_vision_observation())
+
+    assert len(script.requests) == 3
+    assert [
+        message["content"] for message in policy._messages if message.get("role") == "tool"
+    ] == ["note is required: describe what you observe and why you chose this capture"] * 3
+
+
+def test_imageless_capture_is_rejected_without_ending_the_trial() -> None:
+    script = _Script(
+        [
+            _tool_response("take_pic", {"note": "I need the current camera view."}),
+            _tool_response("done", {"summary": "continued after the dropout"}),
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="look"))
+
+    chunk = policy.act(_vision_observation(cameras=()))
+
+    assert chunk.actions[0].meta["stop_reason"] == "done"
+    assert len(script.requests) == 2
+    results = [message["content"] for message in policy._messages if message.get("role") == "tool"]
+    assert results[:2] == [
+        "no camera images are available in this observation",
+        "done: continued after the dropout",
+    ]
+
+
+def test_repeated_imageless_capture_rejections_escalate_with_bounded_calls() -> None:
+    capture = _tool_response(
+        "take_pic",
+        {
+            "cameras": ["top"],
+            "note": "I need the top view despite the camera dropout.",
+        },
+    )
+    script = _Script([capture])
+    policy = _policy(script, images="on_demand", max_llm_calls=50)
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="look"))
+
+    rejection = "no camera images are available in this observation"
+    with pytest.raises(RuntimeError, match=f"last error: {rejection}"):
+        policy.act(_vision_observation(cameras=()))
+
+    results = [message["content"] for message in policy._messages if message.get("role") == "tool"]
+    assert results == [rejection] * 4
+    assert len(script.requests) == 4
+    assert len(script.requests) < policy.config.max_llm_calls
+
+
 def test_take_pic_before_move_short_circuits_with_contiguous_results() -> None:
     script = _Script(
         [
@@ -1063,10 +1126,38 @@ def test_invalid_capture_after_move_keeps_chunk_and_leaves_queue_slot_open() -> 
     assert [message["content"] for message in policy._messages[-3:]] == [
         "executing move_joints over 11 steps (1.1s)",
         "unknown or unavailable camera 'missing'; available now: 'top', 'wrist'",
-        "queued: frames arrive with the next observation, once the motion has finished playing",
+        "queued: frames arrive with the next observation, after the motion plays",
     ]
     assert policy._pending is not None
     assert policy._pending.requested == ("top",)
+
+
+def test_imageless_capture_after_move_is_rejected_without_queuing() -> None:
+    script = _Script(
+        [
+            _multi_tool_response(
+                [
+                    ("move_joints", {"targets": {"joint": 0.2}}),
+                    (
+                        "take_pic",
+                        {"note": "I need to inspect the result after moving."},
+                    ),
+                ]
+            )
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="move and inspect"))
+
+    chunk = policy.act(_vision_observation(cameras=()))
+
+    assert len(chunk) == 11
+    assert [message["content"] for message in policy._messages[-2:]] == [
+        "executing move_joints over 11 steps (1.1s)",
+        "no camera images are available in this observation",
+    ]
+    assert policy._pending is None
 
 
 def test_two_take_pic_calls_capture_once_and_answer_the_second_ignored() -> None:
@@ -1118,19 +1209,52 @@ def test_unknown_tool_error_names_take_pic_in_on_demand_mode() -> None:
     assert errors[0] == ("unknown tool 'look'; available: move_joints, done, give_up, take_pic")
 
 
-def test_repeated_bare_capture_rejections_do_not_increment_failures() -> None:
-    capture = _tool_response(
-        "take_pic",
-        {"note": "I need every view that has not already been shown."},
-    )
+def test_valid_capture_after_an_earlier_error_is_ignored_with_failure_reason() -> None:
     script = _Script(
-        [capture, capture, capture, capture, _tool_response("done", {"summary": "enough"})]
+        [
+            _multi_tool_response(
+                [
+                    (
+                        "take_pic",
+                        {"cameras": ["nope"], "note": "I need a camera view."},
+                    ),
+                    (
+                        "take_pic",
+                        {"cameras": ["top"], "note": "I will use the top view."},
+                    ),
+                ]
+            ),
+            _tool_response("done", {"summary": "corrected"}),
+        ]
     )
     policy = _policy(script, images="on_demand")
     policy.bind(_VisionAbsoluteEmbodiment().info)
     policy.reset(Scene(id="s0", instruction="look"))
 
     policy.act(_vision_observation())
+
+    results = [message["content"] for message in policy._messages if message.get("role") == "tool"]
+    assert results[:2] == [
+        "unknown or unavailable camera 'nope'; available now: 'top', 'wrist'",
+        "ignored: an earlier call in this turn failed",
+    ]
+
+
+def test_repeated_bare_capture_rejections_escalate_with_bounded_calls() -> None:
+    capture = _tool_response(
+        "take_pic",
+        {"note": "I need every view that has not already been shown."},
+    )
+    script = _Script([capture])
+    policy = _policy(script, images="on_demand", max_llm_calls=50)
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="look"))
+
+    with pytest.raises(
+        RuntimeError,
+        match="last error: already shown for this observation",
+    ):
+        policy.act(_vision_observation())
 
     rejections = [
         message["content"]
@@ -1146,9 +1270,10 @@ def test_repeated_bare_capture_rejections_do_not_increment_failures() -> None:
                 "the view cannot change until the robot moves"
             )
         ]
-        * 3
+        * 4
     )
     assert len(script.requests) == 5
+    assert len(script.requests) < policy.config.max_llm_calls
 
 
 def test_named_immediate_capture_reveals_only_unshown_cameras() -> None:
@@ -1216,7 +1341,7 @@ def test_chained_capture_arrives_on_next_observation_with_playout_and_residual()
     ]
     assert first_results == [
         "executing move_joints over 11 steps (1.1s)",
-        "queued: frames arrive with the next observation, once the motion has finished playing",
+        "queued: frames arrive with the next observation, after the motion plays",
     ]
     arrived = script.requests[1]["messages"][-1]
     assert (

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -1220,7 +1220,7 @@ def test_chained_capture_arrives_on_next_observation_with_playout_and_residual()
     ]
     arrived = script.requests[1]["messages"][-1]
     assert (
-        "the motion finished playing (11 of 11 steps). largest remaining offset "
+        "The motion finished playing (11 of 11 steps). Largest remaining offset "
         "from the requested target is 0.004 on joint." in arrived["content"][0]["text"]
     )
     assert arrived["content"][1]["text"] == "camera 'top' (step 15):"
@@ -1249,7 +1249,7 @@ def test_chained_capture_reports_default_controller_partial_playout(tmp_path: Pa
 
     arrived = script.requests[1]["messages"][-1]["content"][0]["text"]
     assert (
-        "the motion played 1 of 11 steps before this observation; it did not run to the end."
+        "The motion played 1 of 11 steps before this observation; it did not run to the end."
     ) in arrived
 
 
@@ -1273,7 +1273,7 @@ def test_chained_capture_uses_neutral_narration_when_step_does_not_advance() -> 
     policy.act(_vision_observation(q=0.2, env_step=0))
 
     arrived = script.requests[1]["messages"][-1]["content"][0]["text"]
-    assert "these frames follow the motion." in arrived
+    assert "These frames follow the motion." in arrived
     assert "finished playing" not in arrived
     assert "motion played" not in arrived
 
@@ -1304,7 +1304,7 @@ def test_missing_queued_camera_is_narrated_without_raising() -> None:
     policy.act(_vision_observation(q=0.1, env_step=len(chunk), cameras=("top",)))
 
     arrived = script.requests[1]["messages"][-1]["content"]
-    assert "missing camera(s) in this observation: 'wrist'." in arrived[0]["text"]
+    assert "Missing camera(s) in this observation: 'wrist'." in arrived[0]["text"]
     assert [part["text"] for part in arrived if part["type"] == "text"][1:] == [
         f"camera 'top' (step {len(chunk)}):"
     ]
@@ -1338,7 +1338,7 @@ def test_queued_capture_is_dropped_when_trial_terminates_and_reset_clears_it(
     policy.act(_vision_observation())
     fresh_observation = script.requests[1]["messages"][-1]["content"]
     assert all(part["type"] != "image_url" for part in fresh_observation)
-    assert "these frames follow the motion." not in fresh_observation[0]["text"]
+    assert "These frames follow the motion." not in fresh_observation[0]["text"]
 
 
 def test_take_pic_after_done_is_ignored_because_the_trial_ends() -> None:

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -936,6 +936,32 @@ def test_extra_tool_calls_are_answered_but_not_executed(tmp_path: Path) -> None:
     ]
 
 
+def test_extras_behind_a_failed_call_name_the_failure_in_always_mode() -> None:
+    # The reason string is not scoped to on-demand mode: blaming the model for
+    # a surplus call when the real cause was the earlier failure misleads it in
+    # either mode.
+    script = _Script(
+        [
+            _multi_tool_response(
+                [
+                    ("move_by", {"deltas": {"nope": 0.05}}),
+                    ("give_up", {"reason": "extra"}),
+                ]
+            ),
+            _tool_response("done", {"summary": "recovered"}),
+        ]
+    )
+    policy = _policy(script)
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="stop"))
+
+    policy.act(Observation(extra={"env_step": 0}))
+
+    results = [message["content"] for message in policy._messages if message.get("role") == "tool"]
+    assert results[0].startswith("unknown dimension 'nope'")
+    assert results[1] == "ignored: an earlier call in this turn failed"
+
+
 def test_on_demand_observation_names_available_cameras_without_sending_frames() -> None:
     script = _Script([_tool_response("done", {"summary": "observed state"})])
     policy = _policy(script, images="on_demand")
@@ -1032,6 +1058,32 @@ def test_imageless_capture_is_rejected_without_ending_the_trial() -> None:
         "no camera images are available in this observation",
         "done: continued after the dropout",
     ]
+
+
+def test_a_dropout_rejection_does_not_count_toward_the_three_strike_guard() -> None:
+    # The dropout sits between two genuine errors. Treated as an error it would
+    # be the third strike and kill the trial, which is what it did before the
+    # rejection class existed; treated as the free rejection it is, the trial
+    # survives to the next decision.
+    script = _Script(
+        [
+            _tool_response("take_pic", {"note": "  "}, add_default_note=False),
+            _tool_response("take_pic", {"note": "The dropout may have cleared."}),
+            _tool_response("take_pic", {"note": ""}, add_default_note=False),
+            _tool_response("done", {"summary": "survived two errors around a dropout"}),
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="look"))
+
+    chunk = policy.act(_vision_observation(cameras=()))
+
+    assert chunk.actions[0].meta["stop_reason"] == "done"
+    results = [message["content"] for message in policy._messages if message.get("role") == "tool"]
+    assert results[1] == "no camera images are available in this observation"
+    assert results[0] == results[2]
+    assert results[0].startswith("note is required")
 
 
 def test_repeated_imageless_capture_rejections_escalate_with_bounded_calls() -> None:

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -20,13 +20,22 @@ import pytest
 
 from inspect_robots import eval as ir_eval
 from inspect_robots.approver import ChainApprover, ClampApprover, DeltaLimitApprover
+from inspect_robots.controller import DefaultController
 from inspect_robots.embodiment import EmbodimentInfo
+from inspect_robots.errors import ConfigError
 from inspect_robots.logging.sink import NullSink
 from inspect_robots.mock import CubePickEmbodiment
 from inspect_robots.rollout import TrialRecord
 from inspect_robots.scene import Scene
 from inspect_robots.scorer import success_at_end
-from inspect_robots.spaces import ActionSemantics, Box, ObservationSpace, StateField, StateSpec
+from inspect_robots.spaces import (
+    ActionSemantics,
+    Box,
+    CameraSpec,
+    ObservationSpace,
+    StateField,
+    StateSpec,
+)
 from inspect_robots.task import Task
 from inspect_robots.types import Action, Observation, StepResult
 from inspect_robots_agent import LLMAgentPolicy
@@ -210,6 +219,72 @@ class _AbsoluteEmbodiment:
 
     def close(self) -> None:
         return None
+
+
+class _VisionAbsoluteEmbodiment:
+    def __init__(self, *, terminate_after_first_step: bool = False) -> None:
+        self._q = np.array([0.0])
+        self._steps = 0
+        self._terminate_after_first_step = terminate_after_first_step
+        self.info = EmbodimentInfo(
+            name="vision-absolute-test",
+            action_space=Box(
+                shape=(1,),
+                low=np.array([-1.0]),
+                high=np.array([1.0]),
+                semantics=ActionSemantics("joint_pos", dim_labels=("joint",)),
+            ),
+            observation_space=ObservationSpace(
+                cameras=(
+                    CameraSpec(name="top", height=2, width=2, channels=3),
+                    CameraSpec(name="wrist", height=2, width=2, channels=3),
+                ),
+                state=StateSpec(fields=(StateField(key="q", shape=(1,)),)),
+            ),
+            control_hz=10.0,
+            is_simulated=True,
+        )
+
+    def reset(self, scene: Scene, *, seed: int | None = None) -> Observation:
+        self._q = np.array([0.0])
+        self._steps = 0
+        return self._observe(scene.instruction)
+
+    def step(self, action: Action) -> StepResult:
+        self._steps += 1
+        self._q = np.asarray(action.data, dtype=np.float64).copy()
+        terminated = self._terminate_after_first_step and self._steps == 1
+        return StepResult(
+            observation=self._observe(None),
+            terminated=terminated,
+            termination_reason="test termination" if terminated else None,
+        )
+
+    def close(self) -> None:
+        return None
+
+    def _observe(self, instruction: str | None) -> Observation:
+        return Observation(
+            images={
+                "top": np.full((2, 2, 3), self._steps, dtype=np.uint8),
+                "wrist": np.full((2, 2, 3), self._steps + 10, dtype=np.uint8),
+            },
+            state={"q": self._q.copy()},
+            instruction=instruction,
+        )
+
+
+def _vision_observation(
+    *,
+    q: float = 0.0,
+    env_step: object = 0,
+    cameras: tuple[str, ...] = ("top", "wrist"),
+) -> Observation:
+    images = {
+        name: np.full((2, 2, 3), index, dtype=np.uint8)
+        for index, name in enumerate(cameras, start=1)
+    }
+    return Observation(state={"q": np.array([q])}, images=images, extra={"env_step": env_step})
 
 
 # --- tests -----------------------------------------------------------------------
@@ -414,7 +489,7 @@ def test_transcript_echo_reports_conversation_in_order(
     assert positions == sorted(positions)
 
 
-def test_transcript_echo_marks_extra_tool_calls_before_executed_result(
+def test_transcript_echo_reports_tool_results_in_call_order(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     policy = _policy(
@@ -444,9 +519,9 @@ def test_transcript_echo_marks_extra_tool_calls_before_executed_result(
         '[agent] << tool_call done({"summary": "first executes"})',
         '[agent] << tool_call give_up({"reason": "extra"})',
         '[agent] << tool_call give_up({"reason": "second extra"})',
-        "[agent] -- ignored: one tool call per turn",
-        "[agent] -- ignored: one tool call per turn",
         "[agent] -- done: first executes",
+        "[agent] -- ignored: one tool call per turn",
+        "[agent] -- ignored: one tool call per turn",
     ]
 
 
@@ -844,12 +919,481 @@ def test_extra_tool_calls_are_answered_but_not_executed(tmp_path: Path) -> None:
     sink = _RecordingSink()
     ir_eval(_task(), _policy(script), CubePickEmbodiment(), log_dir=str(tmp_path), sinks=[sink])
     assert sink.records[0].termination_reason == "done"
-    ignored = [
-        message
-        for message in script.requests[1]["messages"]
-        if message.get("content") == "ignored: one tool call per turn"
+    results = [
+        message for message in script.requests[1]["messages"] if message.get("role") == "tool"
     ]
-    assert len(ignored) == 1
+    assert results == [
+        {
+            "role": "tool",
+            "tool_call_id": "call_0",
+            "content": "executing move_by over 1 steps (0.1s)",
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "ignored: one tool call per turn",
+        },
+    ]
+
+
+def test_on_demand_observation_names_available_cameras_without_sending_frames() -> None:
+    script = _Script([_tool_response("done", {"summary": "observed state"})])
+    policy = _policy(script, images="on_demand")
+    embodiment = _VisionAbsoluteEmbodiment()
+    policy.bind(embodiment.info)
+    policy.reset(Scene(id="s0", instruction="look selectively"))
+
+    policy.act(_vision_observation())
+
+    observation = script.requests[0]["messages"][-1]
+    assert observation["role"] == "user"
+    assert observation["content"][0]["text"].endswith(
+        "Cameras available to take_pic: 'top', 'wrist'."
+    )
+    assert all(part["type"] != "image_url" for part in observation["content"])
+    assert [tool["function"]["name"] for tool in script.requests[0]["tools"]] == [
+        "move_joints",
+        "done",
+        "give_up",
+        "take_pic",
+    ]
+
+
+def test_immediate_capture_appends_results_then_frames_and_redecides() -> None:
+    script = _Script(
+        [
+            _tool_response(
+                "take_pic",
+                {"cameras": ["top"], "note": "I need to inspect the top view first."},
+            ),
+            _tool_response("done", {"summary": "looked"}),
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="look"))
+
+    chunk = policy.act(_vision_observation(env_step=7))
+
+    assert chunk.actions[0].meta["request_stop"] is True
+    assert len(script.requests) == 2
+    history = script.requests[1]["messages"]
+    assistant_index = next(
+        index
+        for index, message in enumerate(history)
+        if message.get("tool_calls") and message["tool_calls"][0]["function"]["name"] == "take_pic"
+    )
+    assert history[assistant_index + 1] == {
+        "role": "tool",
+        "tool_call_id": "call_take_pic",
+        "content": "captured 1 frame(s): 'top'",
+    }
+    frame_message = history[assistant_index + 2]
+    assert frame_message["role"] == "user"
+    assert frame_message["content"][0]["text"] == "camera 'top' (step 7):"
+    assert frame_message["content"][1]["type"] == "image_url"
+
+
+def test_take_pic_before_move_short_circuits_with_contiguous_results() -> None:
+    script = _Script(
+        [
+            _multi_tool_response(
+                [
+                    ("take_pic", {"note": "I need to look before moving."}),
+                    ("move_joints", {"targets": {"joint": 0.5}}),
+                ]
+            ),
+            _tool_response("done", {"summary": "decided after looking"}),
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="inspect"))
+
+    chunk = policy.act(_vision_observation())
+
+    assert chunk.actions[0].meta["stop_reason"] == "done"
+    history = script.requests[1]["messages"]
+    results = [message for message in history if message.get("role") == "tool"]
+    assert results == [
+        {
+            "role": "tool",
+            "tool_call_id": "call_0",
+            "content": "captured 2 frame(s): 'top', 'wrist'",
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "ignored: one tool call per turn",
+        },
+    ]
+    result_indices = [history.index(result) for result in results]
+    assert result_indices[1] == result_indices[0] + 1
+    assert {result["tool_call_id"] for result in results} == {"call_0", "call_1"}
+
+
+def test_invalid_capture_after_move_keeps_chunk_and_leaves_queue_slot_open() -> None:
+    script = _Script(
+        [
+            _multi_tool_response(
+                [
+                    ("move_joints", {"targets": {"joint": 0.2}}),
+                    (
+                        "take_pic",
+                        {
+                            "cameras": ["missing"],
+                            "note": "I need a view after the move.",
+                        },
+                    ),
+                    (
+                        "take_pic",
+                        {"cameras": ["top"], "note": "I will use the available top view."},
+                    ),
+                ]
+            )
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="move and inspect"))
+
+    chunk = policy.act(_vision_observation())
+
+    assert len(chunk) == 11
+    assert [message["content"] for message in policy._messages[-3:]] == [
+        "executing move_joints over 11 steps (1.1s)",
+        "unknown or unavailable camera 'missing'; available now: 'top', 'wrist'",
+        "queued: frames arrive with the next observation, once the motion has finished playing",
+    ]
+    assert policy._pending is not None
+    assert policy._pending.requested == ("top",)
+
+
+def test_two_take_pic_calls_capture_once_and_answer_the_second_ignored() -> None:
+    script = _Script(
+        [
+            _multi_tool_response(
+                [
+                    ("take_pic", {"note": "I need the current views."}),
+                    ("take_pic", {"note": "I am asking twice."}),
+                ]
+            ),
+            _tool_response("done", {"summary": "looked once"}),
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="look"))
+
+    policy.act(_vision_observation())
+
+    results = [message["content"] for message in policy._messages if message.get("role") == "tool"]
+    assert results[:2] == [
+        "captured 2 frame(s): 'top', 'wrist'",
+        "ignored: one tool call per turn",
+    ]
+    image_messages = [
+        message
+        for message in policy._messages
+        if isinstance(message.get("content"), list)
+        and any(part.get("type") == "image_url" for part in message["content"])
+    ]
+    assert len(image_messages) == 1
+
+
+def test_unknown_tool_error_names_take_pic_in_on_demand_mode() -> None:
+    script = _Script(
+        [
+            _tool_response("look", {"note": "wrong tool"}),
+            _tool_response("done", {"summary": "corrected"}),
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="look"))
+
+    policy.act(_vision_observation())
+
+    errors = [message["content"] for message in policy._messages if message.get("role") == "tool"]
+    assert errors[0] == ("unknown tool 'look'; available: move_joints, done, give_up, take_pic")
+
+
+def test_repeated_bare_capture_rejections_do_not_increment_failures() -> None:
+    capture = _tool_response(
+        "take_pic",
+        {"note": "I need every view that has not already been shown."},
+    )
+    script = _Script(
+        [capture, capture, capture, capture, _tool_response("done", {"summary": "enough"})]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="look"))
+
+    policy.act(_vision_observation())
+
+    rejections = [
+        message["content"]
+        for message in policy._messages
+        if message.get("role") == "tool"
+        and str(message["content"]).startswith("already shown for this observation:")
+    ]
+    assert (
+        rejections
+        == [
+            (
+                "already shown for this observation: 'top', 'wrist'; "
+                "the view cannot change until the robot moves"
+            )
+        ]
+        * 3
+    )
+    assert len(script.requests) == 5
+
+
+def test_named_immediate_capture_reveals_only_unshown_cameras() -> None:
+    script = _Script(
+        [
+            _tool_response(
+                "take_pic",
+                {"cameras": ["top"], "note": "I need the top view."},
+            ),
+            _tool_response(
+                "take_pic",
+                {
+                    "cameras": ["top", "wrist"],
+                    "note": "I also need the wrist view.",
+                },
+            ),
+            _tool_response("done", {"summary": "both seen"}),
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="look"))
+
+    policy.act(_vision_observation())
+
+    results = [message["content"] for message in policy._messages if message.get("role") == "tool"]
+    assert results[:2] == [
+        "captured 1 frame(s): 'top'",
+        "captured 1 frame(s): 'wrist' (already shown: 'top')",
+    ]
+    frame_messages = [
+        message
+        for message in policy._messages
+        if isinstance(message.get("content"), list)
+        and any(part.get("type") == "image_url" for part in message["content"])
+    ]
+    assert frame_messages[1]["content"][0]["text"] == "camera 'wrist' (step 0):"
+    assert len(frame_messages[1]["content"]) == 2
+
+
+def test_chained_capture_arrives_on_next_observation_with_playout_and_residual() -> None:
+    script = _Script(
+        [
+            _multi_tool_response(
+                [
+                    ("move_joints", {"targets": {"joint": 0.2}}),
+                    ("take_pic", {"note": "I need to inspect the result after moving."}),
+                ]
+            ),
+            _tool_response("done", {"summary": "inspected"}),
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="move and look"))
+
+    chunk = policy.act(_vision_observation(env_step=4))
+    policy.act(_vision_observation(q=0.196, env_step=15))
+
+    assert len(chunk) == 11
+    first_results = [
+        message["content"]
+        for message in script.requests[1]["messages"]
+        if message.get("role") == "tool"
+    ]
+    assert first_results == [
+        "executing move_joints over 11 steps (1.1s)",
+        "queued: frames arrive with the next observation, once the motion has finished playing",
+    ]
+    arrived = script.requests[1]["messages"][-1]
+    assert (
+        "the motion finished playing (11 of 11 steps). largest remaining offset "
+        "from the requested target is 0.004 on joint." in arrived["content"][0]["text"]
+    )
+    assert arrived["content"][1]["text"] == "camera 'top' (step 15):"
+    assert arrived["content"][3]["text"] == "camera 'wrist' (step 15):"
+
+
+def test_chained_capture_reports_default_controller_partial_playout(tmp_path: Path) -> None:
+    script = _Script(
+        [
+            _multi_tool_response(
+                [
+                    ("move_joints", {"targets": {"joint": 0.2}}),
+                    ("take_pic", {"note": "I need to see where one played step ends."}),
+                ]
+            ),
+            _tool_response("done", {"summary": "partial observed"}),
+        ]
+    )
+    ir_eval(
+        _task(max_steps=4),
+        _policy(script, images="on_demand"),
+        _VisionAbsoluteEmbodiment(),
+        log_dir=str(tmp_path),
+        controller=DefaultController(replan_interval=1),
+    )
+
+    arrived = script.requests[1]["messages"][-1]["content"][0]["text"]
+    assert (
+        "the motion played 1 of 11 steps before this observation; it did not run to the end."
+    ) in arrived
+
+
+def test_chained_capture_uses_neutral_narration_when_step_does_not_advance() -> None:
+    script = _Script(
+        [
+            _multi_tool_response(
+                [
+                    ("move_joints", {"targets": {"joint": 0.2}}),
+                    ("take_pic", {"note": "I need the post-motion views."}),
+                ]
+            ),
+            _tool_response("done", {"summary": "observed"}),
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="move"))
+
+    policy.act(_vision_observation(env_step=0))
+    policy.act(_vision_observation(q=0.2, env_step=0))
+
+    arrived = script.requests[1]["messages"][-1]["content"][0]["text"]
+    assert "these frames follow the motion." in arrived
+    assert "finished playing" not in arrived
+    assert "motion played" not in arrived
+
+
+def test_missing_queued_camera_is_narrated_without_raising() -> None:
+    script = _Script(
+        [
+            _multi_tool_response(
+                [
+                    ("move_joints", {"targets": {"joint": 0.1}}),
+                    (
+                        "take_pic",
+                        {
+                            "cameras": ["top", "wrist"],
+                            "note": "I need both views after the move.",
+                        },
+                    ),
+                ]
+            ),
+            _tool_response("done", {"summary": "used available view"}),
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="move"))
+
+    chunk = policy.act(_vision_observation(env_step=0))
+    policy.act(_vision_observation(q=0.1, env_step=len(chunk), cameras=("top",)))
+
+    arrived = script.requests[1]["messages"][-1]["content"]
+    assert "missing camera(s) in this observation: 'wrist'." in arrived[0]["text"]
+    assert [part["text"] for part in arrived if part["type"] == "text"][1:] == [
+        f"camera 'top' (step {len(chunk)}):"
+    ]
+
+
+def test_queued_capture_is_dropped_when_trial_terminates_and_reset_clears_it(
+    tmp_path: Path,
+) -> None:
+    script = _Script(
+        [
+            _multi_tool_response(
+                [
+                    ("move_joints", {"targets": {"joint": 0.1}}),
+                    ("take_pic", {"note": "I want a frame after this move."}),
+                ]
+            ),
+            _tool_response("done", {"summary": "new trial"}),
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    ir_eval(
+        _task(max_steps=3),
+        policy,
+        _VisionAbsoluteEmbodiment(terminate_after_first_step=True),
+        log_dir=str(tmp_path),
+    )
+
+    assert policy._pending is not None
+    policy.reset(Scene(id="next", instruction="fresh trial"))
+    assert policy._pending is None
+    policy.act(_vision_observation())
+    fresh_observation = script.requests[1]["messages"][-1]["content"]
+    assert all(part["type"] != "image_url" for part in fresh_observation)
+    assert "these frames follow the motion." not in fresh_observation[0]["text"]
+
+
+def test_take_pic_after_done_is_ignored_because_the_trial_ends() -> None:
+    script = _Script(
+        [
+            _multi_tool_response(
+                [
+                    ("done", {"summary": "finished"}),
+                    ("take_pic", {"note": "This cannot arrive after the stop."}),
+                ]
+            )
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="stop"))
+
+    chunk = policy.act(_vision_observation())
+
+    assert chunk.actions[0].meta["request_stop"] is True
+    assert [message["content"] for message in policy._messages[-2:]] == [
+        "done: finished",
+        "ignored: the trial ends with this call",
+    ]
+    assert policy._pending is None
+
+
+def test_images_mode_is_recorded_and_invalid_values_have_a_fix() -> None:
+    policy = _policy(_Script([_text_response("unused")]), images="on_demand")
+
+    assert policy.config.images == "on_demand"
+    with pytest.raises(ConfigError, match=r"(?s)images must be one of.*fix:"):
+        _policy(_Script([_text_response("unused")]), images="sometimes")
+
+
+def test_on_demand_prompt_and_no_tool_nudge_describe_chaining() -> None:
+    script = _Script(
+        [
+            _text_response("I should use a tool."),
+            _tool_response("done", {"summary": "corrected"}),
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="inspect"))
+
+    policy.act(_vision_observation())
+
+    assert (
+        "Camera images are not attached automatically"
+        in script.requests[0]["messages"][0]["content"]
+    )
+    assert script.requests[1]["messages"][-1]["content"] == (
+        "Respond with one motion tool call, one motion followed by take_pic, or take_pic alone."
+    )
 
 
 def test_effort_defaults_low_and_is_tunable(tmp_path: Path) -> None:

--- a/plugins/inspect-robots-agent/tests/test_responses.py
+++ b/plugins/inspect-robots-agent/tests/test_responses.py
@@ -170,6 +170,72 @@ def test_translates_history_tools_and_request_options() -> None:
     assert all("type" not in item for item in history_messages)
 
 
+def test_capture_history_keeps_function_outputs_in_call_order_before_images() -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(200, json=_response())
+
+    _client(handler).complete(
+        messages=[
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    _tool_call("move", "move_joints", '{"targets":{"joint":0.2}}'),
+                    _tool_call("pic", "take_pic", '{"note":"inspect"}'),
+                ],
+            },
+            {"role": "tool", "tool_call_id": "move", "content": "executing move"},
+            {
+                "role": "tool",
+                "tool_call_id": "pic",
+                "content": "captured 1 frame(s): 'top'",
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "camera 'top' (step 1):"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,cG5n"},
+                    },
+                ],
+            },
+        ],
+        tools=[],
+    )
+
+    assert bodies[0]["input"] == [
+        {
+            "type": "function_call",
+            "call_id": "move",
+            "name": "move_joints",
+            "arguments": '{"targets":{"joint":0.2}}',
+        },
+        {
+            "type": "function_call",
+            "call_id": "pic",
+            "name": "take_pic",
+            "arguments": '{"note":"inspect"}',
+        },
+        {"type": "function_call_output", "call_id": "move", "output": "executing move"},
+        {
+            "type": "function_call_output",
+            "call_id": "pic",
+            "output": "captured 1 frame(s): 'top'",
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "camera 'top' (step 1):"},
+                {"type": "input_image", "image_url": "data:image/png;base64,cG5n"},
+            ],
+        },
+    ]
+
+
 def test_optional_request_fields_are_omitted_when_unset() -> None:
     bodies: list[dict[str, Any]] = []
 

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -505,13 +505,33 @@ def test_take_pic_validation_uses_images_present_now() -> None:
     assert wrong_type.error == "cameras must be a non-empty list of strings when provided"
     assert empty.error == "cameras must be a non-empty list of strings when provided"
     assert blank_note.error is not None and blank_note.error.startswith("note is required:")
-    assert imageless.error == "no camera images are available in this observation"
+    assert imageless.error is None and imageless.capture == ()
 
     all_cameras = toolset.execute(_call("take_pic", note=note), observation)
     named = toolset.execute(_call("take_pic", cameras=["top"], note=note), observation)
     assert all_cameras.error is None and all_cameras.capture is None
     assert named.error is None and named.capture == ("top",)
     assert named.chunk is None
+
+
+def test_explicit_take_pic_rejects_an_imageless_observation() -> None:
+    toolset = build_toolset(
+        _absolute_space(),
+        _camera_obs_space(),
+        control_hz=10.0,
+        images="on_demand",
+    )
+    result = toolset.execute(
+        _call(
+            "take_pic",
+            cameras=["top"],
+            note="I need the top view to verify the arm position.",
+        ),
+        Observation(state={"q": np.array([0.0])}),
+    )
+
+    assert result.error is None
+    assert result.capture == ()
 
 
 # --- absolute-mode synthesis ---------------------------------------------------

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -11,7 +11,14 @@ import pytest
 
 from inspect_robots.approver import ChainApprover, ClampApprover, DeltaLimitApprover
 from inspect_robots.mock import CubePickEmbodiment
-from inspect_robots.spaces import ActionSemantics, Box, ObservationSpace, StateField, StateSpec
+from inspect_robots.spaces import (
+    ActionSemantics,
+    Box,
+    CameraSpec,
+    ObservationSpace,
+    StateField,
+    StateSpec,
+)
 from inspect_robots.types import Observation
 from inspect_robots_agent._llm import ToolCall
 from inspect_robots_agent._tools import ToolResult, ToolsetError, build_toolset
@@ -53,6 +60,16 @@ def _absolute_space(
 
 def _absolute_obs_space(dim: int = 1, key: str = "q") -> ObservationSpace:
     return ObservationSpace(state=StateSpec(fields=(StateField(key=key, shape=(dim,)),)))
+
+
+def _camera_obs_space() -> ObservationSpace:
+    return ObservationSpace(
+        cameras=(
+            CameraSpec(name="top", height=2, width=2),
+            CameraSpec(name="wrist", height=2, width=2),
+        ),
+        state=StateSpec(fields=(StateField(key="q", shape=(1,)),)),
+    )
 
 
 def _delta_space(
@@ -417,6 +434,86 @@ def test_schemas_match_control_mode_and_remove_duration() -> None:
     assert displacement_parameters[0]["properties"]["note"]["type"] == "string"
 
 
+def test_take_pic_schema_is_exposed_only_on_demand() -> None:
+    always = build_toolset(_absolute_space(), _camera_obs_space(), control_hz=10.0)
+    on_demand = build_toolset(
+        _absolute_space(),
+        _camera_obs_space(),
+        control_hz=10.0,
+        images="on_demand",
+    )
+
+    assert [schema["function"]["name"] for schema in always.schemas()] == [
+        "move_joints",
+        "done",
+        "give_up",
+    ]
+    assert [schema["function"]["name"] for schema in on_demand.schemas()] == [
+        "move_joints",
+        "done",
+        "give_up",
+        "take_pic",
+    ]
+    capture = on_demand.schemas()[-1]["function"]
+    assert capture["parameters"]["required"] == ["note"]
+    assert capture["parameters"]["properties"]["cameras"]["items"] == {"type": "string"}
+    assert "top" in capture["description"] and "wrist" in capture["description"]
+
+    stray = always.execute(
+        _call("take_pic", note="I need to inspect the wrist camera."),
+        Observation(
+            state={"q": np.array([0.0])},
+            images={"top": np.zeros((2, 2, 3), dtype=np.uint8)},
+        ),
+    )
+    assert stray.error == "unknown tool 'take_pic'; available: move_joints, done, give_up"
+
+
+def test_on_demand_requires_a_declared_camera_at_bind_time() -> None:
+    with pytest.raises(ToolsetError, match=r"fix: drop -P images=on_demand"):
+        build_toolset(
+            _absolute_space(),
+            _absolute_obs_space(),
+            control_hz=10.0,
+            images="on_demand",
+        )
+
+
+def test_take_pic_validation_uses_images_present_now() -> None:
+    toolset = build_toolset(
+        _absolute_space(),
+        _camera_obs_space(),
+        control_hz=10.0,
+        images="on_demand",
+    )
+    image = np.zeros((2, 2, 3), dtype=np.uint8)
+    observation = Observation(state={"q": np.array([0.0])}, images={"top": image})
+    note = "I need a current image to verify the arm position."
+
+    unknown = toolset.execute(_call("take_pic", cameras=["side"], note=note), observation)
+    absent = toolset.execute(_call("take_pic", cameras=["wrist"], note=note), observation)
+    wrong_type = toolset.execute(_call("take_pic", cameras="top", note=note), observation)
+    empty = toolset.execute(_call("take_pic", cameras=[], note=note), observation)
+    blank_note = toolset.execute(_call("take_pic", cameras=["top"], note=" "), observation)
+    imageless = toolset.execute(
+        _call("take_pic", note=note),
+        Observation(state={"q": np.array([0.0])}),
+    )
+
+    assert unknown.error == "unknown or unavailable camera 'side'; available now: 'top'"
+    assert absent.error == "unknown or unavailable camera 'wrist'; available now: 'top'"
+    assert wrong_type.error == "cameras must be a non-empty list of strings when provided"
+    assert empty.error == "cameras must be a non-empty list of strings when provided"
+    assert blank_note.error is not None and blank_note.error.startswith("note is required:")
+    assert imageless.error == "no camera images are available in this observation"
+
+    all_cameras = toolset.execute(_call("take_pic", note=note), observation)
+    named = toolset.execute(_call("take_pic", cameras=["top"], note=note), observation)
+    assert all_cameras.error is None and all_cameras.capture is None
+    assert named.error is None and named.capture == ("top",)
+    assert named.chunk is None
+
+
 # --- absolute-mode synthesis ---------------------------------------------------
 
 
@@ -434,6 +531,33 @@ def test_move_joints_derives_steps_and_snaps_bit_exact_target() -> None:
     snapped = _execute_absolute(0.3, current=-0.1)
     assert snapped.chunk is not None
     assert snapped.chunk.actions[-1].data[0] == 0.3
+
+
+def test_absolute_result_carries_target_and_residual_is_best_effort() -> None:
+    toolset = build_toolset(
+        _absolute_space(labels=("joint",)),
+        _absolute_obs_space(),
+        control_hz=10.0,
+    )
+    result = toolset.execute(
+        _call("move_joints", targets={"joint": 0.5}),
+        _obs({"q": np.array([0.0])}),
+    )
+
+    assert result.target is not None
+    assert np.array_equal(result.target, np.array([0.5]))
+    assert toolset.residual(result.target, _obs({"q": np.array([0.496])})) == (
+        "joint",
+        pytest.approx(0.004),
+    )
+    assert toolset.residual(result.target, Observation()) is None
+    assert toolset.residual(result.target, _obs({"q": np.array([0.1, 0.2])})) is None
+    assert toolset.residual(result.target, _obs({"q": np.array([np.nan])})) is None
+
+    displacement = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+    moved = displacement.execute(_call("move_by", deltas={"0": 0.05}), Observation())
+    assert moved.target is None
+    assert displacement.residual(np.zeros(2), Observation()) is None
 
 
 def test_move_joints_clips_every_interpolant_into_box() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #173.

Two changes to the agent policy's perception loop, both behind a new `-P images=` knob that defaults to today's behavior. Design: `plans/0027-agent-on-demand-vision.md`.

## On-demand capture

`-P images=on_demand` stops attaching camera frames to every observation message. Observations carry the state text plus the names of the cameras present right now, and a new `take_pic(cameras?, note)` tool delivers frames when the model asks for them. A camera is revealed at most once per observation, since its view cannot change until the robot moves.

## Chained tool calls

`act()` now walks every tool call in an assistant turn instead of answering the extras with a blanket `ignored`. A motion followed by `take_pic` in the same turn queues the capture, and the frames arrive with the observation the rollout delivers after the controller has played the chunk. `take_pic` placed *before* a motion short-circuits the turn instead, so the model re-decides with the frames in hand rather than executing a motion it chose blind.

## Reporting playout, not arrival

The queued frames carry a narration line built from what the rollout actually did: how many of the chunk's steps played, and, for absolute modes, the largest measured offset from the requested target.

That residual is the point. A full step count does not prove the arm arrived: `rollout()` hands every action to the approver chain and never reports a rewrite, a tight `--max-action-delta` truncates interpolants, and `SmoothingController` blends every action so the commanded value is never the interpolant's endpoint. The policy cannot make the rollout wait for arrival, but it can measure how far off the arm ended up and say so.

## Notes for review

- `images=always` is the default and is unchanged except in two respects, both recorded in CHANGELOG: tool results now follow the model's call order, and an extra behind a call that *failed* is answered `ignored: an earlier call in this turn failed` rather than being blamed as a surplus call.
- A well-formed capture refused for world-state reasons (everything already shown, or a runtime camera dropout) is a rejection, not a tool error. The first per decision is free; later ones escalate to the existing three-strike guard, which bounds the loop.
- The `camera 'x' (step N):` label is byte-identical to before, because `_html.py` matches it with `fullmatch` to re-attach stored frames in `inspect-robots view`.
- No file under `src/inspect_robots/` is touched.

Plugin version 0.13.0 → 0.14.0. Verified: ruff, ruff-format, mypy --strict, 293 plugin tests, 754 core tests.

Not verified live: the workspace API key is over its usage limit until 2026-08-01, so an end-to-end run against a real model was not possible. The CLI wiring, bind, and on-demand observation path were exercised up to the HTTP call; everything past that is covered by scripted-transport tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)