### PR TITLE
Wire capture: eval logs record 100% of what the LLM saw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- Wire capture: eval logs now record 100% of what the LLM saw. The agent
+  policy captures every request/response attempt at the wire-client
+  serialization point (tool schemas, evicted view, depth composites,
+  `cache_control` breakpoints, retries) into `wire/<run_id>/` sidecars with
+  content-addressed image blobs, on by default (`-P wire_capture=false` to
+  opt out). New core `on_trial_start` policy hook (fail-safe: a raising
+  hook errors the trial, never the eval), HTML report **Wire** section, and
+  `inspect --wire` call-table/dump. Format contract in
+  `inspect_robots_agent._capture`; guide in *Logging & Rerun* (#206, #207).
+
 - Rerun sink: transcript `TextLog` rows at `trial/<scene>/e<epoch>/llm` are now
   paired with a markdown `TextDocument` at `…/llm/latest` — add a Text Document
   view for a wrapped, timeline-synced transcript reading pane (#203).

--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -145,3 +145,45 @@ the placeholder in place.
 of assembling the path from the transcript label. That remains the right advice
 for programmatic consumers. The `view` command performs this join internally
 with the same sanitizer and an exact-match-or-degrade contract.
+
+## Wire capture
+
+The agent policy records **exactly what each LLM call sent and received** —
+by default, for every run. The saved transcript alone is not that object:
+outgoing requests carry the tool schemas, only the newest `image_horizon`
+frames (older ones become elision stubs), rendered depth composites, and, on
+the Anthropic wire, `cache_control` breakpoints — none of which survive into
+`policy_transcripts`. Wire capture stores the real thing, per attempt,
+including retries and the failed calls a run died on.
+
+Layout, under the log directory:
+
+```
+wire/<run_id>/<trial_id>/calls.jsonl   one JSON row per HTTP attempt
+wire/<run_id>/blobs/<sha256>.png       content-addressed image bytes
+```
+
+Each row records `call`, `attempt`, `endpoint`, `t`, `duration_s`,
+`request`, `status`, `response`, and (failed attempts only) `error`. Image
+payloads inside `request` are replaced by `$blob:<sha256>` sentinels — the
+sha of the decoded PNG stored once in `blobs/` — with every other part key,
+including data-URL prefixes and `cache_control`, preserved verbatim.
+Restoring a byte-faithful request is a string substitution: replace each
+sentinel with the base64 of its blob file. The trial's record points at its
+capture via `metadata["wire_capture"]`.
+
+Browse it with either viewer:
+
+- `inspect-robots view <log>` — each trial gains a collapsible **Wire**
+  section: per-call status, params, delta-rendered messages as sent, and
+  the frames the model could actually see, deduplicated against the
+  report's embedded-media budget.
+- `inspect-robots inspect <log> --wire` — a per-trial call table;
+  `--wire N` (with `--trial <scene>-e<epoch>` when the log has several
+  trials) dumps every attempt row of call `N`.
+
+Capture is best-effort and can never fail an eval: any sink error prints
+one warning and disables capture for that trial. Disable it entirely with
+`-P wire_capture=false`. Budget for roughly `store_frames`-scale disk usage
+(a 100-call three-camera trial with depth rendering writes on the order of
+100 MB, dominated by blobs).

--- a/plans/0031-wire-capture.md
+++ b/plans/0031-wire-capture.md
@@ -252,6 +252,11 @@ remains available via `inspect --wire`.
 Tools render once per trial (the toolset is fixed at `bind()`; schemas are
 identical across calls by construction).
 
+**Torn tails.** Rows are flushed per attempt, but a SIGKILL mid-write
+can strand a torn final line; readers therefore consume the **longest
+valid prefix** of JSON-object lines and drop only the unparsable tail —
+all-or-nothing parsing would discard exactly the crashed trial's capture.
+
 **Pointer resolution.** No viewer resolves `metadata["transcript"]` today;
 the only code resolving it is `_summarize.py:53-68`
 (`log_path.parent / pointer` with an `is_relative_to` traversal guard,

--- a/plans/0031-wire-capture.md
+++ b/plans/0031-wire-capture.md
@@ -1,0 +1,388 @@
+# 0031 — Wire capture: the log records 100% of what the LLM saw
+
+Closes robocurve/inspect-robots#206.
+
+## Problem
+
+The persisted transcript diverges from actual wire traffic four ways:
+
+1. **Tools never persisted.** `Toolset.schemas()` (`_tools.py:113`) — the
+   move tool name, bounds text, and valid dimension labels the model is
+   given — is sent on every request and appears nowhere in the log.
+2. **Images stripped.** `_sanitize()` (`policy.py:107`) replaces every
+   `image_url` part with `[image omitted: streamed camera frame]` in both
+   `policy_transcripts` and the JSONL sidecar written by `on_trial_end`
+   (`policy.py:523`). Depth composites (`depth="render"`) are never stored.
+3. **Evicted-view divergence.** The wire sends `_evicted_view()`
+   (`policy.py:123`) — only the last `image_horizon` frame messages, elision
+   stubs; on the Anthropic wire the anchor becomes a `cache_control`
+   `{"type": "ephemeral"}` breakpoint in the translated body — while the log stores the
+   full un-evicted conversation. The logged object is not the object the
+   model received.
+4. **Per-call bodies unrecoverable.** Retries, per-attempt status codes,
+   exact request params, and raw response payloads are not captured
+   anywhere.
+
+Debugging "why did the model do that?" (e.g. today's #206 trigger: auditing
+whether a run's model was told about `move_joints` at all) currently
+requires inference from code, not evidence from the log.
+
+## Design
+
+Replay-grade, always-on capture at the wire-client serialization point —
+the only place the actual outbound object exists — plus viewer integration
+so what-the-model-saw is browsable per call.
+
+### Capture sink (`plugins/inspect-robots-agent/src/inspect_robots_agent/_capture.py`)
+
+New module, stdlib-only (`json`, `hashlib`, `base64`, `pathlib`, `time`).
+
+```python
+class WireCapture:
+    def begin_trial(self, log_dir: str, run_id: str, trial_id: str) -> None: ...
+    def record(self, *, attempt: int, endpoint: str, request: dict,
+               status: int | None, response_text: str | None,
+               error: str | None, t_start: float, duration_s: float) -> None: ...
+    def end_trial(self) -> str | None:  # relative path for record.metadata
+    @property
+    def began(self) -> bool: ...  # True once begin_trial has ever run on this sink
+```
+
+Clients pass the raw `response.text` (or `None` on transport error); the
+**sink** does one guarded `json.loads` — the parsed value when it is a
+JSON object, the first 2000 chars of text otherwise — so the dict-vs-text decision lives in one tested place,
+not three clients, and `record()` can run before the client's own
+`response.json()` raise path.
+
+The sink owns the `call` index: clients cannot know trial boundaries, so
+they never pass one. `record()` increments the sink's internal call
+counter whenever `attempt == 0` (a retry shares its call's index); the
+counter resets in `begin_trial`; the first call of a trial stamps `call: 0`. Clients pass `t_start` (their
+`time.time()` taken before **that attempt's** post — with backoff
+sleeps, attempts diverge by seconds) and `duration_s`, both per-attempt.
+
+- `begin_trial` stores the resolved `<log_dir>/wire/<run_id>/<trial_id>/`
+  target; directories and `calls.jsonl` are created lazily on the first
+  `record()`, so a zero-LLM-call trial (e.g. `reset()` raising before any
+  `act()`) leaves no empty files, and `end_trial` returns `None` when no
+  row was written (no metadata pointer for empty capture). `<trial_id>` is
+  `f"{scene_id}-e{epoch}"` with the scene id passed through a local
+  replica of core `_safe` (`frames.py:21-33`) **in full — character
+  class plus the crc32 disambiguation suffix** (stdlib-only, no private
+  core import): scene ids are foreign text; a `/` or `..` must not nest
+  or escape the wire dir, and without the crc32 suffix two ids differing
+  only in unsafe characters would silently append into the same
+  `calls.jsonl`, cross-attributing trials. The metadata pointer records the sanitized path.
+  (The transcript sidecar at `policy.py:533` predates this and stays
+  as-is.)
+- `record` deep-copies the request, walks it for image parts, and replaces
+  each with a blob reference; blob bytes go to
+  `<log_dir>/wire/<run_id>/blobs/<sha256>.png` (one `blobs/` dir per run,
+  shared across trials — frames repeat across attempts and dedupe by
+  content hash; write skipped when the file exists). One JSON line per
+  **attempt** — retries are calls the provider saw, so each is a row.
+  **Each `record()` flushes its row to disk before returning** (append +
+  flush; no buffered handle may hold the final row) — crash durability is
+  the design's rationale, and the row a SIGKILL would strand in a buffer
+  is exactly the call the run died on.
+- Image-part shapes recognized, per wire:
+  - chat: `{"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}`
+  - responses: `{"type": "input_image", "image_url": "data:image/png;base64,..."}`
+  - anthropic: `{"type": "image", "source": {"type": "base64", "media_type": ..., "data": ...}}`
+  Substitution happens at the **base64-payload** level, not the part
+  level. The coherent triple, stated once as the contract:
+  - **What is replaced:** exactly the base64 payload text — the substring
+    after `base64,` in a chat/responses data URL, or the whole
+    `source.data` value on the Anthropic wire (which is bare base64) —
+    becomes the sentinel `$blob:<sha256>`. Data-URL prefixes and **every
+    key of the part are preserved verbatim**, including `cache_control`,
+    which the Anthropic translation attaches to the final turn's last
+    block (`_anthropic.py:289-298,400-406`), i.e. routinely to an image
+    part.
+  - **What is hashed and stored:** the sha256 is over the **decoded PNG
+    bytes**, which are what `blobs/<sha256>.png` holds (directly viewable
+    files).
+  - **How readers find and restore references:** scan string values for
+    `\$blob:[0-9a-f]{64}` (unanchored — the sentinel may follow a
+    data-URL prefix); restore by substituting the sentinel with
+    `base64(blob file bytes)`. Wire-agnostic, no re-wrapping.
+- JSONL row schema (the **format contract**, documented in the module
+  docstring and `docs/`):
+
+```json
+{"call": 3, "attempt": 0, "endpoint": "/chat/completions",
+ "t": 1753668000.123, "duration_s": 2.41,
+ "request": {"model": "...", "messages": [...], "tools": [...]},
+ "status": 200, "response": {...}}
+```
+
+  `response` is the parsed body whenever it parses as a JSON **object**
+  (any status), else the first 2000 chars of text; transport errors record
+  `"status": null`, `"response": null`, and `"error": "<str(exc)>"` (the
+  `error` param; omitted from the row when `None`). `call` is the sink's
+  0-based logical call index (attempts of one call share it). `t` is the
+  caller's `t_start`.
+
+**Row-write ordering is the forensic core.** Each client calls `record()`
+at the point where (status, body-or-error) is first known and **before any
+raise or parse that could skip it**: before the non-retryable-4xx raise
+(`_llm.py:218-226`, `_anthropic.py:161-165`), before `response.json()`
+parsing that could throw on a malformed 200, and before the Anthropic
+terminal-`stop_reason` raise (`_anthropic.py:424-426`) — that last one is
+an ordinary 200 row; the raise is client-layer semantics, not wire truth.
+The calls the run *died on* are exactly the ones capture exists for.
+
+### Core hook: `on_trial_start`
+
+`PolicyBase` (`src/inspect_robots/policy.py:96`) gains
+`on_trial_start(self, scene_id: str, epoch: int, log_dir: str, run_id: str) -> None`
+— a `# noqa: B027` no-op default mirroring `on_trial_end`, invoked by the
+rollout in `eval.py` immediately before the first observation of each
+trial, symmetric with the existing `on_trial_end` call site. Backward
+compatible: existing policies inherit the no-op. This exists so capture
+*streams* — a crashed or killed run keeps every call captured up to the
+failure, which is precisely the run you want forensics on. (The
+`on_trial_end`-only alternative would buffer capture in memory and lose it
+on crash; rejected.)
+
+The core `Policy` Protocol docstring enumerates "four optional hooks"
+(`src/inspect_robots/policy.py:57-59`); that contract text is updated to
+five as part of the change. The addition is additive with a no-op default,
+the same shape `on_trial_end` took when it landed.
+
+**Hook failure contract.** At hook time no `TrialRecord` exists yet (the
+record is born inside `rollout()` or synthesized by the `PolicyError`
+fallback, `eval.py:367-373`), so "degrade the record" is not expressible.
+Instead: `eval.py` wraps the invocation; on exception it **skips the
+rollout** and synthesizes an errored `TrialRecord` exactly as the
+`PolicyError` fallback does — keeping `SceneResult`'s parallel tuples
+(`epochs`, `operator_judgements`, `operator_notes`, `trial_metadata`,
+`termination_reasons`, `policy_transcripts`, `eval.py:456-469`) aligned —
+counts it toward `errored_trials`/`fail_on_error`, and fires the sink
+bus's trial-end — but **not** `policy.on_trial_end`: the transcript
+contract is "at trial end after a successful `reset()`" (core
+`policy.py:67-68`, honored via `policy_reset_ok` at `rollout.py:329-330`),
+and `reset()` lives inside the skipped `rollout()`; firing the policy hook
+here would let this very plugin persist the *previous* trial's still-held
+`_messages` under the new trial's id. A raising hook must never lose the
+whole log. This carves an exception into `on_trial_end`'s documented
+"called for errored and cancelled trials too" promise (core
+`policy.py:62-65` and `:105-111`) — both docstrings are amended in the
+same commit: "...except trials whose `on_trial_start` raised, which never
+reached `reset()`". (Call site: immediately
+before `rollout()`, **after** the sink-bus `on_trial_start` at
+`eval.py:331` — so a raising policy hook still yields a matched sink
+`on_trial_start`/`on_trial_end` pair, preserving the sink protocol's
+documented per-trial order (`logging/sink.py:3-5`). Same hook name,
+different protocol; both docstrings note the distinction.)
+
+**Sink lifecycle contract.** `record()` outside an open trial —
+before `begin_trial`, after `end_trial`, or when `begin_trial` never ran —
+is a **no-op**. `begin_trial` resets all per-trial state (target dir,
+lazy-file handle, call counter, dead flag), so a failed or skipped
+`begin_trial` can never bleed rows into a previous trial's file. This also
+defines version skew: a plugin running against an older core whose
+`eval()` never calls `on_trial_start` simply captures nothing; the
+plugin's `on_trial_end`, seeing `capture.began` false with
+`wire_capture=True`, prints one stderr note **once per policy instance**
+(`[agent] wire capture inactive: core predates on_trial_start`) instead
+of writing a metadata pointer. `began` is a permanent latch —
+set by the first `begin_trial`, cleared by nothing — so the plugin may
+call `end_trial` first and consult `began` after without a spurious skew
+warning. (`began` also disambiguates
+"begun-but-zero-rows" — silent, no pointer — from "never begun".)
+
+### Wire-client integration
+
+Each of the three clients (constructors `_llm.py:171`,
+`_responses.py:21`, `_anthropic.py:51`) takes
+`capture: WireCapture | None = None` at construction and, in `complete()`, wraps the existing post: on every
+attempt, after the response (or transport error) is known, calls
+`capture.record(...)` with the exact `body` it posted. No control-flow
+changes; the retry loop, error guidance, and parsing stay as they are.
+
+`LLMAgentPolicy.__init__` grows `wire_capture: bool = True` (recorded in
+`AgentPolicyConfig`); when true it owns a `WireCapture` passed to the
+client it constructs, `on_trial_start` calls `begin_trial`, and
+`on_trial_end` calls `end_trial` and — when it returns a path — sets
+`record.metadata["wire_capture"] = "wire/<run_id>/<trial_id>/calls.jsonl"`
+next to the existing `metadata["transcript"]` pointer. The `end_trial`
+call happens **before** the existing empty-transcript early return
+(`policy.py:525-527`), so a trial whose LLM calls all failed still gets
+its capture pointer.
+
+### Failure semantics
+
+Capture must never fail an eval. The sink's public methods are wrapped
+whole: on the first exception of **any type** (`OSError`, decode errors,
+serialization surprises — the invariant is absolute, so the catch is
+too) the sink prints one
+warning line (`[agent] wire capture disabled for this trial: <err>`) **unconditionally to
+stderr** — not via the policy's `_echo`, which is gated on
+`transcript_echo=False` by default (`policy.py:841-843`) and reachable only
+from the policy, not the wire clients that call `record()`. The sink is
+self-contained: it owns its warning path, marks itself dead for the trial,
+and subsequent `record()` calls no-op. A run with broken capture is a run
+with a warning, not a failed trial. Capture never mutates the live request (`record`
+receives the body after the post result is known; blob substitution
+operates on a deep copy).
+
+### Viewer: HTML report (`src/inspect_robots/_html.py`)
+
+`render_html` already renders per-trial chat transcripts with optional
+frame images (`_FrameContext`, `_frame_image` → data-URI `<img>`). New:
+when `record.metadata["wire_capture"]` resolves, each trial section gains a
+collapsible **"Wire"** subsection: one `<details>` per call/attempt showing
+endpoint, status, duration, the request's non-`messages` prompt-bearing and
+param fields per wire — on the Anthropic wire that includes `body["system"]`
+(where the system prompt and `prior_learnings` live, `_anthropic.py:122-129`)
+— rendered **once per trial** like tools, with a note on any call where
+it changed (it is built once at `reset()` and can carry 32 KB of
+`prior_learnings`; repeating it per call would defeat the text bounding)
+— plus model, effort/temperature, tool count — the messages — **delta-rendered**: each call shows only the messages
+new since the previous row, plus a one-line note per earlier message
+whose as-sent form changed (eviction stubs arriving), with elision stubs
+and `cache_control` breakpoints visible on whatever is shown — and blob
+images. Delta rendering is what bounds the wire section's *text*: the
+JSONL embeds the full history per row (quadratic — see Storage), and
+repeating it across ~100 `<details>` blocks would contradict the
+openable-document rationale the budget exists for. Total rendered text
+stays proportional to the transcript. The full as-sent body of any call
+remains available via `inspect --wire`.
+Tools render once per trial (the toolset is fixed at `bind()`; schemas are
+identical across calls by construction).
+
+**Pointer resolution.** No viewer resolves `metadata["transcript"]` today;
+the only code resolving it is `_summarize.py:53-68`
+(`log_path.parent / pointer` with an `is_relative_to` traversal guard,
+because the pointer is foreign text). That helper moves to a new core
+module `_pointers.py`, imported by both `_summarize.py` and `_html.py`
+(`_summarize` already imports from `cli`, and `cli` imports `_html` — a
+shared leaf module avoids the cycle). `render_html` gains a `log_path`
+parameter (plumbed from `_cmd_view`) so relative pointers resolve. The
+per-run blob dir derives from the pointer as
+`pointer.parent.parent / "blobs"` (`wire/<run_id>/<trial_id>/calls.jsonl`
+→ `wire/<run_id>/blobs/`). `$blob` values read from foreign JSONL are
+validated as 64-char lowercase sha256 hex before any path is built from
+them (a hostile `"$blob": "../../x"` is rejected, the reference rendered
+as broken).
+
+**Payload budget.** The existing report bounds frame embeds with
+`_FrameBudget` (`_html.py:30-37`; the 50 MB default lives in the
+`render_html` signature, `_html.py:557`) precisely to keep
+documents openable. `render_html` already constructs one budget object unconditionally
+(`_html.py:613`); it just never reaches trial rendering without a
+`_FrameContext`. The change is threading: pass the existing budget to the
+wire renderer too, and generalize the header chip label from "frames
+truncated at N MB" to "embedded media truncated at N MB". Each distinct blob is
+embedded **once per trial** at its first reference, with a
+document-unique anchor id (`wire-<safe_trial_id>-<sha[:12]>`, trial id
+passed through `_safe()` as the frames path already does, `_html.py:464`
+— scene ids are foreign text and land in an HTML attribute); every later
+reference to the same sha renders as an internal link to that anchor —
+**only if the anchor was actually emitted**; when the first reference was
+budget-denied, later references render the elision placeholder too (the
+evicted view re-references the same frames on consecutive calls — naive
+inlining would repeat ~10 refs/call × 100 calls into a multi-hundred-MB
+document). A blob denied by the budget renders an inline
+`[blob elided: media budget]` placeholder (the existing frame path degrades to its `[image omitted]` placeholder
+text plus the chip; the wire placeholder names the budget explicitly).
+
+### Viewer: `inspect` CLI (`src/inspect_robots/cli.py`)
+
+`inspect-robots inspect <log> --wire [CALL]`: without `CALL`, prints a
+call table for every trial (trial id, call#, attempt, endpoint, status,
+duration, image count, new-blob bytes); with `CALL`, pretty-prints **every attempt row** for that call index
+(retries share it; the retried call is the forensically interesting one),
+request and response, `$blob` references left symbolic.
+Because a log holds many trials, the single-call dump takes an optional
+`--trial SCENE-eEPOCH` selector; it is required (guided error listing the
+trial ids) when the log has more than one trial with capture. Follows the
+existing `--transcript` flag's structure (`cli.py:1214`).
+
+### Storage
+
+A 100-call, 3-camera trial with the default `depth="render"` ≈ 6 new
+frames/call (RGB + depth composite per camera, `_depth.py:73`) × ~150 KB
+≈ 90 MB of blobs. The JSONL is **quadratic in call count** — each row
+embeds the full message history to date plus the toolset, and the
+responses wire additionally carries `reasoning.encrypted_content` both
+ways (`_responses.py:63,81`) — so a 100-call trial's `calls.jsonl` runs
+tens of MB, not single digits; text is cheap next to the blobs but not
+free. Same order overall as `store_frames=True` (already the rig
+default). Not gated in v1;
+`wire_capture=false` is the escape hatch. Blobs and JSONL live under the
+log dir, so log-dir lifecycle management covers them.
+
+## Tests
+
+Plugin (`plugins/inspect-robots-agent/tests/` — CI gates plugins at
+`--cov-fail-under=0`; the 100% bar here is self-imposed, as this
+plugin's suite has held to date):
+- `test_capture.py`: blob extraction/substitution per wire shape; dedup
+  (same frame twice → one file); JSONL row schema; retry rows (attempt>0
+  shares the call index; attempt==0 increments it); transport error rows;
+  dead-sink semantics after an injected exception; closed-sink no-ops
+  (`record()` without `begin_trial` and after `end_trial` — the
+  version-skew path); `begin_trial` resets state so a skipped trial
+  cannot bleed rows into the previous trial's file; the version-skew
+  stderr note fires exactly once per policy instance (latched);
+  deep-copy (live body unmutated). All of this lives in the **plugin**
+  suite — core CI installs only the root package and cannot import
+  `inspect_robots_agent`.
+- Row-ordering: a non-retryable 4xx, a malformed-JSON 200, an Anthropic
+  terminal-`stop_reason` 200, a responses-wire 200 with
+  `payload["status"] == "failed"` (`_responses.py:181-184`), and a
+  well-formed-but-wrong-shape 200 (parser `KeyError`, `_llm.py:236`) each
+  leave their row in `calls.jsonl` even though `complete()` raises.
+- e2e (`test_policy_e2e.py` pattern, mock transport): run a trial, then
+  assert the captured request for call N — after inlining blobs — is
+  **dict-equal** (compare after `json.loads`; asserting raw bytes would pin
+  httpx's serializer) to the body the mock transport received, including
+  the evicted view, elision stubs, and (anthropic wire) the
+  `cache_control` breakpoint placement produced by
+  `_with_cache_breakpoint`; assert `metadata["wire_capture"]` resolves.
+- Zero-LLM-call trial (policy error before first call): no `wire/` files,
+  no metadata key, `end_trial` returns `None`.
+- `wire_capture=false` → no `wire/` dir, no metadata key.
+
+Core (`tests/`, 100% scope):
+- `on_trial_start` invoked per trial before first `act()` (CubePick mock),
+  no-op default harmless for hook-less policies; a *raising*
+  `on_trial_start` skips that trial's rollout, synthesizes an errored
+  record with all `SceneResult` parallel tuples aligned, counts toward
+  `errored_trials`/`fail_on_error`, does **not** fire
+  `policy.on_trial_end` (never-reset trial; sink bus trial-end still
+  fires), and the eval completes with a log.
+- `_html.py`: wire section renders (blob inlined, stub visible), absent
+  cleanly when metadata key missing or files deleted; hostile
+  `$blob:../../x`-style values rejected (rendered broken, no path
+  escape) — this is a security guard over foreign JSONL and gets its own
+  test; budget-denied blob renders `[blob elided: media budget]`; repeat
+  reference renders an internal link to the first embed's anchor.
+- CLI `--wire` table and single-call dump; missing capture → guided message.
+- No API-snapshot change: the hook is a method on `PolicyBase`, not an
+  `__all__` entry; `tests/test_api_snapshot.py` cannot register it
+  (verified — the snapshot asserts `__all__` membership only).
+
+## Tasks
+
+1. Core: `on_trial_start` hook + eval-loop call + tests.
+2. Plugin: `_capture.py` + unit tests (no wiring yet).
+3. Plugin: wire-client `capture` param + policy wiring + config field +
+   e2e dict-equality tests + docs (format contract).
+4. Core: HTML wire section + `inspect --wire` + tests.
+5. Docs: README (agent plugin) + `docs/` log-format page; CHANGELOG.
+
+Each task is one commit passing all gates (`ruff check`, `ruff format
+--check`, `mypy` strict, `pytest --cov` at 100% in its scope).
+
+## Out of scope
+
+- A replay *executor* (re-sending captured calls); the format contract is
+  the deliverable — replay is `jq` + inlining away.
+- Capture for non-agent policies (gr00t, molmoact2 run no LLM wire; the
+  format is documented so future LLM policies can adopt the sink).
+- Redaction: request bodies carry no credentials (auth lives in headers,
+  which are never captured).
+- Retention/pruning of `wire/` dirs.

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -180,6 +180,17 @@ The speed fraction defaults to `0.1` and applies only to absolute modes.
 `LLMAgentPolicy.transcript()` returns the current conversation as a deep copy with streamed camera frames replaced by omission markers, ready for core eval-log persistence.
 Camera labels such as `camera 'top_cam' (step 480):` provide the join key from a transcript observation to its stored frame.
 Live Rerun transcript streaming happens automatically when a Rerun sink is attached.
+
+Wire capture is on by default (`-P wire_capture=false` to disable): every
+request attempt each wire client posts — tool schemas, evicted view, depth
+composites, cache breakpoints — and every response land in
+`wire/<run_id>/<trial_id>/calls.jsonl` under the log directory, with image
+payloads deduplicated as `$blob:<sha256>` references into
+`wire/<run_id>/blobs/`. The format contract lives in the
+`inspect_robots_agent._capture` module docstring; browse captures with
+`inspect-robots view` (Wire section) or `inspect-robots inspect --wire`.
+Requires a core with the `on_trial_start` policy hook; on older cores the
+policy prints one notice and captures nothing.
 At trial end, `record.metadata["llm_usage"]` records `llm_calls` and the summed
 integer token counters returned by the wire. The native Anthropic wire
 includes input, output, cache-creation, and cache-read tokens; other wires

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
@@ -17,6 +17,8 @@ import httpx
 
 from inspect_robots_agent._llm import AssistantMessage, Provider, ToolCall
 
+from ._capture import WireCapture
+
 _ANTHROPIC_VERSION = "2023-06-01"
 _FAST_MODE_BETA = "fast-mode-2026-02-01"
 
@@ -58,6 +60,7 @@ class AnthropicClient:
         max_retries: int = 3,
         backoff_s: float = 1.0,
         transport: httpx.BaseTransport | None = None,
+        capture: WireCapture | None = None,
     ):
         self._provider = provider
         self._max_output_tokens = max_output_tokens
@@ -73,6 +76,7 @@ class AnthropicClient:
         self._speed = speed
         self._max_retries = max_retries
         self._backoff_s = backoff_s
+        self._capture = capture
         # tool_use id -> the verbatim content array of the response it came in.
         # Keyed on id alone because the API guarantees tool_use ids are unique
         # within a conversation; a gateway that recycles them would replay the
@@ -139,14 +143,37 @@ class AnthropicClient:
         last_error = "unknown error"
         last_status: int | None = None
         for attempt in range(self._max_retries):
+            t_start = time.time() if self._capture is not None else 0.0
             try:
                 response = self._http.post("/messages", json=body)
             except httpx.TransportError as exc:
+                if self._capture is not None:
+                    self._capture.record(
+                        attempt=attempt,
+                        endpoint="/messages",
+                        request=body,
+                        status=None,
+                        response_text=None,
+                        error=str(exc),
+                        t_start=t_start,
+                        duration_s=time.time() - t_start,
+                    )
                 last_error = str(exc)
                 # Reset, or a 429 followed by a connection failure would emit
                 # the fast-mode rate-limit guidance for the wrong cause.
                 last_status = None
             else:
+                if self._capture is not None:
+                    self._capture.record(
+                        attempt=attempt,
+                        endpoint="/messages",
+                        request=body,
+                        status=response.status_code,
+                        response_text=response.text,
+                        error=None,
+                        t_start=t_start,
+                        duration_s=time.time() - t_start,
+                    )
                 last_status = response.status_code
                 if response.status_code == 200:
                     payload = response.json()

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_capture.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_capture.py
@@ -223,6 +223,9 @@ class WireCapture:
             self._blob_dir.mkdir(parents=True, exist_ok=True)
             # Atomic publish: a partial write must never sit under the
             # content hash, or dedup would pin the poisoned bytes run-long.
+            # The deterministic temp name is safe only while trials run
+            # sequentially in one process and run_ids are uuid-suffixed;
+            # parallel trials would need per-writer temp names.
             tmp = self._blob_dir / f".{digest}.tmp"
             tmp.write_bytes(decoded)
             os.replace(tmp, path)

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_capture.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_capture.py
@@ -1,0 +1,228 @@
+"""Replay-grade, per-attempt LLM wire capture.
+
+Capture is stored below the evaluation log directory as
+``wire/<run_id>/<trial_id>/calls.jsonl`` with decoded image bytes deduplicated
+at ``wire/<run_id>/blobs/<sha256>.png``. Each JSONL row contains ``call``,
+``attempt``, ``endpoint``, ``t``, ``duration_s``, ``request``, ``status``, and
+``response``; ``error`` is present only for failed attempts.
+There is one row per attempt. ``call`` is the zero-based logical call shared by
+its retries, and ``t`` is the attempt's caller-supplied start time. A response
+that parses as a JSON object is stored as that object at any HTTP status;
+non-object or invalid JSON is stored as its first 2000 text characters, and a
+missing response is stored as null.
+
+Inline PNG payloads in supported chat, Responses, and Anthropic image parts are
+replaced in a deep copy of the request by ``$blob:<sha256>``. Data-URL prefixes
+and all other part keys remain intact. Readers find references by scanning
+string values for the unanchored pattern ``\\$blob:[0-9a-f]{64}`` and restore
+them by replacing the sentinel with base64 of the corresponding decoded PNG
+blob.
+
+Capture is best-effort and cannot fail an evaluation. The first failure in a
+trial emits one stderr warning, disables that trial's sink, and is never
+re-raised. Trials and files are opened lazily, so closed or zero-record trials
+produce no rows or metadata pointer.
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import json
+import re
+import sys
+import zlib
+from pathlib import Path
+from typing import Any, TextIO
+
+_SAFE_RE = re.compile(r"[^A-Za-z0-9._-]+")
+_PNG_DATA_URL_PREFIX = "data:image/png;base64,"
+_FAILURE_PREFIX = "[agent] wire capture disabled for this trial: "
+_VERSION_SKEW_NOTE = "[agent] wire capture inactive: core predates on_trial_start"
+
+
+def _safe(name: str) -> str:
+    safe = _SAFE_RE.sub("-", name)
+    if safe != name:
+        safe = f"{safe}-{zlib.crc32(name.encode()) & 0xFFFFFFFF:08x}"
+    return safe
+
+
+class WireCapture:
+    """Persist exact LLM request attempts without affecting policy execution."""
+
+    def __init__(self) -> None:
+        """Create a closed sink with no trial history."""
+        self._began = False
+        self._warned_version_skew = False
+        self._target_dir: Path | None = None
+        self._blob_dir: Path | None = None
+        self._relative_path: str | None = None
+        self._handle: TextIO | None = None
+        self._rows_written = False
+        self._call = -1
+        self._dead = True
+        self._warned_failure = False
+
+    @property
+    def began(self) -> bool:
+        """Return whether ``begin_trial`` has ever run on this instance."""
+        return self._began
+
+    def begin_trial(self, log_dir: str, run_id: str, trial_id: str) -> None:
+        """Open a logical trial while deferring all filesystem creation."""
+        try:
+            previous_handle = self._handle
+            # Clear every destination before closing the prior trial so even a
+            # failing close cannot send later rows to its file.
+            self._target_dir = None
+            self._blob_dir = None
+            self._relative_path = None
+            self._handle = None
+            self._rows_written = False
+            self._call = -1
+            self._dead = False
+            self._warned_failure = False
+            self._began = True
+
+            if previous_handle is not None:
+                previous_handle.close()
+
+            safe_trial_id = _safe(trial_id)
+            run_dir = Path(log_dir) / "wire" / run_id
+            self._target_dir = run_dir / safe_trial_id
+            self._blob_dir = run_dir / "blobs"
+            self._relative_path = (Path("wire") / run_id / safe_trial_id / "calls.jsonl").as_posix()
+        except BaseException as exc:
+            self._disable(exc)
+
+    def record(
+        self,
+        *,
+        attempt: int,
+        endpoint: str,
+        request: dict[str, Any],
+        status: int | None,
+        response_text: str | None,
+        error: str | None,
+        t_start: float,
+        duration_s: float,
+    ) -> None:
+        """Append and flush one provider attempt when a trial is open."""
+        try:
+            if self._dead or self._target_dir is None or self._blob_dir is None:
+                return
+
+            if attempt == 0:
+                self._call += 1
+            captured_request = copy.deepcopy(request)
+            self._replace_blobs(captured_request)
+
+            row: dict[str, Any] = {
+                "call": self._call,
+                "attempt": attempt,
+                "endpoint": endpoint,
+                "t": t_start,
+                "duration_s": duration_s,
+                "request": captured_request,
+                "status": status,
+                "response": self._response_value(response_text),
+            }
+            if error is not None:
+                row["error"] = error
+            line = json.dumps(row, separators=(",", ":")) + "\n"
+
+            if self._handle is None:
+                self._target_dir.mkdir(parents=True, exist_ok=True)
+                self._handle = (self._target_dir / "calls.jsonl").open("a", encoding="utf-8")
+            self._handle.write(line)
+            self._handle.flush()
+            self._rows_written = True
+        except BaseException as exc:
+            self._disable(exc)
+
+    def end_trial(self) -> str | None:
+        """Close the trial and return its relative JSONL pointer when nonempty."""
+        pointer = self._relative_path if self._rows_written else None
+        try:
+            handle = self._handle
+            self._handle = None
+            self._dead = True
+            if handle is not None:
+                handle.close()
+            return pointer
+        except BaseException as exc:
+            self._disable(exc)
+            return pointer
+
+    def warn_if_never_began(self) -> None:
+        """Warn once when an older core never invoked the policy start hook."""
+        if self._began or self._warned_version_skew:
+            return
+        self._warned_version_skew = True
+        try:
+            print(_VERSION_SKEW_NOTE, file=sys.stderr)
+        except BaseException:
+            # Diagnostics are subordinate to the never-fail capture contract.
+            return
+
+    def _disable(self, exc: BaseException) -> None:
+        self._dead = True
+        if self._warned_failure:
+            return
+        self._warned_failure = True
+        try:
+            print(f"{_FAILURE_PREFIX}{exc}", file=sys.stderr)
+        except BaseException:
+            return
+
+    def _replace_blobs(self, value: Any) -> None:
+        if isinstance(value, dict):
+            part_type = value.get("type")
+            if part_type == "image_url":
+                image_url = value.get("image_url")
+                if isinstance(image_url, dict):
+                    url = image_url.get("url")
+                    if isinstance(url, str) and url.startswith(_PNG_DATA_URL_PREFIX):
+                        image_url["url"] = self._replace_data_url(url)
+            elif part_type == "input_image":
+                url = value.get("image_url")
+                if isinstance(url, str) and url.startswith(_PNG_DATA_URL_PREFIX):
+                    value["image_url"] = self._replace_data_url(url)
+            elif part_type == "image":
+                source = value.get("source")
+                if isinstance(source, dict) and source.get("type") == "base64":
+                    payload = source.get("data")
+                    if isinstance(payload, str):
+                        source["data"] = self._store_blob(payload)
+            for child in value.values():
+                self._replace_blobs(child)
+        elif isinstance(value, list):
+            for child in value:
+                self._replace_blobs(child)
+
+    def _replace_data_url(self, value: str) -> str:
+        payload = value[len(_PNG_DATA_URL_PREFIX) :]
+        return _PNG_DATA_URL_PREFIX + self._store_blob(payload)
+
+    def _store_blob(self, payload: str) -> str:
+        # record() rejects closed trials before blob extraction can reach here.
+        assert self._blob_dir is not None
+        decoded = base64.b64decode(payload)
+        digest = hashlib.sha256(decoded).hexdigest()
+        path = self._blob_dir / f"{digest}.png"
+        if not path.exists():
+            self._blob_dir.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(decoded)
+        return f"$blob:{digest}"
+
+    @staticmethod
+    def _response_value(response_text: str | None) -> Any:
+        if response_text is None:
+            return None
+        try:
+            parsed = json.loads(response_text)
+        except (json.JSONDecodeError, RecursionError):
+            return response_text[:2000]
+        return parsed if isinstance(parsed, dict) else response_text[:2000]

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_capture.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_capture.py
@@ -30,6 +30,7 @@ import base64
 import copy
 import hashlib
 import json
+import os
 import re
 import sys
 import zlib
@@ -96,6 +97,8 @@ class WireCapture:
             self._relative_path = (Path("wire") / run_id / safe_trial_id / "calls.jsonl").as_posix()
         except BaseException as exc:
             self._disable(exc)
+            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                raise
 
     def record(
         self,
@@ -141,6 +144,8 @@ class WireCapture:
             self._rows_written = True
         except BaseException as exc:
             self._disable(exc)
+            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                raise
 
     def end_trial(self) -> str | None:
         """Close the trial and return its relative JSONL pointer when nonempty."""
@@ -154,6 +159,8 @@ class WireCapture:
             return pointer
         except BaseException as exc:
             self._disable(exc)
+            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                raise
             return pointer
 
     def warn_if_never_began(self) -> None:
@@ -214,7 +221,11 @@ class WireCapture:
         path = self._blob_dir / f"{digest}.png"
         if not path.exists():
             self._blob_dir.mkdir(parents=True, exist_ok=True)
-            path.write_bytes(decoded)
+            # Atomic publish: a partial write must never sit under the
+            # content hash, or dedup would pin the poisoned bytes run-long.
+            tmp = self._blob_dir / f".{digest}.tmp"
+            tmp.write_bytes(decoded)
+            os.replace(tmp, path)
         return f"$blob:{digest}"
 
     @staticmethod

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
@@ -17,6 +17,8 @@ import httpx
 
 from inspect_robots.errors import ConfigError
 
+from ._capture import WireCapture
+
 ENV_MODEL = "INSPECT_ROBOTS_MODEL"
 
 _OPENROUTER_BASE = "https://openrouter.ai/api/v1"
@@ -176,10 +178,12 @@ class ChatClient:
         max_retries: int = 3,
         backoff_s: float = 1.0,
         transport: httpx.BaseTransport | None = None,
+        capture: WireCapture | None = None,
     ):
         self._provider = provider
         self._max_retries = max_retries
         self._backoff_s = backoff_s
+        self._capture = capture
         headers = {}
         if provider.api_key:
             headers["Authorization"] = f"Bearer {provider.api_key}"
@@ -207,11 +211,34 @@ class ChatClient:
 
         last_error = "unknown error"
         for attempt in range(self._max_retries):
+            t_start = time.time() if self._capture is not None else 0.0
             try:
                 response = self._http.post("/chat/completions", json=body)
             except httpx.TransportError as exc:
+                if self._capture is not None:
+                    self._capture.record(
+                        attempt=attempt,
+                        endpoint="/chat/completions",
+                        request=body,
+                        status=None,
+                        response_text=None,
+                        error=str(exc),
+                        t_start=t_start,
+                        duration_s=time.time() - t_start,
+                    )
                 last_error = str(exc)
             else:
+                if self._capture is not None:
+                    self._capture.record(
+                        attempt=attempt,
+                        endpoint="/chat/completions",
+                        request=body,
+                        status=response.status_code,
+                        response_text=response.text,
+                        error=None,
+                        t_start=t_start,
+                        duration_s=time.time() - t_start,
+                    )
                 if response.status_code == 200:
                     return _parse_message(response.json())
                 last_error = f"HTTP {response.status_code}: {response.text[:500]}"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_responses.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_responses.py
@@ -9,6 +9,8 @@ import httpx
 
 from inspect_robots_agent._llm import AssistantMessage, Provider, ToolCall
 
+from ._capture import WireCapture
+
 
 class ResponsesClient:
     """Blocking Responses client with raw reasoning-item replay and bounded retries.
@@ -26,10 +28,12 @@ class ResponsesClient:
         max_retries: int = 3,
         backoff_s: float = 1.0,
         transport: httpx.BaseTransport | None = None,
+        capture: WireCapture | None = None,
     ):
         self._provider = provider
         self._max_retries = max_retries
         self._backoff_s = backoff_s
+        self._capture = capture
         self._raw_items_by_call_id: dict[str, list[dict[str, Any]]] = {}
         headers = {}
         if provider.api_key:
@@ -69,11 +73,34 @@ class ResponsesClient:
 
         last_error = "unknown error"
         for attempt in range(self._max_retries):
+            t_start = time.time() if self._capture is not None else 0.0
             try:
                 response = self._http.post("/responses", json=body)
             except httpx.TransportError as exc:
+                if self._capture is not None:
+                    self._capture.record(
+                        attempt=attempt,
+                        endpoint="/responses",
+                        request=body,
+                        status=None,
+                        response_text=None,
+                        error=str(exc),
+                        t_start=t_start,
+                        duration_s=time.time() - t_start,
+                    )
                 last_error = str(exc)
             else:
+                if self._capture is not None:
+                    self._capture.record(
+                        attempt=attempt,
+                        endpoint="/responses",
+                        request=body,
+                        status=response.status_code,
+                        response_text=response.text,
+                        error=None,
+                        t_start=t_start,
+                        duration_s=time.time() - t_start,
+                    )
                 if response.status_code == 200:
                     message, output = _parse_response(response.json())
                     for item in output:

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -49,6 +49,8 @@ from inspect_robots_agent._png import png_data_url
 from inspect_robots_agent._responses import ResponsesClient
 from inspect_robots_agent._tools import Toolset, build_toolset
 
+from ._capture import WireCapture
+
 _MAX_CONSECUTIVE_FAILURES = 3
 
 #: The only endpoint that serves /v1/messages without an explicit base_url.
@@ -184,6 +186,7 @@ class AgentPolicyConfig(PolicyConfig):
     base_url: str | None = None
     api_key_env: str | None = None
     wire: str = "chat"
+    wire_capture: bool = True
     speed: str | None = None
     #: Effective per-response cap on ``wire=anthropic``; ``None`` on the other
     #: wires, where nothing constrained the output.
@@ -230,6 +233,7 @@ class LLMAgentPolicy(PolicyBase):
         base_url: str | None = None,
         api_key_env: str | None = None,
         wire: str = "chat",
+        wire_capture: bool = True,
         speed: str | None = None,
         max_output_tokens: int | None = None,
         max_llm_calls: int = 100,
@@ -414,6 +418,7 @@ class LLMAgentPolicy(PolicyBase):
             if wire == "anthropic"
             else None
         )
+        self._capture = WireCapture() if wire_capture else None
         self._client: ChatClient | ResponsesClient | AnthropicClient
         if wire == "anthropic":
             assert resolved_max_output_tokens is not None
@@ -422,11 +427,12 @@ class LLMAgentPolicy(PolicyBase):
                 max_output_tokens=resolved_max_output_tokens,
                 speed=speed,
                 transport=transport,
+                capture=self._capture,
             )
         elif wire == "responses":
-            self._client = ResponsesClient(provider, transport=transport)
+            self._client = ResponsesClient(provider, transport=transport, capture=self._capture)
         else:
-            self._client = ChatClient(provider, transport=transport)
+            self._client = ChatClient(provider, transport=transport, capture=self._capture)
         self._max_llm_calls = max_llm_calls
         self._temperature = temperature
         # Robot control is latency-sensitive: default to low reasoning effort
@@ -445,6 +451,7 @@ class LLMAgentPolicy(PolicyBase):
             base_url=provider.base_url,
             api_key_env=api_key_env,
             wire=wire,
+            wire_capture=wire_capture,
             speed=speed,
             max_output_tokens=resolved_max_output_tokens,
             max_llm_calls=max_llm_calls,
@@ -520,8 +527,19 @@ class LLMAgentPolicy(PolicyBase):
         self._pending = None
         self._revealed.clear()
 
+    def on_trial_start(self, scene_id: str, epoch: int, log_dir: str, run_id: str) -> None:
+        """Begin streaming wire attempts for the next trial when enabled."""
+        if self._capture is not None:
+            self._capture.begin_trial(log_dir, run_id, f"{scene_id}-e{epoch}")
+
     def on_trial_end(self, record: TrialRecord, log_dir: str, run_id: str) -> None:
-        """Persist the transcript at the end of the trial."""
+        """Persist wire capture and the transcript at the end of the trial."""
+        if self._capture is not None:
+            capture_path = self._capture.end_trial()
+            if capture_path is not None:
+                record.metadata["wire_capture"] = capture_path
+            self._capture.warn_if_never_began()
+
         messages = self.transcript()
         if not messages:
             return

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -18,7 +19,10 @@ from inspect_robots_agent._anthropic import (
     _DEFAULT_MAX_OUTPUT_TOKENS,
     AnthropicClient,
     _parse_response,
+    _translate_messages,
+    _with_cache_breakpoint,
 )
+from inspect_robots_agent._capture import WireCapture
 from inspect_robots_agent._llm import Provider
 from inspect_robots_agent._png import png_data_url
 
@@ -86,6 +90,11 @@ def _capture(*responses: dict[str, Any], status: int = 200) -> tuple[list[httpx.
         return httpx.Response(status, json=payload)
 
     return seen, handler
+
+
+def _wire_rows(tmp_path: Path) -> list[dict[str, Any]]:
+    path = tmp_path / "wire/run-1/scene-e0/calls.jsonl"
+    return [json.loads(line) for line in path.read_text().splitlines()]
 
 
 _SYSTEM = {"role": "system", "content": "you drive a robot"}
@@ -203,6 +212,36 @@ def test_final_string_content_wraps_into_cached_text_block() -> None:
             "cache_control": {"type": "ephemeral"},
         }
     ]
+
+
+def test_cache_breakpoint_defensive_shapes_and_foreign_role_anchors() -> None:
+    non_content = {"role": "user", "content": None}
+    thinking_only = {
+        "role": "assistant",
+        "content": [{"type": "thinking", "thinking": "private"}],
+    }
+
+    assert _with_cache_breakpoint(non_content) is non_content
+    assert _with_cache_breakpoint(thinking_only) is thinking_only
+
+    _, translated = _translate_messages(
+        [
+            {
+                "role": "tool",
+                "tool_call_id": "toolu_1",
+                "content": "ok",
+                "cache_anchor": True,
+            },
+            {
+                "role": "assistant",
+                "content": "continued",
+                "cache_anchor": True,
+            },
+        ],
+        {},
+    )
+    assert translated[0]["content"][-1]["cache_control"] == {"type": "ephemeral"}
+    assert translated[1]["content"][-1]["cache_control"] == {"type": "ephemeral"}
 
 
 def test_replayed_final_assistant_breakpoint_is_copy_on_write_and_stable() -> None:
@@ -571,6 +610,40 @@ def test_terminal_responses_do_not_populate_the_cache(stop_reason: str) -> None:
         client.complete([_USER], [])
 
     assert client._raw_blocks_by_tool_use_id == {}
+
+
+def test_capture_precedes_terminal_stop_reason_raise(tmp_path: Path) -> None:
+    payload = _anthropic_response(_text("partial"), stop_reason="refusal")
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    client = _client(
+        lambda request: httpx.Response(200, json=payload),
+        capture=capture,
+    )
+
+    with pytest.raises(RuntimeError, match="refused"):
+        client.complete([_USER], [])
+
+    (row,) = _wire_rows(tmp_path)
+    assert row["status"] == 200
+    assert row["response"] == payload
+
+
+def test_capture_records_anthropic_transport_error(tmp_path: Path) -> None:
+    def offline(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("anthropic offline", request=request)
+
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    client = _client(offline, max_retries=1, capture=capture)
+
+    with pytest.raises(RuntimeError, match="anthropic offline"):
+        client.complete([_USER], [])
+
+    (row,) = _wire_rows(tmp_path)
+    assert row["status"] is None
+    assert row["response"] is None
+    assert row["error"] == "anthropic offline"
 
 
 # -- parsing ---------------------------------------------------------------------

--- a/plugins/inspect-robots-agent/tests/test_capture.py
+++ b/plugins/inspect-robots-agent/tests/test_capture.py
@@ -439,3 +439,26 @@ def test_blob_write_is_atomic_and_partial_writes_leave_no_blob(
     (blob,) = (tmp_path / "wire/run-1/blobs").glob("*.png")
     assert not list((tmp_path / "wire/run-1/blobs").glob(".*.tmp"))
     assert hashlib.sha256(blob.read_bytes()).hexdigest() == blob.stem
+
+
+class _InterruptingHandle:
+    """Stand-in file handle whose close simulates a mid-close Ctrl-C."""
+
+    def close(self) -> None:
+        raise KeyboardInterrupt
+
+
+def test_keyboard_interrupt_in_begin_and_end_trial_propagates(tmp_path: Path) -> None:
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    _record(capture)
+    capture._handle = cast(TextIO, _InterruptingHandle())
+    with pytest.raises(KeyboardInterrupt):
+        capture.begin_trial(str(tmp_path), "run-1", "scene-e1")
+
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-2", "scene-e0")
+    _record(capture)
+    capture._handle = cast(TextIO, _InterruptingHandle())
+    with pytest.raises(KeyboardInterrupt):
+        capture.end_trial()

--- a/plugins/inspect-robots-agent/tests/test_capture.py
+++ b/plugins/inspect-robots-agent/tests/test_capture.py
@@ -1,0 +1,368 @@
+"""Replay-grade wire capture sink."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+import zlib
+from pathlib import Path
+from typing import Any, TextIO, cast
+
+import pytest
+
+import inspect_robots_agent._capture as capture_module
+from inspect_robots_agent._capture import WireCapture
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\ncapture-test"
+_PAYLOAD = base64.b64encode(_PNG_BYTES).decode("ascii")
+_DATA_URL = f"data:image/png;base64,{_PAYLOAD}"
+
+
+def _record(
+    capture: WireCapture,
+    *,
+    attempt: int = 0,
+    request: dict[str, Any] | None = None,
+    status: int | None = 200,
+    response_text: str | None = '{"ok":true}',
+    error: str | None = None,
+) -> None:
+    capture.record(
+        attempt=attempt,
+        endpoint="/chat/completions",
+        request={} if request is None else request,
+        status=status,
+        response_text=response_text,
+        error=error,
+        t_start=123.5,
+        duration_s=0.25,
+    )
+
+
+def _rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text().splitlines():
+        row = json.loads(line)
+        assert isinstance(row, dict)
+        rows.append(cast(dict[str, Any], row))
+    return rows
+
+
+def test_extracts_all_wire_image_shapes_without_mutating_request(tmp_path: Path) -> None:
+    request: dict[str, Any] = {
+        "messages": [
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": _DATA_URL,
+                    "cache_control": {"scope": "inside"},
+                    "detail": "high",
+                },
+                "cache_control": {"type": "ephemeral"},
+                "vendor": "chat",
+            },
+            {
+                "type": "input_image",
+                "image_url": _DATA_URL,
+                "detail": "auto",
+            },
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": _PAYLOAD,
+                    "vendor": "anthropic-source",
+                },
+                "cache_control": {"type": "ephemeral"},
+                "vendor": "anthropic",
+            },
+        ]
+    }
+    original = json.loads(json.dumps(request))
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+
+    _record(capture, request=request)
+
+    digest = hashlib.sha256(_PNG_BYTES).hexdigest()
+    sentinel = f"$blob:{digest}"
+    row = _rows(tmp_path / "wire/run-1/scene-e0/calls.jsonl")[0]
+    parts = row["request"]["messages"]
+    assert parts[0] == {
+        "type": "image_url",
+        "image_url": {
+            "url": f"data:image/png;base64,{sentinel}",
+            "cache_control": {"scope": "inside"},
+            "detail": "high",
+        },
+        "cache_control": {"type": "ephemeral"},
+        "vendor": "chat",
+    }
+    assert parts[1] == {
+        "type": "input_image",
+        "image_url": f"data:image/png;base64,{sentinel}",
+        "detail": "auto",
+    }
+    assert parts[2] == {
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": "image/png",
+            "data": sentinel,
+            "vendor": "anthropic-source",
+        },
+        "cache_control": {"type": "ephemeral"},
+        "vendor": "anthropic",
+    }
+    assert request == original
+    assert re.fullmatch(r"\$blob:[0-9a-f]{64}", sentinel)
+    assert (tmp_path / f"wire/run-1/blobs/{digest}.png").read_bytes() == _PNG_BYTES
+
+
+def test_blob_deduplication_spans_records_and_trials(tmp_path: Path) -> None:
+    capture = WireCapture()
+    request: dict[str, Any] = {"part": {"type": "input_image", "image_url": _DATA_URL}}
+    capture.begin_trial(str(tmp_path), "run-1", "first-e0")
+    _record(capture, request=request)
+    _record(capture, request=request)
+    capture.end_trial()
+    capture.begin_trial(str(tmp_path), "run-1", "second-e0")
+    _record(capture, request=request)
+    capture.end_trial()
+
+    assert len(list((tmp_path / "wire/run-1/blobs").glob("*.png"))) == 1
+    assert len(_rows(tmp_path / "wire/run-1/first-e0/calls.jsonl")) == 2
+    assert len(_rows(tmp_path / "wire/run-1/second-e0/calls.jsonl")) == 1
+
+
+def test_row_schema_and_response_normalization(tmp_path: Path) -> None:
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    _record(capture, status=503, response_text='{"message":"busy"}')
+    _record(
+        capture,
+        status=None,
+        response_text=None,
+        error="connection reset",
+    )
+    long_text = "not-json-" + "x" * 2100
+    _record(capture, response_text=long_text)
+    array_text = json.dumps(["y" * 2100])
+    _record(capture, response_text=array_text)
+    _record(capture, response_text=None)
+    path = tmp_path / "wire/run-1/scene-e0/calls.jsonl"
+    rows = _rows(path)
+
+    assert set(rows[0]) == {
+        "call",
+        "attempt",
+        "endpoint",
+        "t",
+        "duration_s",
+        "request",
+        "status",
+        "response",
+    }
+    assert rows[0] == {
+        "call": 0,
+        "attempt": 0,
+        "endpoint": "/chat/completions",
+        "t": 123.5,
+        "duration_s": 0.25,
+        "request": {},
+        "status": 503,
+        "response": {"message": "busy"},
+    }
+    assert rows[1]["status"] is None
+    assert rows[1]["response"] is None
+    assert rows[1]["error"] == "connection reset"
+    assert rows[2]["response"] == long_text[:2000]
+    assert rows[3]["response"] == array_text[:2000]
+    assert rows[4]["response"] is None
+
+
+def test_call_counter_retries_and_trial_reset(tmp_path: Path) -> None:
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "first-e0")
+    for attempt in (0, 1, 0, 2, 0):
+        _record(capture, attempt=attempt)
+    assert [row["call"] for row in _rows(tmp_path / "wire/run-1/first-e0/calls.jsonl")] == [
+        0,
+        0,
+        1,
+        1,
+        2,
+    ]
+
+    # Beginning a new trial also closes a still-open prior handle.
+    capture.begin_trial(str(tmp_path), "run-1", "second-e0")
+    _record(capture)
+    pointer = capture.end_trial()
+    assert pointer == "wire/run-1/second-e0/calls.jsonl"
+    assert pointer is not None
+    assert [row["call"] for row in _rows(tmp_path / pointer)] == [0]
+    assert len(_rows(tmp_path / "wire/run-1/first-e0/calls.jsonl")) == 5
+
+
+def test_lazy_creation_and_closed_sink_noops(tmp_path: Path) -> None:
+    capture = WireCapture()
+    _record(capture)
+    assert not capture.began
+    assert not (tmp_path / "wire").exists()
+
+    capture.begin_trial(str(tmp_path), "run-1", "empty-e0")
+    assert capture.began
+    assert capture.end_trial() is None
+    assert not (tmp_path / "wire").exists()
+
+    _record(capture)
+    assert not (tmp_path / "wire").exists()
+
+
+def test_trial_id_is_sanitized_in_path_and_pointer(tmp_path: Path) -> None:
+    trial_id = "a/b-e0"
+    safe_id = f"a-b-e0-{zlib.crc32(trial_id.encode()) & 0xFFFFFFFF:08x}"
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", trial_id)
+    _record(capture)
+
+    pointer = capture.end_trial()
+
+    assert pointer == f"wire/run-1/{safe_id}/calls.jsonl"
+    assert pointer is not None
+    assert (tmp_path / pointer).is_file()
+    assert not (tmp_path / "wire/run-1/a/b-e0").exists()
+
+
+def test_each_record_is_visible_before_end_trial(tmp_path: Path) -> None:
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    path = tmp_path / "wire/run-1/scene-e0/calls.jsonl"
+
+    _record(capture)
+    assert len(_rows(path)) == 1
+    _record(capture)
+    assert len(_rows(path)) == 2
+    capture.end_trial()
+    _record(capture)
+    assert len(_rows(path)) == 2
+    assert capture.began
+
+
+def test_record_failure_disables_trial_and_warns_once(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+
+    _record(capture, request={"unserializable": object()})
+    _record(capture)
+
+    assert capture.end_trial() is None
+    assert capsys.readouterr().err == (
+        "[agent] wire capture disabled for this trial: "
+        "Object of type object is not JSON serializable\n"
+    )
+    assert capsys.readouterr().err == ""
+    assert not (tmp_path / "wire").exists()
+
+
+def test_second_failure_in_dead_trial_stays_silent(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    _record(capture)
+    handle: TextIO = capture.__dict__["_handle"]
+
+    class _BrokenWriteAndClose:
+        def write(self, value: str) -> int:
+            raise OSError("write failed")
+
+        def close(self) -> None:
+            handle.close()
+            raise OSError("close failed")
+
+    capture.__dict__["_handle"] = _BrokenWriteAndClose()
+    _record(capture)
+    _record(capture)
+
+    assert capture.end_trial() == "wire/run-1/scene-e0/calls.jsonl"
+    assert capsys.readouterr().err == (
+        "[agent] wire capture disabled for this trial: write failed\n"
+    )
+
+
+def test_failing_stderr_diagnostics_never_escape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def bad_print(*args: object, **kwargs: object) -> None:
+        raise OSError("stderr unavailable")
+
+    monkeypatch.setattr(capture_module, "print", bad_print, raising=False)
+
+    never_begun = WireCapture()
+    never_begun.warn_if_never_began()
+    never_begun.warn_if_never_began()
+
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    _record(capture, request={"unserializable": object()})
+    _record(capture)
+    assert capture.end_trial() is None
+
+
+def test_begin_and_end_failures_never_escape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    begin_capture = WireCapture()
+
+    def bad_safe(name: str) -> str:
+        raise OSError(f"cannot sanitize {name}")
+
+    monkeypatch.setattr(capture_module, "_safe", bad_safe)
+    begin_capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    _record(begin_capture)
+    assert begin_capture.began
+    assert begin_capture.end_trial() is None
+    assert capsys.readouterr().err == (
+        "[agent] wire capture disabled for this trial: cannot sanitize scene-e0\n"
+    )
+
+    monkeypatch.undo()
+    end_capture = WireCapture()
+    end_capture.begin_trial(str(tmp_path), "run-1", "other-e0")
+    _record(end_capture)
+    handle: TextIO = end_capture.__dict__["_handle"]
+
+    class _BrokenClose:
+        def close(self) -> None:
+            handle.close()
+            raise OSError("close failed")
+
+    end_capture.__dict__["_handle"] = _BrokenClose()
+    assert end_capture.end_trial() == "wire/run-1/other-e0/calls.jsonl"
+    assert capsys.readouterr().err == (
+        "[agent] wire capture disabled for this trial: close failed\n"
+    )
+
+
+def test_version_skew_warning_is_once_per_never_begun_instance(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    capture = WireCapture()
+    capture.warn_if_never_began()
+    capture.warn_if_never_began()
+    assert capsys.readouterr().err == (
+        "[agent] wire capture inactive: core predates on_trial_start\n"
+    )
+
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    capture.end_trial()
+    capture.warn_if_never_began()
+    assert capsys.readouterr().err == ""

--- a/plugins/inspect-robots-agent/tests/test_capture.py
+++ b/plugins/inspect-robots-agent/tests/test_capture.py
@@ -366,3 +366,76 @@ def test_version_skew_warning_is_once_per_never_begun_instance(
     capture.end_trial()
     capture.warn_if_never_began()
     assert capsys.readouterr().err == ""
+
+
+def test_keyboard_interrupt_in_record_propagates_after_disabling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    monkeypatch.setattr(
+        "inspect_robots_agent._capture.copy.deepcopy",
+        lambda value: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+    with pytest.raises(KeyboardInterrupt):
+        _record(capture)
+    monkeypatch.undo()
+    _record(capture)
+    assert capture.end_trial() is None
+    assert "wire capture disabled" in capsys.readouterr().err
+
+
+def test_blob_write_is_atomic_and_partial_writes_leave_no_blob(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+
+    def _partial_write(self: Path, data: bytes) -> int:
+        self.write_text("partial")
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "write_bytes", _partial_write)
+    _record(
+        capture,
+        request={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:image/png;base64,{_PAYLOAD}"},
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    assert "wire capture disabled" in capsys.readouterr().err
+    monkeypatch.undo()
+
+    blob_dir = tmp_path / "wire/run-1/blobs"
+    published = list(blob_dir.glob("*.png")) if blob_dir.exists() else []
+    assert published == []
+
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e1")
+    _record(
+        capture,
+        request={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:image/png;base64,{_PAYLOAD}"},
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    (blob,) = (tmp_path / "wire/run-1/blobs").glob("*.png")
+    assert not list((tmp_path / "wire/run-1/blobs").glob(".*.tmp"))
+    assert hashlib.sha256(blob.read_bytes()).hexdigest() == blob.stem

--- a/plugins/inspect-robots-agent/tests/test_llm.py
+++ b/plugins/inspect-robots-agent/tests/test_llm.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import httpx
 import pytest
 
+import inspect_robots_agent._llm as llm_module
 from inspect_robots.errors import ConfigError
+from inspect_robots_agent._capture import WireCapture
 from inspect_robots_agent._llm import ChatClient, resolve_provider
 
 # --- provider resolution ladder ----------------------------------------------
@@ -229,6 +232,11 @@ def _client(handler: Any, **kwargs: Any) -> ChatClient:
     return ChatClient(provider, transport=httpx.MockTransport(handler), **kwargs)
 
 
+def _wire_rows(tmp_path: Path) -> list[dict[str, Any]]:
+    path = tmp_path / "wire/run-1/scene-e0/calls.jsonl"
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
 def test_complete_sends_wire_format_and_parses_tool_calls() -> None:
     seen: list[httpx.Request] = []
 
@@ -315,6 +323,94 @@ def test_client_error_does_not_retry() -> None:
     with pytest.raises(RuntimeError, match="bad tool schema"):
         client.complete(messages=[], tools=[])
     assert calls["n"] == 1  # 4xx is our bug, not weather; retrying can't help
+
+
+def test_capture_precedes_nonretryable_4xx_raise(tmp_path: Path) -> None:
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    client = _client(
+        lambda request: httpx.Response(400, json={"error": {"message": "bad input"}}),
+        capture=capture,
+    )
+
+    with pytest.raises(RuntimeError, match="bad input"):
+        client.complete(messages=[], tools=[])
+
+    (row,) = _wire_rows(tmp_path)
+    assert row["status"] == 400
+    assert row["response"] == {"error": {"message": "bad input"}}
+
+
+def test_capture_precedes_malformed_json_200_raise(tmp_path: Path) -> None:
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    client = _client(
+        lambda request: httpx.Response(200, text="{not-json"),
+        capture=capture,
+    )
+
+    with pytest.raises(json.JSONDecodeError):
+        client.complete(messages=[], tools=[])
+
+    (row,) = _wire_rows(tmp_path)
+    assert row["status"] == 200
+    assert row["response"] == "{not-json"
+
+
+def test_capture_precedes_wrong_shape_200_key_error(tmp_path: Path) -> None:
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    client = _client(
+        lambda request: httpx.Response(200, json={"choices": [{}]}),
+        capture=capture,
+    )
+
+    with pytest.raises(KeyError, match="message"):
+        client.complete(messages=[], tools=[])
+
+    (row,) = _wire_rows(tmp_path)
+    assert row["status"] == 200
+    assert row["response"] == {"choices": [{}]}
+
+
+def test_capture_retries_share_call_index_and_record_transport_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise httpx.ConnectError("offline", request=request)
+        return httpx.Response(200, json=_tool_call_response())
+
+    class _Clock:
+        def __init__(self) -> None:
+            self._times = iter([10.0, 10.25, 20.0, 20.5])
+
+        def time(self) -> float:
+            return next(self._times)
+
+        def sleep(self, seconds: float) -> None:
+            return None
+
+    monkeypatch.setattr(llm_module, "time", _Clock())
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    client = _client(handler, backoff_s=0.0, capture=capture)
+
+    client.complete(messages=[], tools=[])
+
+    rows = _wire_rows(tmp_path)
+    assert [(row["call"], row["attempt"]) for row in rows] == [(0, 0), (0, 1)]
+    assert [row["t"] for row in rows] == [10.0, 20.0]
+    assert [row["duration_s"] for row in rows] == [0.25, 0.5]
+    assert rows[0]["status"] is None
+    assert rows[0]["response"] is None
+    assert rows[0]["error"] == "offline"
+    assert rows[1]["status"] == 200
+    assert "error" not in rows[1]
 
 
 def test_reasoning_tools_rejection_has_responses_wire_guidance() -> None:

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -7,9 +7,11 @@ guardrails, policy-stop, budgets, error taxonomy) runs for real.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import io
 import json
+import re
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -19,6 +21,7 @@ import httpx
 import numpy as np
 import pytest
 
+import inspect_robots_agent.policy as agent_policy_module
 from inspect_robots import eval as ir_eval
 from inspect_robots.approver import ChainApprover, ClampApprover, DeltaLimitApprover
 from inspect_robots.controller import DefaultController
@@ -38,15 +41,18 @@ from inspect_robots.spaces import (
     StateSpec,
 )
 from inspect_robots.task import Task
-from inspect_robots.types import Action, Observation, StepResult
+from inspect_robots.types import Action, ActionChunk, Observation, StepResult
 from inspect_robots_agent import LLMAgentPolicy
 from inspect_robots_agent._llm import ChatClient, resolve_provider
 from inspect_robots_agent._png import encode_png
+from inspect_robots_agent._tools import ToolResult
 from inspect_robots_agent.policy import (
     _PRIOR_LEARNINGS_TEXT_LIMIT,
     _SYSTEM_TEMPLATE,
     AgentPolicyConfig,
+    _image_parts,
     _observation_content,
+    _PendingCapture,
 )
 
 # --- scripted-conversation harness ---------------------------------------------
@@ -63,6 +69,7 @@ _PRIOR_LEARNINGS_FRAME = (
     "\n\nNotes from a previous attempt at tasks like this one. They may "
     "be wrong or stale; the current observation always wins:\n"
 )
+_BLOB_RE = re.compile(r"\$blob:([0-9a-f]{64})")
 
 
 def _with_default_note(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -157,6 +164,77 @@ class _Script:
         self.requests.append(json.loads(request.content))
         payload = self.queue.pop(0) if len(self.queue) > 1 else self.queue[0]
         return httpx.Response(200, json=payload)
+
+
+class _WireScript:
+    """Serve equivalent move/done turns on each supported provider wire."""
+
+    def __init__(self, wire: str):
+        self.wire = wire
+        self.requests: list[dict[str, Any]] = []
+        self.turns = [
+            (
+                "move_joints",
+                _with_default_note("move_joints", {"targets": {"joint": 0.1}}),
+            ),
+            ("done", {"summary": "captured"}),
+        ]
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(json.loads(request.content))
+        index = min(len(self.requests) - 1, len(self.turns) - 1)
+        name, arguments = self.turns[index]
+        if self.wire == "chat":
+            payload = _tool_response(name, arguments, add_default_note=False)
+        elif self.wire == "responses":
+            payload = {
+                "id": f"resp_{index}",
+                "status": "completed",
+                "output": [
+                    {
+                        "id": f"fc_{index}",
+                        "type": "function_call",
+                        "status": "completed",
+                        "call_id": f"call_{index}",
+                        "name": name,
+                        "arguments": json.dumps(arguments),
+                    }
+                ],
+            }
+        else:
+            payload = {
+                "id": f"msg_{index}",
+                "type": "message",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": f"toolu_{index}",
+                        "name": name,
+                        "input": arguments,
+                    }
+                ],
+                "stop_reason": "tool_use",
+            }
+        return httpx.Response(200, json=payload)
+
+
+def _inline_blobs(value: Any, blob_dir: Path) -> Any:
+    if isinstance(value, str):
+
+        def replace_blob(match: re.Match[str]) -> str:
+            blob = (blob_dir / f"{match.group(1)}.png").read_bytes()
+            return base64.b64encode(blob).decode("ascii")
+
+        return _BLOB_RE.sub(replace_blob, value)
+    if isinstance(value, list):
+        return [_inline_blobs(item, blob_dir) for item in value]
+    if isinstance(value, dict):
+        return {key: _inline_blobs(item, blob_dir) for key, item in value.items()}
+    return value
+
+
+def _wire_rows(path: Path) -> list[dict[str, Any]]:
+    return [cast(dict[str, Any], json.loads(line)) for line in path.read_text().splitlines()]
 
 
 class _FlushRecordingStream(io.StringIO):
@@ -318,6 +396,7 @@ def test_goal_runs_to_done_and_config_lands_in_log(tmp_path: Path) -> None:
     # Headroom splits a box-sized move into two steps, then done holds once.
     assert len(record.steps) == 3
     assert logs[0].eval.policy_config["model"] == "test/model"
+    assert logs[0].eval.policy_config["wire_capture"] is True
     assert logs[0].eval.policy_config["max_llm_calls"] == 100
     assert logs[0].eval.policy_config["max_speed_frac"] == 0.1
     (transcript,) = logs[0].samples[0].policy_transcripts
@@ -325,6 +404,197 @@ def test_goal_runs_to_done_and_config_lands_in_log(tmp_path: Path) -> None:
     assert transcript is not None
     assert "move_by" in serialized and "done" in serialized
     assert "data:" not in serialized
+
+
+@pytest.mark.parametrize("wire", ["chat", "responses", "anthropic"])
+def test_wire_capture_matches_each_transport_body_after_blob_inlining(
+    wire: str, tmp_path: Path
+) -> None:
+    script = _WireScript(wire)
+    sink = _RecordingSink()
+    policy = LLMAgentPolicy(
+        model="test/model",
+        base_url="http://llm.test/v1",
+        wire=wire,
+        image_horizon=1,
+        depth="off",
+        transport=httpx.MockTransport(script),
+        env={},
+    )
+
+    ir_eval(
+        _task(max_steps=20),
+        policy,
+        _VisionAbsoluteEmbodiment(),
+        log_dir=str(tmp_path),
+        sinks=[sink],
+    )
+
+    (record,) = sink.records
+    pointer = record.metadata["wire_capture"]
+    assert isinstance(pointer, str)
+    capture_path = tmp_path / pointer
+    assert capture_path.is_file()
+    rows = _wire_rows(capture_path)
+    row = next(row for row in rows if row["call"] == 1 and row["attempt"] == 0)
+    assert (
+        row["endpoint"]
+        == {
+            "chat": "/chat/completions",
+            "responses": "/responses",
+            "anthropic": "/messages",
+        }[wire]
+    )
+    blob_dir = capture_path.parent.parent / "blobs"
+    captured_request = _inline_blobs(row["request"], blob_dir)
+    assert captured_request == script.requests[1]
+    assert "camera frame(s) elided" in json.dumps(captured_request)
+
+    if wire == "anthropic":
+        elision_blocks = [
+            block
+            for message in captured_request["messages"]
+            if isinstance(message.get("content"), list)
+            for block in message["content"]
+            if "camera frame(s) elided" in block.get("text", "")
+        ]
+        assert elision_blocks
+        assert elision_blocks[-1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_zero_llm_call_trial_creates_no_capture_file_or_metadata(tmp_path: Path) -> None:
+    class _FailsBeforeLLM(LLMAgentPolicy):
+        def act(self, observation: Observation) -> ActionChunk:
+            raise RuntimeError("failed before first LLM call")
+
+    def unexpected_request(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("transport must not be called")
+
+    policy = _FailsBeforeLLM(
+        model="test/model",
+        base_url="http://llm.test/v1",
+        transport=httpx.MockTransport(unexpected_request),
+        env={},
+    )
+    sink = _RecordingSink()
+
+    ir_eval(
+        _task(),
+        policy,
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+        sinks=[sink],
+    )
+
+    (record,) = sink.records
+    assert record.status == "error"
+    assert "wire_capture" not in record.metadata
+    assert not (tmp_path / "wire").exists()
+    assert policy._capture is not None
+    assert policy._capture.end_trial() is None
+
+
+def test_wire_capture_false_constructs_no_sink_or_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def unexpected_capture() -> None:
+        raise AssertionError("WireCapture must not be constructed")
+
+    monkeypatch.setattr(agent_policy_module, "WireCapture", unexpected_capture)
+    script = _Script([_tool_response("done", {"summary": "disabled"})])
+    policy = _policy(script, wire_capture=False)
+    assert isinstance(policy.config, AgentPolicyConfig)
+    assert policy.config.wire_capture is False
+    assert policy._client._capture is None
+    sink = _RecordingSink()
+
+    ir_eval(
+        _task(),
+        policy,
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+        sinks=[sink],
+    )
+
+    assert "wire_capture" not in sink.records[0].metadata
+    assert not (tmp_path / "wire").exists()
+
+
+def test_version_skew_warning_fires_once_across_trial_ends(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    policy = _policy(_Script([_text_response("unused")]))
+    first = TrialRecord(scene_id="s0", epoch=0, seed=0, status="success")
+    second = TrialRecord(scene_id="s0", epoch=1, seed=1, status="success")
+
+    policy.on_trial_end(first, str(tmp_path), "run-1")
+    policy.on_trial_end(second, str(tmp_path), "run-1")
+
+    assert capsys.readouterr().err == (
+        "[agent] wire capture inactive: core predates on_trial_start\n"
+    )
+    assert "wire_capture" not in first.metadata
+    assert "wire_capture" not in second.metadata
+
+
+def test_success_without_action_chunk_retries_the_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = _Script(
+        [
+            _tool_response("done", {"summary": "first"}),
+            _tool_response("done", {"summary": "second"}),
+        ]
+    )
+    policy = _policy(script)
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="stop"))
+    toolset = policy._toolset
+    assert toolset is not None
+    execute = toolset.execute
+    calls = 0
+
+    def no_chunk_once(call: Any, observation: Observation) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return ToolResult(note="accepted without an action")
+        return execute(call, observation)
+
+    monkeypatch.setattr(toolset, "execute", no_chunk_once)
+
+    chunk = policy.act(Observation())
+
+    assert chunk.actions[0].meta["request_stop"] is True
+    assert len(script.requests) == 2
+
+
+def test_pending_narration_handles_absent_target_and_residual(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy = _policy(_Script([_text_response("unused")]))
+    policy.bind(_VisionAbsoluteEmbodiment().info)
+    observation = _vision_observation(env_step=2)
+    without_target = _PendingCapture(
+        requested=("top",),
+        issued_step=1,
+        chunk_len=1,
+        target=None,
+    )
+    assert "finished playing" in policy._pending_narration(without_target, observation, ())
+
+    toolset = policy._toolset
+    assert toolset is not None
+    monkeypatch.setattr(toolset, "residual", lambda target, current: None)
+    with_target = replace(without_target, target=np.array([0.1]))
+    narration = policy._pending_narration(with_target, observation, ())
+    assert "remaining offset" not in narration
+
+
+def test_image_parts_skip_requested_camera_missing_from_observation() -> None:
+    observation = _vision_observation(cameras=("top",))
+
+    assert _image_parts(observation, reveal=("wrist",), depth={}) == []
 
 
 def test_transcript_is_none_before_first_reset() -> None:

--- a/plugins/inspect-robots-agent/tests/test_policy_eviction.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_eviction.py
@@ -109,6 +109,31 @@ def test_on_demand_image_only_message_stubs_to_one_text_part() -> None:
     assert view[0]["content"] == [{"type": "text", "text": "[1 camera frame(s) elided]"}]
 
 
+def test_unlabelled_and_nontext_image_predecessors_are_preserved() -> None:
+    first_image = {
+        "role": "user",
+        "content": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,first"}}],
+    }
+    nontext_label = {
+        "role": "user",
+        "content": [
+            {"type": "vendor_label", "value": 1},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,second"}},
+        ],
+    }
+
+    view = _evicted_view(
+        [first_image, nontext_label, _observation_message("new")],
+        1,
+    )
+
+    assert view[0]["content"] == [{"type": "text", "text": "[1 camera frame(s) elided]"}]
+    assert view[1]["content"] == [
+        {"type": "vendor_label", "value": 1},
+        {"type": "text", "text": "[1 camera frame(s) elided]"},
+    ]
+
+
 def test_non_list_content_passes_through_untouched() -> None:
     plain = {"role": "user", "content": "Respond with exactly one tool call."}
 

--- a/plugins/inspect-robots-agent/tests/test_responses.py
+++ b/plugins/inspect-robots-agent/tests/test_responses.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -13,8 +14,9 @@ from inspect_robots.mock import CubePickEmbodiment
 from inspect_robots.scene import Scene
 from inspect_robots.types import Observation
 from inspect_robots_agent import LLMAgentPolicy
+from inspect_robots_agent._capture import WireCapture
 from inspect_robots_agent._llm import Provider
-from inspect_robots_agent._responses import ResponsesClient
+from inspect_robots_agent._responses import ResponsesClient, _translate_content_parts
 from inspect_robots_agent.policy import AgentPolicyConfig
 
 
@@ -60,6 +62,11 @@ def _tool_call(call_id: str, name: str, arguments: str) -> dict[str, Any]:
 def _client(handler: Any, **kwargs: Any) -> ResponsesClient:
     provider = Provider(base_url="http://llm.test/v1", api_key="sk-test", model="m")
     return ResponsesClient(provider, transport=httpx.MockTransport(handler), **kwargs)
+
+
+def _wire_rows(tmp_path: Path) -> list[dict[str, Any]]:
+    path = tmp_path / "wire/run-1/scene-e0/calls.jsonl"
+    return [json.loads(line) for line in path.read_text().splitlines()]
 
 
 def test_translates_history_tools_and_request_options() -> None:
@@ -169,6 +176,10 @@ def test_translates_history_tools_and_request_options() -> None:
     }
     history_messages = [item for item in body["input"] if "role" in item]
     assert all("type" not in item for item in history_messages)
+
+
+def test_unknown_content_part_is_ignored() -> None:
+    assert _translate_content_parts([{"type": "vendor_extension", "value": "x"}]) == []
 
 
 def test_capture_history_keeps_function_outputs_in_call_order_before_images() -> None:
@@ -503,6 +514,45 @@ def test_failed_status_raises_once_and_does_not_populate_cache() -> None:
             "arguments": "{}",
         }
     ]
+
+
+def test_capture_precedes_failed_payload_raise(tmp_path: Path) -> None:
+    payload = {
+        "id": "resp_failed",
+        "status": "failed",
+        "error": {"message": "reasoning token limit reached"},
+        "output": [],
+    }
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    client = _client(
+        lambda request: httpx.Response(200, json=payload),
+        capture=capture,
+    )
+
+    with pytest.raises(RuntimeError, match="reasoning token limit reached"):
+        client.complete(messages=[], tools=[])
+
+    (row,) = _wire_rows(tmp_path)
+    assert row["status"] == 200
+    assert row["response"] == payload
+
+
+def test_capture_records_responses_transport_error(tmp_path: Path) -> None:
+    def offline(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("responses offline", request=request)
+
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    client = _client(offline, max_retries=1, capture=capture)
+
+    with pytest.raises(RuntimeError, match="responses offline"):
+        client.complete(messages=[], tools=[])
+
+    (row,) = _wire_rows(tmp_path)
+    assert row["status"] is None
+    assert row["response"] is None
+    assert row["error"] == "responses offline"
 
 
 @pytest.mark.parametrize("status_code", [429, 500, 503])

--- a/src/inspect_robots/_html.py
+++ b/src/inspect_robots/_html.py
@@ -16,7 +16,7 @@ import numpy as np
 import numpy.typing as npt
 
 from inspect_robots._pngenc import png_data_url
-from inspect_robots._pointers import resolve_log_pointer
+from inspect_robots._pointers import derive_blob_dir, resolve_log_pointer
 from inspect_robots.frames import _safe
 from inspect_robots.log import EvalLog, SceneResult
 
@@ -514,7 +514,10 @@ def _load_wire_rows(
         return None
     if not loaded or not all(isinstance(row, dict) for row in loaded):
         return None
-    return cast(list[dict[str, Any]], loaded), target.parent.parent / "blobs"
+    blob_dir = derive_blob_dir(log_path, target)
+    if blob_dir is None:
+        return None
+    return cast(list[dict[str, Any]], loaded), blob_dir
 
 
 def _wire_blob_tokens(value: object) -> list[str]:

--- a/src/inspect_robots/_html.py
+++ b/src/inspect_robots/_html.py
@@ -16,7 +16,7 @@ import numpy as np
 import numpy.typing as npt
 
 from inspect_robots._pngenc import png_data_url
-from inspect_robots._pointers import derive_blob_dir, resolve_log_pointer
+from inspect_robots._pointers import derive_blob_dir, read_jsonl_prefix, resolve_log_pointer
 from inspect_robots.frames import _safe
 from inspect_robots.log import EvalLog, SceneResult
 
@@ -507,17 +507,13 @@ def _load_wire_rows(
     target = resolve_log_pointer(log_path, scene.trial_metadata[trial].get("wire_capture"))
     if target is None:
         return None
-    try:
-        with target.open(encoding="utf-8") as handle:
-            loaded = [json.loads(line) for line in handle]
-    except (OSError, UnicodeError, json.JSONDecodeError):
-        return None
-    if not loaded or not all(isinstance(row, dict) for row in loaded):
+    loaded = read_jsonl_prefix(target)
+    if loaded is None:
         return None
     blob_dir = derive_blob_dir(log_path, target)
     if blob_dir is None:
         return None
-    return cast(list[dict[str, Any]], loaded), blob_dir
+    return loaded, blob_dir
 
 
 def _wire_blob_tokens(value: object) -> list[str]:

--- a/src/inspect_robots/_html.py
+++ b/src/inspect_robots/_html.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import html
 import json
 import math
@@ -15,6 +16,7 @@ import numpy as np
 import numpy.typing as npt
 
 from inspect_robots._pngenc import png_data_url
+from inspect_robots._pointers import resolve_log_pointer
 from inspect_robots.frames import _safe
 from inspect_robots.log import EvalLog, SceneResult
 
@@ -25,6 +27,9 @@ _JSON_STRING_LIMIT = 2048
 _FRAME_LABEL_RE = re.compile(r"camera '(?P<name>.*)' \(step (?P<step>\d{1,12})\):")
 _FRAME_PLACEHOLDER = "[image omitted: streamed camera frame]"
 _FRAME_MAX_SIDE = 448
+_BLOB_SENTINEL_RE = re.compile(r"\$blob:([^\s]+)")
+_BLOB_SHA_RE = re.compile(r"[0-9a-f]{64}")
+_MISSING = object()
 
 
 @dataclass
@@ -44,6 +49,17 @@ class _FrameContext:
     frames_dir: Path
     trial_prefix: str
     budget: _FrameBudget
+
+
+@dataclass
+class _WireContext:
+    """Track one trial's blob directory, budget, and emitted image anchors."""
+
+    blob_dir: Path
+    trial_id: str
+    budget: _FrameBudget
+    emitted: set[str]
+    denied: set[str]
 
 
 _STYLES = """
@@ -190,6 +206,12 @@ pre {
   font: 12px/1.5 ui-monospace, SFMono-Regular, Consolas, monospace;
 }
 .none { color: var(--muted); margin: 28px 0; }
+.wire-static, .wire-change { margin: 10px 0; }
+.wire-change { color: var(--muted); }
+.wire-media { margin: 8px 0; }
+.wire-blob { display: block; }
+.wire-broken { color: var(--red); }
+.wire-placeholder { color: var(--muted); }
 """.strip()
 
 
@@ -476,8 +498,229 @@ def _render_trial_transcript(
     return _render_transcript(transcript, _trial_frame_context(frame_ctx, scene_id, trial))
 
 
+def _load_wire_rows(
+    scene: SceneResult, trial: int, log_path: Path | None
+) -> tuple[list[dict[str, Any]], Path] | None:
+    """Load one guarded wire sidecar and derive its run-scoped blob directory."""
+    if log_path is None or trial >= len(scene.trial_metadata):
+        return None
+    target = resolve_log_pointer(log_path, scene.trial_metadata[trial].get("wire_capture"))
+    if target is None:
+        return None
+    try:
+        with target.open(encoding="utf-8") as handle:
+            loaded = [json.loads(line) for line in handle]
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    if not loaded or not all(isinstance(row, dict) for row in loaded):
+        return None
+    return cast(list[dict[str, Any]], loaded), target.parent.parent / "blobs"
+
+
+def _wire_blob_tokens(value: object) -> list[str]:
+    """Return every blob token suffix found recursively in a captured value."""
+    if isinstance(value, str):
+        return [match.group(1) for match in _BLOB_SENTINEL_RE.finditer(value)]
+    if isinstance(value, list):
+        return [token for item in value for token in _wire_blob_tokens(item)]
+    if isinstance(value, dict):
+        return [token for item in value.values() for token in _wire_blob_tokens(item)]
+    return []
+
+
+def _render_wire_blob(token: str, context: _WireContext) -> str:
+    """Render one validated blob reference as an embed, link, elision, or error."""
+    if _BLOB_SHA_RE.fullmatch(token) is None:
+        return (
+            f'<span class="wire-broken">{_escape(f"[broken blob reference: $blob:{token}]")}</span>'
+        )
+    anchor = f"wire-{_safe(context.trial_id)}-{token[:12]}"
+    if token in context.emitted:
+        return f'<a href="#{_escape(anchor)}">[blob {_escape(token[:12])}]</a>'
+    if token in context.denied:
+        return '<span class="wire-placeholder">[blob elided: media budget]</span>'
+
+    # ``token`` has passed the exact lowercase-sha guard above.  Only now may
+    # foreign JSONL text participate in a filesystem path.
+    path = context.blob_dir / f"{token}.png"
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return (
+            f'<span class="wire-broken">{_escape(f"[broken blob reference: $blob:{token}]")}</span>'
+        )
+    encoded = base64.b64encode(raw).decode("ascii")
+    budget = context.budget
+    if budget.truncated or (budget.limit and budget.payload_bytes + len(encoded) > budget.limit):
+        budget.truncated = True
+        context.denied.add(token)
+        return '<span class="wire-placeholder">[blob elided: media budget]</span>'
+    budget.payload_bytes += len(encoded)
+    budget.embedded += 1
+    context.emitted.add(token)
+    return (
+        f'<span class="wire-blob" id="{_escape(anchor)}">'
+        '<img class="frame" loading="lazy" '
+        f'alt="wire blob {_escape(token[:12])}" src="data:image/png;base64,{encoded}"></span>'
+    )
+
+
+def _render_wire_value(value: object, context: _WireContext) -> str:
+    """Render captured JSON verbatim enough for forensic keys, then its blob media."""
+    dumped = json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False)
+    media = "".join(
+        f'<div class="wire-media">{_render_wire_blob(token, context)}</div>'
+        for token in _wire_blob_tokens(value)
+    )
+    return f"<pre>{_escape(dumped)}</pre>{media}"
+
+
+def _wire_messages(request: dict[str, Any]) -> list[object]:
+    """Return the messages-shaped sequence used by any supported wire."""
+    messages = request.get("messages", request.get("input"))
+    return cast(list[object], messages) if isinstance(messages, list) else []
+
+
+def _wire_effort(request: dict[str, Any]) -> object:
+    """Extract the supported top-level or nested effort parameter."""
+    if "reasoning_effort" in request:
+        return request["reasoning_effort"]
+    reasoning = request.get("reasoning")
+    if isinstance(reasoning, dict) and "effort" in reasoning:
+        return reasoning["effort"]
+    output_config = request.get("output_config")
+    if isinstance(output_config, dict) and "effort" in output_config:
+        return output_config["effort"]
+    return "n/a"
+
+
+def _wire_request(row: dict[str, Any]) -> dict[str, Any]:
+    """Return a captured request mapping, degrading malformed rows to empty."""
+    request = row.get("request")
+    return cast(dict[str, Any], request) if isinstance(request, dict) else {}
+
+
+def _render_wire_call(
+    row: dict[str, Any],
+    previous_messages: list[object] | None,
+    first_tools: object,
+    first_system: object,
+    context: _WireContext,
+) -> str:
+    """Render one attempt row with static-field change notes and message deltas."""
+    request = _wire_request(row)
+    messages = _wire_messages(request)
+    if previous_messages is None:
+        changed: list[tuple[int, object]] = []
+        new_messages = messages
+    else:
+        changed = [
+            (index, message)
+            for index, message in enumerate(messages[: len(previous_messages)])
+            if message != previous_messages[index]
+        ]
+        new_messages = messages[len(previous_messages) :]
+
+    notes: list[str] = []
+    if request.get("tools", _MISSING) != first_tools:
+        notes.append("tools changed from the trial's first call")
+    if request.get("system", _MISSING) != first_system:
+        notes.append("system changed from the trial's first call")
+    notes.extend(f"message {index} changed as sent" for index, _ in changed)
+    changes = "".join(f'<p class="wire-change">{_escape(note)}</p>' for note in notes)
+    changed_messages = "".join(
+        (
+            f'<div class="wire-change">message {index} current as-sent form</div>'
+            f"{_render_wire_value(message, context)}"
+        )
+        for index, message in changed
+    )
+    additions = "".join(_render_wire_value(message, context) for message in new_messages)
+    if not additions and not changed_messages:
+        additions = '<p class="wire-change">no new messages</p>'
+
+    tools = request.get("tools")
+    tool_count = len(tools) if isinstance(tools, list) else 0
+    params = "".join(
+        (
+            _definition("model", request.get("model", "n/a")),
+            _definition("effort", _wire_effort(request)),
+            _definition("temperature", request.get("temperature", "n/a")),
+            _definition("tool count", tool_count),
+        )
+    )
+    call = row.get("call", "?")
+    attempt = row.get("attempt", "?")
+    endpoint = row.get("endpoint", "?")
+    status = row.get("status")
+    duration = row.get("duration_s")
+    shown_status = "null" if status is None else status
+    shown_duration = (
+        f"{_number(duration)} s"
+        if isinstance(duration, (int, float)) and not isinstance(duration, bool)
+        else "n/a"
+    )
+    summary = (
+        f"call {_escape(call)} attempt {_escape(attempt)} · {_escape(endpoint)} · "
+        f"status {_escape(shown_status)} · {_escape(shown_duration)}"
+    )
+    return (
+        f'<details class="wire-call"><summary>{summary}</summary>'
+        f"<dl>{params}</dl>{changes}{changed_messages}{additions}</details>"
+    )
+
+
+def _render_trial_wire(
+    scene: SceneResult,
+    trial: int,
+    log_path: Path | None,
+    budget: _FrameBudget,
+) -> str:
+    """Render one trial's guarded wire capture, or nothing when unavailable."""
+    loaded = _load_wire_rows(scene, trial, log_path)
+    if loaded is None:
+        return ""
+    rows, blob_dir = loaded
+    first_request = _wire_request(rows[0])
+    first_tools = first_request.get("tools", _MISSING)
+    first_system = first_request.get("system", _MISSING)
+    context = _WireContext(
+        blob_dir=blob_dir,
+        trial_id=f"{scene.scene_id}-e{trial}",
+        budget=budget,
+        emitted=set(),
+        denied=set(),
+    )
+    static = ""
+    if first_tools is not _MISSING:
+        static += (
+            '<div class="wire-static"><strong>Tools (trial initial)</strong>'
+            f"{_render_wire_value(first_tools, context)}</div>"
+        )
+    if first_system is not _MISSING:
+        static += (
+            '<div class="wire-static"><strong>System (trial initial)</strong>'
+            f"{_render_wire_value(first_system, context)}</div>"
+        )
+
+    calls: list[str] = []
+    previous: list[object] | None = None
+    for row in rows:
+        calls.append(_render_wire_call(row, previous, first_tools, first_system, context))
+        previous = _wire_messages(_wire_request(row))
+    return (
+        '<details class="wire"><summary>'
+        f"Trial {trial} Wire</summary>{static}{''.join(calls)}</details>"
+    )
+
+
 def _scene_section(
-    scene: SceneResult, *, open_transcript: bool, frame_ctx: _FrameContext | None = None
+    scene: SceneResult,
+    *,
+    open_transcript: bool,
+    budget: _FrameBudget,
+    log_path: Path | None,
+    frame_ctx: _FrameContext | None = None,
 ) -> str:
     """Render one complete scene card and its available trial transcripts."""
     instruction = (
@@ -541,11 +784,14 @@ def _scene_section(
         for trial, transcript in enumerate(scene.policy_transcripts)
         if transcript is not None
     )
+    wires = "".join(
+        _render_trial_wire(scene, trial, log_path, budget) for trial in range(len(scene.epochs))
+    )
     return (
         '<section class="scene">'
         f'<div class="scene-head"><h2>{_escape(scene.scene_id)}</h2>'
         f"{_status_badge(scene.status)}</div>{instruction}{error}{reduced_block}{epoch_block}"
-        f"{reasons_block}{judgements_block}{notes_block}{transcripts}</section>"
+        f"{reasons_block}{judgements_block}{notes_block}{transcripts}{wires}</section>"
     )
 
 
@@ -553,6 +799,7 @@ def render_html(
     log: EvalLog,
     *,
     title: str,
+    log_path: Path | None = None,
     frames_dir: Path | None = None,
     frames_budget_bytes: int = 50_000_000,
 ) -> str:
@@ -616,6 +863,8 @@ def render_html(
         _scene_section(
             scene,
             open_transcript=transcript_count == 1,
+            budget=budget,
+            log_path=log_path,
             frame_ctx=frame_ctx,
         )
         for scene in log.samples
@@ -626,7 +875,7 @@ def render_html(
     frames_chip = (
         ""
         if not budget.truncated
-        else '<span class="chip">frames truncated at '
+        else '<span class="chip">embedded media truncated at '
         f"{frames_budget_bytes / 1_000_000:g} MB ({budget.embedded} embedded)</span>"
     )
     meta_tail = (

--- a/src/inspect_robots/_pointers.py
+++ b/src/inspect_robots/_pointers.py
@@ -1,0 +1,24 @@
+"""Resolve portable log pointers without allowing reads outside the log directory.
+
+Both the transcript summarizer and HTML/CLI wire viewers consume paths stored
+in logs as foreign text.  Keeping their traversal guard in this leaf module
+also avoids an ``_html`` → ``_summarize`` → ``cli`` → ``_html`` import cycle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_log_pointer(log_path: Path, pointer: object) -> Path | None:
+    """Resolve a non-empty relative pointer beneath the saved log's directory."""
+    if not isinstance(pointer, str) or not pointer:
+        return None
+    try:
+        root = log_path.parent.resolve()
+        target = (root / pointer).resolve()
+    except OSError:
+        return None
+    if not target.is_relative_to(root):
+        return None
+    return target

--- a/src/inspect_robots/_pointers.py
+++ b/src/inspect_robots/_pointers.py
@@ -7,7 +7,9 @@ also avoids an ``_html`` → ``_summarize`` → ``cli`` → ``_html`` import cyc
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Any
 
 
 def resolve_log_pointer(log_path: Path, pointer: object) -> Path | None:
@@ -35,3 +37,28 @@ def derive_blob_dir(log_path: Path, target: Path) -> Path | None:
     if not blob_dir.is_relative_to(log_path.parent.resolve()):
         return None
     return blob_dir
+
+
+def read_jsonl_prefix(target: Path) -> list[dict[str, Any]] | None:
+    """Read a sidecar's longest valid prefix of JSON-object lines.
+
+    Wire sidecars are append-only and flushed per row; a crash can strand a
+    torn final line, and that torn tail must not discard the rows before it —
+    the crashed call is the forensic payload. Parsing stops at the first
+    unparsable or non-object line; ``None`` means the file itself was
+    unreadable or held no valid row.
+    """
+    rows: list[dict[str, Any]] = []
+    try:
+        with target.open(encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    break
+                if not isinstance(row, dict):
+                    break
+                rows.append(row)
+    except (OSError, UnicodeError):
+        return None
+    return rows or None

--- a/src/inspect_robots/_pointers.py
+++ b/src/inspect_robots/_pointers.py
@@ -22,3 +22,16 @@ def resolve_log_pointer(log_path: Path, pointer: object) -> Path | None:
     if not target.is_relative_to(root):
         return None
     return target
+
+
+def derive_blob_dir(log_path: Path, target: Path) -> Path | None:
+    """Derive a wire sidecar's run-scoped blobs dir, refusing to leave the log dir.
+
+    ``target`` is a ``resolve_log_pointer`` result for ``wire/<run>/<trial>/calls.jsonl``;
+    a shallower hand-crafted pointer would put ``parent.parent`` above the
+    guarded root, so the derivation re-checks containment.
+    """
+    blob_dir = target.parent.parent / "blobs"
+    if not blob_dir.is_relative_to(log_path.parent.resolve()):
+        return None
+    return blob_dir

--- a/src/inspect_robots/_pointers.py
+++ b/src/inspect_robots/_pointers.py
@@ -51,7 +51,15 @@ def read_jsonl_prefix(target: Path) -> list[dict[str, Any]] | None:
     rows: list[dict[str, Any]] = []
     try:
         with target.open(encoding="utf-8") as handle:
-            for line in handle:
+            while True:
+                try:
+                    line = handle.readline()
+                except UnicodeError:
+                    # A torn multi-byte tail is still a torn tail: keep the
+                    # prefix rather than voiding the crashed trial's capture.
+                    break
+                if not line:
+                    break
                 try:
                     row = json.loads(line)
                 except json.JSONDecodeError:
@@ -59,6 +67,6 @@ def read_jsonl_prefix(target: Path) -> list[dict[str, Any]] | None:
                 if not isinstance(row, dict):
                     break
                 rows.append(row)
-    except (OSError, UnicodeError):
+    except OSError:
         return None
     return rows or None

--- a/src/inspect_robots/_summarize.py
+++ b/src/inspect_robots/_summarize.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from inspect_robots._html import _agent_notes, _chat_content, _display_status
+from inspect_robots._pointers import resolve_log_pointer
 from inspect_robots.cli import _OUTCOME_PHRASES
 from inspect_robots.errors import ConfigError
 from inspect_robots.log import EvalLog, SceneResult, read_eval_log
@@ -50,19 +51,14 @@ def _is_dropped(transcript: object) -> bool:
     )
 
 
-def _read_sidecar(scene: SceneResult, index: int, log_dir: Path) -> list[object] | None:
+def _read_sidecar(scene: SceneResult, index: int, log_path: Path) -> list[object] | None:
     if index >= len(scene.trial_metadata):
         return None
     pointer = scene.trial_metadata[index].get("transcript")
-    if not isinstance(pointer, str) or not pointer:
+    target = resolve_log_pointer(log_path, pointer)
+    if target is None:
         return None
-    # The pointer is foreign text from a portable log: refuse anything that
-    # resolves outside the log's directory (absolute paths, ".." traversal),
-    # or summarize would read arbitrary files into the learnings document.
     try:
-        target = (log_dir / pointer).resolve()
-        if not target.is_relative_to(log_dir.resolve()):
-            return None
         with target.open(encoding="utf-8") as handle:
             return [json.loads(line) for line in handle]
     except (OSError, UnicodeError, json.JSONDecodeError):
@@ -80,7 +76,7 @@ def load_transcripts(log: EvalLog, log_path: Path) -> list[TrialTranscript]:
             if inline is not None and not _is_dropped(inline):
                 transcripts.append(TrialTranscript(scene.scene_id, index, inline, "inline"))
                 continue
-            sidecar = _read_sidecar(scene, index, log_path.parent)
+            sidecar = _read_sidecar(scene, index, log_path)
             if sidecar is not None:
                 transcripts.append(TrialTranscript(scene.scene_id, index, sidecar, "sidecar"))
             else:

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -56,7 +56,7 @@ from inspect_robots._html import (
     _is_chat_transcript,
     render_html,
 )
-from inspect_robots._pointers import derive_blob_dir, resolve_log_pointer
+from inspect_robots._pointers import derive_blob_dir, read_jsonl_prefix, resolve_log_pointer
 from inspect_robots.defaults import (
     _ADHOC_MAX_STEPS_FALLBACK,
     _ADHOC_SCORER_FALLBACK,
@@ -851,12 +851,8 @@ def _load_wire_trials(log: EvalLog, log_path: Path) -> list[_WireTrial]:
             target = resolve_log_pointer(log_path, scene.trial_metadata[epoch].get("wire_capture"))
             if target is None:
                 continue
-            try:
-                with target.open(encoding="utf-8") as handle:
-                    loaded = [json.loads(line) for line in handle]
-            except (OSError, UnicodeError, json.JSONDecodeError):
-                continue
-            if not loaded or not all(isinstance(row, dict) for row in loaded):
+            loaded = read_jsonl_prefix(target)
+            if loaded is None:
                 continue
             blob_dir = derive_blob_dir(log_path, target)
             if blob_dir is None:
@@ -864,7 +860,7 @@ def _load_wire_trials(log: EvalLog, log_path: Path) -> list[_WireTrial]:
             trials.append(
                 _WireTrial(
                     f"{scene.scene_id}-e{epoch}",
-                    cast(list[dict[str, Any]], loaded),
+                    loaded,
                     blob_dir,
                 )
             )

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -13,8 +13,8 @@ Subcommands:
   one resolved policy/embodiment pair via
   [`eval_set`][inspect_robots.eval.eval_set]. Prints one status line and a compact
   per-task row instead of a full summary per task.
-- ``inspect-robots inspect LOG.json [--transcript]`` — print a saved eval log and
-  optionally append recorded policy conversations.
+- ``inspect-robots inspect LOG.json [--transcript] [--wire [CALL]]`` — print a
+  saved eval log and optionally append policy conversations or captured wire calls.
 - ``inspect-robots summarize LOG.json [--model M]`` — distill a saved eval log
   into a deterministic digest or model-written learnings file.
 - ``inspect-robots view LOG.json [-o OUT.html] [--open]`` — render a saved eval log
@@ -39,10 +39,12 @@ import fnmatch
 import json
 import math
 import os
+import re
 import shutil
 import sys
 import tempfile
 from collections.abc import Sequence
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
@@ -54,6 +56,7 @@ from inspect_robots._html import (
     _is_chat_transcript,
     render_html,
 )
+from inspect_robots._pointers import resolve_log_pointer
 from inspect_robots.defaults import (
     _ADHOC_MAX_STEPS_FALLBACK,
     _ADHOC_SCORER_FALLBACK,
@@ -282,6 +285,21 @@ def build_parser() -> argparse.ArgumentParser:
         "--transcript",
         action="store_true",
         help="append recorded policy transcripts",
+    )
+    p_inspect.add_argument(
+        "--wire",
+        nargs="?",
+        const=True,
+        default=None,
+        type=int,
+        metavar="CALL",
+        help="append the wire-call table, or dump every attempt for CALL",
+    )
+    p_inspect.add_argument(
+        "--trial",
+        default=None,
+        metavar="SCENE-eEPOCH",
+        help="select a captured trial for --wire CALL",
     )
 
     p_summarize = sub.add_parser(
@@ -801,6 +819,151 @@ def _print_policy_transcripts(log: EvalLog) -> None:
                 _print_degraded(f"    {line}")
 
 
+class _WireTrial(NamedTuple):
+    """A readable wire sidecar and its trial/run filesystem context."""
+
+    trial_id: str
+    rows: list[dict[str, Any]]
+    blob_dir: Path
+
+
+_WIRE_BLOB_RE = re.compile(r"\$blob:([0-9a-f]{64})")
+
+
+def _wire_blob_shas(value: object) -> list[str]:
+    """Return every valid symbolic blob reference in a captured JSON value."""
+    if isinstance(value, str):
+        return [match.group(1) for match in _WIRE_BLOB_RE.finditer(value)]
+    if isinstance(value, list):
+        return [sha for item in value for sha in _wire_blob_shas(item)]
+    if isinstance(value, dict):
+        return [sha for item in value.values() for sha in _wire_blob_shas(item)]
+    return []
+
+
+def _load_wire_trials(log: EvalLog, log_path: Path) -> list[_WireTrial]:
+    """Load every readable guarded wire sidecar referenced by an eval log."""
+    trials: list[_WireTrial] = []
+    for scene in log.samples:
+        for epoch in range(len(scene.epochs)):
+            if epoch >= len(scene.trial_metadata):
+                continue
+            target = resolve_log_pointer(log_path, scene.trial_metadata[epoch].get("wire_capture"))
+            if target is None:
+                continue
+            try:
+                with target.open(encoding="utf-8") as handle:
+                    loaded = [json.loads(line) for line in handle]
+            except (OSError, UnicodeError, json.JSONDecodeError):
+                continue
+            if not loaded or not all(isinstance(row, dict) for row in loaded):
+                continue
+            trials.append(
+                _WireTrial(
+                    f"{scene.scene_id}-e{epoch}",
+                    cast(list[dict[str, Any]], loaded),
+                    target.parent.parent / "blobs",
+                )
+            )
+    return trials
+
+
+def _wire_request(row: dict[str, Any]) -> dict[str, Any]:
+    """Return one row's request mapping, degrading malformed foreign data."""
+    request = row.get("request")
+    return cast(dict[str, Any], request) if isinstance(request, dict) else {}
+
+
+def _print_wire_table(trials: list[_WireTrial]) -> None:
+    """Print the compact all-trials wire attempt table."""
+    if not trials:
+        print("no wire capture recorded")
+        return
+    print("wire calls:")
+    print("  trial  call  attempt  endpoint  status  duration  images  new blob bytes")
+    for trial in trials:
+        seen: set[str] = set()
+        for row in trial.rows:
+            shas = _wire_blob_shas(_wire_request(row))
+            first_shas = set(shas).difference(seen)
+            seen.update(shas)
+            new_bytes = 0
+            for sha in first_shas:
+                with suppress(OSError):
+                    new_bytes += (trial.blob_dir / f"{sha}.png").stat().st_size
+            duration = row.get("duration_s")
+            shown_duration = (
+                f"{duration:.3f}s"
+                if isinstance(duration, (int, float)) and not isinstance(duration, bool)
+                else "-"
+            )
+            status = "-" if row.get("status") is None else str(row["status"])
+            print(
+                f"  {trial.trial_id}  {row.get('call', '-')}  "
+                f"{row.get('attempt', '-')}  {row.get('endpoint', '-')}  "
+                f"{status}  {shown_duration}  {len(shas)}  {new_bytes}"
+            )
+
+
+def _available_wire_trials(trials: list[_WireTrial]) -> str:
+    """Format captured trial ids for a guided CLI error."""
+    return ", ".join(trial.trial_id for trial in trials)
+
+
+def _print_wire_call(trials: list[_WireTrial], call: int, selected_trial: str | None) -> None:
+    """Pretty-print every captured attempt for one logical call index."""
+    if not trials:
+        raise SystemExit("no wire capture recorded; omit CALL to print an empty table")
+    if selected_trial is None:
+        if len(trials) > 1:
+            raise SystemExit(
+                "--trial is required for --wire CALL; available trials: "
+                f"{_available_wire_trials(trials)}"
+            )
+        trial = trials[0]
+    else:
+        matches = [trial for trial in trials if trial.trial_id == selected_trial]
+        if not matches:
+            raise SystemExit(
+                f"wire trial {selected_trial!r} not found; available trials: "
+                f"{_available_wire_trials(trials)}"
+            )
+        trial = matches[0]
+
+    rows = [row for row in trial.rows if row.get("call") == call]
+    if not rows:
+        raise SystemExit(f"wire call {call} not found in trial {trial.trial_id}")
+    print(f"wire trial {trial.trial_id}, call {call}:")
+    for row in rows:
+        print(f"attempt {row.get('attempt', '-')}:")
+        print(f"  endpoint: {row.get('endpoint', '-')}")
+        print(f"  status: {row.get('status')}")
+        print(f"  duration_s: {row.get('duration_s', '-')}")
+        if "error" in row:
+            _print_degraded(f"  error: {row['error']}")
+        for label in ("request", "response"):
+            _print_degraded(f"  {label}:")
+            dumped = json.dumps(row.get(label), indent=2, sort_keys=True, ensure_ascii=False)
+            for line in dumped.splitlines():
+                _print_degraded(f"    {line}")
+
+
+def _print_wire_capture(
+    log: EvalLog,
+    log_path: Path,
+    wire: int | bool,
+    selected_trial: str | None,
+) -> None:
+    """Print either the capture table or every attempt for one call."""
+    trials = _load_wire_trials(log, log_path)
+    if wire is True:
+        if selected_trial is not None:
+            raise SystemExit("--trial requires an integer --wire CALL")
+        _print_wire_table(trials)
+        return
+    _print_wire_call(trials, wire, selected_trial)
+
+
 def _print_run_summary(log: EvalLog, log_path: str, is_adhoc: bool) -> None:
     """Print the compact post-run summary and failure diagnostics."""
     failed = log.status != "success"
@@ -1211,7 +1374,13 @@ def _cmd_eval_set(args: argparse.Namespace) -> int:
     return 0 if success else 1
 
 
-def _cmd_inspect(path: str, *, transcript: bool = False) -> int:
+def _cmd_inspect(
+    path: str,
+    *,
+    transcript: bool = False,
+    wire: int | bool | None = None,
+    trial: str | None = None,
+) -> int:
     from inspect_robots import read_eval_log
 
     log = read_eval_log(path)
@@ -1278,6 +1447,10 @@ def _cmd_inspect(path: str, *, transcript: bool = False) -> int:
     elif _has_policy_transcripts(log):
         print("policy transcripts: recorded (--transcript to print)")
         print(_styled(f"hint: HTML viewer: inspect-robots view {path}", _DIM))
+    if wire is not None:
+        _print_wire_capture(log, Path(path), wire, trial)
+    elif trial is not None:
+        raise SystemExit("--trial requires --wire CALL")
     return 0 if log.status == "success" else 1
 
 
@@ -1314,6 +1487,7 @@ def _cmd_view(args: argparse.Namespace) -> int:
     document = render_html(
         log,
         title=f"{log.eval.task} - {log_path.name}",
+        log_path=log_path,
         frames_dir=frames_dir,
         frames_budget_bytes=int(args.frames_budget * 1_000_000),
     )
@@ -1578,7 +1752,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "eval-set":
         return _cmd_eval_set(args)
     if args.command == "inspect":
-        return _cmd_inspect(args.log, transcript=args.transcript)
+        return _cmd_inspect(
+            args.log,
+            transcript=args.transcript,
+            wire=args.wire,
+            trial=args.trial,
+        )
     if args.command == "summarize":
         return _cmd_summarize(args)
     if args.command == "view":

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -56,7 +56,7 @@ from inspect_robots._html import (
     _is_chat_transcript,
     render_html,
 )
-from inspect_robots._pointers import resolve_log_pointer
+from inspect_robots._pointers import derive_blob_dir, resolve_log_pointer
 from inspect_robots.defaults import (
     _ADHOC_MAX_STEPS_FALLBACK,
     _ADHOC_SCORER_FALLBACK,
@@ -858,11 +858,14 @@ def _load_wire_trials(log: EvalLog, log_path: Path) -> list[_WireTrial]:
                 continue
             if not loaded or not all(isinstance(row, dict) for row in loaded):
                 continue
+            blob_dir = derive_blob_dir(log_path, target)
+            if blob_dir is None:
+                continue
             trials.append(
                 _WireTrial(
                     f"{scene.scene_id}-e{epoch}",
                     cast(list[dict[str, Any]], loaded),
-                    target.parent.parent / "blobs",
+                    blob_dir,
                 )
             )
     return trials

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -329,48 +329,66 @@ def _run_eval(
         for epoch in range(epoch_spec.count):
             trial_seed = derive_seed(seed, scene.init_seed, epoch)
             bus.on_trial_start(scene.id, epoch)
-            record: TrialRecord | None
-            try:
-                record = rollout(
-                    policy,
-                    embodiment,
-                    scene,
-                    max_steps=task_envelope.max_steps,
-                    seed=trial_seed,
-                    epoch=epoch,
-                    controller=controller,
-                    approver=approver,
-                    sink=bus,
-                    frame_store=frame_store,
-                )
-            except _CancelledTrial as exc:
-                status = "cancelled"
-                error = str(exc)
-                scene_status = "cancelled"
-                scene_error = error
-                halted = True
-                cancelled_exc = exc
-                record = exc.record
-            except (EmbodimentFault, SafetyAbort) as exc:
-                # Hardware/safety failures always halt the whole eval; the
-                # partial trial record (if any) is preserved below.
-                status = "error"
-                error = f"{type(exc).__name__}: {exc}"
-                scene_status = "error"
-                scene_error = error
-                halted = True
-                record = exc.record
-            except PolicyError as exc:
-                error_count += 1
-                scene_status = "error"
-                scene_error = f"{type(exc).__name__}: {exc}"
-                record = exc.record or TrialRecord(
-                    scene_id=scene.id,
-                    epoch=epoch,
-                    seed=trial_seed,
-                    status="error",
-                    error=scene_error,
-                )
+            record: TrialRecord | None = None
+            policy_start_failed = False
+            on_trial_start = getattr(policy, "on_trial_start", None)
+            if callable(on_trial_start):
+                try:
+                    on_trial_start(scene.id, epoch, log_dir, run_stamp)
+                except Exception as exc:
+                    policy_start_failed = True
+                    error_count += 1
+                    scene_status = "error"
+                    scene_error = f"policy.on_trial_start failed: {exc}"
+                    record = TrialRecord(
+                        scene_id=scene.id,
+                        epoch=epoch,
+                        seed=trial_seed,
+                        status="error",
+                        error=scene_error,
+                    )
+            if not policy_start_failed:
+                try:
+                    record = rollout(
+                        policy,
+                        embodiment,
+                        scene,
+                        max_steps=task_envelope.max_steps,
+                        seed=trial_seed,
+                        epoch=epoch,
+                        controller=controller,
+                        approver=approver,
+                        sink=bus,
+                        frame_store=frame_store,
+                    )
+                except _CancelledTrial as exc:
+                    status = "cancelled"
+                    error = str(exc)
+                    scene_status = "cancelled"
+                    scene_error = error
+                    halted = True
+                    cancelled_exc = exc
+                    record = exc.record
+                except (EmbodimentFault, SafetyAbort) as exc:
+                    # Hardware/safety failures always halt the whole eval; the
+                    # partial trial record (if any) is preserved below.
+                    status = "error"
+                    error = f"{type(exc).__name__}: {exc}"
+                    scene_status = "error"
+                    scene_error = error
+                    halted = True
+                    record = exc.record
+                except PolicyError as exc:
+                    error_count += 1
+                    scene_status = "error"
+                    scene_error = f"{type(exc).__name__}: {exc}"
+                    record = exc.record or TrialRecord(
+                        scene_id=scene.id,
+                        epoch=epoch,
+                        seed=trial_seed,
+                        status="error",
+                        error=scene_error,
+                    )
 
             if record is not None:
                 total_trials += 1
@@ -404,19 +422,24 @@ def _run_eval(
                     judgements.append(record.operator_judgement)
                     notes.append(record.operator_note)
 
-                on_trial_end = getattr(policy, "on_trial_end", None)
-                if callable(on_trial_end):
-                    try:
-                        on_trial_end(record, log_dir, run_stamp)
-                    except Exception as exc:
-                        # Named `detail`, not `note`: a grader's note is a
-                        # different thing entirely and is collected just above.
-                        detail = f"policy.on_trial_end failed: {exc}"
-                        scene_status = "error"
-                        scene_error = detail if scene_error is None else f"{scene_error}; {detail}"
-                        if status == "success":
-                            status = "error"
-                            error = detail
+                # A never-reset trial must not persist the previous trial's
+                # policy state under this trial's identity.
+                if not policy_start_failed:
+                    on_trial_end = getattr(policy, "on_trial_end", None)
+                    if callable(on_trial_end):
+                        try:
+                            on_trial_end(record, log_dir, run_stamp)
+                        except Exception as exc:
+                            # Named `detail`, not `note`: a grader's note is a
+                            # different thing entirely and is collected just above.
+                            detail = f"policy.on_trial_end failed: {exc}"
+                            scene_status = "error"
+                            scene_error = (
+                                detail if scene_error is None else f"{scene_error}; {detail}"
+                            )
+                            if status == "success":
+                                status = "error"
+                                error = detail
 
                 trial_metadatas.append(record.metadata)
                 termination_reasons.append(record.termination_reason)

--- a/src/inspect_robots/policy.py
+++ b/src/inspect_robots/policy.py
@@ -55,12 +55,16 @@ class PolicyInfo:
 class Policy(Protocol):
     """The VLA contract.
 
-    Policies may additionally define four optional hooks, none part of this
+    Policies may additionally define five optional hooks, none part of this
     Protocol so existing policies stay conformant. ``bind(embodiment_info)``
     lets embodiment-adaptive policies adopt the embodiment's spaces; ``eval()``
     calls it after resolving both components and before compatibility checking.
+    ``on_trial_start(scene_id, epoch, log_dir, run_id)`` runs immediately before
+    each trial's rollout. It is a policy lifecycle hook, distinct from the sink
+    bus hook of the same name, which runs first and takes only scene id and epoch.
     ``on_trial_end(record, log_dir, run_id)`` runs when a trial finishes (including
-    errored and cancelled trials), before sinks see the record. Mutations to
+    errored and cancelled trials, except trials whose ``on_trial_start`` raised,
+    which never reached ``reset()``), before sinks see the record. Mutations to
     ``record.metadata`` land in the log, and exceptions degrade the run to
     status="error" rather than crashing the overall evaluation.
     ``transcript()`` returns a small JSON-serializable audit record for the
@@ -102,12 +106,21 @@ class PolicyBase(ABC):
     def bind(self, embodiment_info: EmbodimentInfo) -> None:  # noqa: B027 - no-op default
         """Default: fixed-space policies ignore the embodiment they run on."""
 
+    def on_trial_start(self, scene_id: str, epoch: int, log_dir: str, run_id: str) -> None:  # noqa: B027
+        """Optional: Hook called by eval() immediately before each trial's rollout.
+
+        This policy hook receives log context and is distinct from the sink bus
+        hook of the same name, which runs first with only scene id and epoch.
+        """
+
     def on_trial_end(self, record: TrialRecord, log_dir: str, run_id: str) -> None:  # noqa: B027
         """Optional: Hook called by eval() when a trial completes.
 
-        Called for errored and cancelled trials too, before sinks see the record.
-        Mutations to record.metadata land in the log, and exceptions degrade the
-        run to status="error" rather than crashing the overall evaluation.
+        Called for errored and cancelled trials too, except trials whose
+        ``on_trial_start`` raised, which never reached ``reset()``, before sinks
+        see the record. Mutations to record.metadata land in the log, and
+        exceptions degrade the run to status="error" rather than crashing the
+        overall evaluation.
         """
 
     def reset(self, scene: Scene) -> None:  # noqa: B027 - intentional no-op default

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -857,8 +857,131 @@ def test_eval_set_forwards_before_scoring(tmp_path: Path) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# 9. on_trial_end hook: artifact persistence via trial metadata.
+# 9. Policy trial lifecycle hooks: setup and artifact persistence.
 # --------------------------------------------------------------------------- #
+def test_on_trial_start_runs_before_each_trials_first_act(tmp_path: Path) -> None:
+    events: list[tuple[object, ...]] = []
+
+    class _StartHookPolicy(ScriptedPolicy):
+        def __init__(self) -> None:
+            super().__init__()
+            self.epoch = -1
+
+        def on_trial_start(self, scene_id: str, epoch: int, log_dir: str, run_id: str) -> None:
+            self.epoch = epoch
+            events.append(("start", scene_id, epoch, log_dir, run_id))
+
+        def act(self, observation: Observation) -> ActionChunk:
+            events.append(("act", self.epoch))
+            return super().act(observation)
+
+    eval(_task(epochs=2), _StartHookPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path))
+
+    starts = [event for event in events if event[0] == "start"]
+    assert [(event[1], event[2], event[3]) for event in starts] == [
+        ("s0", 0, str(tmp_path)),
+        ("s0", 1, str(tmp_path)),
+    ]
+    assert starts[0][4] == starts[1][4]
+    for epoch in range(2):
+        start_index = next(
+            i for i, event in enumerate(events) if event[:3] == ("start", "s0", epoch)
+        )
+        act_index = next(i for i, event in enumerate(events) if event == ("act", epoch))
+        assert start_index < act_index
+
+
+def test_raising_on_trial_start_skips_rollout_but_keeps_results_parallel(
+    tmp_path: Path,
+) -> None:
+    class _LifecycleSink(_RecordingSink):
+        def __init__(self) -> None:
+            super().__init__()
+            self.starts: list[tuple[str, int]] = []
+
+        def on_trial_start(self, scene_id: str, epoch: int) -> None:
+            self.starts.append((scene_id, epoch))
+
+    class _StartFailurePolicy(ScriptedPolicy):
+        def __init__(self) -> None:
+            super().__init__()
+            self.current_epoch = -1
+            self.resets: list[int] = []
+            self.acts: list[int] = []
+            self.ends: list[int] = []
+
+        def on_trial_start(self, scene_id: str, epoch: int, log_dir: str, run_id: str) -> None:
+            self.current_epoch = epoch
+            if epoch == 0:
+                raise RuntimeError("capture setup exploded")
+
+        def reset(self, scene: Scene) -> None:
+            self.resets.append(self.current_epoch)
+            super().reset(scene)
+
+        def act(self, observation: Observation) -> ActionChunk:
+            self.acts.append(self.current_epoch)
+            return super().act(observation)
+
+        def on_trial_end(self, record: TrialRecord, log_dir: str, run_id: str) -> None:
+            self.ends.append(record.epoch)
+
+    policy = _StartFailurePolicy()
+    sink = _LifecycleSink()
+    (log,) = eval(
+        _task(epochs=2),
+        policy,
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+        sinks=[sink, JsonLogSink(str(tmp_path))],
+    )
+
+    scene = log.samples[0]
+    parallel = (
+        scene.epochs,
+        scene.operator_judgements,
+        scene.operator_notes,
+        scene.trial_metadata,
+        scene.termination_reasons,
+        scene.policy_transcripts,
+    )
+    assert {len(values) for values in parallel} == {2}
+    assert scene.epochs[0] == {}
+    assert scene.error == "policy.on_trial_start failed: capture setup exploded"
+    assert log.results.total_trials == 2
+    assert log.results.errored_trials == 1
+    assert policy.resets == [1]
+    assert policy.acts and set(policy.acts) == {1}
+    assert policy.ends == [1]
+    assert sink.starts == [("s0", 0), ("s0", 1)]
+    assert [record.epoch for record in sink.records] == [0, 1]
+    assert sink.records[0].status == "error"
+    assert sink.records[0].error == scene.error
+    assert len(list(tmp_path.glob("*.json"))) == 1
+
+
+def test_raising_on_trial_start_counts_toward_fail_on_error(tmp_path: Path) -> None:
+    class _SecondStartFails(ScriptedPolicy):
+        def on_trial_start(self, scene_id: str, epoch: int, log_dir: str, run_id: str) -> None:
+            if epoch == 1:
+                raise RuntimeError("second setup exploded")
+
+    (log,) = eval(
+        _task(epochs=3),
+        _SecondStartFails(),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+        fail_on_error=True,
+    )
+
+    assert log.status == "error"
+    assert log.error == "fail_on_error threshold exceeded (1 errors)"
+    assert log.results.total_trials == 2
+    assert log.results.errored_trials == 1
+    assert len(log.samples[0].epochs) == 2
+    assert len(list(tmp_path.glob("*.json"))) == 1
+
+
 def test_on_trial_end_hook_persists_metadata_and_recovers_from_errors(tmp_path: Path) -> None:
     task = _task(epochs=2)
     seen_ids: list[str] = []

--- a/tests/test_html_view.py
+++ b/tests/test_html_view.py
@@ -892,6 +892,16 @@ def test_wire_section_is_absent_for_unavailable_sidecars(tmp_path: Path, mode: s
     assert "Trial 0 Wire" not in document
 
 
+def test_wire_section_survives_torn_tail_line(tmp_path: Path) -> None:
+    log, log_path, calls_path = _wire_log(tmp_path, [{"call": 0, "request": {}}])
+    with calls_path.open("a", encoding="utf-8") as handle:
+        handle.write('{"call": 1, "request": {"model": "trunc')
+
+    document = render_html(log, title="torn", log_path=log_path)
+
+    assert "Trial 0 Wire" in document
+
+
 def test_wire_hostile_and_missing_blob_references_render_broken(tmp_path: Path) -> None:
     uppercase = "A" * 64
     missing = "b" * 64

--- a/tests/test_html_view.py
+++ b/tests/test_html_view.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import base64
 import dataclasses
+import hashlib
+import json
 import re
 import struct
 from collections.abc import Sequence
@@ -102,6 +104,29 @@ def _parts(name: str = "top_cam", step: int = 4) -> list[object]:
 
 def _frame_log(parts: Sequence[object], *, role: str = "user") -> EvalLog:
     return _log(transcripts=(_chat({"role": role, "content": list(parts)}),))
+
+
+def _wire_log(
+    tmp_path: Path,
+    rows: Sequence[object],
+    *,
+    pointer: str = "wire/run/scene-0-e0/calls.jsonl",
+    scene_id: str = "scene-0",
+) -> tuple[EvalLog, Path, Path]:
+    log = _log()
+    scene = dataclasses.replace(
+        log.samples[0],
+        scene_id=scene_id,
+        trial_metadata=({"wire_capture": pointer}, {}),
+    )
+    log_path = tmp_path / "run.json"
+    calls_path = tmp_path / pointer
+    calls_path.parent.mkdir(parents=True, exist_ok=True)
+    calls_path.write_text(
+        "".join(f"{json.dumps(row)}\n" for row in rows),
+        encoding="utf-8",
+    )
+    return dataclasses.replace(log, samples=(scene,)), log_path, calls_path
 
 
 def _png_dimensions_from_document(document: str) -> tuple[int, int]:
@@ -719,7 +744,7 @@ def test_frame_budget_embeds_first_then_truncates_remaining(tmp_path: Path) -> N
     assert document.count('<img class="frame"') == 1
     assert document.count("[image omitted: streamed camera frame]") == 2
     budget_mb = payload_size / 1_000_000
-    assert f"frames truncated at {budget_mb:g} MB (1 embedded)" in document
+    assert f"embedded media truncated at {budget_mb:g} MB (1 embedded)" in document
 
 
 def test_zero_frame_budget_is_unlimited(tmp_path: Path) -> None:
@@ -732,7 +757,7 @@ def test_zero_frame_budget_is_unlimited(tmp_path: Path) -> None:
     )
 
     assert document.count('<img class="frame"') == 2
-    assert document.count("frames truncated at") == 0
+    assert document.count("embedded media truncated at") == 0
 
 
 def test_non_truncated_frame_render_has_no_truncation_chip(tmp_path: Path) -> None:
@@ -740,7 +765,7 @@ def test_non_truncated_frame_render_has_no_truncation_chip(tmp_path: Path) -> No
 
     document = render_html(_frame_log(_parts()), title="fits", frames_dir=tmp_path)
 
-    assert document.count("frames truncated at") == 0
+    assert document.count("embedded media truncated at") == 0
 
 
 def test_non_chat_transcript_never_embeds_frames(tmp_path: Path) -> None:
@@ -761,3 +786,300 @@ def test_non_user_chat_messages_never_embed_frames(tmp_path: Path, role: str) ->
 
     assert '<img class="frame"' not in document
     assert "[image omitted: streamed camera frame]" in document
+
+
+def test_wire_section_renders_blob_stubs_breakpoints_and_request_summary(
+    tmp_path: Path,
+) -> None:
+    png = b"\x89PNG\r\nwire"
+    sha = hashlib.sha256(png).hexdigest()
+    row = {
+        "call": 0,
+        "attempt": 0,
+        "endpoint": "/messages",
+        "duration_s": 0.125,
+        "status": 200,
+        "request": {
+            "model": "claude-test",
+            "reasoning_effort": "high",
+            "temperature": 0.2,
+            "system": [{"type": "text", "text": "system prompt"}],
+            "tools": [{"name": "move", "description": "move safely"}],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "[image omitted: context window]",
+                            "count": 1,
+                        },
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": f"$blob:{sha}",
+                            },
+                            "cache_control": {"type": "ephemeral"},
+                        },
+                    ],
+                }
+            ],
+        },
+    }
+    log, log_path, calls_path = _wire_log(tmp_path, [row], scene_id="scene / 0")
+    blob_dir = calls_path.parent.parent / "blobs"
+    blob_dir.mkdir()
+    (blob_dir / f"{sha}.png").write_bytes(png)
+
+    document = render_html(log, title="wire", log_path=log_path)
+
+    anchor = f"wire-{_safe('scene / 0-e0')}-{sha[:12]}"
+    assert "Trial 0 Wire" in document
+    assert "/messages" in document
+    assert "claude-test" in document and "high" in document and "0.2" in document
+    assert "[image omitted: context window]" in document
+    assert "cache_control" in document and "ephemeral" in document
+    assert f'id="{anchor}"' in document
+    assert f"data:image/png;base64,{base64.b64encode(png).decode('ascii')}" in document
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["missing-metadata", "deleted", "traversal", "empty", "non-object", "malformed"],
+)
+def test_wire_section_is_absent_for_unavailable_sidecars(tmp_path: Path, mode: str) -> None:
+    if mode == "missing-metadata":
+        document = render_html(_log(), title="absent", log_path=tmp_path / "run.json")
+    elif mode == "traversal":
+        log = _log()
+        scene = dataclasses.replace(
+            log.samples[0],
+            trial_metadata=({"wire_capture": "../outside/calls.jsonl"}, {}),
+        )
+        document = render_html(
+            dataclasses.replace(log, samples=(scene,)),
+            title="absent",
+            log_path=tmp_path / "run.json",
+        )
+    else:
+        log, log_path, calls_path = _wire_log(tmp_path, [{"request": {}}])
+        if mode == "deleted":
+            calls_path.unlink()
+        elif mode == "empty":
+            calls_path.write_text("", encoding="utf-8")
+        elif mode == "non-object":
+            calls_path.write_text("[]\n", encoding="utf-8")
+        else:
+            calls_path.write_text("{\n", encoding="utf-8")
+        document = render_html(log, title="absent", log_path=log_path)
+
+    assert "Trial 0 Wire" not in document
+
+
+def test_wire_hostile_and_missing_blob_references_render_broken(tmp_path: Path) -> None:
+    uppercase = "A" * 64
+    missing = "b" * 64
+    row = {
+        "call": 0,
+        "attempt": 0,
+        "endpoint": "/responses",
+        "duration_s": "unknown",
+        "status": 200,
+        "request": {
+            "input": [
+                {"content": "$blob:../../x"},
+                {"content": f"$blob:{uppercase}"},
+                {"content": f"$blob:{missing}"},
+            ],
+            "tools": "malformed",
+        },
+    }
+    log, log_path, _ = _wire_log(tmp_path, [row])
+
+    document = render_html(log, title="hostile", log_path=log_path)
+
+    assert document.count("broken blob reference") == 3
+    assert "../../x" in document
+    assert "data:image/png;base64," not in document
+
+
+def test_wire_budget_denial_never_emits_a_dangling_repeat_link(tmp_path: Path) -> None:
+    png = b"budgeted"
+    sha = hashlib.sha256(png).hexdigest()
+    message = {"role": "user", "content": f"data:image/png;base64,$blob:{sha}"}
+    rows = [
+        {
+            "call": call,
+            "attempt": 0,
+            "endpoint": "/chat/completions",
+            "duration_s": 0.1,
+            "status": 200,
+            "request": {"messages": [message] if call == 0 else [message, message]},
+        }
+        for call in range(2)
+    ]
+    log, log_path, calls_path = _wire_log(tmp_path, rows)
+    blob_dir = calls_path.parent.parent / "blobs"
+    blob_dir.mkdir()
+    (blob_dir / f"{sha}.png").write_bytes(png)
+
+    document = render_html(log, title="budget", log_path=log_path, frames_budget_bytes=1)
+
+    assert document.count("[blob elided: media budget]") == 2
+    assert f'href="#wire-scene-0-e0-{sha[:12]}"' not in document
+    assert "embedded media truncated at" in document
+
+
+def test_wire_repeat_blob_links_to_the_single_first_embed(tmp_path: Path) -> None:
+    png = b"repeat"
+    sha = hashlib.sha256(png).hexdigest()
+    reference = f"data:image/png;base64,$blob:{sha}"
+    rows = [
+        {
+            "call": 0,
+            "attempt": 0,
+            "endpoint": "/responses",
+            "duration_s": 0.1,
+            "status": 200,
+            "request": {"input": [{"content": reference}]},
+        },
+        {
+            "call": 1,
+            "attempt": 0,
+            "endpoint": "/responses",
+            "duration_s": 0.2,
+            "status": 200,
+            "request": {"input": [{"content": reference}, {"content": reference}]},
+        },
+    ]
+    log, log_path, calls_path = _wire_log(tmp_path, rows)
+    blob_dir = calls_path.parent.parent / "blobs"
+    blob_dir.mkdir()
+    (blob_dir / f"{sha}.png").write_bytes(png)
+
+    document = render_html(log, title="repeat", log_path=log_path)
+
+    anchor = f"wire-scene-0-e0-{sha[:12]}"
+    assert document.count(f'id="{anchor}"') == 1
+    assert document.count(f'href="#{anchor}"') == 1
+
+
+def test_wire_messages_are_delta_rendered_with_changed_as_sent_form(
+    tmp_path: Path,
+) -> None:
+    old_message = {"role": "user", "content": "original full text"}
+    rewritten = {
+        "role": "user",
+        "content": [{"type": "text", "text": "[image omitted: evicted view]"}],
+    }
+    new_message = {
+        "role": "assistant",
+        "content": [{"type": "text", "text": "brand-new message"}],
+        "cache_control": {"type": "ephemeral"},
+    }
+    rows = [
+        {
+            "call": 0,
+            "attempt": 0,
+            "endpoint": "/messages",
+            "duration_s": 0.1,
+            "status": 200,
+            "request": {"messages": [old_message]},
+        },
+        {
+            "call": 1,
+            "attempt": 0,
+            "endpoint": "/messages",
+            "duration_s": 0.1,
+            "status": 200,
+            "request": {
+                "messages": [rewritten, new_message],
+                "reasoning": {"effort": "medium"},
+            },
+        },
+    ]
+    log, log_path, _ = _wire_log(tmp_path, rows)
+
+    document = render_html(log, title="delta", log_path=log_path)
+    second_call = document[document.index("call 1 attempt 0") :]
+
+    assert "message 0 changed as sent" in second_call
+    assert "[image omitted: evicted view]" in second_call
+    assert "brand-new message" in second_call
+    assert "cache_control" in second_call
+    assert "original full text" not in second_call
+
+
+def test_wire_tools_and_system_render_once_then_only_report_changes(
+    tmp_path: Path,
+) -> None:
+    rows = [
+        {
+            "call": 0,
+            "attempt": 0,
+            "endpoint": "/messages",
+            "duration_s": 0.1,
+            "status": 200,
+            "request": {
+                "system": "initial-system",
+                "tools": [{"name": "initial-tool"}],
+                "messages": [],
+                "output_config": {"effort": "low"},
+            },
+        },
+        {
+            "call": 0,
+            "attempt": 1,
+            "endpoint": "/messages",
+            "duration_s": 0.2,
+            "status": 429,
+            "request": {
+                "system": "initial-system",
+                "tools": [{"name": "initial-tool"}],
+                "messages": [],
+            },
+        },
+        {
+            "call": 1,
+            "attempt": 0,
+            "endpoint": "/messages",
+            "duration_s": 0.3,
+            "status": 200,
+            "request": {
+                "system": "changed-system",
+                "tools": [{"name": "changed-tool"}],
+                "messages": [],
+            },
+        },
+    ]
+    log, log_path, _ = _wire_log(tmp_path, rows)
+
+    document = render_html(log, title="static", log_path=log_path)
+
+    assert document.count("initial-system") == 1
+    assert document.count("initial-tool") == 1
+    assert "changed-system" not in document
+    assert "changed-tool" not in document
+    assert document.count("tools changed from the trial") == 1
+    assert document.count("system changed from the trial") == 1
+    assert "no new messages" in document
+
+
+def test_wire_malformed_request_degrades_to_an_empty_call(tmp_path: Path) -> None:
+    row = {
+        "call": 0,
+        "attempt": 0,
+        "endpoint": "/chat/completions",
+        "duration_s": None,
+        "status": None,
+        "request": [],
+    }
+    log, log_path, _ = _wire_log(tmp_path, [row])
+
+    document = render_html(log, title="malformed", log_path=log_path)
+
+    assert "Trial 0 Wire" in document
+    assert "no new messages" in document
+    assert "<dd>n/a</dd>" in document

--- a/tests/test_html_view.py
+++ b/tests/test_html_view.py
@@ -847,7 +847,7 @@ def test_wire_section_renders_blob_stubs_breakpoints_and_request_summary(
 
 @pytest.mark.parametrize(
     "mode",
-    ["missing-metadata", "deleted", "traversal", "empty", "non-object", "malformed"],
+    ["missing-metadata", "deleted", "traversal", "shallow", "empty", "non-object", "malformed"],
 )
 def test_wire_section_is_absent_for_unavailable_sidecars(tmp_path: Path, mode: str) -> None:
     if mode == "missing-metadata":
@@ -857,6 +857,20 @@ def test_wire_section_is_absent_for_unavailable_sidecars(tmp_path: Path, mode: s
         scene = dataclasses.replace(
             log.samples[0],
             trial_metadata=({"wire_capture": "../outside/calls.jsonl"}, {}),
+        )
+        document = render_html(
+            dataclasses.replace(log, samples=(scene,)),
+            title="absent",
+            log_path=tmp_path / "run.json",
+        )
+    elif mode == "shallow":
+        # A depth-0 pointer resolves inside the log dir, but its derived
+        # blobs dir (parent.parent / "blobs") would land one level above it.
+        (tmp_path / "calls.jsonl").write_text('{"call": 0}\n', encoding="utf-8")
+        log = _log()
+        scene = dataclasses.replace(
+            log.samples[0],
+            trial_metadata=({"wire_capture": "calls.jsonl"}, {}),
         )
         document = render_html(
             dataclasses.replace(log, samples=(scene,)),

--- a/tests/test_pointers.py
+++ b/tests/test_pointers.py
@@ -1,0 +1,35 @@
+"""Tests for guarded portable-log pointer resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from inspect_robots._pointers import resolve_log_pointer
+
+
+def test_resolve_log_pointer_accepts_only_paths_beneath_log_directory(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "run.json"
+
+    assert resolve_log_pointer(log_path, "wire/run/trial/calls.jsonl") == (
+        tmp_path / "wire/run/trial/calls.jsonl"
+    )
+    assert resolve_log_pointer(log_path, "") is None
+    assert resolve_log_pointer(log_path, None) is None
+    assert resolve_log_pointer(log_path, "../outside.jsonl") is None
+    assert resolve_log_pointer(log_path, tmp_path / "sidecar.jsonl") is None
+
+
+def test_resolve_log_pointer_degrades_resolution_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fail_resolve(self: Path) -> Path:
+        del self
+        raise OSError("unreadable")
+
+    monkeypatch.setattr(Path, "resolve", fail_resolve)
+
+    assert resolve_log_pointer(tmp_path / "run.json", "wire/calls.jsonl") is None

--- a/tests/test_pointers.py
+++ b/tests/test_pointers.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from inspect_robots._pointers import resolve_log_pointer
+from inspect_robots._pointers import read_jsonl_prefix, resolve_log_pointer
 
 
 def test_resolve_log_pointer_accepts_only_paths_beneath_log_directory(
@@ -33,3 +33,31 @@ def test_resolve_log_pointer_degrades_resolution_errors(
     monkeypatch.setattr(Path, "resolve", fail_resolve)
 
     assert resolve_log_pointer(tmp_path / "run.json", "wire/calls.jsonl") is None
+
+
+def test_read_jsonl_prefix_keeps_rows_before_first_bad_line(tmp_path: Path) -> None:
+    path = tmp_path / "calls.jsonl"
+    path.write_text('{"call": 0}\n{"call": 1}\n{"torn', encoding="utf-8")
+    assert read_jsonl_prefix(path) == [{"call": 0}, {"call": 1}]
+
+
+def test_read_jsonl_prefix_stops_at_non_object_line(tmp_path: Path) -> None:
+    path = tmp_path / "calls.jsonl"
+    path.write_text('{"call": 0}\n[]\n{"call": 2}\n', encoding="utf-8")
+    assert read_jsonl_prefix(path) == [{"call": 0}]
+
+
+def test_read_jsonl_prefix_none_for_empty_missing_or_undecodable(tmp_path: Path) -> None:
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("", encoding="utf-8")
+    assert read_jsonl_prefix(empty) is None
+    assert read_jsonl_prefix(tmp_path / "absent.jsonl") is None
+    torn_first = tmp_path / "torn.jsonl"
+    torn_first.write_bytes(b"\xff\xfe")
+    assert read_jsonl_prefix(torn_first) is None
+
+
+def test_read_jsonl_prefix_keeps_prefix_before_torn_multibyte_tail(tmp_path: Path) -> None:
+    path = tmp_path / "calls.jsonl"
+    path.write_bytes(b'{"call": 0}\n{"note": "\xe2\x82')
+    assert read_jsonl_prefix(path) == [{"call": 0}]

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -1146,6 +1146,34 @@ def _write_log(log: EvalLog, tmp_path: Path, name: str) -> Path:
     return path
 
 
+def _write_wire_log(
+    tmp_path: Path,
+    trials: tuple[list[dict[str, object]], ...],
+    *,
+    pointer_override: str | None = None,
+) -> tuple[Path, Path]:
+    log = _step_limit_log(reasons=tuple("success" for _ in trials))
+    pointers: list[dict[str, object]] = []
+    for epoch, rows in enumerate(trials):
+        pointer = (
+            pointer_override
+            if pointer_override is not None
+            else f"wire/run/s0-e{epoch}/calls.jsonl"
+        )
+        pointers.append({"wire_capture": pointer})
+        if pointer_override is None:
+            calls_path = tmp_path / pointer
+            calls_path.parent.mkdir(parents=True, exist_ok=True)
+            calls_path.write_text(
+                "".join(f"{json.dumps(row)}\n" for row in rows),
+                encoding="utf-8",
+            )
+    scene = dataclasses.replace(log.samples[0], trial_metadata=tuple(pointers))
+    log_path = _write_log(dataclasses.replace(log, samples=(scene,)), tmp_path, "wire.json")
+    blob_dir = tmp_path / "wire" / "run" / "blobs"
+    return log_path, blob_dir
+
+
 def _view_frame_log(frames_dir: str) -> EvalLog:
     log = _transcript_log()
     chat = [
@@ -1271,10 +1299,12 @@ def test_view_frames_budget_is_forwarded_as_decimal_megabytes(
         log: EvalLog,
         *,
         title: str,
+        log_path: Path,
         frames_dir: Path | None,
         frames_budget_bytes: int,
     ) -> str:
         del log, title, frames_dir
+        assert log_path == path
         received.append(frames_budget_bytes)
         return "<html></html>"
 
@@ -1680,6 +1710,187 @@ def test_plain_inspect_mentions_recorded_policy_transcripts(
     assert "policy transcripts: recorded (--transcript to print)" in out
     assert f"hint: HTML viewer: inspect-robots view {path}" in out
     assert "scene s0, trial 0:" not in out
+
+
+def test_inspect_wire_table_reports_attempts_images_and_new_blob_bytes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sha = "a" * 64
+    missing_sha = "c" * 64
+    reference = f"data:image/png;base64,$blob:{sha}"
+    rows: list[dict[str, object]] = [
+        {
+            "call": 0,
+            "attempt": 0,
+            "endpoint": "/chat/completions",
+            "duration_s": 0.1251,
+            "status": 429,
+            "request": {
+                "messages": [{"content": [reference, reference, f"$blob:{missing_sha}", 3]}]
+            },
+            "response": {"error": "retry"},
+        },
+        {
+            "call": 0,
+            "attempt": 1,
+            "endpoint": "/chat/completions",
+            "duration_s": True,
+            "status": None,
+            "request": {"messages": [{"content": reference}]},
+            "response": None,
+        },
+    ]
+    path, blob_dir = _write_wire_log(tmp_path, (rows,))
+    blob_dir.mkdir(parents=True)
+    (blob_dir / f"{sha}.png").write_bytes(b"blob")
+
+    assert main(["inspect", str(path), "--wire"]) == 0
+
+    out = capsys.readouterr().out
+    assert "wire calls:" in out
+    assert "trial  call  attempt  endpoint  status  duration  images  new blob bytes" in out
+    assert "s0-e0  0  0  /chat/completions  429  0.125s  3  4" in out
+    assert "s0-e0  0  1  /chat/completions  -  -  1  0" in out
+
+
+def test_inspect_wire_call_dumps_every_retry_with_symbolic_blobs(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sha = "b" * 64
+    rows: list[dict[str, object]] = [
+        {
+            "call": 3,
+            "attempt": attempt,
+            "endpoint": "/responses",
+            "duration_s": 0.2,
+            "status": status,
+            "request": {"input": [{"image_url": f"$blob:{sha}"}]},
+            "response": response,
+        }
+        for attempt, status, response in (
+            (0, 500, {"error": "retry"}),
+            (1, 200, "raw response"),
+        )
+    ]
+    rows[0]["error"] = "temporary transport detail"
+    path, _ = _write_wire_log(tmp_path, (rows,))
+
+    assert main(["inspect", str(path), "--wire", "3"]) == 0
+
+    out = capsys.readouterr().out
+    assert "wire trial s0-e0, call 3:" in out
+    assert out.count("attempt ") == 2
+    assert f"$blob:{sha}" in out
+    assert '"error": "retry"' in out
+    assert '"raw response"' in out
+    assert "endpoint: /responses" in out
+    assert "status: 500" in out
+    assert "error: temporary transport detail" in out
+
+
+def test_inspect_wire_call_requires_trial_for_multiple_captures(
+    tmp_path: Path,
+) -> None:
+    row = {
+        "call": 0,
+        "attempt": 0,
+        "endpoint": "/messages",
+        "duration_s": 0.1,
+        "status": 200,
+        "request": {},
+        "response": {},
+    }
+    path, _ = _write_wire_log(tmp_path, ([row], [row]))
+
+    with pytest.raises(
+        SystemExit,
+        match=r"--trial is required.*available trials: s0-e0, s0-e1",
+    ):
+        main(["inspect", str(path), "--wire", "0"])
+
+
+def test_inspect_wire_trial_selects_one_capture(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    first = {
+        "call": 0,
+        "attempt": 0,
+        "endpoint": "/first",
+        "duration_s": 0.1,
+        "status": 200,
+        "request": {},
+        "response": {},
+    }
+    second = {**first, "endpoint": "/second"}
+    path, _ = _write_wire_log(tmp_path, ([first], [second]))
+
+    assert main(["inspect", str(path), "--wire", "0", "--trial", "s0-e1"]) == 0
+
+    out = capsys.readouterr().out
+    assert "wire trial s0-e1, call 0:" in out
+    assert "/first" not in out
+
+
+def test_inspect_wire_missing_capture_is_non_error_for_table_and_error_for_call(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_log(_step_limit_log(reasons=("success",)), tmp_path, "none-wire.json")
+
+    assert main(["inspect", str(path), "--wire"]) == 0
+    assert "no wire capture recorded" in capsys.readouterr().out
+
+    with pytest.raises(SystemExit, match="no wire capture recorded"):
+        main(["inspect", str(path), "--wire", "0"])
+
+
+def test_inspect_wire_hostile_pointer_is_treated_as_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path, _ = _write_wire_log(tmp_path, ([],), pointer_override="../outside/calls.jsonl")
+
+    assert main(["inspect", str(path), "--wire"]) == 0
+    assert "no wire capture recorded" in capsys.readouterr().out
+
+
+def test_inspect_wire_guides_invalid_trial_call_and_trial_without_dump(
+    tmp_path: Path,
+) -> None:
+    row = {
+        "call": 1,
+        "attempt": 0,
+        "endpoint": "/responses",
+        "duration_s": 0.1,
+        "status": 200,
+        "request": {},
+        "response": {},
+    }
+    path, _ = _write_wire_log(tmp_path, ([row],))
+
+    with pytest.raises(SystemExit, match=r"wire trial 'missing' not found.*s0-e0"):
+        main(["inspect", str(path), "--wire", "1", "--trial", "missing"])
+    with pytest.raises(SystemExit, match="wire call 2 not found in trial s0-e0"):
+        main(["inspect", str(path), "--wire", "2"])
+    with pytest.raises(SystemExit, match="--trial requires an integer --wire CALL"):
+        main(["inspect", str(path), "--wire", "--trial", "s0-e0"])
+    with pytest.raises(SystemExit, match="--trial requires --wire CALL"):
+        main(["inspect", str(path), "--trial", "s0-e0"])
+
+
+@pytest.mark.parametrize("contents", [None, "", "[]\n", "{\n"])
+def test_inspect_wire_unreadable_or_invalid_sidecars_are_missing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    contents: str | None,
+) -> None:
+    path, _ = _write_wire_log(tmp_path, ([{}],))
+    calls_path = tmp_path / "wire" / "run" / "s0-e0" / "calls.jsonl"
+    if contents is None:
+        calls_path.unlink()
+    else:
+        calls_path.write_text(contents, encoding="utf-8")
+
+    assert main(["inspect", str(path), "--wire"]) == 0
+    assert "no wire capture recorded" in capsys.readouterr().out
 
 
 def test_run_summary_adds_agent_conversation_hint_when_recorded(

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -1852,6 +1852,19 @@ def test_inspect_wire_hostile_pointer_is_treated_as_missing(
     assert "no wire capture recorded" in capsys.readouterr().out
 
 
+def test_inspect_wire_keeps_rows_before_a_torn_tail_line(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    row = {"call": 0, "attempt": 0, "endpoint": "/chat/completions", "status": 200}
+    path, calls_path = _write_wire_log(tmp_path, ([row],))
+    with calls_path.open("a", encoding="utf-8") as handle:
+        handle.write('{"call": 1, "attempt": 0, "sta')
+
+    assert main(["inspect", str(path), "--wire"]) == 0
+    out = capsys.readouterr().out
+    assert "/chat/completions" in out
+
+
 def test_inspect_wire_shallow_pointer_is_treated_as_missing(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -1856,7 +1856,8 @@ def test_inspect_wire_keeps_rows_before_a_torn_tail_line(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     row = {"call": 0, "attempt": 0, "endpoint": "/chat/completions", "status": 200}
-    path, calls_path = _write_wire_log(tmp_path, ([row],))
+    path, _ = _write_wire_log(tmp_path, ([row],))
+    calls_path = tmp_path / "wire/run/s0-e0/calls.jsonl"
     with calls_path.open("a", encoding="utf-8") as handle:
         handle.write('{"call": 1, "attempt": 0, "sta')
 

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -1852,6 +1852,16 @@ def test_inspect_wire_hostile_pointer_is_treated_as_missing(
     assert "no wire capture recorded" in capsys.readouterr().out
 
 
+def test_inspect_wire_shallow_pointer_is_treated_as_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (tmp_path / "calls.jsonl").write_text('{"call": 0}\n', encoding="utf-8")
+    path, _ = _write_wire_log(tmp_path, ([],), pointer_override="calls.jsonl")
+
+    assert main(["inspect", str(path), "--wire"]) == 0
+    assert "no wire capture recorded" in capsys.readouterr().out
+
+
 def test_inspect_wire_guides_invalid_trial_call_and_trial_without_dump(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes #206.

Replay-grade, always-on capture of every LLM request/response at the wire-client serialization point (`plugins/inspect-robots-agent`), with content-addressed image blobs, plus full viewer integration (HTML report wire section, `inspect --wire`).

Design: `plans/0031-wire-capture.md` (7 critique rounds, gate clear).

Tasks land as sequential commits:
1. Core `on_trial_start` hook (+ hook-failure contract)
2. Plugin `WireCapture` sink
3. Wire-client + policy wiring, e2e dict-equality tests
4. Core viewers (HTML wire section, `inspect --wire`)
5. Docs (format contract), CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)