### PR TITLE
chore(website): override serialize-javascript and sockjs uuid past advisories

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -16936,15 +16936,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -17930,12 +17921,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {
@@ -19420,13 +19411,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/website/package.json
+++ b/website/package.json
@@ -36,6 +36,12 @@
     "@types/react": "^19.0.0",
     "typescript": "~6.0.2"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5",
+    "sockjs": {
+      "uuid": "^11.1.1"
+    }
+  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
Fixes 3 of the 4 open Dependabot alerts, all npm transitive deps of the Docusaurus site (build-time only, the published site is static):

- serialize-javascript 6.0.2 → 7.0.7 (alert 1, high: RCE via RegExp.flags; alert 3, moderate: CPU-exhaustion DoS). Top-level override; both consumers (copy-webpack-plugin, css-minimizer-webpack-plugin) use the unchanged `serialize()` API.
- uuid 8.3.2 → 11.1.1 under sockjs (alert 2, moderate: buffer bounds in v3/v5/v6). Scoped override; sockjs only calls `require('uuid').v4`, which uuid 11's CJS build still exports.

Docusaurus 3.10.2 is already the latest release, so the parent chain cannot be upgraded past these; overrides are the only route.

Deliberately not fixed: brace-expansion (alert 4, high). The advisory's only patched version, 5.0.8, drops the bare-function CJS export that minimatch@3 (via serve-handler) requires, so overriding it breaks `docusaurus serve`. The vulnerable code path there expands trusted site-config glob patterns in the local-only serve command, so the practical exposure is nil; recommend dismissing that alert as tolerable risk until upstream minimatch/serve-handler move.

Verified: `npm run build` passes end to end with the new lockfile (API docs generated, static site + llms.txt emitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)