### PR TITLE
chore: ignore rerun .rrd recordings alongside eval log sinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,5 +223,7 @@ __marimo__/
 # uv.lock is committed: CI installs with `uv sync --locked` for reproducible
 # builds. Run `uv lock` after changing dependencies in pyproject.toml.
 
-# Eval outputs (default sink directory) must never be committed (#212).
+# Run artifacts: eval log sinks and rerun recordings live outside version
+# control; share them as release assets or external storage instead.
 logs/
+*.rrd


### PR DESCRIPTION
The rerun sink can write .rrd recordings (rerun_sink.py); like the log sink directory, they are run artifacts and belong outside version control. Groups the two under one comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)