### PR TITLE
feat(logging): wrapped LLM transcript reading pane in the rerun sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- Rerun sink: transcript `TextLog` rows at `trial/<scene>/e<epoch>/llm` are now
+  paired with a markdown `TextDocument` at `…/llm/latest` — add a Text Document
+  view for a wrapped, timeline-synced transcript reading pane (#203).
+
 - `OPERATOR_END` termination-reason constant (`"operator_end"`): the standard
   reason for "a human ended this episode by keypress, verdict pending". Attended
   runs now prompt for exactly those trials — registered tasks and `eval-set`

--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -80,7 +80,9 @@ Policies that support transcript streaming automatically add conversation rows
 at `trial/<scene>/e<epoch>/llm`. In the Rerun viewer, add a TextLog view and
 select that entity path. Tool results use the DEBUG level and system prompts use
 TRACE, so enable both levels in the view's log-level filter to see the whole
-conversation.
+conversation. The same updates are also available as markdown at
+`trial/<scene>/e<epoch>/llm/latest`; add a Text Document view for a wrapped
+reading pane that stays synchronized with the timeline cursor.
 
 Scrubbing the `step` timeline highlights the transcript rows emitted for that
 control step alongside its camera and state data. This live stream is a

--- a/plans/0030-rerun-transcript-document.md
+++ b/plans/0030-rerun-transcript-document.md
@@ -1,0 +1,169 @@
+# 0030 — rerun sink: wrapped LLM transcript reading pane (TextDocument)
+
+Issue: #203. PR: #204. Status: gate-clear after critique round 2 (round 1 findings applied (named the
+exact-equality test the new emission changes; intra-entry newlines now become
+markdown hard breaks so the sink's own multi-line structure survives
+rendering); round 2: no substantive issues, minors folded in).
+
+## Problem
+
+The rerun sink emits each rendered transcript entry as a `rr.TextLog` row at
+`{prefix}/llm` (`_emit_transcript`, `src/inspect_robots/logging/rerun_sink.py`).
+The viewer renders `TextLog` as a table with single-line rows, and Rerun's
+`TextLogView` has no word-wrap option (verified against rerun-sdk 0.34.1:
+`TextLogFormat` exposes only `monospace_body`). LLM messages are long, so the
+one view we give operators for the transcript truncates almost everything;
+reading a message requires clicking its row (Selection panel) or hovering for
+a tooltip, and neither follows the timeline cursor. During failure triage —
+scrubbing a rollout while watching the cameras — the transcript is effectively
+unreadable.
+
+Replacing `TextLog` with `TextDocument` was considered and rejected: it would
+lose the scannable history table, per-entry level coloring/filtering, and the
+ability for multiple same-step entries to coexist (`TextDocument` has
+latest-at semantics — same entity + same time index = overwrite).
+
+## Design
+
+Keep the `TextLog` emission exactly as is, and **additionally** log each
+transcript payload's entries joined into one markdown `TextDocument` at
+`{prefix}/llm/latest`:
+
+```python
+def _emit_transcript(self, rr: Any, payload: _TranscriptPayload) -> None:
+    self._set_step(rr, payload.t)
+    for level, text in payload.entries:
+        rr.log(f"{payload.prefix}/llm", rr.TextLog(text, level=level))
+    self._emit_transcript_document(rr, payload)
+```
+
+- **Latest-at is the feature.** A `TextDocumentView` on `{prefix}/llm/latest`
+  shows the document current at the timeline cursor, so transcript reading
+  stays in lockstep with scrubbing. Word wrap is on by default in that view.
+- **One document per payload, not per entry.** Entries logged separately at
+  the same step would overwrite each other; joining sidesteps that and gives
+  the operator the whole step's exchange in one pane. Cross-payload overwrite
+  at the same `t` is out of scope by contract: the sink protocol documents
+  that the rollout calls `log_policy_messages` at most once per control step
+  (`src/inspect_robots/logging/sink.py:8-9`).
+- **Markdown.** `media_type="text/markdown"` (string literal, so we don't
+  depend on the `rr.MediaType` constant existing). Each entry is prefixed
+  with its level so the information `TextLog` carries in row color isn't lost
+  in the document:
+
+  ```
+  **[INFO]** assistant: I can see the bowl…
+
+  ---
+
+  **[DEBUG]** tool: move_arm(…)
+  ```
+
+  Join separator: `\n\n---\n\n`. Raw LLM text may itself contain markdown;
+  rendering it is desired (code blocks, lists), and a message that renders
+  oddly is still strictly more readable than a truncated table cell.
+
+- **Intra-entry newlines become markdown hard breaks.** `_render_message`
+  joins content parts and tool-call lines with bare `"\n"`
+  (`rerun_sink.py:92,103`), which markdown renders as a soft break — the
+  entry would flatten into one run-on paragraph, losing structure the sink
+  itself created (e.g. `"user: camera 'top':\n[image_url part]\nafter"`).
+  The compose step therefore applies `text.replace("\n", "  \n")` (trailing
+  two-space hard break) to each entry before prefixing the level. Known
+  cosmetic caveat: if an entry contains a fenced code block, the added
+  trailing spaces land inside the fence; they are invisible in rendering and
+  acceptable. Same posture for two sibling ambiguities: raw content whose own
+  `---` line follows a blank line renders like the entry separator (the
+  `**[LEVEL]**` prefix disambiguates), and an unclosed code fence in one
+  entry swallows the rendered separator and subsequent entries — renders
+  oddly still beats a truncated table cell.
+
+### Compatibility and edge cases
+
+- **Old SDK surface without `TextDocument`:** resolve via
+  `getattr(rr, "TextDocument", None)`; when absent, skip the document
+  emission silently — the `TextLog` table still works, and warning once per
+  eval about a purely additive nicety is noise. (This matches the sink's
+  existing tiered-degradation philosophy but is even weaker than the
+  compress fallback, deliberately: nothing is lost that the sink emitted
+  before this plan.)
+- **Empty `payload.entries`:** skip the document (don't log an empty body
+  that would blank the pane at that step). The `TextLog` loop already
+  no-ops naturally.
+- **Where the join happens:** in the worker-thread emit path
+  (`_emit_transcript_document`), not at enqueue time. Entries are already
+  snapshotted tuples, the join is cheap, and this keeps the queue payloads
+  and drop-accounting untouched — a dropped `_TranscriptPayload` drops both
+  representations together, as it should.
+- **Failure isolation:** `_worker_loop` already wraps `_emit` in the
+  once-warned `try/except`; the document emission inherits that. No new
+  failure surface on the control path.
+
+### Non-changes
+
+- No blueprint shipping. The sink has never sent a blueprint; choosing one is
+  a separate discussion (would also cover camera/plot layout). Operators add
+  a Text Document view manually or via their own blueprint.
+- No changes to `_render_message`, payload dataclasses, queueing,
+  backpressure, or drop accounting.
+- No new config knob. The document costs ~the same bytes as the rows we
+  already send; a toggle would be a knob nobody turns.
+
+## Implementation steps
+
+1. `_emit_transcript_document(rr, payload)` in `RerunSink`, called from
+   `_emit_transcript`. Guard: `TextDocument` attr present, entries non-empty.
+   Compose
+   `"\n\n---\n\n".join(f"**[{level}]** " + text.replace("\n", "  \n") for
+   level, text in entries)`, log at `f"{payload.prefix}/llm/latest"` with
+   `media_type="text/markdown"`.
+2. Module docstring: **add** a sentence stating that transcripts are emitted
+   as `TextLog` rows at `{prefix}/llm` paired with a markdown `TextDocument`
+   at `{prefix}/llm/latest` (wrapped, timeline-synced reading pane). The
+   current docstring never introduces transcript entities at all — its only
+   transcript mention is the backpressure drop-ordering clause, which is the
+   wrong place to extend.
+3. Tests (`tests/test_rerun_sink.py`), following the existing
+   `_install_fake_rerun` pattern:
+   - fake gains a `TextDocument` class capturing `(text, media_type)` **by
+     default** — the fake should model the modern SDK surface; the legacy
+     surface is the opt-out (`del`/flag), mirroring how the modern fake
+     already carries `set_time`/`Scalars`.
+   - **existing test updated:**
+     `test_policy_messages_emit_ordered_levels_on_the_step_timeline`
+     (`tests/test_rerun_sink.py:387-394`) asserts the logged list by exact
+     equality; it gains the new `("trial/scene/e2/llm/latest", …)` entry.
+     Audit the rest of the suite for other exact-equality assertions over
+     `logged` that a transcript emission feeds.
+   - transcript emission logs both the `TextLog` rows at `{prefix}/llm` and
+     one document at `{prefix}/llm/latest`; document body contains every
+     entry's text, level prefixes, and the separator; `media_type` is
+     `"text/markdown"`.
+   - a multi-line entry (content parts / tool_call lines) renders with hard
+     breaks: assert the **full composed body** by exact equality for a known
+     multi-line fixture (e.g. the existing
+     `user: camera 'top':\n[image_url part]\nafter` rendering-table case),
+     pinning level prefix, `"  \n"` transform, and separator in one
+     assertion, matching the suite's exact-equality style.
+   - multiple entries in one payload → exactly one document log call.
+   - empty-entries payload → no document log call.
+   - fake *without* a `TextDocument` attribute → no error, `TextLog` rows
+     still logged, nothing logged at `…/llm/latest`.
+4. Docs: `docs/guide/logging-and-rerun.md` § "Live transcript in the viewer"
+   (currently "add a TextLog view") gains the `…/llm/latest` entity and the
+   suggestion to add a Text Document view for wrapped, timeline-synced
+   reading. No README change (its viewer-streams line is generic and does
+   not enumerate transcript entities).
+
+## Acceptance
+
+- All existing tests pass; new tests cover every new branch (repo gate:
+  100% coverage).
+- `uv run inspect-robots run --rerun …` on a live viewer shows the existing
+  `llm` table plus a `llm/latest` entity that renders wrapped markdown in a
+  Text Document view and tracks the timeline cursor.
+
+## Out of scope
+
+- Shipping a default blueprint (table + document side by side).
+- Any change to yam/agent packages; rig enablement is release + venv bump.

