### PR TITLE
fix(rollout): persist post-action frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- `FrameStore` now persists each post-action observation once and exposes it
+  through `StepRecord.result_image_refs`. Stored records strip camera arrays
+  from both pre-action and post-action observations, and the terminal visual
+  state is recoverable for offline scoring.
+
 - The Rerun sink now sends a per-trial blueprint that groups labeled action
   dimensions by arm, overlays aligned measured state, and lays out cameras,
   transcript, events, and reward alongside the joint plots

--- a/plans/0032-post-action-frame-persistence.md
+++ b/plans/0032-post-action-frame-persistence.md
@@ -1,0 +1,69 @@
+# Post-action frame persistence
+
+## Problem
+
+`FrameStore` currently writes each step's pre-action `Observation`, then stores
+the unmodified `StepResult` in `StepRecord`. This has two consequences:
+
+1. `StepResult.observation.images` retains full camera arrays in memory, so a
+   stored trajectory does not satisfy the frame-store memory bound.
+2. The post-action observation from the final step has no sidecar reference.
+   Offline scorers therefore cannot reconstruct the terminal visual state.
+
+For non-terminal steps, the same post-action observation becomes the next
+pre-action observation and is stored one iteration later. The terminal
+observation has no next iteration and is lost from the sidecar sequence.
+
+## Contract
+
+With a `FrameStore`, every distinct rollout observation is written exactly once:
+
+- reset observation at frame index `0`;
+- result of step `t` at frame index `t + 1`.
+
+`StepRecord.observation` and `StepRecord.result.observation` contain no image
+arrays. Their handles live in `image_refs` and `result_image_refs`,
+respectively. Without a `FrameStore`, both observations and object identity
+remain unchanged.
+
+This makes a trial with `n` steps and one camera produce `n + 1` frame files.
+The final `result_image_refs` always identifies the terminal post-action frame.
+
+## Implementation
+
+The rollout stores the reset observation before entering the control loop. Each
+iteration then:
+
+1. gives the full current observation to the policy and sinks;
+2. executes the action;
+3. stores and strips the resulting observation at index `t + 1`;
+4. records both pre-action and post-action handles; and
+5. reuses the post-action stored view as the next step's pre-action view.
+
+Reusing the stored view prevents duplicate writes. The live observation with
+images remains available for the next policy call, so policy behavior and sink
+output do not change.
+
+## Compatibility
+
+`result_image_refs` is appended to `StepRecord` with a default of `None`, so
+existing keyword and positional constructors remain valid. `StepRecord` is an
+in-memory scorer interface and is not serialized in schema-versioned
+`EvalLog`, so no log migration is required.
+
+Runs without `FrameStore` preserve the original `Observation` and `StepResult`
+objects. Runs with `FrameStore` intentionally replace only the recorded
+`StepResult` with an image-stripped copy.
+
+## Verification
+
+Regression coverage must prove:
+
+- pre-action and post-action arrays are absent from stored records;
+- both reference maps load valid lossless arrays;
+- frame indices are contiguous from `0` through the terminal `n`;
+- one-camera trials write exactly `n + 1` files; and
+- the terminal post-action frame is recoverable.
+
+All existing lint, format, strict typing, and 100% line and branch coverage
+gates remain required.

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -63,8 +63,10 @@ def derive_seed(eval_seed: int | None, scene_seed: int | None, epoch: int) -> in
 class StepRecord:
     """One step of a recorded trajectory.
 
-    When a [`FrameStore`][inspect_robots.frames.FrameStore] is used, ``observation`` has its
-    images stripped and ``image_refs`` holds on-disk handles instead (R5).
+    When a [`FrameStore`][inspect_robots.frames.FrameStore] is used, both
+    ``observation`` and ``result.observation`` have their images stripped.
+    ``image_refs`` and ``result_image_refs`` hold the corresponding on-disk
+    handles instead (R5).
     """
 
     t: int
@@ -72,6 +74,7 @@ class StepRecord:
     action: Action
     result: StepResult
     image_refs: Mapping[str, FrameRef] | None = None
+    result_image_refs: Mapping[str, FrameRef] | None = None
 
 
 @dataclass
