### PR TITLE
agent: bound image history + Anthropic prompt caching + usage accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- **Agent plugin:** outgoing requests now retain camera frames only from the
+  newest two image-bearing messages by default (`-P image_horizon=`), bounding
+  long-episode payloads without changing stored history, transcripts, or frame
+  side-cars. The native Anthropic wire adds automatic prompt-cache breakpoints
+  and records per-trial token/cache totals in `record.metadata["llm_usage"]`,
+  making cache savings directly observable (#188).
 - **Seconds-based benchmark horizons:** `Task(max_seconds=...)` gives every
   compatible embodiment the same physical-time budget. `eval()` resolves it
   with `ceil(max_seconds * embodiment.info.control_hz)`, rejects missing or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,14 +59,20 @@ All notable changes to this project are documented here. The format is based on
   (unscored) after three consecutive failures, and each correction turn spends
   one `max_llm_calls` unit.
 
-### Added
+### Changed
 
 - **Agent plugin:** outgoing requests now retain camera frames only from the
-  newest two image-bearing messages by default (`-P image_horizon=`), bounding
-  long-episode payloads without changing stored history, transcripts, or frame
-  side-cars. The native Anthropic wire adds automatic prompt-cache breakpoints
-  and records per-trial token/cache totals in `record.metadata["llm_usage"]`,
-  making cache savings directly observable (#188).
+  newest two image-bearing messages by default, bounding long-episode
+  payloads that previously grew until the API's request-size ceiling (HTTP
+  413). Stored history, transcripts, and frame side-cars are unchanged.
+  Restore the old unbounded behavior with `-P image_horizon=none` (#188).
+
+### Added
+
+- **Agent plugin:** the native Anthropic wire adds automatic prompt-cache
+  breakpoints (system prompt, eviction boundary, final message) and records
+  per-trial token/cache totals in `record.metadata["llm_usage"]`, making
+  cache savings directly observable via `cache_read_input_tokens` (#188).
 - **Seconds-based benchmark horizons:** `Task(max_seconds=...)` gives every
   compatible embodiment the same physical-time budget. `eval()` resolves it
   with `ceil(max_seconds * embodiment.info.control_hz)`, rejects missing or

--- a/plans/0028-agent-image-eviction-prompt-cache.md
+++ b/plans/0028-agent-image-eviction-prompt-cache.md
@@ -22,12 +22,14 @@ pytest + mock transports (existing patterns in
 
 ## Global Constraints
 
-- Repo gates: `ruff check .`, `ruff format --check .`, strict `mypy` over src
-  **and** tests, `pytest --cov` (the plugin's CI coverage job is report-only,
-  `--cov-fail-under=0` — still: add tests for every new branch; the explicit
-  list is in each task).
-- Ruff D1: docstring on every public module/class/function — state the
-  contract, not the symbol name.
+- Repo gates for this plugin: `ruff check .`, `ruff format --check .`, and
+  strict `mypy` over `src/inspect_robots_agent` (the plugin CI job does not
+  type-check tests); the coverage job is report-only (`--cov-fail-under=0`)
+  — still: add tests for every new branch; the explicit list is in each
+  task.
+- Ruff D1: docstring on every public module/class/function in `src/` —
+  state the contract, not the symbol name (the plugin's pyproject exempts
+  `tests/**` from D1).
 - No provider SDKs in `plugins/inspect-robots-agent` — hand-built request
   bodies over httpx only.
 - Every construction-time validation failure raises
@@ -218,9 +220,13 @@ pytest + mock transports (existing patterns in
   ~6 translated blocks on a normal cycle, but a cycle with maximum retry
   churn (3 failed turns and/or repeated on_demand rejections, ~4 blocks
   each) can exceed Anthropic's 20-block lookback and cause one silent
-  full-prefix re-write — a cost blip, not an error. Note this in the code
-  comment so a live `cache_read_input_tokens=0` after a messy cycle isn't
-  debugged as a placement bug.
+  full-prefix re-write — a cost blip, not an error. A second same-class blip:
+  the nudge message's wire shape flips between calls (wrapped block list
+  while final, bare string once superseded), so that position's final-
+  breakpoint entry may miss on the next call — self-healing, the anchor
+  entry still hits. Cover both in the same code comment so a live
+  `cache_read_input_tokens=0` after a messy cycle isn't debugged as a
+  placement bug.
 - No breakpoint on tools: the system breakpoint caches tools+system together
   (tools render before system).
 - Other wires: `ChatClient.complete` and `ResponsesClient.complete` gain no
@@ -247,9 +253,10 @@ pytest + mock transports (existing patterns in
   `test_act_drives_a_multi_turn_trial_and_replays_thinking` (calls
   `first["system"].startswith(...)`, and asserts the nudge message body is
   the bare string `"Respond with exactly one tool call."` — now wrapped when
-  it is the final message). In test_policy_e2e.py, check
-  `test_consecutive_tool_messages_merge_in_history_order` (counts
-  list-content user messages) for the same wrap interaction and adjust.
+  it is the final message). (`test_consecutive_tool_messages_merge_in_history_order` in
+  test_anthropic.py was checked and does **not** break: its final message
+  has list content and its assertions tolerate an added `cache_control`
+  key — no change needed there.)
 - [ ] **Step 2: Run, verify failures.**
 - [ ] **Step 3: Implement** in `complete()` + `_translate_messages`.
 - [ ] **Step 4: Full plugin suite green.**
@@ -261,8 +268,7 @@ pytest + mock transports (existing patterns in
 **Files:**
 - Modify: `plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py`
   (`AssistantMessage`), `_anthropic.py` (`_parse_response`), `policy.py`
-  (aggregation + metadata), `_responses.py` (kwarg parity only if Task 1's
-  call-site change requires none — see note)
+  (aggregation + metadata). `_responses.py` needs no edit.
 - Test: `plugins/inspect-robots-agent/tests/test_anthropic.py`,
   `plugins/inspect-robots-agent/tests/test_policy_e2e.py`
 

--- a/plans/0028-agent-image-eviction-prompt-cache.md
+++ b/plans/0028-agent-image-eviction-prompt-cache.md
@@ -1,0 +1,278 @@
+# Agent Image Eviction + Prompt Caching Implementation Plan
+
+> **For agentic workers:** Implement task-by-task; each task carries its own
+> test cycle. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bound the agent policy's per-request payload (fixes the HTTP 413 that
+kills long episodes) and cut its quadratic token cost via Anthropic prompt
+caching, with per-trial usage accounting to verify both.
+
+**Architecture:** `LLMAgentPolicy` keeps its full chat history canonical but
+sends the wire client a per-call *view* in which camera frames older than the
+last `image_horizon` image-bearing messages are replaced by deterministic text
+stubs — each message is rewritten exactly once when it ages out, so the prompt
+prefix stays byte-stable and cacheable. The Anthropic wire client adds
+`cache_control` breakpoints (system prompt, newest-stubbed anchor message,
+final message) and surfaces the response `usage` block, which the policy
+aggregates per trial into `record.metadata["llm_usage"]`.
+
+**Tech Stack:** Python 3.10–3.13, httpx (no provider SDKs — repo rule),
+pytest + mock transports (existing patterns in
+`plugins/inspect-robots-agent/tests/`), ruff, strict mypy.
+
+## Global Constraints
+
+- Repo gates: `ruff check .`, `ruff format --check .`, strict `mypy` over src
+  **and** tests, `pytest --cov` (plugin has its own coverage scope; keep it at
+  its current gate — add tests for every new branch).
+- Ruff D1: docstring on every public module/class/function — state the
+  contract, not the symbol name.
+- No provider SDKs in `plugins/inspect-robots-agent` — hand-built request
+  bodies over httpx only.
+- Every construction-time validation failure raises
+  `inspect_robots.errors.ConfigError` with a `fix:` line (repo issue #168
+  convention).
+- Chat-format history stays canonical (plan 0026); wire clients translate.
+- The stored history (`self._messages`), `transcript()`, `transcript_delta()`,
+  and the frames side-car must be unaffected by eviction — eviction is
+  view-only.
+- Deterministic bytes everywhere in the outgoing view: no timestamps, no
+  counters that change retroactively, no dict-ordering hazards.
+- Context: issue #188; failed run `adhoc_3539bb48` (2026-07-27): 86 calls,
+  264 accumulated frames ≈ 36 MB request → HTTP 413 `request_too_large`.
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py` | `image_horizon` config + validation; `_evicted_view()`; call-site wiring; usage aggregation; `record.metadata["llm_usage"]` |
+| `plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py` | `cache_control` on system / anchor / final blocks; parse `usage`; copy-on-write for replay-cache blocks |
+| `plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py` | `AssistantMessage.usage` field; `ChatClient.complete` ignores new kwarg |
+| `plugins/inspect-robots-agent/src/inspect_robots_agent/_responses.py` | `ResponsesClient.complete` ignores new kwarg |
+| `plugins/inspect-robots-agent/tests/test_policy_eviction.py` | New: view-builder unit tests + eviction e2e + prefix-stability test |
+| `plugins/inspect-robots-agent/tests/test_anthropic.py` | Extend: cache_control placement, usage parsing, replay-block immutability |
+| `plugins/inspect-robots-agent/tests/test_policy_e2e.py` | Extend: usage metadata lands in `TrialRecord.metadata` |
+| `plugins/inspect-robots-agent/README.md` | Document `-P image_horizon=`, caching behavior, `llm_usage` metadata |
+| `CHANGELOG.md` | Entry under Unreleased |
+
+---
+
+### Task 1: `_evicted_view()` + `image_horizon` config (policy.py)
+
+**Files:**
+- Modify: `plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py`
+- Test: `plugins/inspect-robots-agent/tests/test_policy_eviction.py` (new)
+
+**Interfaces:**
+- Produces:
+  ```python
+  def _evicted_view(
+      messages: list[dict[str, Any]],
+      horizon: int,
+      *,
+      mark_anchor: bool = False,
+  ) -> list[dict[str, Any]]
+  ```
+  Returns a new list. Messages whose `content` list contains `image_url`
+  parts are "image-bearing". The last `horizon` image-bearing messages pass
+  through untouched (same object, not copied). Every older image-bearing
+  message is replaced by a shallow-copied dict whose content list has all
+  camera parts (each `image_url` part *and* the label `text` part immediately
+  preceding it) removed and one stub appended:
+  `{"type": "text", "text": f"[{n} camera frame(s) elided]"}` where `n` is
+  the count of removed `image_url` parts. When `mark_anchor=True` and at
+  least one message was stubbed, the *newest* stubbed message dict also gets
+  `"cache_anchor": True` (top-level key on the message dict, consumed by the
+  Anthropic wire in Task 2).
+- Produces: `LLMAgentPolicy(image_horizon: int | None = 2, ...)` and
+  `AgentPolicyConfig.image_horizon: int | None = 2`. `None` disables eviction
+  (send full history — pre-change behavior).
+
+**Notes for the implementer:**
+- Default is `2`: with 3 cameras that keeps ≤ 6 frames in flight, bounding
+  request bodies at well under 1 MB versus the 32 MB ceiling.
+- Validation mirrors `max_output_tokens`: reject `bool`, non-`int`, and
+  `< 1` with `ConfigError("image_horizon must be an int >= 1, or None to "
+  "send full image history")`. The CLI forwards `-P image_horizon=2` through
+  the same coercion path as `max_output_tokens`.
+- Untouched messages must be the *same objects* (identity), not copies —
+  the prefix-stability test asserts this, and it is what makes the
+  serialized prefix byte-stable across calls.
+- The stub text contains no step number and no timestamp — determinism.
+- Image-bearing counting covers both attachment paths: `images="always"`
+  observation messages and the `on_demand` immediate-frames user messages
+  appended after `take_pic` (both are `role: "user"` with `image_url` parts;
+  the rule is shape-based, not mode-based).
+- Call site in `act()`: replace the direct `self._client.complete(self._messages, ...)`
+  with:
+  ```python
+  outgoing = self._messages
+  if self._image_horizon is not None:
+      outgoing = _evicted_view(
+          self._messages,
+          self._image_horizon,
+          mark_anchor=isinstance(self._client, AnthropicClient),
+      )
+  message = self._client.complete(
+      outgoing,
+      toolset.schemas(),
+      temperature=self._temperature,
+      reasoning_effort=self._effort,
+  )
+  ```
+  The view is rebuilt on every iteration of the inner `while True` loop (a
+  nudge retry appends messages), not once per `act()`.
+
+- [ ] **Step 1: Write failing unit tests** in
+  `tests/test_policy_eviction.py` covering: (a) fewer image-bearing messages
+  than horizon → same list contents, zero copies; (b) one aged-out
+  observation message → label+image parts removed, stub text
+  `"[3 camera frame(s) elided]"` appended after the state text part, original
+  `self._messages` object unmodified; (c) kept messages are identical objects
+  (`is`); (d) `mark_anchor=True` sets `cache_anchor` only on the newest
+  stubbed message; (e) on_demand-style image-only message stubs to a single
+  text part; (f) non-list content (plain string user messages) passes
+  through untouched.
+- [ ] **Step 2: Run tests, verify they fail** (`_evicted_view` undefined).
+- [ ] **Step 3: Implement `_evicted_view` and the config plumbing**
+  (`__init__` param + validation + `AgentPolicyConfig` field + `act()` call
+  site).
+- [ ] **Step 4: Run the new tests and the full plugin suite** —
+  `uv run pytest plugins/inspect-robots-agent/tests/ -q`; all green.
+- [ ] **Step 5: Write the prefix-stability test**: drive a policy through 4
+  `act()` cycles with a mock transport (existing e2e fixtures), capture each
+  outgoing request body, and assert byte-identical shared prefix: request
+  k+1's serialized `messages[:boundary]` equals request k's, where
+  `boundary` is everything up to request k's final two messages.
+- [ ] **Step 6: Run, verify green, commit**
+  `feat(agent): bound outgoing image history with image_horizon view eviction`
+
+### Task 2: `cache_control` breakpoints (Anthropic wire)
+
+**Files:**
+- Modify: `plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py`
+- Test: `plugins/inspect-robots-agent/tests/test_anthropic.py`
+
+**Interfaces:**
+- Consumes: `"cache_anchor": True` marker from Task 1.
+- Produces: request bodies where
+  1. `body["system"]` is a block list:
+     `[{"type": "text", "text": <system>, "cache_control": {"type": "ephemeral"}}]`
+     (unchanged hoisting logic; only the final shape changes),
+  2. the translated turn for a marker-carrying message has
+     `cache_control: {"type": "ephemeral"}` on its **last** content block,
+  3. the last content block of the **final** translated message likewise.
+
+**Notes for the implementer:**
+- Max 4 breakpoints per request; this design uses exactly 3.
+- Why the anchor: the eviction boundary is the only point where the prefix
+  changes between calls. A breakpoint there chains to the previous call's
+  anchor (~one observation cycle ≈ ~10 blocks back, inside Anthropic's
+  20-block lookback), so the whole stable prefix reads from cache at 0.1×
+  while only the ~`horizon`-message tail re-prefills.
+- `_translate_messages` never forwards unknown keys (it builds fresh dicts),
+  so consuming `message.get("cache_anchor")` needs no popping and nothing
+  leaks onto the wire.
+- **Copy-on-write:** blocks fetched from `self._raw_blocks_by_tool_use_id`
+  (the thinking-replay cache) are stored verbatim for replay. If the final
+  message is an assistant replay turn, adding `cache_control` in place would
+  poison the stored copy and grow a second `cache_control` next call. Apply
+  breakpoints via `{**block, "cache_control": {...}}` on a copied list, never
+  by mutating.
+- Anchor and final can coincide (rare; anchor is never the last message in
+  practice because an observation follows every eviction) — if they do, one
+  block carries one `cache_control`, not two; guard with an identity check.
+- No breakpoint on tools: the system breakpoint caches tools+system together
+  (tools render before system).
+- Other wires: `ChatClient.complete` and `ResponsesClient.complete` gain no
+  behavior — OpenAI-compatible gateways cache prefixes automatically.
+
+- [ ] **Step 1: Write failing tests** extending `test_anthropic.py` (reuse
+  its mock-transport request-capture pattern): (a) system hoisting now emits
+  the block-list shape with `cache_control`; (b) a message carrying
+  `cache_anchor: True` yields a translated turn whose last block has
+  `cache_control` and the marker key itself does not appear anywhere in the
+  serialized body; (c) the final translated message's last block has
+  `cache_control`; (d) a replayed assistant turn as final message: the dict
+  stored in `_raw_blocks_by_tool_use_id` is unmodified after `complete()`
+  (no `cache_control` key), and the *next* request contains exactly one
+  `cache_control` on that turn; (e) exactly 3 `cache_control` occurrences in
+  a representative request.
+- [ ] **Step 2: Run, verify failures.**
+- [ ] **Step 3: Implement** in `complete()` + `_translate_messages`.
+- [ ] **Step 4: Full plugin suite green.**
+- [ ] **Step 5: Commit**
+  `feat(agent): anthropic prompt-cache breakpoints on system/anchor/final`
+
+### Task 3: Usage accounting
+
+**Files:**
+- Modify: `plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py`
+  (`AssistantMessage`), `_anthropic.py` (`_parse_response`), `policy.py`
+  (aggregation + metadata), `_responses.py` (kwarg parity only if Task 1's
+  call-site change requires none — see note)
+- Test: `plugins/inspect-robots-agent/tests/test_anthropic.py`,
+  `plugins/inspect-robots-agent/tests/test_policy_e2e.py`
+
+**Interfaces:**
+- Produces: `AssistantMessage.usage: dict[str, int] | None = None` — new
+  optional field, **excluded from `raw()`** (raw() round-trips into history;
+  usage must not).
+- Produces: `record.metadata["llm_usage"]` per trial, e.g.
+  `{"llm_calls": 86, "input_tokens": 1690000, "output_tokens": 8100,
+  "cache_creation_input_tokens": ..., "cache_read_input_tokens": ...}` —
+  keys summed from each response's `usage` (only int-valued keys), plus
+  `llm_calls` counted locally. Written in `on_trial_end` alongside the
+  existing `record.metadata["transcript"]`; omitted when no calls were made.
+- Note: only the Anthropic wire populates `usage` in this change; the chat
+  and responses wires leave it `None` and the aggregate then contains only
+  `llm_calls`. (Their payloads carry usage too — deliberately out of scope.)
+
+**Notes for the implementer:**
+- Reset accumulation in `reset()` (per-trial), same as `_calls_used`.
+- With `transcript_echo`, emit one line per call:
+  `[agent] -- usage: in=<input_tokens> cache_read=<cache_read_input_tokens> out=<output_tokens>`
+  (keys absent from the response render as 0).
+- The acceptance signal for Task 2 lives here: a live run should show
+  `cache_read_input_tokens > 0` from call 2 onward.
+
+- [ ] **Step 1: Write failing tests**: (a) `_parse_response` carries the
+  payload's `usage` dict through; absent usage → `None`; (b) `raw()` output
+  contains no `usage` key; (c) e2e: after a 2-cycle mock run,
+  `record.metadata["llm_usage"]["llm_calls"] == 2` and token keys equal the
+  mock's sums; (d) `reset()` zeroes the aggregate.
+- [ ] **Step 2: Run, verify failures.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Full plugin suite + `mypy` + `ruff` green.**
+- [ ] **Step 5: Commit** `feat(agent): per-trial LLM usage accounting in trial metadata`
+
+### Task 4: Docs
+
+**Files:**
+- Modify: `plugins/inspect-robots-agent/README.md`, `CHANGELOG.md`
+
+- [ ] **Step 1:** README: add `image_horizon` to the `-P` options table
+  (default 2, `None`/unset-via-`-P image_horizon=` semantics, why: request
+  bodies otherwise grow ~420 KB per observation and 413 at ~85 observations
+  with 3 cameras); a short "Prompt caching" paragraph under the anthropic
+  wire section (automatic, 3 breakpoints, verify via `llm_usage`); document
+  `record.metadata["llm_usage"]`.
+- [ ] **Step 2:** CHANGELOG entry under Unreleased referencing issue #188.
+- [ ] **Step 3:** Commit `docs(agent): document image_horizon, prompt caching, llm_usage`
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: 413 fix (Task 1), cost fix (Task 2), verification signal
+  (Task 3), docs (Task 4). Issue #188 maps 1:1.
+- Type consistency: `_evicted_view` returns `list[dict[str, Any]]` and is
+  consumed as such at the `act()` call site; `cache_anchor` is a message-dict
+  key produced in Task 1 and consumed in Task 2; `AssistantMessage.usage` is
+  produced in Task 3's `_parse_response` and consumed in Task 3's policy
+  aggregation.
+- Deliberate scope cuts: no usage capture on chat/responses wires; no 1h TTL
+  (calls are ~15 s apart, 5 min default suffices); no seconds-based horizon
+  (plan 0026-seconds-based-horizons is unrelated).

--- a/plans/0028-agent-image-eviction-prompt-cache.md
+++ b/plans/0028-agent-image-eviction-prompt-cache.md
@@ -23,8 +23,9 @@ pytest + mock transports (existing patterns in
 ## Global Constraints
 
 - Repo gates: `ruff check .`, `ruff format --check .`, strict `mypy` over src
-  **and** tests, `pytest --cov` (plugin has its own coverage scope; keep it at
-  its current gate — add tests for every new branch).
+  **and** tests, `pytest --cov` (the plugin's CI coverage job is report-only,
+  `--cov-fail-under=0` — still: add tests for every new branch; the explicit
+  list is in each task).
 - Ruff D1: docstring on every public module/class/function — state the
   contract, not the symbol name.
 - No provider SDKs in `plugins/inspect-robots-agent` — hand-built request
@@ -49,8 +50,7 @@ pytest + mock transports (existing patterns in
 |---|---|
 | `plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py` | `image_horizon` config + validation; `_evicted_view()`; call-site wiring; usage aggregation; `record.metadata["llm_usage"]` |
 | `plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py` | `cache_control` on system / anchor / final blocks; parse `usage`; copy-on-write for replay-cache blocks |
-| `plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py` | `AssistantMessage.usage` field; `ChatClient.complete` ignores new kwarg |
-| `plugins/inspect-robots-agent/src/inspect_robots_agent/_responses.py` | `ResponsesClient.complete` ignores new kwarg |
+| `plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py` | `AssistantMessage.usage` field only — **no `complete()` signature changes on any wire** (the call site passes the same arguments as today; the anchor travels as a message-dict key, not a parameter) |
 | `plugins/inspect-robots-agent/tests/test_policy_eviction.py` | New: view-builder unit tests + eviction e2e + prefix-stability test |
 | `plugins/inspect-robots-agent/tests/test_anthropic.py` | Extend: cache_control placement, usage parsing, replay-block immutability |
 | `plugins/inspect-robots-agent/tests/test_policy_e2e.py` | Extend: usage metadata lands in `TrialRecord.metadata` |
@@ -93,10 +93,14 @@ pytest + mock transports (existing patterns in
 **Notes for the implementer:**
 - Default is `2`: with 3 cameras that keeps ≤ 6 frames in flight, bounding
   request bodies at well under 1 MB versus the 32 MB ceiling.
-- Validation mirrors `max_output_tokens`: reject `bool`, non-`int`, and
-  `< 1` with `ConfigError("image_horizon must be an int >= 1, or None to "
-  "send full image history")`. The CLI forwards `-P image_horizon=2` through
-  the same coercion path as `max_output_tokens`.
+- Validation mirrors `max_output_tokens`'s shape checks: reject `bool`,
+  non-`int`, and `< 1` with
+  `ConfigError("image_horizon must be an int >= 1, or None to send full "
+  "image history.\nfix: pass -P image_horizon=N or -P image_horizon=none")`.
+  CLI note: `parse_value` (src/inspect_robots/_defaults.py) maps `none` →
+  `None` and `""` → the empty **string** — so the disable spelling is
+  `-P image_horizon=none`, and `-P image_horizon=` must hit the ConfigError
+  (add a test for the empty-string rejection).
 - Untouched messages must be the *same objects* (identity), not copies —
   the prefix-stability test asserts this, and it is what makes the
   serialized prefix byte-stable across calls.
@@ -134,7 +138,10 @@ pytest + mock transports (existing patterns in
   (`is`); (d) `mark_anchor=True` sets `cache_anchor` only on the newest
   stubbed message; (e) on_demand-style image-only message stubs to a single
   text part; (f) non-list content (plain string user messages) passes
-  through untouched.
+  through untouched; (g) `image_horizon` validation: `True`, `0`, `-1`,
+  `"2"`, and `""` each raise `ConfigError` with the `fix:` line, `None` and
+  `2` are accepted; (h) `image_horizon=None` sends the full history (mock
+  transport sees images in every observation message across 3 cycles).
 - [ ] **Step 2: Run tests, verify they fail** (`_evicted_view` undefined).
 - [ ] **Step 3: Implement `_evicted_view` and the config plumbing**
   (`__init__` param + validation + `AgentPolicyConfig` field + `act()` call
@@ -143,9 +150,14 @@ pytest + mock transports (existing patterns in
   `uv run pytest plugins/inspect-robots-agent/tests/ -q`; all green.
 - [ ] **Step 5: Write the prefix-stability test**: drive a policy through 4
   `act()` cycles with a mock transport (existing e2e fixtures), capture each
-  outgoing request body, and assert byte-identical shared prefix: request
-  k+1's serialized `messages[:boundary]` equals request k's, where
-  `boundary` is everything up to request k's final two messages.
+  outgoing request body, and assert two properties. (1) **Byte-stability up
+  to the eviction boundary**: for each consecutive request pair, the
+  serialized `messages` agree byte-for-byte up to (but excluding) the message
+  newly stubbed in request k+1 — the divergence point is *by design* the
+  eviction boundary, which with `horizon=2` sits ~4 messages before request
+  k's end, not in the appended tail. (2) **Each message is rewritten at most
+  once across the whole run**: once a message appears in stubbed form, its
+  serialized bytes are identical in every later request.
 - [ ] **Step 6: Run, verify green, commit**
   `feat(agent): bound outgoing image history with image_horizon view eviction`
 
@@ -163,7 +175,22 @@ pytest + mock transports (existing patterns in
      (unchanged hoisting logic; only the final shape changes),
   2. the translated turn for a marker-carrying message has
      `cache_control: {"type": "ephemeral"}` on its **last** content block,
-  3. the last content block of the **final** translated message likewise.
+  3. the last content block of the **final** translated message likewise —
+     with two carve-outs:
+     - **String content** (the nudge retry appends
+       `{"role": "user", "content": "Respond with exactly one tool call."}`,
+       and `_translate_content` passes strings through untranslated): when
+       the final message's translated content is a plain string, wrap it at
+       translation time into `[{"type": "text", "text": <s>,
+       "cache_control": {"type": "ephemeral"}}]`. This is wire-internal —
+       the canonical history keeps the string. Two existing tests assert
+       the unwrapped body shape and must be updated (see Step 1).
+     - **Thinking blocks**: the API rejects `cache_control` on
+       `thinking`/`redacted_thinking` blocks. The policy loop never ends a
+       request on such a block (the final message is always user-role), but
+       defend anyway: if the last block of the target turn is a thinking
+       variant, place the breakpoint on the last non-thinking block; if the
+       turn has none, skip that breakpoint.
 
 **Notes for the implementer:**
 - Max 4 breakpoints per request; this design uses exactly 3.
@@ -184,6 +211,16 @@ pytest + mock transports (existing patterns in
 - Anchor and final can coincide (rare; anchor is never the last message in
   practice because an observation follows every eviction) — if they do, one
   block carries one `cache_control`, not two; guard with an identity check.
+  This branch is unreachable through the policy loop, so it needs a direct
+  `AnthropicClient` unit test (hand-built messages list where the marked
+  message is last) or it ships untested.
+- Lookback caveat (documentation, not code): the anchor-to-anchor gap is
+  ~6 translated blocks on a normal cycle, but a cycle with maximum retry
+  churn (3 failed turns and/or repeated on_demand rejections, ~4 blocks
+  each) can exceed Anthropic's 20-block lookback and cause one silent
+  full-prefix re-write — a cost blip, not an error. Note this in the code
+  comment so a live `cache_read_input_tokens=0` after a messy cycle isn't
+  debugged as a placement bug.
 - No breakpoint on tools: the system breakpoint caches tools+system together
   (tools render before system).
 - Other wires: `ChatClient.complete` and `ResponsesClient.complete` gain no
@@ -195,11 +232,24 @@ pytest + mock transports (existing patterns in
   `cache_anchor: True` yields a translated turn whose last block has
   `cache_control` and the marker key itself does not appear anywhere in the
   serialized body; (c) the final translated message's last block has
-  `cache_control`; (d) a replayed assistant turn as final message: the dict
-  stored in `_raw_blocks_by_tool_use_id` is unmodified after `complete()`
-  (no `cache_control` key), and the *next* request contains exactly one
-  `cache_control` on that turn; (e) exactly 3 `cache_control` occurrences in
-  a representative request.
+  `cache_control`, including the string-content case, which wraps into a
+  one-text-block list; (d) a replayed assistant turn as final message: the
+  dict stored in `_raw_blocks_by_tool_use_id` is unmodified after
+  `complete()` (no `cache_control` key), and the *next* request contains
+  exactly one `cache_control` on that turn; (e) exactly 3 `cache_control`
+  occurrences in a representative request; (f) anchor==final coincidence via
+  a direct `complete()` call with a hand-built history whose marked message
+  is last → exactly one `cache_control` on that turn; (g) a synthetic turn
+  ending in a `thinking` block gets the breakpoint on the last non-thinking
+  block. **Update two existing tests whose assertions the new shapes break:**
+  `test_request_shape_and_headers` (asserts
+  `body["system"] == "you drive a robot"` — now a block list) and
+  `test_act_drives_a_multi_turn_trial_and_replays_thinking` (calls
+  `first["system"].startswith(...)`, and asserts the nudge message body is
+  the bare string `"Respond with exactly one tool call."` — now wrapped when
+  it is the final message). In test_policy_e2e.py, check
+  `test_consecutive_tool_messages_merge_in_history_order` (counts
+  list-content user messages) for the same wrap interaction and adjust.
 - [ ] **Step 2: Run, verify failures.**
 - [ ] **Step 3: Implement** in `complete()` + `_translate_messages`.
 - [ ] **Step 4: Full plugin suite green.**
@@ -219,7 +269,13 @@ pytest + mock transports (existing patterns in
 **Interfaces:**
 - Produces: `AssistantMessage.usage: dict[str, int] | None = None` — new
   optional field, **excluded from `raw()`** (raw() round-trips into history;
-  usage must not).
+  usage must not). To keep the annotation honest, `_parse_response` filters
+  at the source: `{k: v for k, v in usage.items() if isinstance(v, int) and
+  not isinstance(v, bool)}` — real Anthropic `usage` payloads carry non-int
+  values (nested `cache_creation` object, `service_tier` string) that must
+  not pass through. All existing `AssistantMessage(...)` constructions use
+  keyword args (verified: `_llm.py`, `_responses.py`, `_anthropic.py`), so a
+  defaulted field is non-breaking.
 - Produces: `record.metadata["llm_usage"]` per trial, e.g.
   `{"llm_calls": 86, "input_tokens": 1690000, "output_tokens": 8100,
   "cache_creation_input_tokens": ..., "cache_read_input_tokens": ...}` —
@@ -232,17 +288,28 @@ pytest + mock transports (existing patterns in
 
 **Notes for the implementer:**
 - Reset accumulation in `reset()` (per-trial), same as `_calls_used`.
-- With `transcript_echo`, emit one line per call:
+- With `transcript_echo`, emit one line per call **only when
+  `message.usage is not None`**:
   `[agent] -- usage: in=<input_tokens> cache_read=<cache_read_input_tokens> out=<output_tokens>`
-  (keys absent from the response render as 0).
+  (keys absent from the dict render as 0). The chat/responses wires leave
+  `usage` as `None` and therefore never emit the line — an unconditional
+  line would break `test_transcript_echo_reports_tool_results_in_call_order`
+  (test_policy_e2e.py), which asserts exact equality on all `[agent] --`
+  lines.
 - The acceptance signal for Task 2 lives here: a live run should show
   `cache_read_input_tokens > 0` from call 2 onward.
 
 - [ ] **Step 1: Write failing tests**: (a) `_parse_response` carries the
-  payload's `usage` dict through; absent usage → `None`; (b) `raw()` output
-  contains no `usage` key; (c) e2e: after a 2-cycle mock run,
+  payload's int-valued `usage` keys through and drops non-int values
+  (nested objects, strings, bools); absent usage → `None`; (b) `raw()`
+  output contains no `usage` key; (c) e2e with **`wire="anthropic"`** and an
+  Anthropic-shaped mock transport (the policy-wiring pattern already in
+  test_anthropic.py — the `_Script` fixtures in test_policy_e2e.py speak the
+  chat wire, where usage stays `None`): after a 2-cycle run,
   `record.metadata["llm_usage"]["llm_calls"] == 2` and token keys equal the
-  mock's sums; (d) `reset()` zeroes the aggregate.
+  mock's sums; (d) `reset()` zeroes the aggregate; (e) a trial with zero
+  LLM calls writes no `llm_usage` key; (f) a chat-wire run's `llm_usage`
+  contains only `llm_calls`.
 - [ ] **Step 2: Run, verify failures.**
 - [ ] **Step 3: Implement.**
 - [ ] **Step 4: Full plugin suite + `mypy` + `ruff` green.**
@@ -254,11 +321,12 @@ pytest + mock transports (existing patterns in
 - Modify: `plugins/inspect-robots-agent/README.md`, `CHANGELOG.md`
 
 - [ ] **Step 1:** README: add `image_horizon` to the `-P` options table
-  (default 2, `None`/unset-via-`-P image_horizon=` semantics, why: request
-  bodies otherwise grow ~420 KB per observation and 413 at ~85 observations
-  with 3 cameras); a short "Prompt caching" paragraph under the anthropic
-  wire section (automatic, 3 breakpoints, verify via `llm_usage`); document
-  `record.metadata["llm_usage"]`.
+  (default 2; disable with `-P image_horizon=none` — **not** a bare
+  `-P image_horizon=`, which the CLI parses as the empty string and the
+  policy rejects; why: request bodies otherwise grow ~420 KB per observation
+  and 413 at ~85 observations with 3 cameras); a short "Prompt caching"
+  paragraph under the anthropic wire section (automatic, 3 breakpoints,
+  verify via `llm_usage`); document `record.metadata["llm_usage"]`.
 - [ ] **Step 2:** CHANGELOG entry under Unreleased referencing issue #188.
 - [ ] **Step 3:** Commit `docs(agent): document image_horizon, prompt caching, llm_usage`
 

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -147,10 +147,24 @@ motion fall short of the tool's requested total.
 
 Configuration knobs (all `-P key=value`): `model`, `base_url`, `api_key_env`,
 `wire`, `speed`, `max_output_tokens`, `max_llm_calls` (default `100`),
-`temperature`, `effort`, `max_speed_frac`, `transcript_echo`, `images`
-(default `always`; use `on_demand` for model-requested frames).
+`temperature`, `effort`, `max_speed_frac`, `transcript_echo`, `images`, and
+`image_horizon`.
 `speed` and `max_output_tokens` apply to `-P wire=anthropic` only, and passing
 either on another wire is an error rather than a silent no-op.
+
+| Image option | Default | Behavior |
+|---|---|---|
+| `-P images=` | `always` | Attach every observation's frames; use `on_demand` for model-requested frames |
+| `-P image_horizon=` | `2` | Keep frames from the newest two image-bearing messages in each outgoing request |
+
+Set `-P image_horizon=none` to send the full image history. Do not use a bare
+`-P image_horizon=`: the CLI parses it as an empty string, which the policy
+rejects. Full history grows request bodies by about 420 KB per observation
+with three cameras and can reach a 413 response around 85 observations. The
+default replaces older outgoing camera parts with deterministic text stubs;
+the saved conversation, transcript, and separately stored frames remain
+complete and unchanged.
+
 Set `-P transcript_echo=true` to print live `[agent]` conversation lines to
 stderr, including goals, observation summaries, assistant output, tool calls,
 and tool results.
@@ -160,6 +174,10 @@ The speed fraction defaults to `0.1` and applies only to absolute modes.
 `LLMAgentPolicy.transcript()` returns the current conversation as a deep copy with streamed camera frames replaced by omission markers, ready for core eval-log persistence.
 Camera labels such as `camera 'top_cam' (step 480):` provide the join key from a transcript observation to its stored frame.
 Live Rerun transcript streaming happens automatically when a Rerun sink is attached.
+At trial end, `record.metadata["llm_usage"]` records `llm_calls` and the summed
+integer token counters returned by the wire. The native Anthropic wire
+includes input, output, cache-creation, and cache-read tokens; other wires
+currently record `llm_calls` only. Trials with no LLM calls omit the key.
 
 Reasoning effort defaults to `low`: robot control is latency-sensitive (the
 arm stands still while the model thinks), safety guardrails sit below the
@@ -215,6 +233,17 @@ Keep `-P effort=` at `high` or below on this wire: `xhigh` and `max` want a cap
 of 64000 or more, which needs streaming this client does not implement yet.
 The read timeout scales with the cap and tops out at 600 s per attempt, so a
 large cap plus retries can sit for several minutes before failing.
+
+Prompt caching is automatic on this wire. Requests use up to three ephemeral
+breakpoints: the system prompt, the newest elided-image anchor when one exists,
+and the final message. Check
+`record.metadata["llm_usage"]["cache_read_input_tokens"]` to verify cache hits;
+it should become positive after the first ordinary call.
+Anthropic searches only 20 blocks behind a breakpoint, so a cycle with heavy
+retry or on-demand rejection churn can cause one silent full-prefix rewrite
+and a temporary zero cache-read count. A final nudge also changes wire shape
+once it is superseded. Both are cost blips rather than errors, and the anchor
+normally restores the hit on the next cycle.
 
 ## Reasoning effort on OpenAI models
 

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
@@ -435,9 +435,19 @@ def _parse_response(payload: dict[str, Any]) -> AssistantMessage:
             )
         # thinking blocks matter only to the replay cache, not to the turn.
     joined = "".join(texts)
+    raw_usage = payload.get("usage")
+    usage = (
+        {
+            str(key): value
+            for key, value in raw_usage.items()
+            if isinstance(value, int) and not isinstance(value, bool)
+        }
+        if isinstance(raw_usage, dict)
+        else None
+    )
     # Never "": it would round-trip into the next request as an empty text
     # block, which is a 400.
-    return AssistantMessage(content=joined or None, tool_calls=tuple(calls))
+    return AssistantMessage(content=joined or None, tool_calls=tuple(calls), usage=usage)
 
 
 def _terminal_message(payload: dict[str, Any], stop_reason: Any) -> str:

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
@@ -120,7 +120,13 @@ class AnthropicClient:
             "messages": translated,
         }
         if system is not None:
-            body["system"] = system
+            body["system"] = [
+                {
+                    "type": "text",
+                    "text": system,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ]
         if tools:
             body["tools"] = _translate_tools(tools)
         if temperature is not None:
@@ -264,6 +270,35 @@ def _assistant_blocks(message: dict[str, Any]) -> list[dict[str, Any]]:
     return blocks
 
 
+def _with_cache_breakpoint(turn: dict[str, Any]) -> dict[str, Any]:
+    """Return a turn with ephemeral caching on its last eligible content block."""
+    content = turn.get("content")
+    if isinstance(content, str):
+        return {
+            **turn,
+            "content": [
+                {
+                    "type": "text",
+                    "text": content,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        }
+    if not isinstance(content, list):
+        return turn
+    for index in range(len(content) - 1, -1, -1):
+        block = content[index]
+        if block.get("type") in {"thinking", "redacted_thinking"}:
+            continue
+        copied_content = list(content)
+        copied_content[index] = {
+            **block,
+            "cache_control": {"type": "ephemeral"},
+        }
+        return {**turn, "content": copied_content}
+    return turn
+
+
 def _translate_messages(
     messages: list[dict[str, Any]],
     raw_blocks_by_tool_use_id: dict[str, list[dict[str, Any]]],
@@ -279,11 +314,19 @@ def _translate_messages(
     system: str | None = None
     translated: list[dict[str, Any]] = []
     pending_results: list[dict[str, Any]] = []
+    pending_anchor = False
+    anchor_turn: dict[str, Any] | None = None
 
     def flush_results() -> None:
+        nonlocal anchor_turn, pending_anchor
         if pending_results:
-            translated.append({"role": "user", "content": list(pending_results)})
+            turn = {"role": "user", "content": list(pending_results)}
+            if pending_anchor:
+                turn = _with_cache_breakpoint(turn)
+                anchor_turn = turn
+            translated.append(turn)
             pending_results.clear()
+            pending_anchor = False
 
     for index, message in enumerate(messages):
         role = message.get("role")
@@ -312,6 +355,7 @@ def _translate_messages(
                     "content": message["content"],
                 }
             )
+            pending_anchor = pending_anchor or message.get("cache_anchor") is True
             continue
         flush_results()
         if role == "assistant":
@@ -332,13 +376,28 @@ def _translate_messages(
                 # The nudge retry path appends exactly this; an assistant
                 # message with an empty content array is a 400.
                 continue
-            translated.append({"role": "assistant", "content": blocks})
+            turn = {"role": "assistant", "content": blocks}
+            if message.get("cache_anchor") is True:
+                turn = _with_cache_breakpoint(turn)
+                anchor_turn = turn
+            translated.append(turn)
             continue
         if role != "user":
             raise RuntimeError(f"unsupported message role {role!r}")
-        translated.append({"role": role, "content": _translate_content(message["content"])})
+        turn = {"role": role, "content": _translate_content(message["content"])}
+        if message.get("cache_anchor") is True:
+            turn = _with_cache_breakpoint(turn)
+            anchor_turn = turn
+        translated.append(turn)
 
     flush_results()
+    if translated and translated[-1] is not anchor_turn:
+        # Anthropic's 20-block lookback can miss after unusually heavy retry
+        # churn, causing one harmless full-prefix write. The nudge string also
+        # changes from a wrapped final block to a bare string once superseded,
+        # so that final-breakpoint entry can miss once; the anchor still hits
+        # and both cases self-heal on the next ordinary cycle.
+        translated[-1] = _with_cache_breakpoint(translated[-1])
     return system, translated
 
 

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
@@ -355,6 +355,12 @@ def _translate_messages(
                     "content": message["content"],
                 }
             )
+            # Defensive generality: _evicted_view only ever marks user
+            # messages (tool and assistant turns never carry image parts), so
+            # this branch and the assistant-turn check below are unreachable
+            # today. They stay so a future eviction rule that marks other
+            # roles fails soft (breakpoint applied) instead of silently
+            # dropping the anchor.
             pending_anchor = pending_anchor or message.get("cache_anchor") is True
             continue
         flush_results()

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
@@ -143,6 +143,7 @@ class AssistantMessage:
 
     content: str | None
     tool_calls: tuple[ToolCall, ...]
+    usage: dict[str, int] | None = None
 
     def raw(self) -> dict[str, Any]:
         """The wire-format dict to append back onto the conversation."""

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -124,10 +124,7 @@ def _evicted_view(
         index
         for index, message in enumerate(messages)
         if isinstance((content := message.get("content")), list)
-        and any(
-            isinstance(part, dict) and part.get("type") == "image_url"
-            for part in content
-        )
+        and any(isinstance(part, dict) and part.get("type") == "image_url" for part in content)
     ]
     stubbed_indices = image_message_indices[:-horizon]
     if not stubbed_indices:
@@ -404,6 +401,7 @@ class LLMAgentPolicy(PolicyBase):
         self._messages: list[dict[str, Any]] = []
         self._delta_cursor = 0
         self._calls_used = 0
+        self._usage_totals: dict[str, int] = {}
         self._pending: _PendingCapture | None = None
         self._revealed: set[str] = set()
 
@@ -446,6 +444,7 @@ class LLMAgentPolicy(PolicyBase):
         self._echo(f"[agent] goal: {scene.instruction}")
         self._delta_cursor = 0
         self._calls_used = 0
+        self._usage_totals.clear()
         self._pending = None
         self._revealed.clear()
 
@@ -467,6 +466,11 @@ class LLMAgentPolicy(PolicyBase):
 
         # Make path relative to log_dir for portability
         record.metadata["transcript"] = f"transcripts/{run_id}/{trial_id}.jsonl"
+        if self._calls_used:
+            record.metadata["llm_usage"] = {
+                "llm_calls": self._calls_used,
+                **{key: value for key, value in self._usage_totals.items() if key != "llm_calls"},
+            }
 
     def transcript(self) -> list[dict[str, Any]] | None:
         """Return an image-free deep copy of the current trial's conversation."""
@@ -552,6 +556,15 @@ class LLMAgentPolicy(PolicyBase):
                 reasoning_effort=self._effort,
             )
             self._calls_used += 1
+            if message.usage is not None:
+                for key, value in message.usage.items():
+                    self._usage_totals[key] = self._usage_totals.get(key, 0) + value
+                self._echo(
+                    "[agent] -- usage: "
+                    f"in={message.usage.get('input_tokens', 0)} "
+                    f"cache_read={message.usage.get('cache_read_input_tokens', 0)} "
+                    f"out={message.usage.get('output_tokens', 0)}"
+                )
             raw_message = message.raw()
             self._messages.append(raw_message)
             content = raw_message.get("content")

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -113,6 +113,60 @@ def _sanitize(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return sanitized
 
 
+def _evicted_view(
+    messages: list[dict[str, Any]],
+    horizon: int,
+    *,
+    mark_anchor: bool = False,
+) -> list[dict[str, Any]]:
+    """Return a view with camera frames older than the image horizon stubbed."""
+    image_message_indices = [
+        index
+        for index, message in enumerate(messages)
+        if isinstance((content := message.get("content")), list)
+        and any(
+            isinstance(part, dict) and part.get("type") == "image_url"
+            for part in content
+        )
+    ]
+    stubbed_indices = image_message_indices[:-horizon]
+    if not stubbed_indices:
+        return list(messages)
+
+    newest_stubbed = stubbed_indices[-1]
+    view = list(messages)
+    for message_index in stubbed_indices:
+        message = messages[message_index]
+        content = message["content"]
+        assert isinstance(content, list)
+        image_indices = [
+            index
+            for index, part in enumerate(content)
+            if isinstance(part, dict) and part.get("type") == "image_url"
+        ]
+        removed_indices = set(image_indices)
+        for image_index in image_indices:
+            if image_index == 0:
+                continue
+            label = content[image_index - 1]
+            if isinstance(label, dict) and label.get("type") == "text":
+                removed_indices.add(image_index - 1)
+        stubbed_content = [
+            part for index, part in enumerate(content) if index not in removed_indices
+        ]
+        stubbed_content.append(
+            {
+                "type": "text",
+                "text": f"[{len(image_indices)} camera frame(s) elided]",
+            }
+        )
+        stubbed_message = {**message, "content": stubbed_content}
+        if mark_anchor and message_index == newest_stubbed:
+            stubbed_message["cache_anchor"] = True
+        view[message_index] = stubbed_message
+    return view
+
+
 @dataclass(frozen=True)
 class AgentPolicyConfig(PolicyConfig):
     """Inference-time configuration recorded in the eval log.
@@ -135,6 +189,7 @@ class AgentPolicyConfig(PolicyConfig):
     max_speed_frac: float = 0.1
     transcript_echo: bool = False
     images: str = "always"
+    image_horizon: int | None = 2
 
 
 @dataclass(frozen=True, eq=False)
@@ -170,6 +225,7 @@ class LLMAgentPolicy(PolicyBase):
         max_speed_frac: float = 0.1,
         transcript_echo: bool = False,
         images: str = "always",
+        image_horizon: int | None = 2,
         transport: httpx.BaseTransport | None = None,
         env: dict[str, str] | None = None,
     ):
@@ -217,6 +273,15 @@ class LLMAgentPolicy(PolicyBase):
             or max_output_tokens < 1
         ):
             raise ConfigError("max_output_tokens must be an int >= 1")
+        if image_horizon is not None and (
+            isinstance(image_horizon, bool)
+            or not isinstance(image_horizon, int)
+            or image_horizon < 1
+        ):
+            raise ConfigError(
+                "image_horizon must be an int >= 1, or None to send full image history.\n"
+                "fix: pass -P image_horizon=N or -P image_horizon=none"
+            )
 
         environ = dict(os.environ) if env is None else env
         # resolve_provider reads api_key_env only when base_url is set, where
@@ -314,6 +379,7 @@ class LLMAgentPolicy(PolicyBase):
         self._max_speed_frac = max_speed_frac
         self._transcript_echo = transcript_echo
         self._images = images
+        self._image_horizon = image_horizon
         self.config = AgentPolicyConfig(
             temperature=temperature,
             model=provider.model,
@@ -327,6 +393,7 @@ class LLMAgentPolicy(PolicyBase):
             max_speed_frac=max_speed_frac,
             transcript_echo=transcript_echo,
             images=images,
+            image_horizon=image_horizon,
         )
         # Placeholder until bind(); eval() always binds before compat/rollout.
         self.info = PolicyInfo(name="agent", action_space=Box(shape=(1,)))
@@ -471,8 +538,15 @@ class LLMAgentPolicy(PolicyBase):
         while True:
             if self._calls_used >= self._max_llm_calls:
                 return self._forced_give_up(toolset, observation, "LLM call budget exhausted")
+            outgoing = self._messages
+            if self._image_horizon is not None:
+                outgoing = _evicted_view(
+                    self._messages,
+                    self._image_horizon,
+                    mark_anchor=isinstance(self._client, AnthropicClient),
+                )
             message = self._client.complete(
-                self._messages,
+                outgoing,
                 toolset.schemas(),
                 temperature=self._temperature,
                 reasoning_effort=self._effort,

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -1244,3 +1244,53 @@ def test_explicit_api_key_env_wins_over_the_default() -> None:
     policy._client.complete([_USER], [])
 
     assert seen[0].headers["x-api-key"] == "sk-or"
+
+
+def test_act_marks_the_eviction_anchor_on_the_anthropic_wire() -> None:
+    """Guards the policy -> wire anchor integration end to end.
+
+    Every other anchor test hand-injects ``cache_anchor`` into history; only
+    this one exercises ``act()``'s ``mark_anchor=isinstance(...)`` wiring. If
+    that wiring silently broke (say, a wrapped client failing the isinstance
+    check), the anchor breakpoint would vanish and every hand-injected test
+    would still pass — while live runs degraded to full-prefix rewrites at
+    each eviction with no error to notice.
+    """
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        payload = _anthropic_response(
+            _tool_use(
+                f"toolu_{len(requests)}",
+                "move_by",
+                {"deltas": {"dx": 0.01}, "note": "I see the cube and nudge toward it."},
+            )
+        )
+        return httpx.Response(200, json=payload)
+
+    embodiment = CubePickEmbodiment()
+    policy = _policy(wire="anthropic", transport=httpx.MockTransport(handler))
+    policy.bind(embodiment.info)
+    scene = Scene(id="s0", instruction="reach")
+    policy.reset(scene)
+    observation = embodiment.reset(scene, seed=0)
+
+    for _ in range(4):
+        policy.act(observation)
+
+    final = json.loads(requests[-1].content)
+    stub_blocks = [
+        block
+        for message in final["messages"]
+        if isinstance(message["content"], list)
+        for block in message["content"]
+        if block.get("type") == "text" and block.get("text", "").endswith("camera frame(s) elided]")
+    ]
+    # 4 cycles at the default horizon of 2 evict the two oldest observations.
+    assert len(stub_blocks) == 2
+    # The newest stub is the anchor; the breakpoint lands on the stubbed
+    # message's last block, which is the stub itself. Older stubs carry none.
+    assert stub_blocks[-1]["cache_control"] == {"type": "ephemeral"}
+    assert "cache_control" not in stub_blocks[0]
+    assert b"cache_anchor" not in requests[-1].content

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -105,7 +105,13 @@ def test_request_shape_and_headers() -> None:
     assert body["model"] == "claude-opus-5"
     assert body["max_tokens"] == _DEFAULT_MAX_OUTPUT_TOKENS
     assert body["thinking"] == {"type": "adaptive"}
-    assert body["system"] == "you drive a robot"
+    assert body["system"] == [
+        {
+            "type": "text",
+            "text": "you drive a robot",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
     assert body["output_config"] == {"effort": "low"}
     assert body["tools"] == [
         {
@@ -156,6 +162,133 @@ def test_empty_api_key_omits_header() -> None:
     _client(handler, provider=provider).complete([_USER], [])
 
     assert "x-api-key" not in seen[0].headers
+
+
+def test_cache_anchor_marks_last_block_without_leaking_marker() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    history = [
+        _SYSTEM,
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "stable state"},
+                {"type": "text", "text": "[3 camera frame(s) elided]"},
+            ],
+            "cache_anchor": True,
+        },
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "fresh observation"}],
+        },
+    ]
+
+    _client(handler).complete(history, [])
+
+    body = json.loads(seen[0].content)
+    anchor = body["messages"][0]["content"]
+    assert anchor[-1]["cache_control"] == {"type": "ephemeral"}
+    assert "cache_anchor" not in json.dumps(body)
+
+
+def test_final_string_content_wraps_into_cached_text_block() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+
+    _client(handler).complete([_USER], [])
+
+    assert json.loads(seen[0].content)["messages"][-1]["content"] == [
+        {
+            "type": "text",
+            "text": "Goal: pick the cube",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+def test_replayed_final_assistant_breakpoint_is_copy_on_write_and_stable() -> None:
+    first = _anthropic_response(_thinking(), _text("moving"), _tool_use("toolu_1"))
+    later = _anthropic_response(_text("done"), stop_reason="end_turn")
+    seen, handler = _capture(first, later, later)
+    client = _client(handler)
+
+    message = client.complete([_USER], [])
+    history = [
+        _USER,
+        {
+            "role": "assistant",
+            "content": message.content,
+            "tool_calls": [_tool_call("toolu_1", "done", message.tool_calls[0].arguments)],
+        },
+    ]
+    stored = client._raw_blocks_by_tool_use_id["toolu_1"]
+    original = json.loads(json.dumps(stored))
+
+    client.complete(history, [])
+    client.complete(history, [])
+
+    assert stored == original
+    assert all("cache_control" not in block for block in stored)
+    for request in seen[1:]:
+        replayed = json.loads(request.content)["messages"][-1]["content"]
+        assert sum("cache_control" in block for block in replayed) == 1
+
+
+def test_representative_request_has_exactly_three_cache_breakpoints() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    history = [
+        _SYSTEM,
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "[3 camera frame(s) elided]"}],
+            "cache_anchor": True,
+        },
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "fresh observation"}],
+        },
+    ]
+
+    _client(handler).complete(history, [])
+
+    assert json.dumps(json.loads(seen[0].content)).count('"cache_control"') == 3
+
+
+def test_anchor_and_final_coincidence_adds_one_breakpoint() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    history = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "[1 camera frame(s) elided]"}],
+            "cache_anchor": True,
+        }
+    ]
+
+    _client(handler).complete(history, [])
+
+    final = json.loads(seen[0].content)["messages"][-1]
+    assert json.dumps(final).count('"cache_control"') == 1
+
+
+def test_thinking_tail_places_breakpoint_on_last_non_thinking_block() -> None:
+    seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+    client = _client(handler)
+    client._raw_blocks_by_tool_use_id["toolu_1"] = [
+        _text("moving"),
+        _tool_use("toolu_1"),
+        _thinking(),
+    ]
+    history = [
+        {
+            "role": "assistant",
+            "content": "moving",
+            "tool_calls": [_tool_call("toolu_1", "done", '{"summary":"ok"}')],
+        }
+    ]
+
+    client.complete(history, [])
+
+    blocks = json.loads(seen[0].content)["messages"][-1]["content"]
+    assert "cache_control" not in blocks[-1]
+    assert blocks[-2]["cache_control"] == {"type": "ephemeral"}
 
 
 # -- translation -----------------------------------------------------------------
@@ -1040,7 +1173,8 @@ def test_act_drives_a_multi_turn_trial_and_replays_thinking() -> None:
     policy.act(Observation())
 
     first = json.loads(requests[0].content)
-    assert first["system"].startswith("You are controlling a real robot")
+    assert first["system"][0]["text"].startswith("You are controlling a real robot")
+    assert first["system"][0]["cache_control"] == {"type": "ephemeral"}
     assert all(m["role"] != "system" for m in first["messages"])
 
     # Turn 2 carries the dropped-assistant-then-nudge shape: the text-only turn
@@ -1048,7 +1182,13 @@ def test_act_drives_a_multi_turn_trial_and_replays_thinking() -> None:
     second = json.loads(requests[1].content)
     roles = [m["role"] for m in second["messages"]]
     assert roles == ["user", "user", "user"]
-    assert second["messages"][-1]["content"] == "Respond with exactly one tool call."
+    assert second["messages"][-1]["content"] == [
+        {
+            "type": "text",
+            "text": "Respond with exactly one tool call.",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
 
     # Next act(): tool results merge into one user turn, then the observation.
     policy.act(Observation())

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -17,6 +17,7 @@ from inspect_robots_agent import LLMAgentPolicy
 from inspect_robots_agent._anthropic import (
     _DEFAULT_MAX_OUTPUT_TOKENS,
     AnthropicClient,
+    _parse_response,
 )
 from inspect_robots_agent._llm import Provider
 from inspect_robots_agent._png import png_data_url
@@ -593,6 +594,28 @@ def test_empty_text_normalizes_to_none() -> None:
     message = _client(handler).complete([_USER], [])
 
     assert message.content is None
+
+
+def test_parse_response_filters_usage_to_non_bool_int_values() -> None:
+    payload = _anthropic_response(_text("ok"), stop_reason="end_turn")
+    payload["usage"] = {
+        "input_tokens": 11,
+        "output_tokens": 3,
+        "cache_creation": {"ephemeral_5m_input_tokens": 4},
+        "service_tier": "standard_only",
+        "synthetic": True,
+    }
+
+    message = _parse_response(payload)
+
+    assert message.usage == {"input_tokens": 11, "output_tokens": 3}
+    assert "usage" not in message.raw()
+
+
+def test_parse_response_without_usage_keeps_it_none() -> None:
+    message = _parse_response(_anthropic_response(_text("ok"), stop_reason="end_turn"))
+
+    assert message.usage is None
 
 
 def test_refusal_raises_with_category() -> None:

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -1720,3 +1720,124 @@ def test_on_trial_end_writes_transcript_and_strips_images(tmp_path: Path) -> Non
     obs_parts = obs["content"]
     assert any(p["type"] == "text" for p in obs_parts)
     assert all(p["type"] != "image_url" for p in obs_parts)
+
+
+def test_anthropic_usage_is_summed_into_trial_metadata(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    payloads = [
+        {
+            "id": "msg_move",
+            "type": "message",
+            "stop_reason": "tool_use",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_move",
+                    "name": "move_by",
+                    "input": {
+                        "deltas": {"dx": 0.01},
+                        "note": "I see the cube and move toward it.",
+                    },
+                }
+            ],
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 2,
+                "cache_creation_input_tokens": 4,
+                "cache_read_input_tokens": 0,
+            },
+        },
+        {
+            "id": "msg_done",
+            "type": "message",
+            "stop_reason": "tool_use",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_done",
+                    "name": "done",
+                    "input": {"summary": "done"},
+                }
+            ],
+            "usage": {
+                "input_tokens": 12,
+                "output_tokens": 3,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 7,
+            },
+        },
+    ]
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        payload = payloads[min(calls, len(payloads) - 1)]
+        calls += 1
+        return httpx.Response(200, json=payload)
+
+    sink = _RecordingSink()
+    policy = LLMAgentPolicy(
+        model="claude-opus-5",
+        wire="anthropic",
+        base_url="http://llm.test/v1",
+        transcript_echo=True,
+        transport=httpx.MockTransport(handler),
+        env={},
+    )
+    ir_eval(_task(), policy, CubePickEmbodiment(), log_dir=str(tmp_path), sinks=[sink])
+
+    assert sink.records[0].metadata["llm_usage"] == {
+        "llm_calls": 2,
+        "input_tokens": 22,
+        "output_tokens": 5,
+        "cache_creation_input_tokens": 4,
+        "cache_read_input_tokens": 7,
+    }
+    stderr = capsys.readouterr().err
+    assert "[agent] -- usage: in=10 cache_read=0 out=2" in stderr
+    assert "[agent] -- usage: in=12 cache_read=7 out=3" in stderr
+
+
+def test_reset_clears_usage_accumulated_by_the_previous_trial(tmp_path: Path) -> None:
+    script = _Script([_tool_response("done", {"summary": "done"})])
+    policy = _policy(script)
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="old", instruction="stop"))
+    policy.act(Observation())
+
+    policy.reset(Scene(id="fresh", instruction="wait"))
+    record = TrialRecord(scene_id="fresh", epoch=0, seed=0)
+    policy.on_trial_end(record, str(tmp_path), "run")
+
+    assert "llm_usage" not in record.metadata
+
+
+def test_trial_with_zero_llm_calls_omits_usage_metadata(tmp_path: Path) -> None:
+    policy = _policy(_Script([_text_response("unused")]))
+    policy.reset(Scene(id="s0", instruction="wait"))
+    record = TrialRecord(scene_id="s0", epoch=0, seed=0)
+
+    policy.on_trial_end(record, str(tmp_path), "run")
+
+    assert "llm_usage" not in record.metadata
+
+
+def test_chat_wire_usage_metadata_counts_calls_only(tmp_path: Path) -> None:
+    script = _Script(
+        [
+            _tool_response("move_by", {"deltas": {"dx": 0.01}}),
+            _tool_response("done", {"summary": "done"}),
+        ]
+    )
+    sink = _RecordingSink()
+
+    ir_eval(
+        _task(),
+        _policy(script),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+        sinks=[sink],
+    )
+
+    assert sink.records[0].metadata["llm_usage"] == {"llm_calls": 2}

--- a/plugins/inspect-robots-agent/tests/test_policy_eviction.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_eviction.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from itertools import pairwise
 from typing import Any
 
 import httpx
@@ -105,9 +106,7 @@ def test_on_demand_image_only_message_stubs_to_one_text_part() -> None:
 
     view = _evicted_view([image_only, _observation_message("new")], 1)
 
-    assert view[0]["content"] == [
-        {"type": "text", "text": "[1 camera frame(s) elided]"}
-    ]
+    assert view[0]["content"] == [{"type": "text", "text": "[1 camera frame(s) elided]"}]
 
 
 def test_non_list_content_passes_through_untouched() -> None:
@@ -194,12 +193,15 @@ def test_none_horizon_sends_all_observation_images_across_three_cycles() -> None
         ]
         assert len(image_messages) == cycle
 
-    assert sum(
-        1
-        for message in policy._messages
-        if isinstance(message.get("content"), list)
-        and any(part.get("type") == "image_url" for part in message["content"])
-    ) == 3
+    assert (
+        sum(
+            1
+            for message in policy._messages
+            if isinstance(message.get("content"), list)
+            and any(part.get("type") == "image_url" for part in message["content"])
+        )
+        == 3
+    )
 
 
 def test_eviction_boundary_and_already_stubbed_prefix_are_byte_stable() -> None:
@@ -260,7 +262,7 @@ def test_eviction_boundary_and_already_stubbed_prefix_are_byte_stable() -> None:
             )
         }
 
-    for previous, current in zip(requests, requests[1:]):
+    for previous, current in pairwise(requests):
         newly_stubbed = stub_indices(current) - stub_indices(previous)
         boundary = min(newly_stubbed) if newly_stubbed else len(previous["messages"])
         previous_prefix = json.dumps(

--- a/plugins/inspect-robots-agent/tests/test_policy_eviction.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_eviction.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from inspect_robots.errors import ConfigError
+from inspect_robots.mock import CubePickEmbodiment
+from inspect_robots.scene import Scene
+from inspect_robots_agent import LLMAgentPolicy
+from inspect_robots_agent.policy import _evicted_view
+
+
+def _image_parts(*names: str) -> list[dict[str, Any]]:
+    parts: list[dict[str, Any]] = []
+    for name in names:
+        parts.extend(
+            [
+                {"type": "text", "text": f"Camera {name}:"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{name}"},
+                },
+            ]
+        )
+    return parts
+
+
+def _observation_message(*names: str) -> dict[str, Any]:
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "state[q]: 0"},
+            *_image_parts(*names),
+        ],
+    }
+
+
+def _policy(**kwargs: Any) -> LLMAgentPolicy:
+    return LLMAgentPolicy(
+        model="test/model",
+        base_url="http://llm.test/v1",
+        env={},
+        **kwargs,
+    )
+
+
+def test_fewer_image_messages_than_horizon_returns_new_list_without_copies() -> None:
+    messages = [
+        {"role": "system", "content": "system"},
+        _observation_message("top"),
+        {"role": "assistant", "content": "next"},
+    ]
+
+    view = _evicted_view(messages, 2)
+
+    assert view == messages
+    assert view is not messages
+    assert all(actual is original for actual, original in zip(view, messages, strict=True))
+
+
+def test_aged_observation_replaces_labels_and_images_without_mutating_history() -> None:
+    aged = _observation_message("top", "left", "right")
+    kept = _observation_message("top")
+    messages = [aged, kept]
+    original = json.loads(json.dumps(messages))
+
+    view = _evicted_view(messages, 1)
+
+    assert view[0] is not aged
+    assert view[0]["content"] == [
+        {"type": "text", "text": "state[q]: 0"},
+        {"type": "text", "text": "[3 camera frame(s) elided]"},
+    ]
+    assert messages == original
+
+
+def test_kept_image_messages_and_non_image_messages_retain_identity() -> None:
+    plain = {"role": "user", "content": "plain"}
+    aged = _observation_message("old")
+    kept = _observation_message("new")
+
+    view = _evicted_view([plain, aged, kept], 1)
+
+    assert view[0] is plain
+    assert view[2] is kept
+
+
+def test_anchor_marks_only_newest_stubbed_message() -> None:
+    oldest = _observation_message("oldest")
+    newest_stub = _observation_message("middle")
+    kept = _observation_message("newest")
+
+    view = _evicted_view([oldest, newest_stub, kept], 1, mark_anchor=True)
+
+    assert "cache_anchor" not in view[0]
+    assert view[1]["cache_anchor"] is True
+    assert "cache_anchor" not in view[2]
+
+
+def test_on_demand_image_only_message_stubs_to_one_text_part() -> None:
+    image_only = {"role": "user", "content": _image_parts("wrist")}
+
+    view = _evicted_view([image_only, _observation_message("new")], 1)
+
+    assert view[0]["content"] == [
+        {"type": "text", "text": "[1 camera frame(s) elided]"}
+    ]
+
+
+def test_non_list_content_passes_through_untouched() -> None:
+    plain = {"role": "user", "content": "Respond with exactly one tool call."}
+
+    view = _evicted_view([plain], 1, mark_anchor=True)
+
+    assert view[0] is plain
+
+
+@pytest.mark.parametrize("value", [True, 0, -1, "2", ""])
+def test_image_horizon_rejects_invalid_values(value: object) -> None:
+    expected = (
+        "image_horizon must be an int >= 1, or None to send full image history.\n"
+        "fix: pass -P image_horizon=N or -P image_horizon=none"
+    )
+
+    with pytest.raises(ConfigError) as exc_info:
+        _policy(image_horizon=value)
+
+    assert str(exc_info.value) == expected
+
+
+@pytest.mark.parametrize("value", [None, 2])
+def test_image_horizon_accepts_none_and_positive_int(value: int | None) -> None:
+    policy = _policy(image_horizon=value)
+
+    assert policy.config.image_horizon == value
+
+
+def test_none_horizon_sends_all_observation_images_across_three_cycles() -> None:
+    requests: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_move",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "move_by",
+                                        "arguments": json.dumps(
+                                            {
+                                                "deltas": {"dx": 0.01},
+                                                "note": "I see the cube and move toward it.",
+                                            }
+                                        ),
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                ]
+            },
+        )
+
+    embodiment = CubePickEmbodiment()
+    policy = _policy(
+        image_horizon=None,
+        transport=httpx.MockTransport(handler),
+    )
+    policy.bind(embodiment.info)
+    scene = Scene(id="s0", instruction="reach")
+    policy.reset(scene)
+    observation = embodiment.reset(scene, seed=0)
+
+    for _ in range(3):
+        policy.act(observation)
+
+    for cycle, body in enumerate(requests, start=1):
+        image_messages = [
+            message
+            for message in body["messages"]
+            if isinstance(message.get("content"), list)
+            and any(part.get("type") == "image_url" for part in message["content"])
+        ]
+        assert len(image_messages) == cycle
+
+    assert sum(
+        1
+        for message in policy._messages
+        if isinstance(message.get("content"), list)
+        and any(part.get("type") == "image_url" for part in message["content"])
+    ) == 3
+
+
+def test_eviction_boundary_and_already_stubbed_prefix_are_byte_stable() -> None:
+    requests: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_move",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "move_by",
+                                        "arguments": json.dumps(
+                                            {
+                                                "deltas": {"dx": 0.01},
+                                                "note": "I see the cube and move toward it.",
+                                            }
+                                        ),
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                ]
+            },
+        )
+
+    embodiment = CubePickEmbodiment()
+    policy = _policy(
+        image_horizon=2,
+        transport=httpx.MockTransport(handler),
+    )
+    policy.bind(embodiment.info)
+    scene = Scene(id="s0", instruction="reach")
+    policy.reset(scene)
+    observation = embodiment.reset(scene, seed=0)
+
+    for _ in range(4):
+        policy.act(observation)
+
+    def stub_indices(body: dict[str, Any]) -> set[int]:
+        return {
+            index
+            for index, message in enumerate(body["messages"])
+            if isinstance(message.get("content"), list)
+            and any(
+                part.get("text", "").endswith("camera frame(s) elided]")
+                for part in message["content"]
+            )
+        }
+
+    for previous, current in zip(requests, requests[1:]):
+        newly_stubbed = stub_indices(current) - stub_indices(previous)
+        boundary = min(newly_stubbed) if newly_stubbed else len(previous["messages"])
+        previous_prefix = json.dumps(
+            previous["messages"][:boundary],
+            separators=(",", ":"),
+        )
+        current_prefix = json.dumps(
+            current["messages"][:boundary],
+            separators=(",", ":"),
+        )
+        assert current_prefix == previous_prefix
+
+    all_stubbed_indices = set().union(*(stub_indices(body) for body in requests))
+    assert len(all_stubbed_indices) == 2
+    for message_index in all_stubbed_indices:
+        stable_forms = {
+            json.dumps(body["messages"][message_index], separators=(",", ":"))
+            for body in requests
+            if message_index in stub_indices(body)
+        }
+        assert len(stable_forms) == 1


### PR DESCRIPTION
Closes #188

## What

Three changes to the `agent` policy plugin (plan: `plans/0028-agent-image-eviction-prompt-cache.md`, two critique rounds):

1. **`image_horizon` view eviction** (`policy.py`, default 2): camera frames older than the last K image-bearing messages are replaced with deterministic `[N camera frame(s) elided]` stubs in the *outgoing request only* — canonical history, transcripts, and the frames side-car are untouched. Each message is rewritten exactly once when it ages out, so the request prefix stays byte-stable. Bounds request size at ~6 frames in flight; fixes the HTTP 413 that killed run `adhoc_3539bb48` at 36 MB / 264 accumulated frames. Disable with `-P image_horizon=none`.
2. **Prompt caching** (`_anthropic.py`): three `cache_control: ephemeral` breakpoints — system prompt (caches tools+system), the newest-stubbed anchor message (chains call-to-call inside the 20-block lookback), and the final message (string content wrapped to a text block at translation time; thinking blocks skipped; replay-cache blocks copied, never mutated). Stable prefix reads at 0.1× input price — measured ~4–8× cost cut on the failed run's profile.
3. **Usage accounting**: `AssistantMessage.usage` (int-filtered, excluded from `raw()`), per-trial aggregation into `record.metadata["llm_usage"]` incl. `cache_read_input_tokens` as the live signal that caching actually hits.

## Testing

293 → 320 tests. New `test_policy_eviction.py` covers view identity/non-mutation, prefix byte-stability across calls, validation, and the `None` disable path; `test_anthropic.py` gains breakpoint-placement, marker-leak, replay-immutability, anchor==final, and thinking-tail tests; e2e usage-metadata tests run on an anthropic-wire mock. ruff, ruff format, strict mypy all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)