### PR TITLE
ci: bump actions/checkout to v5 for the Node 24 runtime

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       issues: write  # open the failure alert
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # hatch-vcs derives the version from git tags
       - name: Install uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: lint · type
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # hatch-vcs needs full history/tags for versioning
       - name: Install uv
@@ -41,7 +41,7 @@ jobs:
     name: docs build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # hatch-vcs needs full history/tags for versioning
       - name: Install uv
@@ -80,7 +80,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install uv
@@ -103,7 +103,7 @@ jobs:
     name: test (rerun extra)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install uv
@@ -137,7 +137,7 @@ jobs:
             python-version: "3.12"
             numpy: "numpy>=2"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install uv
@@ -160,7 +160,7 @@ jobs:
     name: core-only import (no rerun/torch)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install uv
@@ -191,7 +191,7 @@ jobs:
     name: plugin · isaacsim (no Isaac)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install uv
@@ -230,7 +230,7 @@ jobs:
     name: plugin · xpolicylab
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install uv
@@ -265,7 +265,7 @@ jobs:
     name: plugin · ros
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install uv
@@ -301,7 +301,7 @@ jobs:
     name: plugin · agent
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install uv
@@ -337,7 +337,7 @@ jobs:
     name: plugin · capx
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install uv

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
     name: build docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # hatch-vcs needs full history/tags for versioning
       - name: Install uv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     outputs:
       tag: ${{ steps.bump.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # full tag history to find the latest version
       - name: Compute next tag from latest v* tag
@@ -73,7 +73,7 @@ jobs:
     permissions:
       id-token: write  # OIDC token for PyPI trusted publishing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.cut.outputs.tag || github.ref }}
           fetch-depth: 0  # hatch-vcs derives the version from git tags
@@ -93,7 +93,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.cut.outputs.tag || github.ref }}
       - name: Install uv
@@ -116,7 +116,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.cut.outputs.tag || github.ref }}
       - name: Install uv
@@ -139,7 +139,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.cut.outputs.tag || github.ref }}
       - name: Install uv
@@ -162,7 +162,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.cut.outputs.tag || github.ref }}
       - name: Install uv
@@ -185,7 +185,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.cut.outputs.tag || github.ref }}
       - name: Install uv


### PR DESCRIPTION
GitHub is deprecating Node 20 on Actions runners and force-runs `actions/checkout@v4` on Node 24, emitting a warning on every job (seen in the v0.23.0 release run annotations). v5 targets Node 24 natively and is a drop-in: same inputs and defaults, no behavior change.

Bumps all 20 usages across `ci.yml`, `release.yml`, `canary.yml`, and `docs.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)