### PR TITLE
docs: drop the stale version from CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,4 +7,3 @@ type: software
 license: MIT
 repository-code: "https://github.com/robocurve/inspect-robots"
 url: "https://inspectrobots.org/"
-version: "0.3.0"


### PR DESCRIPTION
Follow-up to #178, which removed the same stale version from the README BibTeX and missed this file.

`CITATION.cff` read `version: "0.3.0"` against a released 0.22.0. `version` is optional in CFF 1.2.0, and hatch-vcs already derives the real version from the git tag, so removing it leaves no second copy to rot.

Nothing else changes. `url` stays the docs landing page and `repository-code` stays the repo, which is what those two fields are for, and the README BibTeX keeps citing the repo since BibTeX has room for one URL.