### PR TITLE
chore(pre-commit): make local hooks self-sufficient via --extra dev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,28 +30,28 @@ repos:
     hooks:
       - id: ruff-check
         name: ruff (lint, autofix)
-        entry: uv run ruff check --fix
+        entry: uv run --extra dev ruff check --fix
         language: system
         types_or: [python, pyi]
         require_serial: true
 
       - id: ruff-format
         name: ruff (format)
-        entry: uv run ruff format
+        entry: uv run --extra dev ruff format
         language: system
         types_or: [python, pyi]
         require_serial: true
 
       - id: mypy
         name: mypy (strict)
-        entry: uv run mypy
+        entry: uv run --extra dev mypy
         language: system
         types: [python]
         pass_filenames: false
 
       - id: pytest-coverage
         name: pytest (100% coverage gate)
-        entry: uv run pytest --cov --cov-report=term-missing
+        entry: uv run --extra dev pytest --cov --cov-report=term-missing
         language: system
         always_run: true # run on every push, even when no .py files changed
         pass_filenames: false


### PR DESCRIPTION
The local ruff/mypy/pytest hooks ran bare `uv run <tool>`, which resolves the project environment without the dev extra. In a fresh checkout or git worktree that environment lacks the dev tools, so the pre-push coverage gate fails with `unrecognized arguments: --cov` (pytest-cov absent). The ruff and mypy commit hooks have the same latent problem; they only pass in fresh worktrees when no Python files are staged.

Passing `--extra dev` lets uv provision the tools wherever the hook runs. Validated end-to-end: this PR's own push ran the fixed pre-push gate from a fresh worktree with no `.venv` (the exact previously-failing scenario) and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)