### PR TITLE
feat(agent): render per-camera depth into observation messages and take_pic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- **Agent plugin:** per-camera metric depth from observation extras now renders
+  as near-bright grayscale beside its RGB camera in automatic observations and
+  `take_pic` reveals. Labels anchor the render with the 2nd–98th percentile
+  bright/dim distances, valid-pixel percentage, and optional center depth;
+  `-P depth=off` is the payload-cost kill-switch (#190).
 - **Seconds-based benchmark horizons:** `Task(max_seconds=...)` gives every
   compatible embodiment the same physical-time budget. `eval()` resolves it
   with `ceil(max_seconds * embodiment.info.control_hz)`, rejects missing or

--- a/plans/0028-agent-depth-render.md
+++ b/plans/0028-agent-depth-render.md
@@ -23,16 +23,31 @@ One seam, both modes: `_image_parts` gains depth parts per rendered camera.
 `take_pic` inherits the behavior because its reveal path calls the same
 helper with `reveal=<captured names>` (`policy.py:617,723`).
 
-For each camera `name` in the rendered set, when
-`observation.extra[f"{name}_depth"]` exists and the policy's `depth` knob is
-`"render"` (default):
+**Resolution happens once, at observation receipt — never at render time.**
+The embodiment contract is resolve-on-receipt, and in `images="on_demand"`
+an immediate `take_pic` reveal renders at `policy.py:613-619` after one or
+more LLM round-trips inside the same `act()` (the `while True` at :471) —
+tens of seconds after the observation arrived. A thunk resolved that late
+returns depth captured *now*, silently misaligned with the frozen RGB shown
+beside it. So: at `act()` entry, when the `depth` knob is `"render"`, every
+`observation.extra[f"{name}_depth"]` for `name` in `observation.images` is
+resolved into a per-observation cache
+`dict[str, npt.NDArray[np.float64] | str]` (bare `np.ndarray` trips the
+plugin's mypy `disallow_any_generics`; the file already uses
+`npt.NDArray[np.float64]`) — array on success, human-readable failure text
+on any error — and both render paths consume only the cache. Each thunk is called exactly once per
+observation (pinned by an e2e test across an `on_demand` `act()` with a
+late `take_pic`).
 
-1. **Resolve.** If the value is callable, call it under `try/except
-   Exception`; a failing thunk must not kill the observation message — emit
-   the text line `depth 'left_cam' unavailable: {exc}` and no image. A
-   non-callable value is used as-is. `np.asarray(value, dtype=np.float64)`
-   must be 2-D; anything else gets the same unavailable line (reason
-   "expected an HxW array").
+For each camera `name` in the rendered set with a cache entry:
+
+1. **Resolve (at receipt, into the cache).** If the value is callable, call
+   it; coerce with `np.asarray(value, dtype=np.float64)` and require 2-D —
+   the call *and* the coercion sit in one `try/except Exception` (asarray
+   itself raises on non-numeric values), and any failure stores the text
+   `depth 'left_cam' unavailable: {reason}` in the cache instead of an
+   array. A failing thunk must never kill the observation message: a
+   text-only cache entry renders as that line with no image.
 2. **Normalize.** Valid pixels are finite and > 0. If fewer than 1% of
    pixels are valid, emit `depth 'left_cam': no usable depth this frame
    ({pct}% valid)` and no image. Otherwise the render window is the 2nd–98th
@@ -40,9 +55,11 @@ For each camera `name` in the rendered set, when
    lo, lo+1e-3).
 3. **Render.** Grayscale, near = bright: valid pixels map linearly from the
    window to 255 (at lo) down to 64 (at hi), clipped; invalid pixels are 0
-   (pure black, distinguishable from the dimmest valid 64). uint8 H×W×3 (the
-   existing `png_data_url` / `encode_png` in `_png.py` accepts the same
-   shapes as RGB frames). No colormap dependency; a perceptual colormap is
+   (pure black, distinguishable from the dimmest valid 64). Emit **2-D
+   uint8 H×W** — `encode_png` (`_png.py:34-35`) handles `ndim == 2` as true
+   grayscale (colour type 0), identical appearance at a third of the raw
+   bytes of H×W×3, which matters for the LLM-payload cost the `depth` knob
+   exists to control. No colormap dependency; a perceptual colormap is
    YAGNI while the metric anchors carry the absolute information.
 4. **Anchor the scale in text.** The colormap discards absolute scale, which
    is the entire point of depth, so the label line carries it:
