### PR TITLE
feat(cli): optional grader notes after the operator verdict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- **Grader notes:** a prompted operator verdict is now followed by one optional
+  line of free text. Bare Enter records nothing, so a grader with nothing to add
+  pays a single keypress. Notes reach the JSON log and the HTML report, a note
+  is kept even on a trial the grader answered `skip`, and no note ever moves a
+  score (#174).
 - **Policy lifecycle hook: `on_trial_end`** — policies can now hook into
   the end of a trial to persist state or artifacts. The orchestrator calls
   `policy.on_trial_end(record, log_dir, run_id)` and any metadata the policy

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -100,7 +100,9 @@ grader notes (Enter for none): gripper closed early, cube still in frame
 ```
 
 Prompted verdicts are recorded in the log. The CLI then asks for one optional
-line of grader notes. Bare Enter or whitespace-only input records no note.
+line of grader notes. Bare Enter or whitespace-only input records no note. An
+adopted embodiment verdict is not followed by a notes prompt, so a self-scoring
+embodiment still costs no keypresses per trial.
 `skip` records no judgement, but a grader note entered for that trial is still
 recorded. Notes never affect the score. Piped/CI stdin, `--no-prompt`, or a
 registered `--task` run never prompt or adopt an embodiment verdict: unattended

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -95,13 +95,17 @@ and prints `operator verdict adopted from embodiment: success` (or `failure`) so
 the operator can catch a mistaken adoption live.
 
 ```text
-did the robot succeed? [y/n/partial/skip] (partial scores as failure)
+did the robot succeed? [y/n/partial/skip] (partial scores as failure) n
+grader notes (Enter to skip): gripper closed early, cube still in frame
 ```
 
-Prompted verdicts are recorded in the log (`skip` records nothing). Piped/CI
-stdin, `--no-prompt`, or a registered `--task` run never prompt or adopt an
-embodiment verdict: unattended runs stay non-blocking, and an unjudged trial
-honestly scores as failure with "no operator judgement recorded".
+Prompted verdicts are recorded in the log. The CLI then asks for one optional
+line of grader notes. Bare Enter or whitespace-only input records no note.
+`skip` records no judgement, but a grader note entered for that trial is still
+recorded. Notes never affect the score. Piped/CI stdin, `--no-prompt`, or a
+registered `--task` run never prompt or adopt an embodiment verdict: unattended
+runs stay non-blocking, and an unjudged trial honestly scores as failure with
+"no operator judgement recorded".
 
 ## `inspect-robots setup`
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -96,7 +96,7 @@ the operator can catch a mistaken adoption live.
 
 ```text
 did the robot succeed? [y/n/partial/skip] (partial scores as failure) n
-grader notes (Enter to skip): gripper closed early, cube still in frame
+grader notes (Enter for none): gripper closed early, cube still in frame
 ```
 
 Prompted verdicts are recorded in the log. The CLI then asks for one optional

--- a/plans/0005-zero-config-cli.md
+++ b/plans/0005-zero-config-cli.md
@@ -210,7 +210,10 @@ read by the scorer. Today there is no seam. Add one:
   `{y, yes, n, no, partial, skip}` (a typo like `yse` must not be recorded as a
   failing verdict). `EOFError` counts as `skip`. `skip` → `operator_judgement`
   stays `None` (scores as "no operator judgement recorded") and **no** operator
-  event is appended (`operator_event` requires a `str` verdict). Any other
+  event is appended (`operator_event` requires a `str` verdict).
+  (Superseded in part by plan 0027: a skipped trial that carries a grader note
+  does append an operator event, with `verdict="skip"` and the note.
+  `operator_judgement` still stays `None`, so scoring is unchanged.) Any other
   answer is recorded verbatim (normalized) via `record.operator_judgement` plus
   `transcript.operator_event(t=len(record.steps), verdict=...)` appended to
   `record.events`. The prompt text notes that `partial` counts as failure in the

--- a/plans/0027-grader-notes.md
+++ b/plans/0027-grader-notes.md
@@ -1,0 +1,176 @@
+# 0027 — grader notes: one optional free-text line after the operator verdict
+
+Issue: #174. Status: draft.
+
+## Problem
+
+An ad-hoc interactive run ends each trial at `_prompt_operator`
+(`cli.py:528`), which asks `did the robot succeed? [y/n/partial/skip]` and
+stores the answer on `TrialRecord.operator_judgement`. That token is the whole
+of what the log keeps from the human who watched the robot.
+
+Everything else the grader saw is dropped: the gripper closed two frames early,
+the cube had already rolled out of frame, the arm clipped the table on
+approach, camera 2 was unplugged so the trial is unusable rather than failed.
+That qualitative read is the part a human is uniquely good at producing, and it
+is what someone reading the log later needs in order to interpret an `n` — or
+to decide the trial should not have counted at all.
+
+The verdict has a full persistence path already (`TrialRecord` → parallel
+`SceneResult.operator_judgements` → JSON log → HTML view). Notes have none, so
+"let the grader type something" is only half the work: without the same path,
+the text dies with the terminal session.
+
+## Design
+
+One optional prompt, immediately after the verdict prompt, on the same code
+path. Typing text records it; pressing Enter on an empty line records nothing.
+Notes ride the existing verdict plumbing, field for field.
+
+```
+did the robot succeed? [y/n/partial/skip] (partial scores as failure) n
+grader notes (Enter to skip): gripper closed early, cube still in frame
+```
+
+### Prompt contract
+
+- `_NOTES_PROMPT = "grader notes (Enter to skip): "`, asked once, after the
+  verdict loop accepts an answer.
+- The answer is `.strip()`ed. Empty (bare Enter) or whitespace-only means no
+  notes: the field stays `None`. Any other content is stored verbatim after
+  stripping, case preserved — unlike the verdict, notes are never lowercased.
+- One line. `input()` reads to the first newline, so a multi-line editor,
+  raw-key capture, and any termios/tty handling are out of scope. The prompt is
+  reached only under `sys.stdin.isatty()` (`cli.py:911`), so line editing comes
+  from the terminal for free.
+- `EOFError` on the notes prompt yields `None` — the same defensive treatment
+  the verdict prompt already has, for a stdin that closes mid-run.
+- No re-prompting and no validation: every string is a legal note.
+
+### When the prompt appears
+
+| Verdict path | Verdict prompt | Notes prompt |
+|---|---|---|
+| `y` / `n` / `partial` | asked | asked |
+| `skip` | asked | asked |
+| `EOFError` on the verdict prompt | closed stdin | not asked |
+| Adopted from a definitive embodiment verdict | not asked | not asked |
+
+Two of those rows are deliberate and worth stating outright.
+
+**`skip` still gets a notes prompt, and a note on a skipped trial is
+recorded.** Skip means "record no judgement", not "record nothing" — "camera
+unplugged, rerun this" is the single most valuable note a grader writes, and it
+belongs to exactly the trial they refused to grade. `operator_judgement` stays
+`None` on skip, unchanged; only `operator_notes` is populated. Prompting and
+then dropping what was typed would be silent data loss, which is the one
+outcome this feature must not have.
+
+**The adopted-verdict path stays prompt-free.** When the embodiment terminated
+with a definitive `success`/`failure`, `_prompt_operator` announces the adoption
+and returns without asking anything (`cli.py:537-544`). Its whole point is that
+an attended run of a self-scoring embodiment costs zero keypresses per trial;
+adding a notes prompt there would reintroduce the keypress this branch exists to
+remove. A grader who wants to flag a mistaken adoption is not served by this
+plan. If that need turns out to be real, it is a separate change with its own
+argument, not a rider on this one.
+
+### EOF on the verdict prompt
+
+Today the `EOFError` handler assigns `answer = "skip"` and the `skip` branch
+then returns without recording. With notes in the picture that path must not
+fall through to a second `input()` on an already-closed stdin, so the handler
+returns immediately instead. Behavior is identical to today (no judgement, no
+event, no exception); only the route to it is shorter.
+
+### Persistence, mirroring the verdict exactly
+
+| Layer | Change |
+|---|---|
+| `rollout.TrialRecord` | new `operator_notes: str | None = None`, documented as qualitative-only, next to `operator_judgement` |
+| `transcript.operator_event` | new keyword `notes: str | None = None`, always present in `data` so the event shape is uniform |
+| `eval.py` trial loop | collect `record.operator_notes` into a `notes` list beside `judgements`, `None` for errored trials (they are never scored and never prompted) |
+| `log.SceneResult` | new `operator_notes: tuple[str | None, ...] = ()`, strictly parallel to `epochs`, documented like its siblings |
+| `log.EvalLog.from_dict` | `sample["operator_notes"] = tuple(sample.get("operator_notes", ()))` — the `.get` is what keeps logs written before this field readable |
+| `_html.py` | render the notes for a scene under the existing judgement/reason blocks |
+
+`SCHEMA_VERSION` does not change. A defaulted field read through `.get` is the
+same additive move `operator_judgements`, `termination_reasons`, and
+`policy_transcripts` each made; an older reader ignores the key and a newer
+reader supplies the default.
+
+### Event recording
+
+The operator event is appended when there is a verdict to record **or** a note
+to record:
+
+- `y`/`n`/`partial`: appended as today, now carrying `notes` (possibly `None`).
+- `skip` with a note: appended with `verdict="skip"` and the note, so the
+  transcript explains the gap. `operator_judgement` stays `None`.
+- `skip` with no note: nothing appended, exactly as today.
+
+### HTML view
+
+`_render_scene` already emits chip rows for trial scores, termination reasons,
+and operator judgements (`_html.py:495-517`). Notes are free text, not tokens,
+so a chip row is the wrong shape: they get their own block under the judgement
+row, one entry per trial that has a note, labelled with its trial index so a
+note is readable against the parallel chip rows above it. Scenes with no notes
+at all emit nothing, the same way an empty judgement tuple emits nothing.
+
+Text goes through the module's `_escape` at interpolation, like every other
+foreign string on the page. No truncation: a note is one operator-typed line,
+and the page already carries a shared payload budget for the parts that can
+actually get large (frames, transcripts).
+
+### What does not change
+
+- **Scoring.** `_OperatorScorer` reads `operator_judgement` and nothing else
+  (`scorer.py:246`). Notes are qualitative; a note must never move a number,
+  and no scorer, metric, or reducer learns about this field.
+- **Unattended runs.** The prompt is behind `is_adhoc and not --no-prompt and
+  sys.stdin.isatty()` (`cli.py:907-916`); CI and headless runs still see
+  neither prompt.
+- **`inspect-robots inspect`.** It does not print operator judgements today, so
+  it does not gain notes here.
+- **Core dependencies.** Nothing new; `input()` is stdlib.
+
+## Testing
+
+The repo gates at 100% coverage, so every branch below is a test.
+
+CLI prompt (`tests/test_registry_cli.py`, alongside the existing
+`_prompt_operator` tests):
+
+- verdict `y` plus a typed note: judgement `"y"`, `operator_notes` set, one
+  operator event carrying both.
+- bare Enter at the notes prompt: `operator_notes is None`, event `notes` key
+  present and `None`.
+- whitespace-only note: treated as empty.
+- note text is not lowercased and is stripped at both ends.
+- `skip` plus a note: `operator_judgement is None`, `operator_notes` set, event
+  appended with `verdict="skip"`.
+- `skip` plus bare Enter: no judgement, no notes, no event (today's behavior).
+- `EOFError` on the verdict prompt: nothing recorded, notes prompt never
+  reached (assert the fake input saw exactly one call).
+- `EOFError` on the notes prompt: verdict recorded, `operator_notes is None`.
+- adopted-verdict path: unchanged, and the fake input is never called.
+
+Log and orchestration:
+
+- `tests/test_eval_log.py`: round-trip a log with notes; a dict with the key
+  deleted still reads back with `operator_notes == ()`.
+- `tests/test_eval_orchestration.py`: `operator_notes` is parallel to `epochs`,
+  with `None` for an errored trial.
+- `tests/test_strict_json.py`: the new key survives the strict JSON sink.
+- `tests/test_html_view.py`: a scene with notes renders them escaped; a scene
+  with only `None` entries renders no notes block.
+
+Docs: `docs/guide/cli.md` gains the notes line in the transcript sample and a
+sentence on the Enter-to-skip contract and the skip-plus-note case. `CHANGELOG.md`
+gets an `Added` entry under `[Unreleased]`.
+
+## Rollout
+
+One PR. Additive at every layer, defaulted everywhere, no schema bump, no
+behavior change for unattended runs — nothing to stage or flag.

--- a/plans/0027-grader-notes.md
+++ b/plans/0027-grader-notes.md
@@ -199,6 +199,20 @@ predicate is "has at least one non-`None` entry", and trials whose entry is
 `None` contribute no row at all — a missing note is not worth an `n/a` when
 most trials will not have one.
 
+Markup and style are specified here rather than left to taste, because
+`_html.py` carries one fixed inline stylesheet (`:140-188`) and an invented
+class renders unstyled. Emit `<h3>Grader notes</h3>` followed by one
+`<div class="grader-note"><span class="note-label">trial {index}</span>{note}</div>`
+per non-`None` entry, and add a `.grader-note` rule to that stylesheet beside
+`.agent-note`: neutral, using the existing `--line`/`--muted`/`--bg` custom
+properties, with `overflow-wrap: anywhere` so a long note cannot widen the
+card. The existing `.note-label` (`:179-183`) is reused for the trial index.
+
+Do not reuse `.agent-note` itself (`:175-178`, emitted at `:295`). It is the
+amber callout for an LLM policy's own tool-call notes; rendering a human
+grader's note in it, under a label reading "agent note", would attribute the
+sentence to the wrong author.
+
 Text goes through the module's `_escape` at interpolation, like every other
 foreign string on the page. No truncation: a note is one operator-typed line,
 and the page already carries a shared payload budget for the parts that can
@@ -263,7 +277,7 @@ CLI prompt (`tests/test_registry_cli.py`, next to the tests above):
 
 - verdict `y` plus a typed note: judgement `"y"`, `operator_note` set, one
   operator event carrying both.
-- bare Enter at the notes prompt: `operator_note is None`, event `notes` key
+- bare Enter at the notes prompt: `operator_note is None`, event `note` key
   present and `None`.
 - whitespace-only note: treated as empty.
 - note text is not lowercased and is stripped at both ends.
@@ -297,6 +311,14 @@ Log, orchestration, view:
   `operator_notes=(None, None)` rather than the empty tuple that
   `test_absent_optional_fields_and_empty_scene_sequences_are_omitted` uses at
   `:162`. An empty tuple would pass against the wrong implementation.
+- `tests/test_html_view.py:182-209`
+  (`test_every_foreign_text_surface_is_escaped_exactly_once`) is the repo's
+  guard for the escaping claim above, and its `dataclasses.replace` fixture
+  (`:194-200`) does not set `operator_notes` — so it stays green against an
+  implementation that interpolates a note raw, and the coverage gate does not
+  care because the unescaped line still runs. Add `operator_notes=(attack,
+  None)` to that fixture. The `>= 8` count at `:208` is a lower bound and needs
+  no edit.
 
 Docs and public text:
 

--- a/plans/0027-grader-notes.md
+++ b/plans/0027-grader-notes.md
@@ -1,6 +1,6 @@
 # 0027 — grader notes: one optional free-text line after the operator verdict
 
-Issue: #174. Status: draft.
+Issue: #174. Status: draft (revised after critique round 1).
 
 ## Problem
 
@@ -13,8 +13,15 @@ Everything else the grader saw is dropped: the gripper closed two frames early,
 the cube had already rolled out of frame, the arm clipped the table on
 approach, camera 2 was unplugged so the trial is unusable rather than failed.
 That qualitative read is the part a human is uniquely good at producing, and it
-is what someone reading the log later needs in order to interpret an `n` — or
-to decide the trial should not have counted at all.
+is what someone reading the log later needs in order to interpret an `n`.
+
+Scope limit, stated up front so the Design is not read as promising more than
+it does: this plan gives that context a place to live. It does not give it
+teeth. A trial the grader considers unusable still scores exactly as it does
+today (`skip` → `Score(value=False, explanation="no operator judgement
+recorded")`, `scorer.py:243-249`) and still counts in the `operator` metric.
+Excluding a trial from the numbers is a scoring change, needs its own argument
+about what an eval's denominator means, and is out of scope here.
 
 The verdict has a full persistence path already (`TrialRecord` → parallel
 `SceneResult.operator_judgements` → JSON log → HTML view). Notes have none, so
@@ -43,6 +50,10 @@ grader notes (Enter to skip): gripper closed early, cube still in frame
   raw-key capture, and any termios/tty handling are out of scope. The prompt is
   reached only under `sys.stdin.isatty()` (`cli.py:911`), so line editing comes
   from the terminal for free.
+- Whitespace-only input collapsing to "no notes" is a deliberate narrowing of
+  the request's literal "any char aside from Enter". A lone space is a slip,
+  not a note, and storing `" "` would put an empty chip in the HTML view for
+  no one's benefit.
 - `EOFError` on the notes prompt yields `None` — the same defensive treatment
   the verdict prompt already has, for a stdin that closes mid-run.
 - No re-prompting and no validation: every string is a legal note.
@@ -62,18 +73,38 @@ Two of those rows are deliberate and worth stating outright.
 recorded.** Skip means "record no judgement", not "record nothing" — "camera
 unplugged, rerun this" is the single most valuable note a grader writes, and it
 belongs to exactly the trial they refused to grade. `operator_judgement` stays
-`None` on skip, unchanged; only `operator_notes` is populated. Prompting and
+`None` on skip, unchanged; only `operator_note` is populated. Prompting and
 then dropping what was typed would be silent data loss, which is the one
 outcome this feature must not have.
 
 **The adopted-verdict path stays prompt-free.** When the embodiment terminated
 with a definitive `success`/`failure`, `_prompt_operator` announces the adoption
-and returns without asking anything (`cli.py:537-544`). Its whole point is that
-an attended run of a self-scoring embodiment costs zero keypresses per trial;
-adding a notes prompt there would reintroduce the keypress this branch exists to
-remove. A grader who wants to flag a mistaken adoption is not served by this
-plan. If that need turns out to be real, it is a separate change with its own
-argument, not a rider on this one.
+and returns without asking anything (`cli.py:537-544`). The distinction is not
+"one keypress is too many" — it is that this branch takes *zero* input, so a
+notes prompt would convert a run that needs no human at the keyboard into one
+that does, trial after trial, including when the operator has walked away. On
+the prompted path the human is already at the keyboard answering, so one more
+Enter is an increment on an interaction that exists, not a new obligation. A
+grader who wants to flag a mistaken adoption is not served by this plan; if
+that need turns out to be real, it is a separate change with its own argument,
+not a rider on this one.
+
+### Why a second prompt and not one line
+
+The alternative is folding notes into the verdict line and splitting on the
+first space (`n gripper closed early`), which costs no extra keypress. Rejected
+for two reasons:
+
+- It changes the verdict contract. `_PROMPT_ANSWERS` is an exact-match set and
+  anything outside it re-prompts (`cli.py:552-554`); splitting the line means a
+  typo'd verdict with trailing words (`ye gripper...`) has to be diagnosed
+  against a note the parser cannot distinguish from a mistake. The strict
+  matcher is the reason the current prompt is hard to answer wrong.
+- Nobody would find it. A trailing free-text field on an existing line is
+  invisible unless the prompt string advertises it, and the prompt is already
+  carrying `[y/n/partial/skip] (partial scores as failure)`. `grader notes
+  (Enter to skip):` teaches the feature exists to every operator who runs one
+  trial, which for an opt-in habit like note-taking is the whole ballgame.
 
 ### EOF on the verdict prompt
 
@@ -85,34 +116,66 @@ event, no exception); only the route to it is shorter.
 
 ### Persistence, mirroring the verdict exactly
 
+Singular on the trial, plural on the scene, matching every sibling pair in the
+codebase (`operator_judgement`/`operator_judgements`,
+`termination_reason`/`termination_reasons`,
+`policy_transcript`/`policy_transcripts`). Reusing one name for both a `str`
+and a `tuple[str | None, ...]` would make `eval.py`'s collector read as a type
+error.
+
 | Layer | Change |
 |---|---|
-| `rollout.TrialRecord` | new `operator_notes: str | None = None`, documented as qualitative-only, next to `operator_judgement` |
-| `transcript.operator_event` | new keyword `notes: str | None = None`, always present in `data` so the event shape is uniform |
-| `eval.py` trial loop | collect `record.operator_notes` into a `notes` list beside `judgements`, `None` for errored trials (they are never scored and never prompted) |
+| `rollout.TrialRecord` | new `operator_note: str | None = None`, documented as qualitative-only, next to `operator_judgement` |
+| `transcript.operator_event` | new keyword `notes: str | None = None`, always present in `data` |
+| `eval.py` trial loop | collect `record.operator_note` into a `notes` list beside `judgements`, `None` for errored trials (they are never scored and never prompted) |
 | `log.SceneResult` | new `operator_notes: tuple[str | None, ...] = ()`, strictly parallel to `epochs`, documented like its siblings |
 | `log.EvalLog.from_dict` | `sample["operator_notes"] = tuple(sample.get("operator_notes", ()))` — the `.get` is what keeps logs written before this field readable |
 | `_html.py` | render the notes for a scene under the existing judgement/reason blocks |
 
 `SCHEMA_VERSION` does not change. A defaulted field read through `.get` is the
 same additive move `operator_judgements`, `termination_reasons`, and
-`policy_transcripts` each made; an older reader ignores the key and a newer
-reader supplies the default.
+`policy_transcripts` each made, and it buys the guarantee the log module
+actually states: newer code reads older logs (`log.py:4-6`). It does not buy
+the reverse — `from_dict` ends in `SceneResult(**sample)`, so an *older* build
+handed a log with this key raises `TypeError`. That has always been true of
+this schema's additive fields and is not a reason to bump the version.
 
 ### Event recording
 
-The operator event is appended when there is a verdict to record **or** a note
-to record:
+`operator_event` gains `notes` as a keyword that is always present in `data`,
+even when `None`. That is this module's existing convention:
+`approval_event(t, modified, detail=None)` writes `"detail": None` rather than
+varying the dict's keys (`transcript.py:47-49`). The cost is three exact-dict
+assertions in the CLI tests, listed under Testing.
+
+The event is appended when there is a verdict to record **or** a note to
+record:
 
 - `y`/`n`/`partial`: appended as today, now carrying `notes` (possibly `None`).
-- `skip` with a note: appended with `verdict="skip"` and the note, so the
-  transcript explains the gap. `operator_judgement` stays `None`.
+- `skip` with a note: appended with `verdict="skip"` and the note.
+  `operator_judgement` stays `None`.
 - `skip` with no note: nothing appended, exactly as today.
+
+The middle case deliberately breaks a current invariant: today an operator
+event exists if and only if a judgement was recorded. After this change an
+event can carry `verdict="skip"` for a trial whose judgement is `None`. That is
+the honest encoding of "the human said something about this trial but declined
+to grade it", and a consumer that reads `verdict` without checking for `"skip"`
+was already wrong (`skip` has never been a judgement).
+
+Worth being precise about what this event buys, since the plan should not
+oversell it: `TrialRecord.events` is not persisted anywhere. `SceneResult` and
+`EvalLog` carry no events field, `JsonLogSink.on_trial_end` is a no-op, and
+`RerunSink.on_trial_end` only flushes. The event is for in-memory consumers and
+custom sinks, and it is there for symmetry with the verdict. The note reaches
+disk solely through `SceneResult.operator_notes`, which is why the end-to-end
+test below is the one that matters.
 
 ### HTML view
 
-`_render_scene` already emits chip rows for trial scores, termination reasons,
-and operator judgements (`_html.py:495-517`). Notes are free text, not tokens,
+`_scene_section` already emits chip rows for trial scores, termination reasons,
+and operator judgements (`_html.py:475`, judgement block at `:508-517`). Notes
+are free text, not tokens,
 so a chip row is the wrong shape: they get their own block under the judgement
 row, one entry per trial that has a note, labelled with its trial index so a
 note is readable against the parallel chip rows above it. Scenes with no notes
@@ -139,27 +202,58 @@ actually get large (frames, transcripts).
 
 The repo gates at 100% coverage, so every branch below is a test.
 
-CLI prompt (`tests/test_registry_cli.py`, alongside the existing
-`_prompt_operator` tests):
+### Existing tests this breaks
 
-- verdict `y` plus a typed note: judgement `"y"`, `operator_notes` set, one
+A second `input()` call per prompted trial invalidates fakes that were written
+for exactly one. These are updates, not new cases, and each must be made
+deliberately rather than by making assertions looser:
+
+- `test_operator_prompt_records_verdict_and_reprompts_on_typos`
+  (`tests/test_registry_cli.py:2047`) drives `answers = iter(["yse", "y"])`.
+  The notes prompt draws a third value and raises `StopIteration`, which
+  escapes through `before_scoring` (`eval.py:387`, outside the trial error
+  handlers) and fails the run. Extend the iterator with the note answer.
+- `test_prompt_operator_still_prompts_without_definitive_verdict`
+  (`tests/test_registry_cli.py:2202`) asserts `len(prompts) == 1`. It becomes
+  2, and asserting both prompt strings is the point of the test now.
+- Three exact-dict event assertions gain the `notes` key:
+  `tests/test_registry_cli.py:2188` (`source="embodiment"` — `notes` is `None`
+  there), `:2229`, and the parametrized adoption test's counterpart.
+- `test_prompt_operator_unit_semantics` (`tests/test_registry_cli.py:2318-2344`)
+  patches `input` to a constant lambda, so the notes prompt would return
+  `"Partial"` and `"skip"` as note text and the skip case's
+  `assert record.events == []` would fail for a reason that looks like correct
+  behavior. Convert each case to an explicit answer sequence.
+
+### New tests
+
+CLI prompt (`tests/test_registry_cli.py`, next to the tests above):
+
+- verdict `y` plus a typed note: judgement `"y"`, `operator_note` set, one
   operator event carrying both.
-- bare Enter at the notes prompt: `operator_notes is None`, event `notes` key
+- bare Enter at the notes prompt: `operator_note is None`, event `notes` key
   present and `None`.
 - whitespace-only note: treated as empty.
 - note text is not lowercased and is stripped at both ends.
-- `skip` plus a note: `operator_judgement is None`, `operator_notes` set, event
+- `skip` plus a note: `operator_judgement is None`, `operator_note` set, event
   appended with `verdict="skip"`.
-- `skip` plus bare Enter: no judgement, no notes, no event (today's behavior).
+- `skip` plus bare Enter: no judgement, no note, no event (today's behavior).
 - `EOFError` on the verdict prompt: nothing recorded, notes prompt never
   reached (assert the fake input saw exactly one call).
-- `EOFError` on the notes prompt: verdict recorded, `operator_notes is None`.
+- `EOFError` on the notes prompt: verdict recorded, `operator_note is None`.
 - adopted-verdict path: unchanged, and the fake input is never called.
+- end to end, mirroring `tests/test_registry_cli.py:2062`: run `main([...])`
+  through the ad-hoc path answering verdict and note, then read the log back
+  and assert `log.samples[0].operator_notes == ("<the note>",)`. This is the
+  only test that catches a `SceneResult(...)` constructed without the new
+  tuple (`eval.py:443-455`), which is the single most likely implementation
+  slip.
 
-Log and orchestration:
+Log, orchestration, view:
 
-- `tests/test_eval_log.py`: round-trip a log with notes; a dict with the key
-  deleted still reads back with `operator_notes == ()`.
+- `tests/test_eval_log.py`: round-trip a log with notes; add `operator_notes`
+  to the field-deletion test at `:106-119` so a dict without the key still
+  reads back as `()`.
 - `tests/test_eval_orchestration.py`: `operator_notes` is parallel to `epochs`,
   with `None` for an errored trial.
 - `tests/test_strict_json.py`: the new key survives the strict JSON sink.
@@ -167,8 +261,10 @@ Log and orchestration:
   with only `None` entries renders no notes block.
 
 Docs: `docs/guide/cli.md` gains the notes line in the transcript sample and a
-sentence on the Enter-to-skip contract and the skip-plus-note case. `CHANGELOG.md`
-gets an `Added` entry under `[Unreleased]`.
+sentence on the Enter-to-skip contract and the skip-plus-note case.
+`CHANGELOG.md` gets an `Added` entry under `[Unreleased]`. Both are
+public-facing text under the `CLAUDE.md` writing-style rule: no em dashes in
+prose, no mid-sentence bold. Do not copy this plan's voice into them.
 
 ## Rollout
 

--- a/plans/0027-grader-notes.md
+++ b/plans/0027-grader-notes.md
@@ -1,6 +1,6 @@
 # 0027 — grader notes: one optional free-text line after the operator verdict
 
-Issue: #174. Status: draft (revised after critique round 1).
+Issue: #174. Status: draft (revised after critique rounds 1 and 2).
 
 ## Problem
 
@@ -125,9 +125,10 @@ error.
 
 | Layer | Change |
 |---|---|
-| `rollout.TrialRecord` | new `operator_note: str | None = None`, documented as qualitative-only, next to `operator_judgement` |
-| `transcript.operator_event` | new keyword `notes: str | None = None`, always present in `data` |
-| `eval.py` trial loop | collect `record.operator_note` into a `notes` list beside `judgements`, `None` for errored trials (they are never scored and never prompted) |
+| `rollout.TrialRecord` | new `operator_note: str | None = None`, next to `operator_judgement`, with its own comment stating it is qualitative and read by nothing that scores (the block at `rollout.py:91-93` is the model) |
+| `transcript.operator_event` | new trailing keyword `note: str | None = None` (after `source`, so the positional call at `tests/test_coverage_completion.py:309` still binds), always present in `data` |
+| `cli._prompt_operator` | docstring extended: it currently states the verdict contract only (`cli.py:529-533`) and must state the notes contract too |
+| `eval.py` trial loop | append `record.operator_note` to a `notes` list at `eval.py:407-409`, beside `termination_reasons` and `policy_transcripts`, not inside the two arms of the status split where `judgements` is appended. Both arms fall through to that point, and an errored trial's `operator_note` is already `None` because errored trials are never prompted, so one append is correct and reads as a smaller diff |
 | `log.SceneResult` | new `operator_notes: tuple[str | None, ...] = ()`, strictly parallel to `epochs`, documented like its siblings |
 | `log.EvalLog.from_dict` | `sample["operator_notes"] = tuple(sample.get("operator_notes", ()))` — the `.get` is what keeps logs written before this field readable |
 | `_html.py` | render the notes for a scene under the existing judgement/reason blocks |
@@ -142,16 +143,24 @@ this schema's additive fields and is not a reason to bump the version.
 
 ### Event recording
 
-`operator_event` gains `notes` as a keyword that is always present in `data`,
-even when `None`. That is this module's existing convention:
+`operator_event` gains `note` as a keyword that is always present in `data`,
+even when `None`. Singular, because an event describes one trial, matching the
+`verdict` key it sits beside and `TrialRecord.operator_note`. Always present,
+because that is this module's existing convention:
 `approval_event(t, modified, detail=None)` writes `"detail": None` rather than
 varying the dict's keys (`transcript.py:47-49`). The cost is three exact-dict
 assertions in the CLI tests, listed under Testing.
 
+The event is kept rather than cut, even though nothing persists it (see below).
+An event stream that records "the operator said `y`" while the note the same
+human typed in the same breath is invisible to it would be a transcript that
+lies by omission, and the transcript is the thing custom sinks and any future
+event persistence read. The symmetry is worth three test edits.
+
 The event is appended when there is a verdict to record **or** a note to
 record:
 
-- `y`/`n`/`partial`: appended as today, now carrying `notes` (possibly `None`).
+- `y`/`n`/`partial`: appended as today, now carrying `note` (possibly `None`).
 - `skip` with a note: appended with `verdict="skip"` and the note.
   `operator_judgement` stays `None`.
 - `skip` with no note: nothing appended, exactly as today.
@@ -174,12 +183,21 @@ test below is the one that matters.
 ### HTML view
 
 `_scene_section` already emits chip rows for trial scores, termination reasons,
-and operator judgements (`_html.py:475`, judgement block at `:508-517`). Notes
-are free text, not tokens,
-so a chip row is the wrong shape: they get their own block under the judgement
-row, one entry per trial that has a note, labelled with its trial index so a
-note is readable against the parallel chip rows above it. Scenes with no notes
-at all emit nothing, the same way an empty judgement tuple emits nothing.
+and operator judgements (`_html.py:475`, judgement block at `:507-517`). Notes
+are free text, not tokens, so a chip row is the wrong shape: they get their own
+block under the judgement row, one entry per trial that has a note, labelled
+with its trial index so a note is readable against the parallel chip rows above
+it.
+
+The skip condition is where this block must **not** copy its neighbours. The
+judgement block skips only on an empty tuple (`if not judgements`), and an
+all-`None` tuple still renders a row of `n/a` chips. `operator_notes` is
+strictly parallel to `epochs`, so the ordinary no-notes run produces `(None,)`
+or `(None, None, ...)`, never `()`. A `if not scene.operator_notes` test would
+therefore emit an empty "Grader notes" heading on nearly every page. The
+predicate is "has at least one non-`None` entry", and trials whose entry is
+`None` contribute no row at all — a missing note is not worth an `n/a` when
+most trials will not have one.
 
 Text goes through the module's `_escape` at interpolation, like every other
 foreign string on the page. No truncation: a note is one operator-typed line,
@@ -209,21 +227,35 @@ for exactly one. These are updates, not new cases, and each must be made
 deliberately rather than by making assertions looser:
 
 - `test_operator_prompt_records_verdict_and_reprompts_on_typos`
-  (`tests/test_registry_cli.py:2047`) drives `answers = iter(["yse", "y"])`.
-  The notes prompt draws a third value and raises `StopIteration`, which
-  escapes through `before_scoring` (`eval.py:387`, outside the trial error
-  handlers) and fails the run. Extend the iterator with the note answer.
-- `test_prompt_operator_still_prompts_without_definitive_verdict`
-  (`tests/test_registry_cli.py:2202`) asserts `len(prompts) == 1`. It becomes
-  2, and asserting both prompt strings is the point of the test now.
-- Three exact-dict event assertions gain the `notes` key:
-  `tests/test_registry_cli.py:2188` (`source="embodiment"` — `notes` is `None`
-  there), `:2229`, and the parametrized adoption test's counterpart.
-- `test_prompt_operator_unit_semantics` (`tests/test_registry_cli.py:2318-2344`)
-  patches `input` to a constant lambda, so the notes prompt would return
-  `"Partial"` and `"skip"` as note text and the skip case's
-  `assert record.events == []` would fail for a reason that looks like correct
-  behavior. Convert each case to an explicit answer sequence.
+  (`tests/test_registry_cli.py:2047`) drives `answers = iter(["yse", "y"])` at
+  `:2054`. The notes prompt draws a third value and raises `StopIteration`,
+  which escapes through `before_scoring` (`eval.py:386`, outside the trial
+  error handlers, and `main()` catches only `KeyboardInterrupt` around `eval()`
+  at `cli.py:948`) and fails the run. Extend the iterator with the note answer.
+- `test_prompt_operator_still_prompts_without_definitive_verdict` (`:2200`)
+  asserts `len(prompts) == 1` (`:2225`) and the exact event dict (`:2228`). Its
+  `_answer` fake (`:2218-2222`) returns `"y"` unconditionally, so leaving it
+  alone would silently record `operator_note == "y"` and force the dict to
+  `{"verdict": "y", "source": "prompt", "note": "y"}` — fixture nonsense that
+  reads like intended behavior. Drive it from the sequence `["y", ""]`, assert
+  both prompt strings, and assert `note` is `None`.
+- `test_prompt_operator_prompts_for_truncated_success_reason` (`:2231`) patches
+  `input` to the constant `lambda _prompt: "n"` (`:2246`) and asserts the exact
+  event dict (`:2252`). Same failure: `"n"` becomes the note. Give it a
+  sequence.
+- `test_prompt_operator_warns_before_judging_step_limited_trial` (`:2255`,
+  fake at `:2269`) is the quiet one. It asserts only `operator_judgement`, so
+  it keeps passing while recording `operator_note == "n"` for a trial it never
+  meant to annotate. Convert it too: a fake that answers a prompt the test does
+  not know exists is a fake that will mislead the next reader.
+- The three exact-dict event assertions that gain the `note` key are therefore
+  `:2188` (the parametrized adoption test, where `note` is `None` and no prompt
+  fires), `:2228`, and `:2252`.
+- `test_prompt_operator_unit_semantics` (`:2307-2344`) patches `input` to
+  constant lambdas at `:2321` (`"Partial"`) and `:2331` (`"skip"`), so the
+  notes prompt would return those strings as note text and the skip case's
+  `assert record.events == []` (`:2334`) would fail for a reason that looks
+  like correct behavior. Convert each case to an explicit answer sequence.
 
 ### New tests
 
@@ -252,19 +284,34 @@ CLI prompt (`tests/test_registry_cli.py`, next to the tests above):
 Log, orchestration, view:
 
 - `tests/test_eval_log.py`: round-trip a log with notes; add `operator_notes`
-  to the field-deletion test at `:106-119` so a dict without the key still
-  reads back as `()`.
+  to the field-deletion test whose `del`s sit at `:107-113`, so a dict without
+  the key still reads back as `()`.
 - `tests/test_eval_orchestration.py`: `operator_notes` is parallel to `epochs`,
   with `None` for an errored trial.
 - `tests/test_strict_json.py`: the new key survives the strict JSON sink.
-- `tests/test_html_view.py`: a scene with notes renders them escaped; a scene
-  with only `None` entries renders no notes block.
+- `tests/test_html_view.py`, with the fixtures pinned deliberately, because the
+  100% gate cannot tell the two candidate skip conditions apart on its own: a
+  `"".join(...)` over all-`None` entries is `""` either way. The "renders
+  notes" case must mix one real note with one `None` so the per-entry filter is
+  exercised in both directions, and the "no notes block" case must use
+  `operator_notes=(None, None)` rather than the empty tuple that
+  `test_absent_optional_fields_and_empty_scene_sequences_are_omitted` uses at
+  `:162`. An empty tuple would pass against the wrong implementation.
 
-Docs: `docs/guide/cli.md` gains the notes line in the transcript sample and a
-sentence on the Enter-to-skip contract and the skip-plus-note case.
-`CHANGELOG.md` gets an `Added` entry under `[Unreleased]`. Both are
-public-facing text under the `CLAUDE.md` writing-style rule: no em dashes in
-prose, no mid-sentence bold. Do not copy this plan's voice into them.
+Docs and public text:
+
+- `docs/guide/cli.md` gains the notes line in the transcript sample and a
+  sentence on the Enter-to-skip contract. It also has a line to *correct*:
+  `:101` currently reads that `skip` records nothing, which stops being true
+  once a skipped trial can carry a note. An added sentence next to an
+  uncorrected one leaves the page contradicting itself.
+- `--no-prompt`'s help string (`cli.py:235`, "never ask the terminal operator
+  for a success verdict") no longer describes everything the flag suppresses.
+  Behavior is unchanged; the sentence is not.
+- `CHANGELOG.md` gets an `Added` entry under `[Unreleased]`.
+- All of the above is public-facing text under the `CLAUDE.md` writing-style
+  rule: no em dashes in prose, no mid-sentence bold. Do not copy this plan's
+  voice into them.
 
 ## Rollout
 

--- a/plans/0027-grader-notes.md
+++ b/plans/0027-grader-notes.md
@@ -1,6 +1,7 @@
 # 0027 — grader notes: one optional free-text line after the operator verdict
 
-Issue: #174. Status: draft (revised after critique rounds 1 and 2).
+Issue: #174. Status: implemented (revised after four critique rounds and two
+rounds of code review; see "Reversals after code review").
 
 ## Problem
 
@@ -36,12 +37,12 @@ Notes ride the existing verdict plumbing, field for field.
 
 ```
 did the robot succeed? [y/n/partial/skip] (partial scores as failure) n
-grader notes (Enter to skip): gripper closed early, cube still in frame
+grader notes (Enter for none): gripper closed early, cube still in frame
 ```
 
 ### Prompt contract
 
-- `_NOTES_PROMPT = "grader notes (Enter to skip): "`, asked once, after the
+- `_NOTES_PROMPT = "grader notes (Enter for none): "`, asked once, after the
   verdict loop accepts an answer.
 - The answer is `.strip()`ed. Empty (bare Enter) or whitespace-only means no
   notes: the field stays `None`. Any other content is stored verbatim after
@@ -105,7 +106,7 @@ for two reasons:
 - Nobody would find it. A trailing free-text field on an existing line is
   invisible unless the prompt string advertises it, and the prompt is already
   carrying `[y/n/partial/skip] (partial scores as failure)`. `grader notes
-  (Enter to skip):` teaches the feature exists to every operator who runs one
+  (Enter for none):` teaches the feature exists to every operator who runs one
   trial, which for an opt-in habit like note-taking is the whole ballgame.
 
 ### EOF on the verdict prompt

--- a/plans/0027-grader-notes.md
+++ b/plans/0027-grader-notes.md
@@ -54,8 +54,10 @@ grader notes (Enter to skip): gripper closed early, cube still in frame
   the request's literal "any char aside from Enter". A lone space is a slip,
   not a note, and storing `" "` would put an empty chip in the HTML view for
   no one's benefit.
-- `EOFError` on the notes prompt yields `None` — the same defensive treatment
-  the verdict prompt already has, for a stdin that closes mid-run.
+- `EOFError` on the notes prompt yields `None`: the verdict already accepted is
+  still recorded, only the note is dropped. (This is deliberately *not* what
+  EOF on the verdict prompt does — see below — because by then there is a
+  verdict worth keeping.)
 - No re-prompting and no validation: every string is a legal note.
 
 ### When the prompt appears
@@ -128,7 +130,7 @@ error.
 | `rollout.TrialRecord` | new `operator_note: str | None = None`, next to `operator_judgement`, with its own comment stating it is qualitative and read by nothing that scores (the block at `rollout.py:91-93` is the model) |
 | `transcript.operator_event` | new trailing keyword `note: str | None = None` (after `source`, so the positional call at `tests/test_coverage_completion.py:309` still binds), always present in `data` |
 | `cli._prompt_operator` | docstring extended: it currently states the verdict contract only (`cli.py:529-533`) and must state the notes contract too |
-| `eval.py` trial loop | append `record.operator_note` to a `notes` list at `eval.py:407-409`, beside `termination_reasons` and `policy_transcripts`, not inside the two arms of the status split where `judgements` is appended. Both arms fall through to that point, and an errored trial's `operator_note` is already `None` because errored trials are never prompted, so one append is correct and reads as a smaller diff |
+| `eval.py` trial loop | three edits, all three required: declare `notes: list[str | None] = []` at `eval.py:316-319` beside `judgements`; append `record.operator_note` at `eval.py:407-409` beside `termination_reasons` and `policy_transcripts`, **not** inside the two arms of the status split where `judgements` is appended (both arms fall through to that point, and an errored trial's `operator_note` is already `None` because errored trials are never prompted, so one append is correct and reads as a smaller diff); pass `operator_notes=tuple(notes)` in the `SceneResult(...)` at `eval.py:443-455` |
 | `log.SceneResult` | new `operator_notes: tuple[str | None, ...] = ()`, strictly parallel to `epochs`, documented like its siblings |
 | `log.EvalLog.from_dict` | `sample["operator_notes"] = tuple(sample.get("operator_notes", ()))` — the `.get` is what keeps logs written before this field readable |
 | `_html.py` | render the notes for a scene under the existing judgement/reason blocks |
@@ -200,10 +202,15 @@ predicate is "has at least one non-`None` entry", and trials whose entry is
 most trials will not have one.
 
 Markup and style are specified here rather than left to taste, because
-`_html.py` carries one fixed inline stylesheet (`:140-188`) and an invented
-class renders unstyled. Emit `<h3>Grader notes</h3>` followed by one
+`_html.py` carries one fixed inline stylesheet (`_STYLES`, `:49-189`) and an
+invented class renders unstyled. Emit `<h3>Grader notes</h3>` followed by one
 `<div class="grader-note"><span class="note-label">trial {index}</span>{note}</div>`
-per non-`None` entry, and add a `.grader-note` rule to that stylesheet beside
+per non-`None` entry, split across two implicitly concatenated f-strings so the
+literal stays under ruff's 100-column limit at the indentation it lands at
+(`pyproject.toml:89`; `ruff format` will not split a long string for you). The
+`<h3>` says "Grader notes" rather than "Operator notes" even though the field
+is `operator_note`: the heading mirrors the wording the human actually saw at
+the prompt. Add a `.grader-note` rule to that stylesheet beside
 `.agent-note`: neutral, using the existing `--line`/`--muted`/`--bg` custom
 properties, with `overflow-wrap: anywhere` so a long note cannot widen the
 card. The existing `.note-label` (`:179-183`) is reused for the trial index.
@@ -242,7 +249,7 @@ deliberately rather than by making assertions looser:
 
 - `test_operator_prompt_records_verdict_and_reprompts_on_typos`
   (`tests/test_registry_cli.py:2047`) drives `answers = iter(["yse", "y"])` at
-  `:2054`. The notes prompt draws a third value and raises `StopIteration`,
+  `:2053`. The notes prompt draws a third value and raises `StopIteration`,
   which escapes through `before_scoring` (`eval.py:386`, outside the trial
   error handlers, and `main()` catches only `KeyboardInterrupt` around `eval()`
   at `cli.py:948`) and fails the run. Extend the iterator with the note answer.
@@ -269,7 +276,10 @@ deliberately rather than by making assertions looser:
   constant lambdas at `:2321` (`"Partial"`) and `:2331` (`"skip"`), so the
   notes prompt would return those strings as note text and the skip case's
   `assert record.events == []` (`:2334`) would fail for a reason that looks
-  like correct behavior. Convert each case to an explicit answer sequence.
+  like correct behavior. Convert those two cases to explicit answer sequences.
+  Its third case (`:2336-2344`) raises `EOFError` on every call and needs no
+  sequence; it is the natural home for the "notes prompt never reached" call
+  counter listed below.
 
 ### New tests
 
@@ -289,7 +299,9 @@ CLI prompt (`tests/test_registry_cli.py`, next to the tests above):
 - `EOFError` on the notes prompt: verdict recorded, `operator_note is None`.
 - adopted-verdict path: unchanged, and the fake input is never called.
 - end to end, mirroring `tests/test_registry_cli.py:2062`: run `main([...])`
-  through the ad-hoc path answering verdict and note, then read the log back
+  through the ad-hoc path answering verdict and note, reusing that test's
+  `--max-steps 3` shape so `cubepick` does not terminate with a definitive
+  verdict and get adopted without ever prompting, then read the log back
   and assert `log.samples[0].operator_notes == ("<the note>",)`. This is the
   only test that catches a `SceneResult(...)` constructed without the new
   tuple (`eval.py:443-455`), which is the single most likely implementation

--- a/plans/0027-grader-notes.md
+++ b/plans/0027-grader-notes.md
@@ -130,7 +130,7 @@ error.
 | `rollout.TrialRecord` | new `operator_note: str | None = None`, next to `operator_judgement`, with its own comment stating it is qualitative and read by nothing that scores (the block at `rollout.py:91-93` is the model) |
 | `transcript.operator_event` | new trailing keyword `note: str | None = None` (after `source`, so the positional call at `tests/test_coverage_completion.py:309` still binds), always present in `data` |
 | `cli._prompt_operator` | docstring extended: it currently states the verdict contract only (`cli.py:529-533`) and must state the notes contract too |
-| `eval.py` trial loop | three edits, all three required: declare `notes: list[str | None] = []` at `eval.py:316-319` beside `judgements`; append `record.operator_note` at `eval.py:407-409` beside `termination_reasons` and `policy_transcripts`, **not** inside the two arms of the status split where `judgements` is appended (both arms fall through to that point, and an errored trial's `operator_note` is already `None` because errored trials are never prompted, so one append is correct and reads as a smaller diff); pass `operator_notes=tuple(notes)` in the `SceneResult(...)` at `eval.py:443-455` |
+| `eval.py` trial loop | three edits, all three required: declare `notes: list[str | None] = []` at `eval.py:316-319` beside `judgements`; append `record.operator_note` beside each `judgements.append(...)` inside both arms of the status split (`None` in the non-success arm); pass `operator_notes=tuple(notes)` in the `SceneResult(...)` at `eval.py:443-455` |
 | `log.SceneResult` | new `operator_notes: tuple[str | None, ...] = ()`, strictly parallel to `epochs`, documented like its siblings |
 | `log.EvalLog.from_dict` | `sample["operator_notes"] = tuple(sample.get("operator_notes", ()))` — the `.get` is what keeps logs written before this field readable |
 | `_html.py` | render the notes for a scene under the existing judgement/reason blocks |
@@ -346,6 +346,30 @@ Docs and public text:
 - All of the above is public-facing text under the `CLAUDE.md` writing-style
   rule: no em dashes in prose, no mid-sentence bold. Do not copy this plan's
   voice into them.
+
+## Reversals after code review
+
+Two decisions above were changed once the code existed, recorded here so the
+plan does not describe something the repo no longer does:
+
+- **`eval.py` collection point.** The draft put the `notes` append at the
+  fall-through point beside `termination_reasons`, arguing for the smaller
+  diff. Review pointed out that this captures the note *after*
+  `policy.on_trial_end` runs while the judgement is captured *before* it, so a
+  policy hook that set `operator_note` would be honoured while the same hook
+  setting `operator_judgement` would be silently dropped. Two fields documented
+  as strictly parallel must be captured by the same rule, so both appends now
+  sit together inside the status split.
+- **Notes prompt wording.** `grader notes (Enter to skip): ` became
+  `grader notes (Enter for none): `. "Skip" is a literal verdict token one
+  prompt earlier, and an operator who typed `skip` at the notes prompt would
+  have recorded the word rather than skipping anything.
+
+Kept unchanged under review, with the reasoning strengthened rather than the
+behavior: the `skip`-with-note event (`operator_event`'s docstring now states
+that `verdict` may be the non-verdict `"skip"`, which is what its consumers
+need), and no control-character filtering of the note (rewriting what a human
+typed is a worse failure than a stray glyph the browser already replaces).
 
 ## Rollout
 

--- a/src/inspect_robots/_html.py
+++ b/src/inspect_robots/_html.py
@@ -176,6 +176,10 @@ img.frame {
   margin: 10px 0 6px; padding: 9px 11px; color: var(--amber);
   background: var(--amber-bg); border-left: 3px solid var(--amber-line);
 }
+.grader-note {
+  margin: 8px 0; padding: 9px 11px; color: var(--muted);
+  background: var(--bg); border: 1px solid var(--line); overflow-wrap: anywhere;
+}
 .note-label {
   display: block; font-size: 10px; font-weight: 750;
   letter-spacing: .09em; text-transform: uppercase;
@@ -515,6 +519,17 @@ def _scene_section(
         if not judgements
         else f'<h3>Operator judgements</h3><div class="score-row">{judgements}</div>'
     )
+    notes = "".join(
+        (
+            f'<div class="grader-note"><span class="note-label">trial {index}</span>'
+            f"{_escape(note)}</div>"
+        )
+        for index, note in enumerate(scene.operator_notes)
+        if note is not None
+    )
+    # Unlike the chip rows above, an all-``None`` tuple emits nothing at all:
+    # ``notes`` is empty exactly when no trial carried a note, and most will not.
+    notes_block = "" if not notes else f"<h3>Grader notes</h3>{notes}"
 
     transcripts = "".join(
         (
@@ -530,7 +545,7 @@ def _scene_section(
         '<section class="scene">'
         f'<div class="scene-head"><h2>{_escape(scene.scene_id)}</h2>'
         f"{_status_badge(scene.status)}</div>{instruction}{error}{reduced_block}{epoch_block}"
-        f"{reasons_block}{judgements_block}{transcripts}</section>"
+        f"{reasons_block}{judgements_block}{notes_block}{transcripts}</section>"
     )
 
 

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -232,7 +232,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_run.add_argument(
         "--no-prompt",
         action="store_true",
-        help="never ask the terminal operator for a success verdict",
+        help="never ask the terminal operator for a success verdict or grader notes",
     )
     p_run.add_argument(
         "--rerun",
@@ -521,6 +521,7 @@ def _build_guardrails(
 
 
 _PROMPT = "did the robot succeed? [y/n/partial/skip] (partial scores as failure) "
+_NOTES_PROMPT = "grader notes (Enter to skip): "
 _PROMPT_ANSWERS = frozenset({"y", "yes", "n", "no", "partial", "skip"})
 _DEFINITIVE_REASONS = frozenset({"success", "failure"})
 
@@ -530,6 +531,7 @@ def _prompt_operator(record: TrialRecord, scene: Scene) -> None:
 
     A terminated episode with a definitive embodiment verdict adopts and announces that
     verdict instead of asking the operator to confirm the same outcome a second time.
+    Prompted verdicts are followed by one optional, stripped, case-preserved grader note.
     """
     from inspect_robots.transcript import operator_event
 
@@ -548,14 +550,19 @@ def _prompt_operator(record: TrialRecord, scene: Scene) -> None:
         try:
             answer = input(_PROMPT).strip().lower()
         except EOFError:
-            answer = "skip"
+            return
         if answer in _PROMPT_ANSWERS:
             break
         print(f"unrecognized answer {answer!r}; expected one of y/n/partial/skip")
-    if answer == "skip":
-        return
-    record.operator_judgement = answer
-    record.events.append(operator_event(t=len(record.steps), verdict=answer))
+    try:
+        note = input(_NOTES_PROMPT).strip() or None
+    except EOFError:
+        note = None
+    record.operator_note = note
+    if answer != "skip":
+        record.operator_judgement = answer
+    if answer != "skip" or note is not None:
+        record.events.append(operator_event(t=len(record.steps), verdict=answer, note=note))
 
 
 def _step_limit_count(log: EvalLog) -> int:

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -521,7 +521,9 @@ def _build_guardrails(
 
 
 _PROMPT = "did the robot succeed? [y/n/partial/skip] (partial scores as failure) "
-_NOTES_PROMPT = "grader notes (Enter to skip): "
+# "Enter for none", not "Enter to skip": `skip` is a literal verdict token one
+# prompt earlier, and typing it here would record the word, not skip anything.
+_NOTES_PROMPT = "grader notes (Enter for none): "
 _PROMPT_ANSWERS = frozenset({"y", "yes", "n", "no", "partial", "skip"})
 _DEFINITIVE_REASONS = frozenset({"success", "failure"})
 
@@ -561,6 +563,11 @@ def _prompt_operator(record: TrialRecord, scene: Scene) -> None:
     record.operator_note = note
     if answer != "skip":
         record.operator_judgement = answer
+    # A skipped trial with a note still gets an event: the human said something
+    # about this trial, and an event stream that recorded the verdict but not
+    # the sentence typed in the same breath would be lying by omission. The
+    # event then carries verdict="skip" with no judgement, which is why
+    # operator_event documents "skip" as "no judgement" for its consumers.
     if answer != "skip" or note is not None:
         record.events.append(operator_event(t=len(record.steps), verdict=answer, note=note))
 

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -405,12 +405,14 @@ def _run_eval(
                     try:
                         on_trial_end(record, log_dir, run_stamp)
                     except Exception as exc:
-                        note = f"policy.on_trial_end failed: {exc}"
+                        # Named `detail`, not `note`: a grader's note is a
+                        # different thing entirely and is collected just above.
+                        detail = f"policy.on_trial_end failed: {exc}"
                         scene_status = "error"
-                        scene_error = note if scene_error is None else f"{scene_error}; {note}"
+                        scene_error = detail if scene_error is None else f"{scene_error}; {detail}"
                         if status == "success":
                             status = "error"
-                            error = note
+                            error = detail
 
                 trial_metadatas.append(record.metadata)
                 termination_reasons.append(record.termination_reason)

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -174,7 +174,8 @@ def eval(
     (never for errored trials, which are recorded but not scored), after the
     rollout returns and before the scorers run. It may mutate the record —
     e.g. capture ``TrialRecord.operator_judgement`` (R6) so the ``operator``
-    scorer can read it. Exceptions it raises propagate to the caller. Note
+    scorer can read it, and ``TrialRecord.operator_note`` alongside it, which
+    is recorded but never scored. Exceptions it raises propagate to the caller. Note
     this fires on the *other* side of scoring from ``LogSink.on_trial_end``.
 
     Raises [`CompatibilityError`][inspect_robots.errors.CompatibilityError] (fail fast, before any
@@ -379,6 +380,7 @@ def _run_eval(
                     if record.status == "error":
                         errored_trials += 1
                     judgements.append(None)
+                    notes.append(None)
                 else:
                     if before_scoring is not None:
                         # The only trials the hook sees are the ones scorers
@@ -391,7 +393,12 @@ def _run_eval(
                         per_scorer_scores[scorer.name].append(score)
                         epoch_values[scorer.name] = value_to_float(score.value)
                     epoch_dicts.append(epoch_values)
+                    # Captured at the same instant as the judgement, on purpose:
+                    # the two are documented as strictly parallel, so a later
+                    # mutation (e.g. from policy.on_trial_end) must not be able
+                    # to reach one of them and miss the other.
                     judgements.append(record.operator_judgement)
+                    notes.append(record.operator_note)
 
                 on_trial_end = getattr(policy, "on_trial_end", None)
                 if callable(on_trial_end):
@@ -408,7 +415,6 @@ def _run_eval(
                 trial_metadatas.append(record.metadata)
                 termination_reasons.append(record.termination_reason)
                 policy_transcripts.append(record.policy_transcript)
-                notes.append(record.operator_note)
                 bus.on_trial_end(record)
 
             if halted:

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -314,6 +314,7 @@ def _run_eval(
         per_scorer_scores: dict[str, list[Score]] = {s.name: [] for s in scorers}
         epoch_dicts: list[dict[str, float]] = []
         judgements: list[str | None] = []
+        notes: list[str | None] = []
         trial_metadatas: list[dict[str, Any]] = []
         termination_reasons: list[str | None] = []
         policy_transcripts: list[Any] = []
@@ -407,6 +408,7 @@ def _run_eval(
                 trial_metadatas.append(record.metadata)
                 termination_reasons.append(record.termination_reason)
                 policy_transcripts.append(record.policy_transcript)
+                notes.append(record.operator_note)
                 bus.on_trial_end(record)
 
             if halted:
@@ -448,6 +450,7 @@ def _run_eval(
                 error=scene_error,
                 instruction=scene.instruction,
                 operator_judgements=tuple(judgements),
+                operator_notes=tuple(notes),
                 trial_metadata=tuple(trial_metadatas),
                 termination_reasons=tuple(termination_reasons),
                 policy_transcripts=tuple(policy_transcripts),

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -175,8 +175,8 @@ def eval(
     rollout returns and before the scorers run. It may mutate the record —
     e.g. capture ``TrialRecord.operator_judgement`` (R6) so the ``operator``
     scorer can read it, and ``TrialRecord.operator_note`` alongside it, which
-    is recorded but never scored. Exceptions it raises propagate to the caller. Note
-    this fires on the *other* side of scoring from ``LogSink.on_trial_end``.
+    is recorded but never scored. Exceptions it raises propagate to the caller.
+    Note this fires on the *other* side of scoring from ``LogSink.on_trial_end``.
 
     Raises [`CompatibilityError`][inspect_robots.errors.CompatibilityError] (fail fast, before any
     rollout) if the policy and embodiment are incompatible, and
@@ -442,12 +442,12 @@ def _run_eval(
                 # A reducer failure (e.g. pass_at_k over fewer epochs than k
                 # after a halt, or mean over categorical scores) degrades to an
                 # error log — it must never crash the eval and lose the log.
-                note = f"reducer {epoch_spec.reducer!r} failed for scorer {name!r}: {exc}"
+                detail = f"reducer {epoch_spec.reducer!r} failed for scorer {name!r}: {exc}"
                 scene_status = "error"
-                scene_error = note if scene_error is None else f"{scene_error}; {note}"
+                scene_error = detail if scene_error is None else f"{scene_error}; {detail}"
                 if status == "success":
                     status = "error"
-                    error = note
+                    error = detail
 
         scene_results.append(
             SceneResult(

--- a/src/inspect_robots/log.py
+++ b/src/inspect_robots/log.py
@@ -68,6 +68,9 @@ class SceneResult:
     # trial, ``None`` when the trial errored or no judgement was captured.
     # Defaults keep logs written before these fields existed readable.
     operator_judgements: tuple[str | None, ...] = ()
+    # Strictly parallel to ``epochs``: qualitative operator context per trial,
+    # ``None`` when no note was captured. Read by nothing that scores.
+    operator_notes: tuple[str | None, ...] = ()
     # Strictly parallel to ``epochs``: trial-specific metadata from the policy.
     trial_metadata: tuple[dict[str, Any], ...] = ()
     # Strictly parallel to ``epochs``: why each recorded trial ended, or
@@ -126,6 +129,7 @@ class EvalLog:
             # written before ``operator_judgements`` existed (newer reads older).
             sample["epochs"] = tuple(sample.get("epochs", ()))
             sample["operator_judgements"] = tuple(sample.get("operator_judgements", ()))
+            sample["operator_notes"] = tuple(sample.get("operator_notes", ()))
             sample["trial_metadata"] = tuple(sample.get("trial_metadata", ()))
             sample["termination_reasons"] = tuple(sample.get("termination_reasons", ()))
             sample["policy_transcripts"] = tuple(sample.get("policy_transcripts", ()))

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -91,6 +91,8 @@ class TrialRecord:
     # Human operator's success verdict, captured once during rollout (R6). Read
     # by OperatorScorer; remains None for unattended/CI runs.
     operator_judgement: str | None = None
+    # Qualitative context from the operator; read by nothing that scores.
+    operator_note: str | None = None
     # Typed transcript of what happened during the trial.
     events: list[Event] = field(default_factory=list)
     # Extensible metadata for the trial (e.g. populated by policies).

--- a/src/inspect_robots/transcript.py
+++ b/src/inspect_robots/transcript.py
@@ -49,9 +49,13 @@ def approval_event(t: int, modified: bool, detail: str | None = None) -> Event:
     return Event(kind="approval", t=t, data={"modified": modified, "detail": detail})
 
 
-def operator_event(t: int, verdict: str, source: str = "prompt") -> Event:
-    """Record the operator's verdict and its source after the rollout ends."""
-    return Event(kind="operator", t=t, data={"verdict": verdict, "source": source})
+def operator_event(t: int, verdict: str, source: str = "prompt", note: str | None = None) -> Event:
+    """Record the operator's verdict, optional note, and source after the rollout ends."""
+    return Event(
+        kind="operator",
+        t=t,
+        data={"verdict": verdict, "source": source, "note": note},
+    )
 
 
 def error_event(t: int, error_type: str, message: str) -> Event:

--- a/src/inspect_robots/transcript.py
+++ b/src/inspect_robots/transcript.py
@@ -50,7 +50,13 @@ def approval_event(t: int, modified: bool, detail: str | None = None) -> Event:
 
 
 def operator_event(t: int, verdict: str, source: str = "prompt", note: str | None = None) -> Event:
-    """Record the operator's verdict, optional note, and source after the rollout ends."""
+    """Record the operator's verdict, optional note, and source after the rollout ends.
+
+    ``verdict`` carries whatever the operator answered, which includes the
+    non-verdict ``"skip"`` when they declined to grade a trial but still left a
+    note. Consumers deriving an outcome from this event must treat ``"skip"``
+    as "no judgement", never as a result.
+    """
     return Event(
         kind="operator",
         t=t,

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -52,6 +52,7 @@ def _golden_log() -> EvalLog:
                 epochs=({"success_at_end": 1.0},),
                 instruction="reach the cube",
                 operator_judgements=("yes",),
+                operator_notes=("gripper closed early",),
                 trial_metadata=({"foo": "bar"},),
                 termination_reasons=("success",),
                 policy_transcripts=(
@@ -90,6 +91,7 @@ def test_golden_log_reads_back(tmp_path: Path) -> None:
     assert restored.samples[0].scene_id == "s0"
     assert restored.samples[0].instruction == "reach the cube"
     assert restored.samples[0].operator_judgements == ("yes",)
+    assert restored.samples[0].operator_notes == ("gripper closed early",)
     assert restored.samples[0].trial_metadata == ({"foo": "bar"},)
     assert restored.samples[0].termination_reasons == ("success",)
     assert restored.samples[0].policy_transcripts == (
@@ -108,6 +110,7 @@ def test_v1_log_without_additive_fields_reads_back(tmp_path: Path) -> None:
     for sample in data["samples"]:
         del sample["instruction"]
         del sample["operator_judgements"]
+        del sample["operator_notes"]
         del sample["trial_metadata"]
         del sample["termination_reasons"]
         del sample["policy_transcripts"]
@@ -117,6 +120,7 @@ def test_v1_log_without_additive_fields_reads_back(tmp_path: Path) -> None:
     assert restored.samples[0].reduced == {"success_at_end": 1.0}
     assert restored.samples[0].instruction is None
     assert restored.samples[0].operator_judgements == ()
+    assert restored.samples[0].operator_notes == ()
     assert restored.samples[0].trial_metadata == ()
     assert restored.samples[0].termination_reasons == ()
     assert restored.samples[0].policy_transcripts == ()

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -756,6 +756,7 @@ def test_before_scoring_skipped_for_errored_trials(tmp_path: Path) -> None:
     def judge(record: TrialRecord, scene: Scene) -> None:
         calls.append(record.epoch)
         record.operator_judgement = "yes"
+        record.operator_note = "clean pickup"
 
     (log,) = eval(
         task,
@@ -768,6 +769,7 @@ def test_before_scoring_skipped_for_errored_trials(tmp_path: Path) -> None:
     scene = log.samples[0]
     assert scene.epochs == ({"operator": 1.0}, {})
     assert scene.operator_judgements == ("yes", None)
+    assert scene.operator_notes == ("clean pickup", None)
 
 
 def test_before_scoring_exception_propagates(tmp_path: Path) -> None:

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -842,7 +842,7 @@ def test_operator_fields_are_captured_before_the_on_trial_end_hook(tmp_path: Pat
     # The verdict and the note are documented as strictly parallel, so they must
     # be read off the record at the same instant. A hook that sets either one
     # runs too late for both: if one append ever drifts past on_trial_end, this
-    # asserts one tuple populated and the other empty, which cannot both hold.
+    # sees that tuple populated while the other is still (None,), and fails.
     class _LateJudgePolicy(ScriptedPolicy):
         def on_trial_end(self, record: TrialRecord, log_dir: str, run_id: str) -> None:
             record.operator_judgement = "y"

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -838,6 +838,23 @@ def test_on_trial_end_hook_persists_metadata_and_recovers_from_errors(tmp_path: 
     assert seen_ids[0] == seen_ids[1]
 
 
+def test_operator_fields_are_captured_before_the_on_trial_end_hook(tmp_path: Path) -> None:
+    # The verdict and the note are documented as strictly parallel, so they must
+    # be read off the record at the same instant. A hook that sets either one
+    # runs too late for both: if one append ever drifts past on_trial_end, this
+    # asserts one tuple populated and the other empty, which cannot both hold.
+    class _LateJudgePolicy(ScriptedPolicy):
+        def on_trial_end(self, record: TrialRecord, log_dir: str, run_id: str) -> None:
+            record.operator_judgement = "y"
+            record.operator_note = "written too late to be recorded"
+
+    (log,) = eval(_task(), _LateJudgePolicy(), CubePickEmbodiment(), log_dir=str(tmp_path))
+
+    scene = log.samples[0]
+    assert scene.operator_judgements == (None,)
+    assert scene.operator_notes == (None,)
+
+
 def test_on_trial_end_hook_error_on_already_errored_trial(tmp_path: Path) -> None:
     # A test to cover the branch where status is ALREADY "error" when the hook throws.
     # This happens if a previous epoch's hook already failed, setting global status="error".

--- a/tests/test_html_view.py
+++ b/tests/test_html_view.py
@@ -65,7 +65,9 @@ def _log(
                 error="one trial failed",
                 instruction="pick up the cube",
                 operator_judgements=("y", None),
-                operator_notes=("gripper closed early", None),
+                # Deliberately on trial 1, not trial 0: a note at index 0 cannot
+                # tell correct indexing apart from enumerating the filtered list.
+                operator_notes=(None, "gripper closed early"),
                 termination_reasons=("success", None),
                 policy_transcripts=transcripts,
             ),
@@ -139,7 +141,7 @@ def test_header_status_metrics_and_scene_content(status: str, label: str, badge_
     assert "Termination reasons" in document and "Operator judgements" in document
     assert "Grader notes" in document
     assert document.count('class="grader-note"') == 1
-    assert ">trial 0</span>gripper closed early</div>" in document
+    assert ">trial 1</span>gripper closed early</div>" in document
     assert "one trial failed" in document
     assert document.count(">n/a</span>") == 2
     assert "prefers-color-scheme: light" in document
@@ -164,7 +166,7 @@ def test_absent_optional_fields_and_empty_scene_sequences_are_omitted() -> None:
         reduced={},
         epochs=(),
         operator_judgements=(),
-        operator_notes=(None, None),
+        operator_notes=(),
         termination_reasons=(),
     )
 
@@ -182,6 +184,19 @@ def test_absent_optional_fields_and_empty_scene_sequences_are_omitted() -> None:
     assert "Trial scores" not in document
     assert "Termination reasons" not in document
     assert "Operator judgements" not in document
+    assert "Grader notes" not in document
+    assert 'class="grader-note"' not in document
+
+
+def test_scene_where_no_trial_carried_a_note_renders_no_grader_notes_block() -> None:
+    # The ordinary case: operator_notes is parallel to epochs, so an unannotated
+    # run is a tuple of Nones, not the empty tuple the omission test above uses.
+    log = _log()
+    scene = dataclasses.replace(log.samples[0], operator_notes=(None, None))
+
+    document = render_html(dataclasses.replace(log, samples=(scene,)), title="no notes")
+
+    assert "Operator judgements" in document
     assert "Grader notes" not in document
     assert 'class="grader-note"' not in document
 

--- a/tests/test_html_view.py
+++ b/tests/test_html_view.py
@@ -65,6 +65,7 @@ def _log(
                 error="one trial failed",
                 instruction="pick up the cube",
                 operator_judgements=("y", None),
+                operator_notes=("gripper closed early", None),
                 termination_reasons=("success", None),
                 policy_transcripts=transcripts,
             ),
@@ -136,6 +137,9 @@ def test_header_status_metrics_and_scene_content(status: str, label: str, badge_
     assert "scene-0" in document and "pick up the cube" in document
     assert "Reduced scores" in document and "Trial scores" in document
     assert "Termination reasons" in document and "Operator judgements" in document
+    assert "Grader notes" in document
+    assert document.count('class="grader-note"') == 1
+    assert ">trial 0</span>gripper closed early</div>" in document
     assert "one trial failed" in document
     assert document.count(">n/a</span>") == 2
     assert "prefers-color-scheme: light" in document
@@ -160,6 +164,7 @@ def test_absent_optional_fields_and_empty_scene_sequences_are_omitted() -> None:
         reduced={},
         epochs=(),
         operator_judgements=(),
+        operator_notes=(None, None),
         termination_reasons=(),
     )
 
@@ -177,6 +182,8 @@ def test_absent_optional_fields_and_empty_scene_sequences_are_omitted() -> None:
     assert "Trial scores" not in document
     assert "Termination reasons" not in document
     assert "Operator judgements" not in document
+    assert "Grader notes" not in document
+    assert 'class="grader-note"' not in document
 
 
 def test_every_foreign_text_surface_is_escaped_exactly_once() -> None:
@@ -197,6 +204,7 @@ def test_every_foreign_text_surface_is_escaped_exactly_once() -> None:
         status=attack,
         instruction=attack,
         error=attack,
+        operator_notes=(attack, None),
     )
     results = dataclasses.replace(log.results, metrics={attack: 1.0})
 

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -2050,7 +2050,7 @@ def test_operator_prompt_records_verdict_and_reprompts_on_typos(
     monkeypatch.setenv(ENV_POLICY, "scripted")
     monkeypatch.setenv(ENV_EMBODIMENT, "cubepick")
     _tty_stdin(monkeypatch)
-    answers = iter(["yse", "y"])
+    answers = iter(["yse", "y", ""])
     monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
     log_dir = tmp_path / "logs"
     rc = main(
@@ -2061,6 +2061,25 @@ def test_operator_prompt_records_verdict_and_reprompts_on_typos(
     log = _read_only_log(log_dir)
     assert log.samples[0].operator_judgements == ("y",)
     assert log.results.metrics["operator"] == 1.0
+
+
+def test_operator_prompt_persists_grader_note_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv(ENV_POLICY, "scripted")
+    monkeypatch.setenv(ENV_EMBODIMENT, "cubepick")
+    _tty_stdin(monkeypatch)
+    answers = iter(["n", "  Gripper Closed Early  "])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+    log_dir = tmp_path / "logs"
+
+    rc = main(["reach the cube", "--max-steps", "3", "--log-dir", str(log_dir)])
+
+    assert rc == 0
+    log = _read_only_log(log_dir)
+    assert log.samples[0].operator_judgements == ("n",)
+    assert log.samples[0].operator_notes == ("Gripper Closed Early",)
+    capsys.readouterr()
 
 
 def test_operator_prompt_adopts_self_confirming_embodiment_verdict(
@@ -2182,10 +2201,15 @@ def test_prompt_operator_adopts_definitive_embodiment_verdict(
     _prompt_operator(record, Scene(id="s0", instruction="reach"))
 
     assert record.operator_judgement == expected_verdict
+    assert record.operator_note is None
     (event,) = record.events
     assert event.kind == "operator"
     assert event.t == 0
-    assert event.data == {"verdict": expected_verdict, "source": "embodiment"}
+    assert event.data == {
+        "verdict": expected_verdict,
+        "source": "embodiment",
+        "note": None,
+    }
 
 
 @pytest.mark.parametrize(
@@ -2202,7 +2226,7 @@ def test_prompt_operator_still_prompts_without_definitive_verdict(
     termination_reason: str | None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from inspect_robots.cli import _prompt_operator
+    from inspect_robots.cli import _NOTES_PROMPT, _PROMPT, _prompt_operator
     from inspect_robots.rollout import TrialRecord
     from inspect_robots.scene import Scene
 
@@ -2214,18 +2238,19 @@ def test_prompt_operator_still_prompts_without_definitive_verdict(
         termination_reason=termination_reason,
     )
     prompts: list[str] = []
+    answers = iter(["y", ""])
 
     def _answer(prompt: str) -> str:
         prompts.append(prompt)
-        return "y"
+        return next(answers)
 
     monkeypatch.setattr("builtins.input", _answer)
     _prompt_operator(record, Scene(id="s0", instruction="reach"))
 
-    assert len(prompts) == 1
+    assert prompts == [_PROMPT, _NOTES_PROMPT]
     assert record.operator_judgement == "y"
     (event,) = record.events
-    assert event.data == {"verdict": "y", "source": "prompt"}
+    assert event.data == {"verdict": "y", "source": "prompt", "note": None}
 
 
 def test_prompt_operator_prompts_for_truncated_success_reason(
@@ -2243,13 +2268,14 @@ def test_prompt_operator_prompts_for_truncated_success_reason(
         truncated=True,
         termination_reason="success",
     )
-    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+    answers = iter(["n", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
 
     _prompt_operator(record, Scene(id="s0", instruction="reach"))
 
     assert record.operator_judgement == "n"
     (event,) = record.events
-    assert event.data == {"verdict": "n", "source": "prompt"}
+    assert event.data == {"verdict": "n", "source": "prompt", "note": None}
 
 
 def test_prompt_operator_warns_before_judging_step_limited_trial(
@@ -2266,7 +2292,8 @@ def test_prompt_operator_warns_before_judging_step_limited_trial(
         truncated=True,
         termination_reason="max_steps",
     )
-    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+    answers = iter(["n", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
 
     _prompt_operator(record, Scene(id="s0", instruction="reach"))
 
@@ -2305,7 +2332,7 @@ def test_operator_scorer_reads_adopted_embodiment_verdict(
 
 
 def test_prompt_operator_unit_semantics(monkeypatch: pytest.MonkeyPatch) -> None:
-    from inspect_robots.cli import _prompt_operator
+    from inspect_robots.cli import _PROMPT, _prompt_operator
     from inspect_robots.rollout import TrialRecord
     from inspect_robots.scene import Scene
 
@@ -2318,7 +2345,8 @@ def test_prompt_operator_unit_semantics(monkeypatch: pytest.MonkeyPatch) -> None
 
     # A verdict is recorded verbatim with an operator event at the final step.
     record = _record()
-    monkeypatch.setattr("builtins.input", lambda _prompt: "Partial")
+    answers = iter(["Partial", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
     _prompt_operator(record, scene)
     assert record.operator_judgement == "partial"
     (event,) = record.events
@@ -2328,20 +2356,115 @@ def test_prompt_operator_unit_semantics(monkeypatch: pytest.MonkeyPatch) -> None
 
     # skip: no judgement, no event.
     record = _record()
-    monkeypatch.setattr("builtins.input", lambda _prompt: "skip")
+    answers = iter(["skip", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
     _prompt_operator(record, scene)
     assert record.operator_judgement is None
     assert record.events == []
 
     # EOF (operator hit Ctrl-D): treated as skip.
-    def _eof(_prompt: str) -> str:
+    prompts: list[str] = []
+
+    def _eof(prompt: str) -> str:
+        prompts.append(prompt)
         raise EOFError
 
     record = _record()
     monkeypatch.setattr("builtins.input", _eof)
     _prompt_operator(record, scene)
     assert record.operator_judgement is None
+    assert record.operator_note is None
     assert record.events == []
+    assert prompts == [_PROMPT]
+
+
+@pytest.mark.parametrize(
+    (
+        "verdict",
+        "note_input",
+        "expected_judgement",
+        "expected_note",
+        "expected_event",
+    ),
+    [
+        (
+            "y",
+            "gripper closed early",
+            "y",
+            "gripper closed early",
+            {"verdict": "y", "source": "prompt", "note": "gripper closed early"},
+        ),
+        ("y", "", "y", None, {"verdict": "y", "source": "prompt", "note": None}),
+        ("y", " \t ", "y", None, {"verdict": "y", "source": "prompt", "note": None}),
+        (
+            "y",
+            "  Mixed CASE  ",
+            "y",
+            "Mixed CASE",
+            {"verdict": "y", "source": "prompt", "note": "Mixed CASE"},
+        ),
+        (
+            "skip",
+            "  camera unplugged  ",
+            None,
+            "camera unplugged",
+            {"verdict": "skip", "source": "prompt", "note": "camera unplugged"},
+        ),
+        ("skip", "", None, None, None),
+    ],
+)
+def test_prompt_operator_records_optional_grader_notes(
+    verdict: str,
+    note_input: str,
+    expected_judgement: str | None,
+    expected_note: str | None,
+    expected_event: dict[str, str | None] | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inspect_robots.cli import _prompt_operator
+    from inspect_robots.rollout import TrialRecord
+    from inspect_robots.scene import Scene
+
+    answers = iter([verdict, note_input])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+    record = TrialRecord(scene_id="s0", epoch=0, seed=0)
+
+    _prompt_operator(record, Scene(id="s0", instruction="reach"))
+
+    assert record.operator_judgement == expected_judgement
+    assert record.operator_note == expected_note
+    if expected_event is None:
+        assert record.events == []
+    else:
+        (event,) = record.events
+        assert event.data == expected_event
+
+
+def test_prompt_operator_keeps_verdict_when_notes_prompt_reaches_eof(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inspect_robots.cli import _NOTES_PROMPT, _PROMPT, _prompt_operator
+    from inspect_robots.rollout import TrialRecord
+    from inspect_robots.scene import Scene
+
+    prompts: list[str] = []
+
+    def _answer(prompt: str) -> str:
+        prompts.append(prompt)
+        if prompt == _PROMPT:
+            return "n"
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _answer)
+    record = TrialRecord(scene_id="s0", epoch=0, seed=0)
+
+    _prompt_operator(record, Scene(id="s0", instruction="reach"))
+
+    assert prompts == [_PROMPT, _NOTES_PROMPT]
+    assert record.operator_judgement == "n"
+    assert record.operator_note is None
+    (event,) = record.events
+    assert event.data == {"verdict": "n", "source": "prompt", "note": None}
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_strict_json.py
+++ b/tests/test_strict_json.py
@@ -19,6 +19,7 @@ from inspect_robots import eval, read_eval_log
 from inspect_robots.approver import ClampApprover
 from inspect_robots.logging.json_log import _sanitize
 from inspect_robots.mock import CubePickEmbodiment, ScriptedPolicy
+from inspect_robots.rollout import TrialRecord
 from inspect_robots.scene import Scene
 from inspect_robots.scorer import min_distance_to_goal, success_at_end
 from inspect_robots.task import Task
@@ -135,6 +136,32 @@ def test_scene_instruction_and_judgements_serialize_strict(tmp_path: Path) -> No
     assert isinstance(sample, dict)
     assert sample["instruction"] == "reach"
     assert sample["operator_judgements"] == [None]
+    assert sample["operator_notes"] == [None]
+
+
+def test_populated_operator_judgement_and_note_serialize_strict(tmp_path: Path) -> None:
+    # A captured judgement and grader note both survive the strict JSON sink.
+    def judge(record: TrialRecord, scene: Scene) -> None:
+        record.operator_judgement = "y"
+        record.operator_note = "Gripper Closed Early"
+
+    (log,) = eval(
+        _task(),
+        ScriptedPolicy(),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+        before_scoring=judge,
+    )
+    assert log.status == "success"
+    (path,) = tmp_path.glob("*.json")
+    data = _read_strict(path)
+    samples = data["samples"]
+    assert isinstance(samples, list)
+    sample = samples[0]
+    assert isinstance(sample, dict)
+    assert sample["instruction"] == "reach"
+    assert sample["operator_judgements"] == ["y"]
+    assert sample["operator_notes"] == ["Gripper Closed Early"]
 
 
 def test_policy_transcript_non_finite_floats_write_as_null(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #174.

After the `did the robot succeed? [y/n/partial/skip]` prompt, an ad-hoc interactive run now offers one optional free-text notes prompt. Typing anything records the note; bare Enter skips it, so a grader who has nothing to add pays a single keypress.

```text
did the robot succeed? [y/n/partial/skip] (partial scores as failure) n
grader notes (Enter for none): gripper closed early, cube still in frame
```

The note follows the verdict's existing persistence path field for field: `TrialRecord.operator_note`, a `note` field on the transcript's operator event, a parallel `SceneResult.operator_notes` tuple in the log (defaulted, no schema bump), and a "Grader notes" block in the HTML view.

Two behaviors worth flagging for review:

- A trial answered `skip` still gets a notes prompt, and a note typed there is recorded. `operator_judgement` stays `None`, so scoring is unchanged, but the event carries `verdict="skip"` with the note. `operator_event`'s docstring now tells consumers to read `"skip"` as "no judgement, never a result". This supersedes part of plan 0005's prompt contract, annotated inline there.
- The embodiment-adopted verdict path stays prompt-free. It takes zero input today, and a notes prompt would turn a run that needs nobody at the keyboard into one that does.

Notes are qualitative only: `operator_scorer` still reads the verdict and nothing else.

Plan: `plans/0027-grader-notes.md`, including a "Reversals after code review" section recording what changed once the code existed.