--- a/src/inspect_robots/logging/rerun_sink.py
+++ b/src/inspect_robots/logging/rerun_sink.py
@@ -41,6 +41,9 @@ no ``flush`` method. A new sink in the same process can still hang in
 
 Each trial's entities are namespaced under ``trial/<scene_id>/e<epoch>`` so
 successive trials never overwrite one another on the shared step timeline.
+Transcripts are emitted as ``TextLog`` rows at ``{prefix}/llm`` paired with a
+markdown ``TextDocument`` at ``{prefix}/llm/latest`` for a wrapped,
+timeline-synced reading pane.
 
 Install with ``pip install "inspect-robots[rerun]"``.
 """
@@ -279,6 +282,19 @@ class RerunSink:
         self._set_step(rr, payload.t)
         for level, text in payload.entries:
             rr.log(f"{payload.prefix}/llm", rr.TextLog(text, level=level))
+        self._emit_transcript_document(rr, payload)
+
+    def _emit_transcript_document(self, rr: Any, payload: _TranscriptPayload) -> None:
+        text_document = getattr(rr, "TextDocument", None)
+        if text_document is None or not payload.entries:
+            return
+        body = "\n\n---\n\n".join(
+            f"**[{level}]** " + text.replace("\n", "  \n") for level, text in payload.entries
+        )
+        rr.log(
+            f"{payload.prefix}/llm/latest",
+            text_document(body, media_type="text/markdown"),
+        )
 
     def _ensure_worker(self) -> None:
         if self._worker is not None and self._worker.is_alive():

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -12,7 +12,7 @@ import time
 import types
 import warnings
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import numpy as np
 import pytest
@@ -242,12 +242,18 @@ class _ExplodingImage(_RawImage):
         raise ValueError("cannot encode")
 
 
+class _TextDocument(NamedTuple):
+    text: str
+    media_type: str
+
+
 def _install_fake_rerun(
     monkeypatch: pytest.MonkeyPatch,
     *,
     image_cls: type[_RawImage] = _CompressibleImage,
     gate: threading.Event | None = None,
     log_error: Exception | None = None,
+    text_document: bool = True,
 ) -> list[tuple[str, object]]:
     """Install a fake ``rerun`` module (new-API surface); return the (path, value) log."""
     logged: list[tuple[str, object]] = []
@@ -271,6 +277,8 @@ def _install_fake_rerun(
     fake.Image = image_cls  # type: ignore[attr-defined]
     fake.Scalars = lambda v: ("Scalars", v)  # type: ignore[attr-defined]
     fake.TextLog = lambda t, *, level=None: ("TextLog", t, level)  # type: ignore[attr-defined]
+    if text_document:
+        fake.TextDocument = _TextDocument  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "rerun", fake)
     return logged
 
@@ -391,8 +399,126 @@ def test_policy_messages_emit_ordered_levels_on_the_step_timeline(
         ("trial/scene/e2/llm", ("TextLog", "tool: result", "DEBUG")),
         ("trial/scene/e2/llm", ("TextLog", "system: prompt", "TRACE")),
         ("trial/scene/e2/llm", ("TextLog", "critic: other", "TRACE")),
+        (
+            "trial/scene/e2/llm/latest",
+            _TextDocument(
+                "**[INFO]** assistant: answer\n\n---\n\n"
+                "**[INFO]** user: question\n\n---\n\n"
+                "**[DEBUG]** tool: result\n\n---\n\n"
+                "**[TRACE]** system: prompt\n\n---\n\n"
+                "**[TRACE]** critic: other",
+                media_type="text/markdown",
+            ),
+        ),
     ]
     sink.on_eval_end(None)  # type: ignore[arg-type]
+
+
+def test_transcript_emission_logs_rows_and_markdown_document(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged = _install_fake_rerun(monkeypatch)
+    rr = sys.modules["rerun"]
+    payload = _TranscriptPayload(
+        "trial/scene/e0",
+        3,
+        (("INFO", "assistant: answer"), ("DEBUG", "tool: result")),
+    )
+
+    RerunSink()._emit_transcript(rr, payload)
+
+    assert logged == [
+        ("set_time", ("step", {"sequence": 3})),
+        ("trial/scene/e0/llm", ("TextLog", "assistant: answer", "INFO")),
+        ("trial/scene/e0/llm", ("TextLog", "tool: result", "DEBUG")),
+        (
+            "trial/scene/e0/llm/latest",
+            _TextDocument(
+                "**[INFO]** assistant: answer\n\n---\n\n**[DEBUG]** tool: result",
+                media_type="text/markdown",
+            ),
+        ),
+    ]
+
+
+def test_transcript_document_composes_multiline_entries_with_hard_breaks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged = _install_fake_rerun(monkeypatch)
+    rr = sys.modules["rerun"]
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "camera 'top':"},
+            {"type": "image_url", "image_url": {"url": "elided"}},
+            {"type": "text", "text": "after"},
+        ],
+    }
+    payload = _TranscriptPayload(
+        "trial/scene/e0",
+        4,
+        (_render_message(message), ("DEBUG", "tool: result")),
+    )
+
+    RerunSink()._emit_transcript(rr, payload)
+
+    documents = [value for path, value in logged if path == "trial/scene/e0/llm/latest"]
+    assert documents == [
+        _TextDocument(
+            "**[INFO]** user: camera 'top':  \n"
+            "[image_url part]  \n"
+            "after\n\n---\n\n"
+            "**[DEBUG]** tool: result",
+            media_type="text/markdown",
+        )
+    ]
+
+
+def test_transcript_payload_emits_exactly_one_document_for_multiple_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged = _install_fake_rerun(monkeypatch)
+    rr = sys.modules["rerun"]
+    payload = _TranscriptPayload(
+        "trial/scene/e0",
+        5,
+        (("INFO", "first"), ("DEBUG", "second"), ("TRACE", "third")),
+    )
+
+    RerunSink()._emit_transcript(rr, payload)
+
+    assert [path for path, _ in logged].count("trial/scene/e0/llm/latest") == 1
+
+
+def test_empty_transcript_payload_emits_no_document(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged = _install_fake_rerun(monkeypatch)
+    rr = sys.modules["rerun"]
+
+    RerunSink()._emit_transcript(rr, _TranscriptPayload("trial/scene/e0", 6, ()))
+
+    assert logged == [("set_time", ("step", {"sequence": 6}))]
+
+
+def test_sdk_without_text_document_keeps_transcript_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged = _install_fake_rerun(monkeypatch, text_document=False)
+    rr = sys.modules["rerun"]
+    payload = _TranscriptPayload(
+        "trial/scene/e0",
+        7,
+        (("INFO", "assistant: answer"), ("DEBUG", "tool: result")),
+    )
+
+    RerunSink()._emit_transcript(rr, payload)
+
+    assert logged == [
+        ("set_time", ("step", {"sequence": 7})),
+        ("trial/scene/e0/llm", ("TextLog", "assistant: answer", "INFO")),
+        ("trial/scene/e0/llm", ("TextLog", "tool: result", "DEBUG")),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -1022,6 +1022,14 @@ def test_trial_end_skips_flush_once_stalled(monkeypatch: pytest.MonkeyPatch) -> 
     sink.on_eval_end(None)  # type: ignore[arg-type]
 
 
+def test_real_rerun_accepts_the_transcript_document_call() -> None:
+    """The real SDK accepts the exact TextDocument construction the sink emits."""
+    rr = pytest.importorskip("rerun")
+    if not hasattr(rr, "TextDocument"):
+        pytest.skip("pre-TextDocument rerun-sdk lacks the archetype")
+    rr.TextDocument("**[INFO]** assistant: hi  \nthere", media_type="text/markdown")
+
+
 def test_real_rerun_process_exits_when_tcp_peer_never_reads() -> None:
     """The real SDK atexit path is bounded after a connected peer stops reading."""
     rr = pytest.importorskip("rerun")


### PR DESCRIPTION
Closes #203

Adds a markdown `TextDocument` emission at `{prefix}/llm/latest` alongside the existing `TextLog` transcript rows in the rerun sink, so the viewer gets a wrapped, timeline-synced transcript reading pane.

Plan: `plans/0030-rerun-transcript-document.md` (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)