@@ -52,26 +69,35 @@ For each camera `name` in the rendered set, when
    ```
 
    followed by the image part. "center" is the depth at (H//2, W//2) when
-   that pixel is valid, omitted otherwise. Numbers use two decimals (metres).
+   that pixel is valid, omitted otherwise. Metres use two decimals; the
+   valid percentage is an integer. When the step label is empty
+   (`_step_label` returns `""`, `policy.py:702-705`), the `(step N)` suffix
+   is omitted exactly as the RGB label omits it (`policy.py:734-735`):
+   `depth 'left_cam': bright 0.09 m -> dim 1.41 m ...`.
 5. **Ordering.** Depth parts follow immediately after that camera's RGB
    parts, inside the same loop, so RGB and depth for one camera are adjacent.
 
 ### Label shape is constrained by the HTML viewer
 
 `src/inspect_robots/_html.py:25` rejoins transcript image slots to saved
-frames with `_FRAME_LABEL_RE = camera '(?P<name>.*)' \(step (?P<step>\d+)\):`.
-Depth labels MUST NOT match it: depth renders have no saved `.npy` frame
-(core saves `observation.images` only), and a matching label would make the
-viewer look for one. The format above starts with `depth '` — it cannot
-match. A test pins this: `_FRAME_LABEL_RE.search(depth_label) is None` using
-the real regex imported from `inspect_robots._html`.
+frames with `_FRAME_LABEL_RE = camera '(?P<name>.*)' \(step
+(?P<step>\d{1,12})\):` (the viewer applies it with `fullmatch`,
+`_html.py:357`). Depth labels MUST NOT match it: depth renders have no
+saved `.npy` frame (core saves `observation.images` only), and a matching
+label would make the viewer look for one. The format above starts with
+`depth '` — it cannot match. A test pins this:
+`_FRAME_LABEL_RE.search(depth_label) is None` using the real regex imported
+from `inspect_robots._html` (`search` is strictly stronger than the
+viewer's `fullmatch`).
 
 In transcripts the depth image part becomes the standard
 `[image omitted: streamed camera frame]` placeholder (`policy.py:111`), so
 saved transcripts keep the metric text line — the valuable part — and drop
-the pixels, exactly like RGB. The HTML viewer shows the depth text with no
-image tile. Acceptable; saving depth renders to the frames dir is core-side
-work and out of scope (noted in #190 as a non-goal).
+the pixels, exactly like RGB. Known cosmetic artifact, accepted: because
+the depth label never matches the join regex, the viewer renders that
+placeholder text verbatim under each depth label (`_html.py:360-371`)
+instead of an image tile. Saving depth renders to the frames dir is
+core-side work and out of scope (noted in #190 as a non-goal).
 
 ### Configuration
 
@@ -104,32 +130,91 @@ plugins/inspect-robots-agent/pyproject.toml plugins/.../src/...` (strict),
 and `python -m pytest plugins/inspect-robots-agent/tests -q`; the core suite
 (`uv run pytest`) must stay green (787 passed baseline).
 
-1. **`_depth.py`** (new module in the plugin, beside `_png.py`):
-   `depth_parts(name: str, value: Any, step_label: str | None) ->
-   list[dict[str, Any]]` implementing resolve/normalize/render/anchor above,
-   returning `[{"type":"text",...}, {"type":"image_url",...}]`, a single
-   text-only list for the unavailable/degenerate cases, or `[]` never (an
-   absent key is the caller's case). Unit tests: happy path (label text
-   format pinned, image is a data URL, near pixel brighter than far pixel,
-   invalid pixel black), thunk called exactly once, failing thunk, non-2-D
-   value, <1% valid, degenerate window, center-invalid omits "center", the
+1. **`_depth.py`** (new module in the plugin, beside `_png.py`). Three
+   functions, final signatures (resolution does NOT live in `depth_parts`):
+   - `_render_depth(depth: npt.NDArray[np.float64]) ->
+     npt.NDArray[np.uint8]` — the normalize+grayscale step alone, 2-D uint8
+     out. Exists so pixel-level tests need no PNG decoder (the repo is
+     encoder-only by design). uint8 input to `encode_png` also bypasses its
+     float-normalization branch, which is load-bearing.
+   - `depth_parts(name: str, entry: npt.NDArray[np.float64] | str,
+     step_label: str) -> list[dict[str, Any]]` — a str entry (failure text
+     from resolution) renders as that text line with no image; an array
+     entry produces `[{"type":"text",...}, {"type":"image_url",...}]` via
+     `_render_depth` + `png_data_url`, or the text-only degenerate cases
+     (<1% valid). Never `[]` (an absent key is the caller's case).
+   - `resolve_depth(observation: Observation) ->
+     dict[str, npt.NDArray[np.float64] | str]` — the per-observation cache
+     builder from Design (call thunk + coerce under one try/except).
+   Unit tests: `_render_depth` — near pixel brighter than far, invalid
+   pixel exactly 0, valid floor 64, degenerate window; `resolve_depth` —
+   thunk called exactly once, failing thunk → text, non-2-D → text,
+   non-numeric → text, plain array passthrough; `depth_parts` — label text
+   format pinned (with and without step label), image is a PNG data URL,
+   str-entry passthrough, <1% valid, center-invalid omits "center", the
    `_FRAME_LABEL_RE` non-match pin.
-2. **Wire into `_image_parts` + config knob**: `_image_parts` gains
-   `extra: Mapping[str, Any]` and `depth_mode: str` parameters (both callers
-   pass `observation.extra` and the config value); per camera, append
-   `depth_parts(...)` when the key exists and mode is `"render"`. Config
-   field + validation + docstring. e2e tests (existing MockTransport style,
-   `test_policy_e2e.py`): observation message contains RGB and depth parts
-   for a camera with a depth thunk in `extra`; `take_pic` reveal includes
-   depth for the captured camera; `depth="off"` and no-key cases match the
-   pre-change message shape exactly; a failing thunk still produces a valid
-   observation message with the unavailable line.
+2. **Resolution cache, wiring, config knob.** Exact signatures (the cache
+   replaces any `extra`/mode threading — `_image_parts` already receives
+   `observation`, and mode is decided at resolution time):
+   - `resolve_depth` (task 1) is called once at `act()` entry
+     (`policy.py:443` area) when the knob is `"render"`, else `{}`.
+   - `_image_parts(observation, *, reveal: tuple[str, ...] | None = None,
+     depth: Mapping[str, Any] | None = None)` — `None` (the default)
+     renders exactly today's output, so the four existing direct-caller
+     tests (`test_policy_e2e.py:395,412,421,437`) pass unchanged.
+   - `_observation_content(..., depth: Mapping[str, Any] | None = None)`
+     threaded from `act()`; same default.
+   Per camera, append `depth_parts(name, cache_entry, step_label)` when the
+   cache has an entry. Config knob follows the existing `images` pattern at
+   all four touch points: `__init__` parameter (`policy.py:159-174`),
+   validation beside the `images` check (`:194-198`), inclusion in the
+   `AgentPolicyConfig(...)` construction (`:317-330`), and a stored
+   `self._depth` read by `act()`. Docstring. e2e tests
+   (existing MockTransport style, `test_policy_e2e.py`): observation
+   message contains RGB and depth parts for a camera with a depth thunk in
+   `extra`; `take_pic` reveal includes depth for the captured camera **and
+   the thunk was called exactly once for that observation despite the late
+   reveal**; `depth="off"` and no-key cases match the pre-change message
+   shape exactly; a failing thunk still produces a valid observation
+   message with the unavailable line.
 3. **Docs**: plugin README section (what renders, the label format, the
    `depth` knob, the transcript/HTML-viewer caveat); CHANGELOG if the plugin
    keeps one (check; the core repo convention applies otherwise).
+
+## Wire clients — verified, no work
+
+All three wire formats consume the canonical chat parts `_image_parts`
+emits: Chat passes through; Responses translates `text`/`image_url`
+(`_responses.py:152-158`); Anthropic requires PNG data URLs
+(`_anthropic.py:213-235`), which `png_data_url` output satisfies. capx's
+`_observation_content` is an independent copy, not an import — no API
+break, and capx does **not** gain depth from this change (it consumes
+metric depth directly through its grasp tooling instead).
 
 ## Out of scope
 
 Consuming `{cam}_intrinsics`; `/act` wire changes; embedding depth into
 `observation.images`; saving depth renders into the frames dir (core);
-colormaps beyond grayscale; per-camera enable lists.
+colormaps beyond grayscale; per-camera enable lists; depth in the capx
+plugin's independent observation renderer.
+
+## Revision note
+
+Plan rev 2, after fresh-context critique: thunk resolution moved from
+render time to a once-per-observation cache at `act()` entry (a late
+`take_pic` reveal would otherwise resolve depth seconds after the RGB it
+sits beside — silently misaligned data on the resolve-on-receipt
+contract); exact signatures for the threading through
+`_observation_content` specified with back-compatible defaults; asarray
+coercion moved inside the failure `try/except` (it raises on non-numeric
+input); 2-D grayscale PNG instead of H×W×3 (a third of the payload);
+regex quote corrected and the viewer's placeholder-text artifact
+documented as accepted.
+
+Plan rev 3, after second critique (no design flaws found): the task-4
+amendment folded into task 1 so the ordered task list states each signature
+exactly once; `_render_depth` split out so pixel-level tests need no PNG
+decoder (the repo is encoder-only); cache type pinned to
+`npt.NDArray[np.float64] | str` for the plugin's strict mypy; empty-step
+label and integer-percent formats specified; the config knob's four
+constructor touch points named.

--- a/plans/0028-agent-depth-render.md
+++ b/plans/0028-agent-depth-render.md
@@ -1,0 +1,135 @@
+# 0028 — Agent: render per-camera depth into observation messages
+
+Closes robocurve/inspect-robots#190.
+
+## Problem
+
+Embodiments can publish per-camera metric depth into `observation.extra`
+(robocurve/inspect-robots-yam#70/#71, merged 2026-07-27): `{cam}_depth` is an
+H×W float32 array of metres *or* a zero-arg callable returning one, aligned
+to and same-resolution as that camera's entry in `observation.images`;
+`{cam}_intrinsics` is a 3×3 K. The agent policy surfaces none of it. Both
+render paths — the `images="always"` observation message and the
+`images="on_demand"` `take_pic` reveal — go through `_image_parts`
+(`policy.py:727-744`), which iterates `observation.images` only; the sole
+`extra` key the policy reads anywhere is `env_step`. An LLM driving a
+depth-capable rig still sees RGB alone and recovers scale by parallax
+(measured on yam_arms: ~15 LLM calls per trial of manual calibration, 0/5
+`stack_the_bowls` successes before the camera-side fix).
+
+## Design
+
+One seam, both modes: `_image_parts` gains depth parts per rendered camera.
+`take_pic` inherits the behavior because its reveal path calls the same
+helper with `reveal=<captured names>` (`policy.py:617,723`).
+
+For each camera `name` in the rendered set, when
+`observation.extra[f"{name}_depth"]` exists and the policy's `depth` knob is
+`"render"` (default):
+
+1. **Resolve.** If the value is callable, call it under `try/except
+   Exception`; a failing thunk must not kill the observation message — emit
+   the text line `depth 'left_cam' unavailable: {exc}` and no image. A
+   non-callable value is used as-is. `np.asarray(value, dtype=np.float64)`
+   must be 2-D; anything else gets the same unavailable line (reason
+   "expected an HxW array").
+2. **Normalize.** Valid pixels are finite and > 0. If fewer than 1% of
+   pixels are valid, emit `depth 'left_cam': no usable depth this frame
+   ({pct}% valid)` and no image. Otherwise the render window is the 2nd–98th
+   percentile of valid values (degenerate window lo == hi widens to
+   lo, lo+1e-3).
+3. **Render.** Grayscale, near = bright: valid pixels map linearly from the
+   window to 255 (at lo) down to 64 (at hi), clipped; invalid pixels are 0
+   (pure black, distinguishable from the dimmest valid 64). uint8 H×W×3 (the
+   existing `png_data_url` / `encode_png` in `_png.py` accepts the same
+   shapes as RGB frames). No colormap dependency; a perceptual colormap is
+   YAGNI while the metric anchors carry the absolute information.
+4. **Anchor the scale in text.** The colormap discards absolute scale, which
+   is the entire point of depth, so the label line carries it:
+
+   ```
+   depth 'left_cam' (step 3): bright 0.09 m -> dim 1.41 m (2nd-98th pctl), 87% valid, center 0.31 m:
+   ```
+
+   followed by the image part. "center" is the depth at (H//2, W//2) when
+   that pixel is valid, omitted otherwise. Numbers use two decimals (metres).
+5. **Ordering.** Depth parts follow immediately after that camera's RGB
+   parts, inside the same loop, so RGB and depth for one camera are adjacent.
+
+### Label shape is constrained by the HTML viewer
+
+`src/inspect_robots/_html.py:25` rejoins transcript image slots to saved
+frames with `_FRAME_LABEL_RE = camera '(?P<name>.*)' \(step (?P<step>\d+)\):`.
+Depth labels MUST NOT match it: depth renders have no saved `.npy` frame
+(core saves `observation.images` only), and a matching label would make the
+viewer look for one. The format above starts with `depth '` — it cannot
+match. A test pins this: `_FRAME_LABEL_RE.search(depth_label) is None` using
+the real regex imported from `inspect_robots._html`.
+
+In transcripts the depth image part becomes the standard
+`[image omitted: streamed camera frame]` placeholder (`policy.py:111`), so
+saved transcripts keep the metric text line — the valuable part — and drop
+the pixels, exactly like RGB. The HTML viewer shows the depth text with no
+image tile. Acceptable; saving depth renders to the frames dir is core-side
+work and out of scope (noted in #190 as a non-goal).
+
+### Configuration
+
+New policy config field, following the existing style
+(`policy.py:136` block): `depth: str = "render"`, accepting `"render"` |
+`"off"`. `"off"` restores today's output byte-for-byte. Unknown values fail
+at construction alongside the existing `images` validation. Rationale: depth
+rendering costs one image per depth camera per observation — for
+LLM-call-budgeted trials the operator needs a kill-switch without
+reconfiguring the embodiment.
+
+No system-prompt changes: the labels are self-describing, and the
+embodiment's own `info.docs` already explains depth (aimed at code-level
+consumers; the rendered parts are what this policy's LLM consumes).
+
+### Failure and absence semantics (exhaustive)
+
+- No `{name}_depth` key → exactly today's parts for that camera.
+- `depth="off"` → exactly today's parts, even when keys exist.
+- Thunk raises → text line, no image, message otherwise intact.
+- Non-2-D / non-numeric value → text line, no image.
+- <1% valid pixels → text line, no image.
+- `{cam}_intrinsics` is never read (non-goal; tool layers consume K).
+
+## Implementation tasks
+
+Ordered; the plugin gates are `uv run --no-sync ruff check
+plugins/inspect-robots-agent`, `ruff format --check`, `mypy --config-file
+plugins/inspect-robots-agent/pyproject.toml plugins/.../src/...` (strict),
+and `python -m pytest plugins/inspect-robots-agent/tests -q`; the core suite
+(`uv run pytest`) must stay green (787 passed baseline).
+
+1. **`_depth.py`** (new module in the plugin, beside `_png.py`):
+   `depth_parts(name: str, value: Any, step_label: str | None) ->
+   list[dict[str, Any]]` implementing resolve/normalize/render/anchor above,
+   returning `[{"type":"text",...}, {"type":"image_url",...}]`, a single
+   text-only list for the unavailable/degenerate cases, or `[]` never (an
+   absent key is the caller's case). Unit tests: happy path (label text
+   format pinned, image is a data URL, near pixel brighter than far pixel,
+   invalid pixel black), thunk called exactly once, failing thunk, non-2-D
+   value, <1% valid, degenerate window, center-invalid omits "center", the
+   `_FRAME_LABEL_RE` non-match pin.
+2. **Wire into `_image_parts` + config knob**: `_image_parts` gains
+   `extra: Mapping[str, Any]` and `depth_mode: str` parameters (both callers
+   pass `observation.extra` and the config value); per camera, append
+   `depth_parts(...)` when the key exists and mode is `"render"`. Config
+   field + validation + docstring. e2e tests (existing MockTransport style,
+   `test_policy_e2e.py`): observation message contains RGB and depth parts
+   for a camera with a depth thunk in `extra`; `take_pic` reveal includes
+   depth for the captured camera; `depth="off"` and no-key cases match the
+   pre-change message shape exactly; a failing thunk still produces a valid
+   observation message with the unavailable line.
+3. **Docs**: plugin README section (what renders, the label format, the
+   `depth` knob, the transcript/HTML-viewer caveat); CHANGELOG if the plugin
+   keeps one (check; the core repo convention applies otherwise).
+
+## Out of scope
+
+Consuming `{cam}_intrinsics`; `/act` wire changes; embedding depth into
+`observation.images`; saving depth renders into the frames dir (core);
+colormaps beyond grayscale; per-camera enable lists.

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -148,7 +148,8 @@ motion fall short of the tool's requested total.
 Configuration knobs (all `-P key=value`): `model`, `base_url`, `api_key_env`,
 `wire`, `speed`, `max_output_tokens`, `max_llm_calls` (default `100`),
 `temperature`, `effort`, `max_speed_frac`, `transcript_echo`, `images`
-(default `always`; use `on_demand` for model-requested frames).
+(default `always`; use `on_demand` for model-requested frames), and `depth`
+(default `render`; use `off` to omit depth renders).
 `speed` and `max_output_tokens` apply to `-P wire=anthropic` only, and passing
 either on another wire is an error rather than a silent no-op.
 Set `-P transcript_echo=true` to print live `[agent]` conversation lines to
@@ -171,6 +172,43 @@ pass `-P effort=none` to omit the parameter for endpoints that reject it
 chat completions requires the literal `none` when function tools are in
 play (any other value, or omitting the field, is a 400). In Python,
 `effort=None` omits the field and `effort="none"` sends the wire value.
+
+## Depth rendering
+
+For each camera, the policy looks for metric depth in
+`observation.extra[f"{cam}_depth"]`. When present, it renders the depth as a
+grayscale image immediately after that camera's RGB image: near is bright,
+far is dim, and invalid pixels are black. Depth follows RGB in both
+`images=always` observations and `take_pic` reveals under
+`images=on_demand`.
+
+Each render is preceded by a metric label:
+
+```text
+depth 'left_cam' (step 3): bright 0.09 m -> dim 1.41 m (2nd-98th pctl), 87% valid, center 0.31 m:
+```
+
+The bright and dim distances anchor the grayscale window at the 2nd and 98th
+percentiles of valid depth. The valid percentage is an integer, and the
+center depth appears only when the center pixel is valid. As with RGB camera
+labels, the `(step N)` suffix is present only when the observation carries an
+integer environment step; otherwise the label starts
+`depth 'left_cam': bright ...`.
+
+Depth rendering defaults to `-P depth=render`. Set `-P depth=off` to restore
+RGB-only observation payloads. Each rendered depth camera adds another image
+to an observation or reveal, so this kill-switch is useful when input payload
+cost matters.
+
+A camera with no `{cam}_depth` key is unchanged. If a depth thunk fails, its
+value is non-numeric or not two-dimensional, or fewer than 1% of its pixels
+are valid, the policy emits a descriptive text line and no depth image.
+
+Saved transcripts retain the metric depth label but replace the depth image
+with the standard `[image omitted: streamed camera frame]` placeholder. The
+HTML viewer shows that placeholder text verbatim below the depth label because
+the frame store has no saved frame for rendered depth. This is a known
+cosmetic artifact; the metric label remains available in the report.
 
 ## Fast mode on Claude
 

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_depth.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_depth.py
@@ -1,0 +1,85 @@
+"""Resolve metric camera depth and render it for LLM observation messages."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from inspect_robots.types import Observation
+from inspect_robots_agent._png import png_data_url
+
+
+def _render_depth(depth: npt.NDArray[np.float64]) -> npt.NDArray[np.uint8]:
+    """Render metric depth as grayscale with near pixels brighter than far pixels."""
+    valid = np.isfinite(depth) & (depth > 0)
+    values = depth[valid]
+    lo, hi = (float(value) for value in np.percentile(values, (2, 98)))
+    if lo == hi:
+        hi = lo + 1e-3
+
+    rendered = np.zeros(depth.shape, dtype=np.uint8)
+    scaled = 255.0 - (depth[valid] - lo) * (255.0 - 64.0) / (hi - lo)
+    rendered[valid] = np.clip(scaled, 64.0, 255.0).round().astype(np.uint8)
+    return rendered
+
+
+def depth_parts(
+    name: str,
+    entry: npt.NDArray[np.float64] | str,
+    step_label: str,
+) -> list[dict[str, Any]]:
+    """Build a metric depth label and optional inline grayscale PNG."""
+    if isinstance(entry, str):
+        return [{"type": "text", "text": entry}]
+
+    valid = np.isfinite(entry) & (entry > 0)
+    valid_count = int(np.count_nonzero(valid))
+    valid_fraction = valid_count / entry.size if entry.size else 0.0
+    valid_pct = round(100 * valid_fraction)
+    if valid_fraction < 0.01:
+        return [
+            {
+                "type": "text",
+                "text": f"depth {name!r}: no usable depth this frame ({valid_pct}% valid)",
+            }
+        ]
+
+    lo, hi = (float(value) for value in np.percentile(entry[valid], (2, 98)))
+    if lo == hi:
+        hi = lo + 1e-3
+    suffix = f" ({step_label})" if step_label else ""
+    text = (
+        f"depth {name!r}{suffix}: bright {lo:.2f} m -> dim {hi:.2f} m "
+        f"(2nd-98th pctl), {valid_pct}% valid"
+    )
+    center = (entry.shape[0] // 2, entry.shape[1] // 2)
+    if valid[center]:
+        text += f", center {entry[center]:.2f} m"
+    text += ":"
+    return [
+        {"type": "text", "text": text},
+        {"type": "image_url", "image_url": {"url": png_data_url(_render_depth(entry))}},
+    ]
+
+
+def resolve_depth(observation: Observation) -> dict[str, npt.NDArray[np.float64] | str]:
+    """Resolve each camera's depth entry once and preserve failures as text."""
+    resolved: dict[str, npt.NDArray[np.float64] | str] = {}
+    for name in observation.images:
+        key = f"{name}_depth"
+        if key not in observation.extra:
+            continue
+        try:
+            value = observation.extra[key]
+            if callable(value):
+                value = value()
+            depth = np.asarray(value, dtype=np.float64)
+            if depth.ndim != 2:
+                raise ValueError(f"expected a 2-D array, got shape {depth.shape}")
+        except Exception as exc:
+            resolved[name] = f"depth {name!r} unavailable: {exc}"
+        else:
+            resolved[name] = depth
+    return resolved

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_depth.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_depth.py
@@ -12,7 +12,11 @@ from inspect_robots_agent._png import png_data_url
 
 
 def _render_depth(depth: npt.NDArray[np.float64]) -> npt.NDArray[np.uint8]:
-    """Render metric depth as grayscale with near pixels brighter than far pixels."""
+    """Render metric depth as grayscale with near pixels brighter than far pixels.
+
+    Requires at least one valid (finite, positive) pixel; ``depth_parts``
+    guarantees this via its <1%-valid guard before calling.
+    """
     valid = np.isfinite(depth) & (depth > 0)
     values = depth[valid]
     lo, hi = (float(value) for value in np.percentile(values, (2, 98)))
@@ -30,14 +34,20 @@ def depth_parts(
     entry: npt.NDArray[np.float64] | str,
     step_label: str,
 ) -> list[dict[str, Any]]:
-    """Build a metric depth label and optional inline grayscale PNG."""
+    """Build a metric depth label and optional inline grayscale PNG.
+
+    Array entries must be 2-D; ``resolve_depth`` guarantees this (a str entry
+    is resolution-failure text and passes through as a plain line).
+    """
     if isinstance(entry, str):
         return [{"type": "text", "text": entry}]
 
     valid = np.isfinite(entry) & (entry > 0)
     valid_count = int(np.count_nonzero(valid))
     valid_fraction = valid_count / entry.size if entry.size else 0.0
-    valid_pct = round(100 * valid_fraction)
+    # Floored, not rounded: 0.9% valid must not print as "1% valid" beside
+    # the no-usable-depth message, and 99.5% must not claim "100% valid".
+    valid_pct = int(100 * valid_fraction)
     if valid_fraction < 0.01:
         return [
             {

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -15,6 +15,7 @@ import copy
 import json
 import os
 import sys
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -33,6 +34,7 @@ from inspect_robots.types import ActionChunk, Observation
 if TYPE_CHECKING:
     from inspect_robots.rollout import TrialRecord
 from inspect_robots_agent._anthropic import _DEFAULT_MAX_OUTPUT_TOKENS, AnthropicClient
+from inspect_robots_agent._depth import depth_parts, resolve_depth
 from inspect_robots_agent._llm import (
     _DIRECT_PROVIDERS,
     _OPENROUTER_BASE,
@@ -60,6 +62,7 @@ _EFFORT_LEVELS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh",
 _WIRE_FORMATS = frozenset({"chat", "responses", "anthropic"})
 _SPEEDS = frozenset({"fast"})
 _IMAGE_MODES = frozenset({"always", "on_demand"})
+_DEPTH_MODES = frozenset({"render", "off"})
 
 _SYSTEM_TEMPLATE = """You are controlling a real robot embodiment named {name!r} \
 through tool calls. Each observation message gives you the current \
@@ -135,6 +138,7 @@ class AgentPolicyConfig(PolicyConfig):
     max_speed_frac: float = 0.1
     transcript_echo: bool = False
     images: str = "always"
+    depth: str = "render"
 
 
 @dataclass(frozen=True, eq=False)
@@ -154,6 +158,8 @@ class LLMAgentPolicy(PolicyBase):
     compatibility check) adopts the embodiment's spaces and builds the tool
     surface from them. Conversation state is per-trial (``reset``), and the
     selected wire client translates that state without changing the loop.
+    Metric camera depth is rendered by default; pass ``depth="off"`` to omit
+    it without resolving any depth entries.
     """
 
     def __init__(
@@ -170,6 +176,7 @@ class LLMAgentPolicy(PolicyBase):
         max_speed_frac: float = 0.1,
         transcript_echo: bool = False,
         images: str = "always",
+        depth: str = "render",
         transport: httpx.BaseTransport | None = None,
         env: dict[str, str] | None = None,
     ):
@@ -195,6 +202,11 @@ class LLMAgentPolicy(PolicyBase):
             raise ConfigError(
                 f"images must be one of {sorted(_IMAGE_MODES)}, got {images!r}.\n"
                 "fix: pass -P images=always or -P images=on_demand"
+            )
+        if depth not in _DEPTH_MODES:
+            raise ConfigError(
+                f"depth must be one of {sorted(_DEPTH_MODES)}, got {depth!r}.\n"
+                "fix: pass -P depth=render or -P depth=off"
             )
         if wire != "anthropic":
             # A dropped speed would bill at standard rates while the user
@@ -314,6 +326,7 @@ class LLMAgentPolicy(PolicyBase):
         self._max_speed_frac = max_speed_frac
         self._transcript_echo = transcript_echo
         self._images = images
+        self._depth = depth
         self.config = AgentPolicyConfig(
             temperature=temperature,
             model=provider.model,
@@ -327,6 +340,7 @@ class LLMAgentPolicy(PolicyBase):
             max_speed_frac=max_speed_frac,
             transcript_echo=transcript_echo,
             images=images,
+            depth=depth,
         )
         # Placeholder until bind(); eval() always binds before compat/rollout.
         self.info = PolicyInfo(name="agent", action_space=Box(shape=(1,)))
@@ -423,6 +437,7 @@ class LLMAgentPolicy(PolicyBase):
                 "LLMAgentPolicy.act() before bind(); run it through eval() or call "
                 "policy.bind(embodiment.info) first"
             )
+        depth = resolve_depth(observation) if self._depth == "render" else {}
         self._revealed.clear()
         reveal: tuple[str, ...] | None = None
         narration: str | None = None
@@ -445,6 +460,7 @@ class LLMAgentPolicy(PolicyBase):
             self._state_labels,
             reveal=reveal,
             narration=narration,
+            depth=depth,
         )
         if self._images == "on_demand":
             available = _quoted_names(tuple(observation.images))
@@ -614,7 +630,11 @@ class LLMAgentPolicy(PolicyBase):
                 self._messages.append(
                     {
                         "role": "user",
-                        "content": _image_parts(observation, reveal=immediate_frames),
+                        "content": _image_parts(
+                            observation,
+                            reveal=immediate_frames,
+                            depth=depth,
+                        ),
                     }
                 )
             if chunk is not None:
@@ -711,6 +731,7 @@ def _observation_content(
     *,
     reveal: tuple[str, ...] | None = None,
     narration: str | None = None,
+    depth: Mapping[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """State as readable text plus camera frames as inline PNG data URLs."""
     lines = ["Current observation."]
@@ -720,7 +741,7 @@ def _observation_content(
     if narration is not None:
         lines.append(narration)
     parts: list[dict[str, Any]] = [{"type": "text", "text": "\n".join(lines)}]
-    parts.extend(_image_parts(observation, reveal=reveal))
+    parts.extend(_image_parts(observation, reveal=reveal, depth=depth))
     return parts
 
 
@@ -728,6 +749,7 @@ def _image_parts(
     observation: Observation,
     *,
     reveal: tuple[str, ...] | None = None,
+    depth: Mapping[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Build frame labels and payloads without changing the report's label join key."""
     parts: list[dict[str, Any]] = []
@@ -740,6 +762,8 @@ def _image_parts(
             continue
         parts.append({"type": "text", "text": f"camera {name!r}{suffix}:"})
         parts.append({"type": "image_url", "image_url": {"url": png_data_url(image)}})
+        if depth is not None and name in depth:
+            parts.extend(depth_parts(name, depth[name], step_label))
     return parts
 
 

--- a/plugins/inspect-robots-agent/tests/test_depth.py
+++ b/plugins/inspect-robots-agent/tests/test_depth.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import numpy as np
+
+from inspect_robots._html import _FRAME_LABEL_RE
+from inspect_robots.types import Observation
+from inspect_robots_agent._depth import _render_depth, depth_parts, resolve_depth
+
+
+def test_render_depth_near_pixel_is_brighter_than_far_pixel() -> None:
+    rendered = _render_depth(np.array([[0.1, 1.0]], dtype=np.float64))
+
+    assert rendered[0, 0] > rendered[0, 1]
+
+
+def test_render_depth_invalid_pixel_is_exactly_zero() -> None:
+    rendered = _render_depth(np.array([[0.0, np.nan, np.inf, 1.0]], dtype=np.float64))
+
+    assert rendered[0, :3].tolist() == [0, 0, 0]
+
+
+def test_render_depth_valid_floor_is_64() -> None:
+    depth = np.arange(1.0, 52.0, dtype=np.float64).reshape(3, 17)
+    rendered = _render_depth(depth)
+
+    assert rendered[2, 15] == 64
+
+
+def test_render_depth_degenerate_window_renders() -> None:
+    rendered = _render_depth(np.full((2, 3), 0.5, dtype=np.float64))
+
+    assert rendered.shape == (2, 3)
+    assert rendered.dtype == np.uint8
+    assert np.all(rendered > 0)
+
+
+def test_resolve_depth_calls_thunk_exactly_once() -> None:
+    calls = 0
+
+    def depth_thunk() -> np.ndarray:
+        nonlocal calls
+        calls += 1
+        return np.ones((2, 2), dtype=np.float64)
+
+    resolved = resolve_depth(
+        Observation(
+            images={"left_cam": np.zeros((2, 2, 3), dtype=np.uint8)},
+            extra={"left_cam_depth": depth_thunk},
+        )
+    )
+
+    assert calls == 1
+    assert isinstance(resolved["left_cam"], np.ndarray)
+
+
+def test_resolve_depth_failing_thunk_becomes_text() -> None:
+    def depth_thunk() -> np.ndarray:
+        raise RuntimeError("camera offline")
+
+    resolved = resolve_depth(
+        Observation(
+            images={"left_cam": np.zeros((2, 2, 3), dtype=np.uint8)},
+            extra={"left_cam_depth": depth_thunk},
+        )
+    )
+
+    assert resolved == {"left_cam": "depth 'left_cam' unavailable: camera offline"}
+
+
+def test_resolve_depth_non_2d_becomes_text() -> None:
+    resolved = resolve_depth(
+        Observation(
+            images={"left_cam": np.zeros((2, 2, 3), dtype=np.uint8)},
+            extra={"left_cam_depth": np.ones(3, dtype=np.float64)},
+        )
+    )
+
+    assert resolved == {
+        "left_cam": "depth 'left_cam' unavailable: expected a 2-D array, got shape (3,)"
+    }
+
+
+def test_resolve_depth_non_numeric_becomes_text() -> None:
+    resolved = resolve_depth(
+        Observation(
+            images={"left_cam": np.zeros((2, 2, 3), dtype=np.uint8)},
+            extra={"left_cam_depth": [["near", "far"]]},
+        )
+    )
+
+    entry = resolved["left_cam"]
+    assert isinstance(entry, str)
+    assert entry.startswith("depth 'left_cam' unavailable:")
+
+
+def test_resolve_depth_plain_array_passthrough() -> None:
+    depth = np.ones((2, 2), dtype=np.float64)
+    resolved = resolve_depth(
+        Observation(
+            images={"left_cam": np.zeros((2, 2, 3), dtype=np.uint8)},
+            extra={"left_cam_depth": depth},
+        )
+    )
+
+    assert resolved["left_cam"] is depth
+
+
+def test_depth_parts_label_with_step_is_exact() -> None:
+    depth = np.concatenate(
+        (
+            np.full(3, 0.09),
+            np.full(81, 0.31),
+            np.full(3, 1.41),
+            np.zeros(13),
+        )
+    ).reshape(10, 10)
+
+    parts = depth_parts("left_cam", depth, "step 3")
+
+    assert parts[0] == {
+        "type": "text",
+        "text": (
+            "depth 'left_cam' (step 3): bright 0.09 m -> dim 1.41 m "
+            "(2nd-98th pctl), 87% valid, center 0.31 m:"
+        ),
+    }
+
+
+def test_depth_parts_label_without_step_is_exact() -> None:
+    depth = np.concatenate(
+        (
+            np.full(3, 0.09),
+            np.full(81, 0.31),
+            np.full(3, 1.41),
+            np.zeros(13),
+        )
+    ).reshape(10, 10)
+
+    parts = depth_parts("left_cam", depth, "")
+
+    assert parts[0] == {
+        "type": "text",
+        "text": (
+            "depth 'left_cam': bright 0.09 m -> dim 1.41 m "
+            "(2nd-98th pctl), 87% valid, center 0.31 m:"
+        ),
+    }
+
+
+def test_depth_parts_image_is_png_data_url() -> None:
+    parts = depth_parts("left_cam", np.ones((2, 2), dtype=np.float64), "step 3")
+
+    assert parts[1]["type"] == "image_url"
+    assert parts[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+def test_depth_parts_string_entry_is_text_only() -> None:
+    text = "depth 'left_cam' unavailable: camera offline"
+
+    assert depth_parts("left_cam", text, "step 3") == [{"type": "text", "text": text}]
+
+
+def test_depth_parts_less_than_one_percent_valid_is_text_only() -> None:
+    parts = depth_parts("left_cam", np.zeros((10, 10), dtype=np.float64), "step 3")
+
+    assert parts == [
+        {
+            "type": "text",
+            "text": "depth 'left_cam': no usable depth this frame (0% valid)",
+        }
+    ]
+
+
+def test_depth_parts_omits_center_when_center_pixel_is_invalid() -> None:
+    depth = np.ones((10, 10), dtype=np.float64)
+    depth[5, 5] = 0.0
+
+    parts = depth_parts("left_cam", depth, "step 3")
+
+    assert "center" not in parts[0]["text"]
+
+
+def test_depth_label_does_not_match_frame_label_regex() -> None:
+    parts = depth_parts("left_cam", np.ones((2, 2), dtype=np.float64), "step 3")
+    depth_label = parts[0]["text"]
+
+    assert _FRAME_LABEL_RE.search(depth_label) is None

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -452,6 +452,98 @@ def test_observation_content_step_label_fallbacks() -> None:
     assert numpy_step[1]["text"] == "camera 'top':"
 
 
+def test_observation_message_places_depth_immediately_after_its_camera() -> None:
+    script = _Script([_tool_response("done", {"summary": "observed depth"})])
+    policy = _policy(script)
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="inspect depth"))
+    observation = _vision_observation(env_step=3)
+    observation = replace(
+        observation,
+        extra={
+            **observation.extra,
+            "top_depth": lambda: np.full((2, 2), 0.5, dtype=np.float64),
+        },
+    )
+
+    policy.act(observation)
+
+    content = script.requests[0]["messages"][-1]["content"]
+    assert content[1]["text"] == "camera 'top' (step 3):"
+    assert content[2]["type"] == "image_url"
+    assert content[3]["text"] == (
+        "depth 'top' (step 3): bright 0.50 m -> dim 0.50 m "
+        "(2nd-98th pctl), 100% valid, center 0.50 m:"
+    )
+    assert content[4]["type"] == "image_url"
+    assert content[5]["text"] == "camera 'wrist' (step 3):"
+
+
+def test_depth_off_preserves_pre_depth_observation_message() -> None:
+    calls = 0
+
+    def depth_thunk() -> np.ndarray:
+        nonlocal calls
+        calls += 1
+        return np.full((2, 2), 0.5, dtype=np.float64)
+
+    script = _Script([_tool_response("done", {"summary": "ignored depth"})])
+    policy = _policy(script, depth="off")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="ignore depth"))
+    observation = _vision_observation(env_step=4)
+    observation = replace(
+        observation,
+        extra={**observation.extra, "top_depth": depth_thunk},
+    )
+    expected = _observation_content(observation, policy._state_labels)
+
+    policy.act(observation)
+
+    assert script.requests[0]["messages"][-1]["content"] == expected
+    assert calls == 0
+
+
+def test_missing_depth_key_preserves_pre_depth_observation_message() -> None:
+    script = _Script([_tool_response("done", {"summary": "rgb only"})])
+    policy = _policy(script)
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="inspect rgb"))
+    observation = _vision_observation(env_step=5)
+    expected = _observation_content(observation, policy._state_labels)
+
+    policy.act(observation)
+
+    assert script.requests[0]["messages"][-1]["content"] == expected
+
+
+def test_failing_depth_thunk_keeps_observation_message_valid() -> None:
+    def depth_thunk() -> np.ndarray:
+        raise RuntimeError("camera offline")
+
+    script = _Script([_tool_response("done", {"summary": "used rgb"})])
+    policy = _policy(script)
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="inspect available data"))
+    observation = _vision_observation(env_step=6)
+    observation = replace(
+        observation,
+        extra={**observation.extra, "top_depth": depth_thunk},
+    )
+
+    policy.act(observation)
+
+    content = script.requests[0]["messages"][-1]["content"]
+    assert content[1]["text"] == "camera 'top' (step 6):"
+    assert content[2]["type"] == "image_url"
+    assert content[3] == {
+        "type": "text",
+        "text": "depth 'top' unavailable: camera offline",
+    }
+    assert content[4]["text"] == "camera 'wrist' (step 6):"
+    assert sum(part["type"] == "image_url" for part in content) == 2
+
+
 def test_transcript_echo_defaults_off(capsys: pytest.CaptureFixture[str]) -> None:
     policy = _policy(_Script([_tool_response("done", {"summary": "quiet"})]))
     policy.bind(CubePickEmbodiment().info)
@@ -1020,6 +1112,44 @@ def test_immediate_capture_appends_results_then_frames_and_redecides() -> None:
     assert frame_message["content"][1]["type"] == "image_url"
 
 
+def test_immediate_capture_reuses_once_resolved_depth() -> None:
+    calls = 0
+
+    def depth_thunk() -> np.ndarray:
+        nonlocal calls
+        calls += 1
+        return np.full((2, 2), 0.5, dtype=np.float64)
+
+    script = _Script(
+        [
+            _tool_response(
+                "take_pic",
+                {"cameras": ["top"], "note": "I need the top RGB and depth view."},
+            ),
+            _tool_response("done", {"summary": "looked with depth"}),
+        ]
+    )
+    policy = _policy(script, images="on_demand")
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="look"))
+    observation = _vision_observation(env_step=7)
+    observation = replace(
+        observation,
+        extra={**observation.extra, "top_depth": depth_thunk},
+    )
+
+    policy.act(observation)
+
+    history = script.requests[1]["messages"]
+    frame_message = history[-1]
+    assert frame_message["role"] == "user"
+    assert frame_message["content"][0]["text"] == "camera 'top' (step 7):"
+    assert frame_message["content"][1]["type"] == "image_url"
+    assert frame_message["content"][2]["text"].startswith("depth 'top' (step 7):")
+    assert frame_message["content"][3]["type"] == "image_url"
+    assert calls == 1
+
+
 def test_immediate_capture_validation_errors_increment_failures() -> None:
     script = _Script([_tool_response("take_pic", {})])
     policy = _policy(script, images="on_demand", max_llm_calls=50)
@@ -1549,6 +1679,14 @@ def test_images_mode_is_recorded_and_invalid_values_have_a_fix() -> None:
     assert policy.config.images == "on_demand"
     with pytest.raises(ConfigError, match=r"(?s)images must be one of.*fix:"):
         _policy(_Script([_text_response("unused")]), images="sometimes")
+
+
+def test_depth_mode_is_recorded_and_invalid_values_have_a_fix() -> None:
+    policy = _policy(_Script([_text_response("unused")]), depth="off")
+
+    assert policy.config.depth == "off"
+    with pytest.raises(ConfigError, match=r"(?s)depth must be one of.*fix:"):
+        _policy(_Script([_text_response("unused")]), depth="sometimes")
 
 
 def test_on_demand_prompt_and_no_tool_nudge_describe_chaining() -> None:


### PR DESCRIPTION
Implements plan `plans/0028-agent-depth-render.md` (in-branch): when an embodiment publishes `{cam}_depth` in `observation.extra`, the agent policy renders a grayscale depth image (near=bright) plus a metric anchor line next to that camera's RGB frame — in `images=\"always\"` observation messages and `take_pic` reveals alike, via the shared `_image_parts` seam. New `depth=\"render\"|\"off\"` policy knob. Depth labels are shaped to never match the HTML viewer's frame-join regex.

Closes #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)