### PR TITLE
agent: pluggable action pre-check surfaced as a correctable tool error

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,8 @@ adapter shipped from this repo as separate packages:
   LLM (Claude, GPT, anything behind an OpenAI-compatible API) drive any
   embodiment through tool calls, as a first-class policy. The same
   `--policy agent` runs ad-hoc instructions and scores on registered tasks
-  next to fine-tuned VLAs.
+  next to fine-tuned VLAs. A programmatic motion pre-check hook can return
+  correctable rejection reasons before absolute action chunks are emitted.
 - **[inspect-robots-capx](plugins/inspect-robots-capx/)**: evaluate CaP-X-style
   code-as-policy agents against a joint-space embodiment. Model-generated
   Python calls separately served SAM3, Contact-GraspNet, and Pyroki helpers,

--- a/plans/0031-agent-action-pre-check.md
+++ b/plans/0031-agent-action-pre-check.md
@@ -86,11 +86,21 @@ PreCheck = Callable[[npt.NDArray[np.float64]], str | None]
   the hook is programmatic-only, following the `prior_learnings` coercion
   guard precedent), stored, and passed to `build_toolset` in `bind()`
   alongside the existing space arguments.
-- Recorded config: `AgentPolicyConfig` gains a `pre_check` field carrying
-  the callable's dotted `module.qualname` string (`None` when unset), so
-  two logs from materially different agents are never pooled as identical
-  configs — the same reproducibility rule that made #199 record the
-  `prior_learnings` path and sha256.
+- Recorded config: `AgentPolicyConfig` gains a `pre_check` field (`str |
+  None`, `None` when unset) identifying the hook. Derivation must handle
+  everything `callable()` admits: use
+  `f"{pre_check.__module__}.{pre_check.__qualname__}"` when both
+  attributes exist (plain functions, methods), else fall back to
+  `f"{type(pre_check).__module__}.{type(pre_check).__qualname__}"`
+  (callable instances, `functools.partial`), via `getattr` with defaults —
+  never a bare attribute access, which would crash at construction and
+  fail strict mypy. Honest scope: this records adapter *code identity*
+  only; two runs of the same adapter over differently configured checkers
+  (say, different `table_height`) record the same string. That is best
+  effort for an unserializable callable, one notch better than nothing and
+  weaker than #199's path+sha256; the README states the limitation and
+  suggests encoding checker config in the callable's qualname (a named
+  factory) when it matters.
 - `build_toolset(...)` gains `pre_check: PreCheck | None = None`, validates
   the displacement-mode refusal (§3) next to its existing mode checks, and
   hands it to `Toolset`.