@@ -263,6 +266,7 @@ def rollout(
         except Exception as exc:
             raise _record_failure(record, EmbodimentFault(str(exc)), -1) from exc
 
+        obs_rec, refs = _store_frames(frame_store, trial_id, 0, obs)
         t = 0
         while t < max_steps:
             prev_inferences = len(store.get(_INFER_KEY, []))
@@ -338,9 +342,23 @@ def rollout(
                 raise _record_failure(record, EmbodimentFault(str(exc)), t) from exc
 
             sink.log_step(t, obs, action, result)
-            obs_rec, refs = _store_frames(frame_store, trial_id, t, obs)
+            result_obs_rec, result_refs = _store_frames(
+                frame_store, trial_id, t + 1, result.observation
+            )
+            result_rec = (
+                result
+                if result_obs_rec is result.observation
+                else replace(result, observation=result_obs_rec)
+            )
             record.steps.append(
-                StepRecord(t=t, observation=obs_rec, action=action, result=result, image_refs=refs)
+                StepRecord(
+                    t=t,
+                    observation=obs_rec,
+                    action=action,
+                    result=result_rec,
+                    image_refs=refs,
+                    result_image_refs=result_refs,
+                )
             )
             record.events.append(
                 step_event(t, result.terminated, result.truncated, result.termination_reason)
@@ -363,6 +381,8 @@ def rollout(
                 record.termination_reason = stop_reason
                 break
             obs = result.observation
+            obs_rec = result_obs_rec
+            refs = result_refs
         else:
             record.truncated = True
             record.termination_reason = "max_steps"

--- a/tests/test_rollout_hardening.py
+++ b/tests/test_rollout_hardening.py
@@ -261,12 +261,20 @@ def test_frame_store_sanitizes_without_collisions(tmp_path: Path) -> None:
 def test_frame_store_streams_to_disk(tmp_path: Path) -> None:
     store = FrameStore(str(tmp_path / "frames"))
     record = _run(ScriptedPolicy(), CubePickEmbodiment(), frame_store=store)
-    assert store.count > 0
+    assert store.count == len(record.steps) + 1
     first = record.steps[0]
-    assert not first.observation.images  # images stripped from the record
+    assert not first.observation.images
+    assert not first.result.observation.images
     assert first.image_refs is not None and "top" in first.image_refs
+    assert first.result_image_refs is not None and "top" in first.result_image_refs
+    assert first.image_refs["top"].t == 0
+    assert first.result_image_refs["top"].t == 1
     loaded = first.image_refs["top"].load()
     assert loaded.shape == (32, 32, 3)
+    terminal = record.steps[-1]
+    assert terminal.result_image_refs is not None
+    assert terminal.result_image_refs["top"].t == terminal.t + 1
+    assert terminal.result_image_refs["top"].load().shape == (32, 32, 3)
 
 
 def test_per_trial_seed_varies_by_epoch() -> None:


### PR DESCRIPTION
## Summary

Persist every distinct rollout observation through `FrameStore`, including the terminal post-action state.

Previously, the rollout stored only each step's pre-action observation. That left full camera arrays inside `StepResult.observation` and gave the terminal observation no sidecar reference, because it never becomes a later step's pre-action input.

## Changes

- store the reset observation at index `0` and each step result at `t + 1`;
- add `StepRecord.result_image_refs` for post-action frame handles;
- strip camera arrays from both recorded pre-action and post-action observations;
- reuse each stored post-action view on the next step, preventing duplicate writes;
- document the storage and compatibility contract in `plans/0032-post-action-frame-persistence.md`;
- add regression coverage for contiguous indexing, exact write count, and terminal-frame recovery.

A one-camera rollout with `n` steps now writes exactly `n + 1` frame files.

## Compatibility

- `result_image_refs` is appended with a default of `None`.
- Runs without `FrameStore` preserve the original observation and result objects.
- `StepRecord` is not part of the schema-versioned `EvalLog`, so no log migration is required.
- Core remains NumPy-only and no exported symbol changes are required.

## Verification

- [x] Tests added/updated, including terminal-state and exact-write-count coverage
- [x] Full upstream CI matrix passes on current `main`
- [x] Coverage: **100% line and branch**
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] Strict `mypy` passes
- [x] `CHANGELOG.md` updated under "Unreleased"
- [x] Core remains NumPy-only

The gap surfaced while building a process-aware evaluator on top of Inspect Robots: https://github.com/Vedangalle/inspect-robots-verifier
