### PR TITLE
fix(agent): raise ConfigError instead of ValueError for constructor v…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- **Agent plugin:** `LLMAgentPolicy` constructor validation for `wire`, `speed`,
+  `effort`, `max_llm_calls`, `max_speed_frac`, and `max_output_tokens` now
+  raises `ConfigError` instead of `ValueError`, consistent with the other
+  constructor checks and the CLI's guided-error rendering (#168).
+
 - **Agent plugin:** runtime camera dropouts in `images=on_demand` now reject
   `take_pic` without treating a well-formed call as a tool error, so a single
   dropout no longer errors the trial. The first world-state rejection in one

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -174,24 +174,21 @@ class LLMAgentPolicy(PolicyBase):
         env: dict[str, str] | None = None,
     ):
         if not np.isfinite(max_speed_frac) or max_speed_frac <= 0:
-            raise ValueError("max_speed_frac must be finite and > 0")
+            raise ConfigError("max_speed_frac must be finite and > 0")
         if max_llm_calls < 1:
-            raise ValueError("max_llm_calls must be >= 1")
+            raise ConfigError("max_llm_calls must be >= 1")
         if effort is not None and effort not in _EFFORT_LEVELS:
-            raise ValueError(
+            raise ConfigError(
                 f"effort must be one of {sorted(_EFFORT_LEVELS)}, or None to omit "
                 f"the field, got {effort!r}"
             )
         # Order matters from here down (plan 0026): wire is validated before
         # the params that are only legal on one wire, the api_key_env default
         # is applied before resolution, and the OpenRouter check after it.
-        # The new wire-gated checks raise ConfigError so the CLI renders them;
-        # the older ValueErrors above are inconsistent with that and tracked
-        # separately in #168, since converting them changes existing behavior.
         if wire not in _WIRE_FORMATS:
-            raise ValueError(f"wire must be one of {sorted(_WIRE_FORMATS)}, got {wire!r}")
+            raise ConfigError(f"wire must be one of {sorted(_WIRE_FORMATS)}, got {wire!r}")
         if speed is not None and speed not in _SPEEDS:
-            raise ValueError(f"speed must be one of {sorted(_SPEEDS)}, or None, got {speed!r}")
+            raise ConfigError(f"speed must be one of {sorted(_SPEEDS)}, or None, got {speed!r}")
         if images not in _IMAGE_MODES:
             raise ConfigError(
                 f"images must be one of {sorted(_IMAGE_MODES)}, got {images!r}.\n"
@@ -217,7 +214,7 @@ class LLMAgentPolicy(PolicyBase):
             or not isinstance(max_output_tokens, int)
             or max_output_tokens < 1
         ):
-            raise ValueError("max_output_tokens must be an int >= 1")
+            raise ConfigError("max_output_tokens must be an int >= 1")
 
         environ = dict(os.environ) if env is None else env
         # resolve_provider reads api_key_env only when base_url is set, where

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -768,7 +768,7 @@ def test_chat_wire_records_no_max_output_tokens() -> None:
     ],
 )
 def test_invalid_configurations_raise(kwargs: dict[str, Any], match: str) -> None:
-    with pytest.raises(ValueError, match=match):
+    with pytest.raises(ConfigError, match=match):
         _policy(**kwargs)
 
 
@@ -785,7 +785,7 @@ def test_wire_gated_params_raise_config_error_so_the_cli_renders_them(
 
 def test_misspelled_wire_reports_the_wire_not_the_speed() -> None:
     # Ordering guard: wire is validated before the params gated on it.
-    with pytest.raises(ValueError, match="wire must be one of"):
+    with pytest.raises(ConfigError, match="wire must be one of"):
         _policy(wire="antropic", speed="fast")
 
 

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -1596,7 +1596,7 @@ def test_effort_defaults_low_and_is_tunable(tmp_path: Path) -> None:
     ir_eval(_task(), _policy(script, effort="none"), CubePickEmbodiment(), log_dir=str(tmp_path))
     assert script.requests[0]["reasoning_effort"] == "none"
 
-    with pytest.raises(ValueError, match=r"or None to omit the field, got 'turbo'"):
+    with pytest.raises(ConfigError, match=r"or None to omit the field, got 'turbo'"):
         _policy(_Script([]), effort="turbo")
 
 
@@ -1628,12 +1628,12 @@ def test_non_default_speed_fraction_is_forwarded_through_bind(tmp_path: Path) ->
 
 @pytest.mark.parametrize("max_speed_frac", [0.0, -0.1, float("inf"), float("nan")])
 def test_policy_rejects_invalid_max_speed_frac(max_speed_frac: float) -> None:
-    with pytest.raises(ValueError, match="max_speed_frac must be finite and > 0"):
+    with pytest.raises(ConfigError, match="max_speed_frac must be finite and > 0"):
         _policy(_Script([]), max_speed_frac=max_speed_frac)
 
 
 def test_policy_rejects_empty_call_budget_and_reads_process_environment() -> None:
-    with pytest.raises(ValueError, match="max_llm_calls must be >= 1"):
+    with pytest.raises(ConfigError, match="max_llm_calls must be >= 1"):
         LLMAgentPolicy(
             model="test/model",
             base_url="http://llm.test/v1",

--- a/plugins/inspect-robots-agent/tests/test_responses.py
+++ b/plugins/inspect-robots-agent/tests/test_responses.py
@@ -8,6 +8,7 @@ from typing import Any
 import httpx
 import pytest
 
+from inspect_robots.errors import ConfigError
 from inspect_robots.mock import CubePickEmbodiment
 from inspect_robots.scene import Scene
 from inspect_robots.types import Observation
@@ -598,7 +599,7 @@ def test_policy_uses_responses_wire_through_act_and_records_config() -> None:
 
 
 def test_policy_rejects_invalid_wire_and_defaults_config_to_chat() -> None:
-    with pytest.raises(ValueError, match="wire must be one of"):
+    with pytest.raises(ConfigError, match="wire must be one of"):
         LLMAgentPolicy(
             model="test/model",
             base_url="http://llm.test/v1",


### PR DESCRIPTION
…alidation

Converts the remaining 6 constructor validation checks in LLMAgentPolicy (wire, speed, effort, max_llm_calls, max_speed_frac, max_output_tokens) from ValueError to ConfigError, consistent with the other checks in the same constructor and with the CLI's guided-error rendering.

Fixes #168

## Summary

What does this change do and why?

## Changes

-

## Checklist

- [x] `pre-commit install` done; hooks pass (or ran `pre-commit run --all-files`)
- [x] Tests added/updated (and the `CubePick` mock exercises the change where applicable)
- [x] Coverage stays at **100%** (`pytest --cov`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `mypy` passes (strict)
- [x] `CHANGELOG.md` updated under "Unreleased"
- [ ] Public API changes are reflected in `inspect_robots.__all__` and the API-snapshot test
- [x] Core stays NumPy-only (new deps are optional extras, lazily imported)

## Related

Closes #