--- a/plans/0031-agent-action-pre-check.md
+++ b/plans/0031-agent-action-pre-check.md
@@ -1,0 +1,162 @@
+# Plan 0031: agent plugin action pre-check (correctable rejection before emission)
+
+Issue: [#210](https://github.com/robocurve/inspect-robots/issues/210)
+Status: draft, pending adversarial critique.
+
+## 1. Problem
+
+Framework approvers have two outcomes: silently modify an action (clamp,
+hold) or `SafetyAbort` the eval. Neither tells the policy anything. For LLM
+policies this wastes the plugin's best asset: the correctable-error loop in
+`LLMAgentPolicy` where any `ToolResult.error` goes back to the model as a
+tool message and the turn continues (`policy.py`, `_MAX_CONSECUTIVE_FAILURES`
+guarded). The plugin already pre-empts guardrails structurally (per-step
+limits mirror `DeltaLimitApprover`); it has no hook for *semantic* checks
+like "this sweep collides".
+
+First consumer: the YAM collision checker
+(robocurve/inspect-robots-yam#85, merged). Its `CollisionChecker.check`
+answers a 14-D configuration query in ~16 us, so checking a whole chunk adds
+well under a millisecond per tool call.
+
+## 2. Goals
+
+- A pluggable pre-check the embodiment side (or the user) can hand to
+  `LLMAgentPolicy`, run on the exact action waypoints a `move` tool call
+  would emit, before the chunk leaves the toolset.
+- Rejection is a first-class correctable tool error: the model is told why,
+  retries within the same `act()` turn, and the rollout never sees the bad
+  chunk. Framework approvers stay in the chain as the hard backstop; the
+  pre-check is UX, not the safety guarantee.
+- Zero new dependencies; the plugin stays httpx-only. The pre-check is an
+  injected callable, like `transport` and `env` already are.
+
+## 3. Non-goals
+
+- No support for displacement control modes in v1. `_move_displacement`
+  emits per-step *delta* vectors; handing those to a configuration checker
+  invites the deltas-read-as-configurations bug class that plan 0011 (yam)
+  guards against. If `pre_check` is set and the bound mode is a
+  displacement mode, `build_toolset` raises `ToolsetError` at bind time.
+  Absolute modes (`joint_pos`, `eef_abs_pose`) are supported.
+- No CLI wiring. `-P` flags carry scalars; a callable cannot cross that
+  boundary. Programmatic construction only, documented (same limitation as
+  framework approvers).
+- No approver-to-policy callback in the core framework. This stays a
+  policy-side pre-emption; core rollout semantics are untouched.
+- No packaged adapter for the YAM checker inside this plugin (it would
+  invert the dependency direction). The README shows the three-line adapter
+  instead.
+
+## 4. Design
+
+### 4.1 The hook
+
+```python
+PreCheck = Callable[[npt.NDArray[np.float64]], str | None]
+```
+
+- Input: a read-only `(steps, dim)` float64 array of the exact action
+  vectors the toolset is about to emit for one `move` call, in the bound
+  action space's semantics (absolute targets, already clipped to bounds,
+  first row is the first commanded waypoint, last row is the final target).
+- Return `None` to allow. Return a non-empty human-readable string to
+  reject; the string becomes the tool error verbatim, so it should say what
+  was wrong and ideally where (the YAM adapter includes the geom pair and
+  waypoint index).
+- Exceptions propagate. A crashing pre-check is a broken safety UX
+  component, not a reason to silently allow motion; the rollout wraps the
+  escape as `PolicyError` and fails the trial loudly.
+
+### 4.2 Plumbing
+
+- `LLMAgentPolicy.__init__` gains keyword `pre_check: PreCheck | None =
+  None`, stored and passed to `build_toolset` in `bind()` alongside the
+  existing space arguments.
+- `build_toolset(...)` gains `pre_check: PreCheck | None = None`, validates
+  the displacement-mode refusal (§3) next to its existing mode checks, and
+  hands it to `Toolset`.
+- `Toolset._move_absolute`: after the interpolated `actions` list is built
+  and clipped (immediately before `_success`), stack the action data into
+  one array and call `pre_check`. On a string, return
+  `ToolResult(error=...)` exactly like the existing bounds errors, prefixed
+  `"pre-check rejected this motion: "` so transcripts distinguish semantic
+  rejections from syntactic ones.
+- `_stop` paths bypass the pre-check: holding the current pose is the
+  fallback safe behavior, and a checker that could veto "stay where you
+  are" would trap the agent with no legal tool call.
+- Rejections count toward the existing consecutive-failures budget like
+  every other tool error. Rationale: bounded by design, consistent with
+  out-of-bounds targets today, and the failure counter resets on any
+  successful call, so a model that corrects on retry is unaffected. If
+  field use shows three consecutive rejections is too tight for semantic
+  correction, widening is a follow-up, not a v1 knob.
+
+### 4.3 Model-facing text
+
+When `pre_check` is set, the system prompt's guardrail sentence gains one
+clause telling the model a motion pre-check may reject moves with a stated
+reason and that it should adjust the target rather than repeat it. No
+prompt change when unset (byte-identical prompts for existing users).
+
+## 5. Testing
+
+Plugin test suite (scripted fake LLM transports, no network), following the
+existing patterns in `plugins/inspect-robots-agent/tests/`:
+
+- Allow path: `pre_check` receives a `(steps, dim)` array whose last row
+  equals the clipped target and whose rows are all within bounds; chunk
+  emitted unchanged; `pre_check` called exactly once per move call.
+- Reject path: string comes back as `ToolResult.error` with the prefix; the
+  scripted model corrects on the next turn and the corrected chunk is
+  emitted; failure counter resets.
+- Persistent rejection: scripted model repeats the same bad move;
+  consecutive-failure guard ends the turn the same way repeated bounds
+  errors do today.
+- Bind-time refusal: displacement-mode space + `pre_check` raises
+  `ToolsetError` naming this plan; absolute mode binds fine; no `pre_check`
+  + displacement mode still binds (no regression).
+- `_stop`/give-up/forced give-up paths never invoke the callable.
+- Exception propagation: a raising `pre_check` escapes `act()`.
+- System prompt: clause present iff `pre_check` is set.
+
+## 6. Docs and release
+
+- Plugin README: new section with the hook contract and the YAM adapter
+  example (three lines: wrap `CollisionChecker.check` into a
+  waypoint-loop returning the report string). States the layering rule:
+  pre-check for feedback, approver chain for enforcement.
+- Root README's agent-plugin blurb: one sentence.
+- Plugin version bump 0.17.0 -> 0.18.0 in its pyproject (static version,
+  publishes with the next core release per repo convention).
+- Core `CHANGELOG.md` entry if the repo records plugin changes there;
+  otherwise the plugin's own changelog section (implementer follows
+  whichever precedent #199/#204 set).
+
+## 7. File tree
+
+```
+inspect-robots/
+├── plans/0031-agent-action-pre-check.md            (this document)
+└── plugins/inspect-robots-agent/
+    ├── pyproject.toml                              (version 0.18.0)
+    ├── README.md                                   (pre-check section)
+    ├── src/inspect_robots_agent/
+    │   ├── _tools.py                               (PreCheck alias, build_toolset arg,
+    │   │                                            move-path invocation, bind-time refusal)
+    │   └── policy.py                               (pre_check kwarg, prompt clause)
+    └── tests/                                      (new tests per §5)
+```
+
+## 8. Resolved questions
+
+- Why `(steps, dim)` array instead of per-waypoint calls: one call per tool
+  call keeps the contract simple, lets the checker vectorize or
+  early-exit, and matches how the toolset already materializes the whole
+  interpolation before emitting.
+- Why absolute modes only: see §3; a wrong answer from a pre-check is
+  worse than no pre-check, and the loud refusal is one line.
+- Why rejections share the failure budget: see §4.2.
+- Why exceptions propagate: a silent allow on checker crash would make the
+  soft gate look like it is working when it is not; the hard gate
+  (approver) still protects the hardware either way.

--- a/plans/0031-agent-action-pre-check.md
+++ b/plans/0031-agent-action-pre-check.md
@@ -1,7 +1,8 @@
 # Plan 0031: agent plugin action pre-check (correctable rejection before emission)
 
 Issue: [#210](https://github.com/robocurve/inspect-robots/issues/210)
-Status: draft, pending adversarial critique.
+Status: revised after adversarial critique round 1 (9 findings, all
+addressed below).
 
 ## 1. Problem
 
@@ -56,23 +57,40 @@ well under a millisecond per tool call.
 PreCheck = Callable[[npt.NDArray[np.float64]], str | None]
 ```
 
-- Input: a read-only `(steps, dim)` float64 array of the exact action
-  vectors the toolset is about to emit for one `move` call, in the bound
-  action space's semantics (absolute targets, already clipped to bounds,
-  first row is the first commanded waypoint, last row is the final target).
+- Input: a `(steps, dim)` float64 array of the exact action vectors the
+  toolset is about to emit for one `move` call, in the bound action
+  space's semantics (absolute targets, already clipped to bounds, first
+  row is the first commanded waypoint, last row is the final target). The
+  array is a stacked copy with `writeable=False` set, so a mutating
+  checker fails loudly and can never corrupt the emitted chunk.
 - Return `None` to allow. Return a non-empty human-readable string to
   reject; the string becomes the tool error verbatim, so it should say what
   was wrong and ideally where (the YAM adapter includes the geom pair and
   waypoint index).
-- Exceptions propagate. A crashing pre-check is a broken safety UX
-  component, not a reason to silently allow motion; the rollout wraps the
-  escape as `PolicyError` and fails the trial loudly.
+- Exceptions propagate unchanged, stated precisely: the rollout wraps
+  *generic* exceptions from the policy as `PolicyError` (trial fails,
+  `fail_on_error` applies), while typed Inspect Robots errors keep their
+  own semantics — a pre-check that raises `SafetyAbort` halts the whole
+  eval, exactly as if an approver had raised it. Both are acceptable
+  outcomes for a crashing or hard-vetoing checker; what is not acceptable
+  is a silent allow. The README documents the distinction so adapter
+  authors choose deliberately. (The YAM `CollisionChecker.check` raises
+  `SafetyAbort` only on non-finite input, which cannot occur here: every
+  waypoint is clipped against finite bounds before the hook runs.)
 
 ### 4.2 Plumbing
 
 - `LLMAgentPolicy.__init__` gains keyword `pre_check: PreCheck | None =
-  None`, stored and passed to `build_toolset` in `bind()` alongside the
-  existing space arguments.
+  None`, validated with `callable(pre_check)` and a guided `ConfigError`
+  otherwise (the message states that `-P` flags cannot carry callables and
+  the hook is programmatic-only, following the `prior_learnings` coercion
+  guard precedent), stored, and passed to `build_toolset` in `bind()`
+  alongside the existing space arguments.
+- Recorded config: `AgentPolicyConfig` gains a `pre_check` field carrying
+  the callable's dotted `module.qualname` string (`None` when unset), so
+  two logs from materially different agents are never pooled as identical
+  configs — the same reproducibility rule that made #199 record the
+  `prior_learnings` path and sha256.
 - `build_toolset(...)` gains `pre_check: PreCheck | None = None`, validates
   the displacement-mode refusal (§3) next to its existing mode checks, and
   hands it to `Toolset`.
@@ -94,10 +112,12 @@ PreCheck = Callable[[npt.NDArray[np.float64]], str | None]
 
 ### 4.3 Model-facing text
 
-When `pre_check` is set, the system prompt's guardrail sentence gains one
-clause telling the model a motion pre-check may reject moves with a stated
-reason and that it should adjust the target rather than repeat it. No
-prompt change when unset (byte-identical prompts for existing users).
+When `pre_check` is set, both system prompt templates
+(`_SYSTEM_TEMPLATE` and `_ON_DEMAND_SYSTEM_TEMPLATE`) gain one clause
+telling the model a motion pre-check may reject moves with a stated reason
+and that it should adjust the target rather than repeat it. No prompt
+change when unset (byte-identical prompts for existing users). The §5
+prompt test covers both templates.
 
 ## 5. Testing
 
@@ -110,9 +130,12 @@ existing patterns in `plugins/inspect-robots-agent/tests/`:
 - Reject path: string comes back as `ToolResult.error` with the prefix; the
   scripted model corrects on the next turn and the corrected chunk is
   emitted; failure counter resets.
-- Persistent rejection: scripted model repeats the same bad move;
-  consecutive-failure guard ends the turn the same way repeated bounds
-  errors do today.
+- Persistent rejection: scripted model repeats the same bad move three
+  times; `act()` raises the same `RuntimeError` repeated bounds errors
+  produce today (which the rollout classifies as `PolicyError`, trial
+  error under `fail_on_error`). The test asserts the `RuntimeError` from
+  `act()`, not a graceful give-up: parity with existing tool-error
+  behavior, no better and no worse.
 - Bind-time refusal: displacement-mode space + `pre_check` raises
   `ToolsetError` naming this plan; absolute mode binds fine; no `pre_check`
   + displacement mode still binds (no regression).
@@ -122,16 +145,25 @@ existing patterns in `plugins/inspect-robots-agent/tests/`:
 
 ## 6. Docs and release
 
-- Plugin README: new section with the hook contract and the YAM adapter
-  example (three lines: wrap `CollisionChecker.check` into a
-  waypoint-loop returning the report string). States the layering rule:
-  pre-check for feedback, approver chain for enforcement.
+- Plugin README: new section with the hook contract and the real YAM
+  adapter code (a short function: loop the waypoints through
+  `CollisionChecker.check`, return the geom-pair string with the waypoint
+  index on a hit, `None` otherwise). States the layering rule: pre-check
+  for feedback, approver chain for enforcement. Two documented caveats:
+  (a) pre-check-pass does not imply approver-pass — the approver sweeps
+  interpolated substeps finer than the emitted waypoint spacing at low
+  control rates, so a chunk can clear the pre-check and still be held
+  mid-chunk with no model feedback; adapters wanting parity should
+  interpolate between waypoints themselves; (b) an over-conservative
+  checker (wrong `table_height`, unmeasured base offsets) that rejects
+  three moves in a row errors the trial rather than reaching `give_up`.
 - Root README's agent-plugin blurb: one sentence.
-- Plugin version bump 0.17.0 -> 0.18.0 in its pyproject (static version,
-  publishes with the next core release per repo convention).
-- Core `CHANGELOG.md` entry if the repo records plugin changes there;
-  otherwise the plugin's own changelog section (implementer follows
-  whichever precedent #199/#204 set).
+- Plugin version bump 0.17.0 -> 0.18.0 in its pyproject and in
+  `tests/test_package.py` (which asserts the exact version and is touched
+  by every bump PR).
+- No core `CHANGELOG.md` entry: the resolved precedent (#199) is that
+  pure-plugin changes stay out of the core changelog, and this feature is
+  pure-plugin.
 
 ## 7. File tree
 
@@ -144,8 +176,11 @@ inspect-robots/
     ├── src/inspect_robots_agent/
     │   ├── _tools.py                               (PreCheck alias, build_toolset arg,
     │   │                                            move-path invocation, bind-time refusal)
-    │   └── policy.py                               (pre_check kwarg, prompt clause)
-    └── tests/                                      (new tests per §5)
+    │   └── policy.py                               (pre_check kwarg + ConfigError guard,
+    │                                                AgentPolicyConfig field, both prompt
+    │                                                templates)
+    └── tests/                                      (new tests per §5; test_package.py
+                                                     version assertion updated)
 ```
 
 ## 8. Resolved questions

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -141,6 +141,76 @@ absolute interpolants. In displacement modes, a value tighter than the action
 box can truncate each `move_by` step. Either setting can make the executed
 motion fall short of the tool's requested total.
 
+## Motion pre-check
+
+Python callers can pass `pre_check=` to `LLMAgentPolicy` to inspect one
+absolute motion before its chunk is emitted. The callable receives a
+read-only float64 array with shape `(steps, dim)`. It contains the exact
+already-clipped action waypoints for one move call. The first row is the first
+commanded waypoint and the last row is the final target. Return `None` to
+allow the motion. Return a nonempty human-readable string to reject it. The
+agent receives `pre-check rejected this motion: <reason>` and can choose a
+different target on the next turn.
+
+Here is an adapter for the collision checker from
+[`inspect-robots-yam`](https://github.com/robocurve/inspect-robots-yam):
+
+```python
+import numpy as np
+import numpy.typing as npt
+
+from inspect_robots_agent import LLMAgentPolicy
+from inspect_robots_yam.collision import CollisionChecker
+
+
+def make_yam_collision_pre_check(checker: CollisionChecker):
+    """Reject the first emitted YAM waypoint whose geometry penetrates."""
+
+    def check_yam_waypoints(
+        waypoints: npt.NDArray[np.float64],
+    ) -> str | None:
+        for index, waypoint in enumerate(waypoints):
+            report = checker.check(waypoint)
+            if report.collided:
+                return f"{report.geom1}:{report.geom2} at waypoint {index}"
+        return None
+
+    return check_yam_waypoints
+
+
+checker = CollisionChecker()
+policy = LLMAgentPolicy(pre_check=make_yam_collision_pre_check(checker))
+```
+
+This hook is programmatic-only. `-P` CLI flags carry serialized values and
+cannot carry callables. Displacement control modes are refused at bind time
+when a pre-check is configured because their emitted vectors are per-step
+deltas, not absolute configurations.
+
+**Layering:** The pre-check supplies model feedback. The framework approver
+chain remains the enforcement backstop. Passing the pre-check does not imply
+that an approver will pass the motion. In particular, the YAM collision
+approver sweeps interpolated substeps finer than the emitted waypoint spacing
+at low control rates. An adapter that needs parity should interpolate and
+check between emitted waypoints itself.
+
+**Exceptions:** Exceptions from the callable propagate. The rollout converts
+a generic exception into `PolicyError`, so the trial fails and
+`fail_on_error` applies. A typed `SafetyAbort` keeps its own meaning and halts
+the eval. A crashing or hard-vetoing adapter must fail visibly. Silently
+allowing the motion is never acceptable.
+
+**Retry budget:** A rejection is a normal tool error. Three rejected moves in
+a row raise a policy error instead of reaching `give_up`. Verify rig
+measurements such as `table_height` and base offsets so an over-conservative
+checker does not consume the budget.
+
+**Recorded identity:** Eval configuration records only the adapter code
+identity as `module.qualname`. Two runs using the same adapter with differently
+configured checkers record the same string. When checker configuration must
+be distinguishable, encode it in a named factory's qualname, for example
+`make_lab_a_table_742mm_pre_check`.
+
 > [!WARNING]
 > Guardrails are on by default at the CLI. **Never pass `--disable-guardrails`
 > on real hardware** unless you fully trust the policy and the rig.

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.17.0"
+version = "0.18.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import math
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -33,6 +34,14 @@ _FALLBACK_HZ = 10.0
 _MAX_DURATION_S = 10.0
 _BACKSTOP_STEP_FRAC = 0.05
 _RELATIVE_HEADROOM = 1e-6
+
+#: A motion hook over the exact clipped absolute waypoints for one move call.
+#:
+#: The input is a read-only stacked float64 copy with shape ``(steps, dim)``.
+#: Its first row is the first commanded waypoint and its last row is the final
+#: target. Return ``None`` to allow the motion or a non-empty reason to reject
+#: it. Exceptions propagate unchanged.
+PreCheck = Callable[[npt.NDArray[np.float64]], str | None]
 
 
 class ToolsetError(Exception):
@@ -77,6 +86,7 @@ class Toolset:
         pose: bool = False,
         images: str = "always",
         cameras: tuple[str, ...] = (),
+        pre_check: PreCheck | None = None,
     ):
         self._absolute = absolute
         self._pose = pose
@@ -99,6 +109,7 @@ class Toolset:
         self._step_limits = step_limits
         self._images = images
         self._cameras = cameras
+        self._pre_check = pre_check
         if absolute:
             self._positive_limits = np.zeros_like(high)
             self._negative_limits = np.zeros_like(low)
@@ -422,6 +433,14 @@ class Toolset:
         ]
         actions[-1] = Action(data=np.clip(target.copy(), self._low, self._high))
         clipped_target = np.clip(target.copy(), self._low, self._high)
+        if self._pre_check is not None:
+            waypoints: npt.NDArray[np.float64] = np.asarray(
+                np.stack([action.data for action in actions]),
+                dtype=np.float64,
+            )
+            waypoints.flags.writeable = False
+            if message := self._pre_check(waypoints):
+                return ToolResult(error="pre-check rejected this motion: " + message)
         return self._success(actions, steps, target=clipped_target)
 
     def _move_displacement(
@@ -491,6 +510,7 @@ def build_toolset(
     control_hz: float | None,
     max_speed_frac: float = 0.1,
     images: str = "always",
+    pre_check: PreCheck | None = None,
 ) -> Toolset:
     """Validate an embodiment's spaces and build its agent-facing tools.
 
@@ -516,6 +536,12 @@ def build_toolset(
         )
     if mode not in _ABSOLUTE_MODES | _DISPLACEMENT_MODES:
         raise ToolsetError(f"control_mode {mode!r} is not supported by the agent policy yet")
+    if pre_check is not None and mode in _DISPLACEMENT_MODES:
+        raise ToolsetError(
+            "pre_check cannot be used with displacement control modes: they emit "
+            "per-step delta vectors that a configuration checker would misread "
+            "(plan 0031)"
+        )
     if control_hz is not None and (not np.isfinite(control_hz) or control_hz <= 0):
         raise ToolsetError("control_hz must be finite and > 0 when declared")
     if not np.isfinite(max_speed_frac) or max_speed_frac <= 0:
@@ -632,4 +658,5 @@ def build_toolset(
         pose=mode in _POSE_MODES,
         images=images,
         cameras=tuple(camera.name for camera in observation_space.cameras),
+        pre_check=pre_check,
     )

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -47,7 +47,7 @@ from inspect_robots_agent._llm import (
 )
 from inspect_robots_agent._png import png_data_url
 from inspect_robots_agent._responses import ResponsesClient
-from inspect_robots_agent._tools import Toolset, build_toolset
+from inspect_robots_agent._tools import PreCheck, Toolset, build_toolset
 
 from ._capture import WireCapture
 
@@ -100,6 +100,11 @@ observation, after the controller has played the motion; the narration reports \
 how much actually played. Placed alone, it looks before you decide what motion \
 to make. When the goal is achieved call done; if it cannot be achieved call \
 give_up. You have a budget of {budget} LLM calls for the whole trial."""
+
+_PRE_CHECK_PROMPT_CLAUSE = (
+    " A motion pre-check may reject a move with a stated reason. Adjust the target "
+    "rather than repeating a rejected move."
+)
 
 _ON_DEMAND_NUDGE = (
     "Respond with one motion tool call, one motion followed by take_pic, or take_pic alone."
@@ -202,6 +207,8 @@ class AgentPolicyConfig(PolicyConfig):
     prior_learnings: str | None = None
     #: SHA-256 hexdigest of the injected prior-learnings text.
     prior_learnings_sha256: str | None = None
+    #: Best-effort module and qualified-name identity of the motion pre-check.
+    pre_check: str | None = None
 
 
 @dataclass(frozen=True, eq=False)
@@ -247,6 +254,7 @@ class LLMAgentPolicy(PolicyBase):
         prior_learnings: str | None = None,
         transport: httpx.BaseTransport | None = None,
         env: dict[str, str] | None = None,
+        pre_check: PreCheck | None = None,
     ) -> None:
         prior_learnings_path: str | None = None
         prior_learnings_text: str | None = None
@@ -284,6 +292,24 @@ class LLMAgentPolicy(PolicyBase):
             prior_learnings_sha256 = hashlib.sha256(
                 prior_learnings_text.encode("utf-8")
             ).hexdigest()
+
+        pre_check_identity: str | None = None
+        if pre_check is not None:
+            if not callable(pre_check):
+                raise ConfigError(
+                    f"pre_check must be callable or None, got {pre_check!r}.\n"
+                    "fix: -P CLI flags cannot carry callables; the pre_check hook is "
+                    "programmatic-only"
+                )
+            module = getattr(pre_check, "__module__", None)
+            qualname = getattr(pre_check, "__qualname__", None)
+            if module is not None and qualname is not None:
+                pre_check_identity = f"{module}.{qualname}"
+            else:
+                hook_type = type(pre_check)
+                type_module = getattr(hook_type, "__module__", None)
+                type_qualname = getattr(hook_type, "__qualname__", None)
+                pre_check_identity = f"{type_module}.{type_qualname}"
 
         if not np.isfinite(max_speed_frac) or max_speed_frac <= 0:
             raise ConfigError("max_speed_frac must be finite and > 0")
@@ -445,6 +471,7 @@ class LLMAgentPolicy(PolicyBase):
         self._depth = depth
         self._image_horizon = image_horizon
         self._prior_learnings_text = prior_learnings_text
+        self._pre_check = pre_check
         self.config = AgentPolicyConfig(
             temperature=temperature,
             model=provider.model,
@@ -463,6 +490,7 @@ class LLMAgentPolicy(PolicyBase):
             image_horizon=image_horizon,
             prior_learnings=prior_learnings_path,
             prior_learnings_sha256=prior_learnings_sha256,
+            pre_check=pre_check_identity,
         )
         # Placeholder until bind(); eval() always binds before compat/rollout.
         self.info = PolicyInfo(name="agent", action_space=Box(shape=(1,)))
@@ -487,6 +515,7 @@ class LLMAgentPolicy(PolicyBase):
             embodiment_info.control_hz,
             self._max_speed_frac,
             images=self._images,
+            pre_check=self._pre_check,
         )
         self._toolset = toolset
         self._state_labels = toolset.state_labels()
@@ -503,6 +532,8 @@ class LLMAgentPolicy(PolicyBase):
         """Start a fresh per-trial conversation with the scene goal and call budget."""
         template = _ON_DEMAND_SYSTEM_TEMPLATE if self._images == "on_demand" else _SYSTEM_TEMPLATE
         formatted = template.format(name=self._embodiment_name, budget=self._max_llm_calls)
+        if self._pre_check is not None:
+            formatted += _PRE_CHECK_PROMPT_CLAUSE
         docs = self._embodiment_docs
         if docs is not None and docs.strip():
             formatted = formatted + "\n\nEmbodiment notes:\n" + docs.strip()

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,7 +6,7 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.17.0"
+    assert inspect_robots_agent.__version__ == "0.18.0"
     assert callable(inspect_robots_agent.agent_policy)
     assert inspect_robots_agent.__all__ == [
         "ENV_MODEL",

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -8,6 +8,7 @@ guardrails, policy-stop, budgets, error taxonomy) runs for real.
 from __future__ import annotations
 
 import base64
+import functools
 import hashlib
 import io
 import json
@@ -19,6 +20,7 @@ from typing import Any, cast
 
 import httpx
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 import inspect_robots_agent.policy as agent_policy_module
@@ -47,6 +49,7 @@ from inspect_robots_agent._llm import ChatClient, resolve_provider
 from inspect_robots_agent._png import encode_png
 from inspect_robots_agent._tools import ToolResult
 from inspect_robots_agent.policy import (
+    _ON_DEMAND_SYSTEM_TEMPLATE,
     _PRIOR_LEARNINGS_TEXT_LIMIT,
     _SYSTEM_TEMPLATE,
     AgentPolicyConfig,
@@ -686,6 +689,66 @@ def test_prior_learnings_default_off_preserves_prompt_and_config() -> None:
     assert isinstance(policy.config, AgentPolicyConfig)
     assert policy.config.prior_learnings is None
     assert policy.config.prior_learnings_sha256 is None
+
+
+@pytest.mark.parametrize(
+    ("images", "template"),
+    [
+        ("always", _SYSTEM_TEMPLATE),
+        ("on_demand", _ON_DEMAND_SYSTEM_TEMPLATE),
+    ],
+)
+def test_pre_check_prompt_clause_is_present_only_when_configured(
+    images: str,
+    template: str,
+) -> None:
+    def allow(waypoints: npt.NDArray[np.float64]) -> str | None:
+        return None
+
+    without = _policy(_Script([_text_response("unused")]), images=images)
+    without.reset(Scene(id="s0", instruction="reach"))
+    without_transcript = without.transcript()
+    assert without_transcript is not None
+    expected = template.format(name="(unbound)", budget=100)
+    assert without_transcript[0]["content"] == expected
+
+    with_hook = _policy(
+        _Script([_text_response("unused")]),
+        images=images,
+        pre_check=allow,
+    )
+    with_hook.reset(Scene(id="s0", instruction="reach"))
+    with_transcript = with_hook.transcript()
+    assert with_transcript is not None
+    prompt = with_transcript[0]["content"]
+    assert prompt.startswith(expected)
+    assert "pre-check may reject a move with a stated reason" in prompt
+    assert "Adjust the target rather than repeating a rejected move" in prompt
+
+
+def test_pre_check_config_records_function_and_callable_type_identity() -> None:
+    def allow(waypoints: npt.NDArray[np.float64]) -> str | None:
+        return None
+
+    unset = _policy(_Script([_text_response("unused")]))
+    plain = _policy(_Script([_text_response("unused")]), pre_check=allow)
+    partial = functools.partial(allow)
+    wrapped = _policy(_Script([_text_response("unused")]), pre_check=partial)
+
+    assert isinstance(unset.config, AgentPolicyConfig)
+    assert isinstance(plain.config, AgentPolicyConfig)
+    assert isinstance(wrapped.config, AgentPolicyConfig)
+    assert unset.config.pre_check is None
+    assert plain.config.pre_check == f"{allow.__module__}.{allow.__qualname__}"
+    assert wrapped.config.pre_check == (f"{type(partial).__module__}.{type(partial).__qualname__}")
+
+
+def test_pre_check_rejects_non_callables_with_programmatic_guidance() -> None:
+    with pytest.raises(
+        ConfigError,
+        match=r"(?s)pre_check must be callable.*-P CLI flags.*programmatic-only",
+    ):
+        _policy(_Script([_text_response("unused")]), pre_check=cast(Any, "checker"))
 
 
 @pytest.mark.parametrize(
@@ -1329,6 +1392,101 @@ def test_recoverable_tool_error_is_fed_back_and_corrected(tmp_path: Path) -> Non
         m for request in script.requests for m in request["messages"] if m.get("role") == "tool"
     ]
     assert any("unknown dimension 'dz'" in str(m["content"]) for m in tool_messages)
+
+
+def test_pre_check_rejection_is_fed_back_and_corrected() -> None:
+    checked_targets: list[float] = []
+
+    def reject_high_target(waypoints: npt.NDArray[np.float64]) -> str | None:
+        target = float(waypoints[-1, 0])
+        checked_targets.append(target)
+        return "joint target enters the keep-out zone" if target > 0.2 else None
+
+    script = _Script(
+        [
+            _tool_response("move_joints", {"targets": {"joint": 0.5}}),
+            _tool_response("move_joints", {"targets": {"joint": 0.1}}),
+        ]
+    )
+    policy = _policy(script, pre_check=reject_high_target)
+    policy.bind(_AbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="move safely"))
+
+    chunk = policy.act(Observation(state={"q": np.array([0.0])}))
+
+    assert checked_targets == [0.5, 0.1]
+    assert chunk.actions[-1].data[0] == 0.1
+    correction = [
+        message for message in script.requests[1]["messages"] if message.get("role") == "tool"
+    ]
+    assert any(
+        message["content"]
+        == "pre-check rejected this motion: joint target enters the keep-out zone"
+        for message in correction
+    )
+
+
+def test_persistent_pre_check_rejections_exhaust_the_failure_budget() -> None:
+    calls = 0
+
+    def reject(waypoints: npt.NDArray[np.float64]) -> str | None:
+        nonlocal calls
+        calls += 1
+        return "joint target enters the keep-out zone"
+
+    script = _Script([_tool_response("move_joints", {"targets": {"joint": 0.5}})])
+    policy = _policy(script, pre_check=reject)
+    policy.bind(_AbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="move safely"))
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "LLM tool calls kept failing; last error: pre-check rejected this motion: "
+            "joint target enters the keep-out zone"
+        ),
+    ):
+        policy.act(Observation(state={"q": np.array([0.0])}))
+    assert calls == 3
+
+
+def test_pre_check_exception_propagates_from_act_unchanged() -> None:
+    error = LookupError("collision model unavailable")
+
+    def crash(waypoints: npt.NDArray[np.float64]) -> str | None:
+        raise error
+
+    script = _Script([_tool_response("move_joints", {"targets": {"joint": 0.1}})])
+    policy = _policy(script, pre_check=crash)
+    policy.bind(_AbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="move safely"))
+
+    with pytest.raises(LookupError) as caught:
+        policy.act(Observation(state={"q": np.array([0.0])}))
+    assert caught.value is error
+
+
+def test_stop_and_forced_give_up_never_call_pre_check() -> None:
+    calls = 0
+
+    def reject(waypoints: npt.NDArray[np.float64]) -> str | None:
+        nonlocal calls
+        calls += 1
+        return "all motion rejected"
+
+    policy = _policy(
+        _Script([_tool_response("done", {"summary": "stop"})]),
+        max_llm_calls=1,
+        pre_check=reject,
+    )
+    policy.bind(_AbsoluteEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="stop"))
+    first = policy.act(Observation(state={"q": np.array([0.0])}))
+    forced = policy.act(Observation(state={"q": np.array([0.0])}))
+
+    assert first.actions[0].meta["stop_reason"] == "done"
+    assert forced.actions[0].meta["stop_reason"] == "give_up"
+    assert calls == 0
 
 
 def test_missing_note_is_fed_back_and_corrected_in_persisted_transcript(

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -7,6 +7,7 @@ from itertools import pairwise
 from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 from inspect_robots.approver import ChainApprover, ClampApprover, DeltaLimitApprover
@@ -139,6 +140,27 @@ def test_build_refuses_unsupported_configurations() -> None:
     )
     with pytest.raises(ToolsetError, match="rotation_repr"):
         build_toolset(quat, _bimanual_obs_space(), control_hz=10.0)
+
+
+def test_pre_check_refuses_displacement_modes_only_when_configured() -> None:
+    def allow(waypoints: npt.NDArray[np.float64]) -> str | None:
+        return None
+
+    with pytest.raises(ToolsetError, match=r"displacement.*plan 0031"):
+        build_toolset(
+            _delta_space(),
+            ObservationSpace(),
+            control_hz=10.0,
+            pre_check=allow,
+        )
+
+    build_toolset(
+        _absolute_space(),
+        _absolute_obs_space(),
+        control_hz=10.0,
+        pre_check=allow,
+    )
+    build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
 
 
 def test_absolute_mode_requires_exactly_one_aligned_state_field() -> None:
@@ -591,6 +613,66 @@ def test_move_joints_clips_every_interpolant_into_box() -> None:
     assert all(-1.0 <= float(action.data[0]) <= 0.3 for action in result.chunk.actions)
 
 
+def test_pre_check_receives_exact_read_only_clipped_waypoints_once() -> None:
+    low = np.array([-1.0, -0.5])
+    high = np.array([0.3, 0.5])
+    space = Box(
+        shape=(2,),
+        low=low,
+        high=high,
+        semantics=ActionSemantics("joint_pos", dim_labels=("a", "b")),
+    )
+    received: list[npt.NDArray[np.float64]] = []
+
+    def allow(waypoints: npt.NDArray[np.float64]) -> str | None:
+        assert waypoints.dtype == np.float64
+        assert waypoints.ndim == 2
+        assert waypoints.shape[1] == 2
+        assert waypoints.flags.writeable is False
+        assert bool(np.all(waypoints >= low))
+        assert bool(np.all(waypoints <= high))
+        assert np.array_equal(waypoints[-1], np.array([0.3, 0.4]))
+        with pytest.raises(ValueError):
+            waypoints[0, 0] = 0.0
+        received.append(waypoints.copy())
+        return None
+
+    toolset = build_toolset(
+        space,
+        _absolute_obs_space(dim=2),
+        control_hz=10.0,
+        pre_check=allow,
+    )
+    result = toolset.execute(
+        _call("move_joints", targets={"a": 0.3, "b": 0.4}),
+        _obs({"q": np.array([-0.1, 0.0])}),
+    )
+
+    assert result.error is None and result.chunk is not None
+    emitted = np.stack([action.data for action in result.chunk.actions])
+    assert len(received) == 1
+    assert np.array_equal(received[0], emitted)
+
+
+def test_pre_check_rejection_returns_a_tool_error_without_a_chunk() -> None:
+    def reject(waypoints: npt.NDArray[np.float64]) -> str | None:
+        return "left_wrist:table at waypoint 4"
+
+    toolset = build_toolset(
+        _absolute_space(),
+        _absolute_obs_space(),
+        control_hz=10.0,
+        pre_check=reject,
+    )
+    result = toolset.execute(
+        _call("move_joints", targets={"joint": 0.3}),
+        _obs(),
+    )
+
+    assert result.error == ("pre-check rejected this motion: left_wrist:table at waypoint 4")
+    assert result.chunk is None
+
+
 def test_move_joints_headroom_stays_within_default_backstop() -> None:
     current = -0.5
     result = _execute_absolute(1.0, current=current)
@@ -910,17 +992,31 @@ def test_valid_move_note_does_not_change_the_motion_chunk() -> None:
 
 
 def test_done_and_give_up_emit_control_mode_hold() -> None:
-    absolute = build_toolset(_bimanual_space(), _bimanual_obs_space(), control_hz=10.0)
-    state = np.full(14, 0.3)
-    result = absolute.execute(
-        _call("done", summary="fork placed"),
-        Observation(state={"joint_pos": state}),
+    calls = 0
+
+    def reject(waypoints: npt.NDArray[np.float64]) -> str | None:
+        nonlocal calls
+        calls += 1
+        return "all motion rejected"
+
+    absolute = build_toolset(
+        _bimanual_space(),
+        _bimanual_obs_space(),
+        control_hz=10.0,
+        pre_check=reject,
     )
-    assert result.error is None and result.chunk is not None
-    (action,) = result.chunk.actions
-    assert np.array_equal(action.data, state)
-    assert action.meta["request_stop"] is True
-    assert action.meta["stop_reason"] == "done"
+    state = np.full(14, 0.3)
+    for name, detail_key in (("done", "summary"), ("give_up", "reason")):
+        result = absolute.execute(
+            _call(name, **{detail_key: "fork placed"}),
+            Observation(state={"joint_pos": state}),
+        )
+        assert result.error is None and result.chunk is not None
+        (action,) = result.chunk.actions
+        assert np.array_equal(action.data, state)
+        assert action.meta["request_stop"] is True
+        assert action.meta["stop_reason"] == name
+    assert calls == 0
 
     displacement = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
     result = displacement.execute(_call("give_up", reason="cannot see"), _obs({}))

--- a/uv.lock
+++ b/uv.lock
@@ -225,7 +225,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -397,7 +397,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #210

Adds a pluggable action pre-check to the agent plugin: `LLMAgentPolicy(pre_check=...)` runs an injected callable on the exact waypoints a move tool call would emit. A rejection comes back to the LLM as a correctable tool error (same loop as bounds errors today), so the model fixes its target instead of the approver silently holding or the eval aborting. Absolute control modes only in v1; displacement modes are refused loudly at bind time. First consumer is the YAM collision checker from inspect-robots-yam#86.

Design in plans/0031-agent-action-pre-check.md. Opening as draft while the plan goes through critique; implementation lands on this branch next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
