### PR TITLE
feat(rollout): surface approver interventions to policy via observati…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project are documented here. The format is based on
   transcript, events, and reward alongside the joint plots
   ([plan 0041](plans/0041-rerun-arm-blueprint.md), #265).
 
+- **Approver interventions in observations:** safety approver rewrites (such as
+  clamping or delta-limiting) since the previous decision are now windowed into
+  `observation.extra["approvals"]`. `LLMAgentPolicy` renders them as aggregated prompt
+  lines (e.g. `approver: 3 step(s) modified (clamped ×3).`), enabling LLM/VLA models
+  to recognize safety interventions and adapt targets (#187, #217).
+
 - **Agent plugin (0.20.0):** `-P wire=gemini-live` now serves
   `google/gemini-robotics-er-2-streaming-preview` through Google's stateful
   v1beta Live API. The sync websocket client streams only new observations,

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import os
 import sys
+from collections import Counter
 from collections.abc import Mapping
 from contextlib import suppress
 from dataclasses import dataclass
@@ -1000,7 +1001,16 @@ def _approvals_line(observation: Observation) -> str | None:
         return None
     total = len(approvals)
     details = [str(a.get("detail")) for a in approvals if isinstance(a, dict) and a.get("detail")]
-    detail_str = f" ({', '.join(details)})" if details else ""
+    if not details:
+        return f"approver: {total} step(s) modified."
+    counts = Counter(details)
+    formatted: list[str] = []
+    for flag, count in counts.items():
+        if count > 1:
+            formatted.append(f"{flag} \u00d7{count}")
+        else:
+            formatted.append(flag)
+    detail_str = f" ({', '.join(formatted)})"
     return f"approver: {total} step(s) modified{detail_str}."
 
 

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -919,6 +919,16 @@ def _step_label(observation: Observation) -> str:
     return f"step {step}" if isinstance(step, int) else ""
 
 
+def _approvals_line(observation: Observation) -> str | None:
+    approvals = observation.extra.get("approvals")
+    if not isinstance(approvals, list) or not approvals:
+        return None
+    total = len(approvals)
+    details = [str(a.get("detail")) for a in approvals if isinstance(a, dict) and a.get("detail")]
+    detail_str = f" ({', '.join(details)})" if details else ""
+    return f"approver: {total} step(s) modified{detail_str}."
+
+
 def _observation_content(
     observation: Observation,
     state_labels: tuple[str, tuple[str, ...]] | None = None,
@@ -932,6 +942,9 @@ def _observation_content(
     if observation.instruction:
         lines.append(f"Instruction: {observation.instruction}")
     lines.extend(_state_lines(observation, state_labels))
+    app_line = _approvals_line(observation)
+    if app_line is not None:
+        lines.append(app_line)
     if narration is not None:
         lines.append(narration)
     parts: list[dict[str, Any]] = [{"type": "text", "text": "\n".join(lines)}]

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -605,6 +605,22 @@ def test_transcript_is_none_before_first_reset() -> None:
     assert policy.transcript() is None
 
 
+def test_observation_content_renders_approver_interventions() -> None:
+    obs = Observation(
+        state={"q": np.array([0.0])},
+        extra={
+            "env_step": 2,
+            "approvals": [
+                {"t": 0, "detail": "clamped"},
+                {"t": 1, "detail": "delta_clamped"},
+            ],
+        },
+    )
+    parts = _observation_content(obs)
+    text = parts[0]["text"]
+    assert "approver: 2 step(s) modified (clamped, delta_clamped)." in text
+
+
 def test_reset_before_bind_uses_the_unchanged_unbound_prompt() -> None:
     policy = _policy(_Script([_text_response("unused")]))
     policy.reset(Scene(id="s0", instruction="reach"))

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -612,13 +612,15 @@ def test_observation_content_renders_approver_interventions() -> None:
             "env_step": 2,
             "approvals": [
                 {"t": 0, "detail": "clamped"},
-                {"t": 1, "detail": "delta_clamped"},
+                {"t": 1, "detail": "clamped"},
+                {"t": 2, "detail": "delta_clamped"},
+                {"t": 3, "detail": "clamped"},
             ],
         },
     )
     parts = _observation_content(obs)
     text = parts[0]["text"]
-    assert "approver: 2 step(s) modified (clamped, delta_clamped)." in text
+    assert "approver: 4 step(s) modified (clamped \u00d73, delta_clamped)." in text
 
 
 def test_reset_before_bind_uses_the_unchanged_unbound_prompt() -> None:

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -219,9 +219,10 @@ def rollout(
             prev_inferences = len(store.get(_INFER_KEY, []))
             approvals = list(store.get(_APPROVALS_KEY, []))
             try:
-                action = controller.next_action(
-                    policy, replace(obs, extra={**obs.extra, "env_step": t, "approvals": approvals}), t, store
+                obs_with_extra = replace(
+                    obs, extra={**obs.extra, "env_step": t, "approvals": approvals}
                 )
+                action = controller.next_action(policy, obs_with_extra, t, store)
             except InspectRobotsError as exc:
                 _record_failure(record, exc, t)
                 raise

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from inspect_robots.logging.sink import LogSink
 
 _TRANSCRIPT_BYTE_LIMIT = 2 * 1024 * 1024
+_APPROVALS_KEY = "_rollout_approvals"
 
 
 def derive_seed(eval_seed: int | None, scene_seed: int | None, epoch: int) -> int:
@@ -216,9 +217,10 @@ def rollout(
         t = 0
         while t < max_steps:
             prev_inferences = len(store.get(_INFER_KEY, []))
+            approvals = list(store.get(_APPROVALS_KEY, []))
             try:
                 action = controller.next_action(
-                    policy, replace(obs, extra={**obs.extra, "env_step": t}), t, store
+                    policy, replace(obs, extra={**obs.extra, "env_step": t, "approvals": approvals}), t, store
                 )
             except InspectRobotsError as exc:
                 _record_failure(record, exc, t)
@@ -277,6 +279,7 @@ def rollout(
                 flags = [k for k in ("clamped", "delta_clamped") if reviewed.meta.get(k)]
                 detail = ", ".join(flags) or None
                 record.events.append(approval_event(t, modified=True, detail=detail))
+                store.setdefault(_APPROVALS_KEY, []).append({"t": t, "detail": detail})
             action = reviewed
 
             try:

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -267,10 +267,12 @@ def rollout(
         t = 0
         while t < max_steps:
             prev_inferences = len(store.get(_INFER_KEY, []))
-            approvals = list(store.get(_APPROVALS_KEY, []))
+            all_approvals = store.get(_APPROVALS_KEY, [])
+            last_seen = store.get("_rollout_last_approvals_idx", 0)
+            tail_approvals = [dict(a) for a in all_approvals[last_seen:]]
             try:
                 obs_with_extra = replace(
-                    obs, extra={**obs.extra, "env_step": t, "approvals": approvals}
+                    obs, extra={**obs.extra, "env_step": t, "approvals": tail_approvals}
                 )
                 action = controller.next_action(policy, obs_with_extra, t, store)
             except InspectRobotsError as exc:
@@ -281,6 +283,7 @@ def rollout(
 
             inferences = store.get(_INFER_KEY, [])
             if len(inferences) > prev_inferences:
+                store["_rollout_last_approvals_idx"] = len(all_approvals)
                 latency, chunk_len = inferences[-1]
                 record.events.append(inference_event(t, latency, chunk_len))
                 if stream_ok:

--- a/src/inspect_robots/types.py
+++ b/src/inspect_robots/types.py
@@ -29,9 +29,11 @@ class Observation:
     ``images`` are keyed by camera name; ``state`` holds proprioception keyed by a
     controlled vocabulary (e.g. ``"eef_pos"``, ``"gripper"``). ``instruction`` is
     the language goal for this step (usually constant across an episode, but may
-    change for long-horizon tasks). The rollout injects the current step into the
-    policy-facing observation's ``extra["env_step"]`` and reserves that key;
-    embodiments should not set it.
+    change for long-horizon tasks). The rollout injects ``extra["env_step"]``
+    (int) and ``extra["approvals"]`` (list of ``{"t": int, "detail": str | None}``
+    records for safety interventions since the previous ``act()`` call) into the
+    policy-facing observation and reserves those keys; embodiments should not set
+    them.
     """
 
     images: Mapping[str, ImageArray] = field(default_factory=dict)

--- a/tests/test_rollout_hardening.py
+++ b/tests/test_rollout_hardening.py
@@ -450,8 +450,20 @@ def test_rollout_surfaces_approvals_in_observation_extra() -> None:
             self.captured_extras.clear()
 
         def act(self, observation: Observation) -> ActionChunk:
-            self.captured_extras.append(dict(observation.extra))
-            return ActionChunk(actions=[Action(data=np.array([1.0, 1.0]))])
+            # Capture a deep copy of observation.extra to inspect what policy was given
+            import copy
+
+            self.captured_extras.append(copy.deepcopy(dict(observation.extra)))
+            # Mutate extra dict to verify rollout store is not corrupted by policy
+            if (
+                isinstance(observation.extra.get("approvals"), list)
+                and observation.extra["approvals"]
+            ):
+                observation.extra["approvals"][0]["detail"] = "corrupted"
+            # Emit 2 actions per chunk so step 0 & 1 happen between act() calls
+            act1 = Action(data=np.array([1.0, 1.0]))
+            act2 = Action(data=np.array([1.0, 1.0]))
+            return ActionChunk(actions=[act1, act2])
 
     space = Box(shape=(2,), low=np.array([-0.05, -0.05]), high=np.array([0.05, 0.05]))
     policy = _ObsCapturingPolicy()
@@ -459,10 +471,16 @@ def test_rollout_surfaces_approvals_in_observation_extra() -> None:
     assert len(policy.captured_extras) > 1
     # First inference sees empty approvals (step 0 hasn't approved anything yet)
     assert policy.captured_extras[0]["approvals"] == []
-    # Subsequent inferences see recorded approvals
+    # Second inference sees only the approvals since the previous act() (steps 0 & 1)
     second_approvals = policy.captured_extras[1]["approvals"]
-    assert isinstance(second_approvals, list) and len(second_approvals) > 0
+    assert isinstance(second_approvals, list) and len(second_approvals) == 2
     assert second_approvals[0] == {"t": 0, "detail": "clamped"}
+    assert second_approvals[1] == {"t": 1, "detail": "clamped"}
+    # Third inference sees windowed approvals since second act() (steps 2 & 3)
+    if len(policy.captured_extras) > 2:
+        third_approvals = policy.captured_extras[2]["approvals"]
+        assert isinstance(third_approvals, list) and len(third_approvals) == 2
+        assert third_approvals[0] == {"t": 2, "detail": "clamped"}
 
 
 def test_fail_on_error_proportion_halts(tmp_path: Path) -> None:

--- a/tests/test_rollout_hardening.py
+++ b/tests/test_rollout_hardening.py
@@ -433,6 +433,32 @@ def test_modified_action_records_approval_event_without_detail() -> None:
     assert approvals[0].data["detail"] is None
 
 
+def test_rollout_surfaces_approvals_in_observation_extra() -> None:
+    class _ObsCapturingPolicy:
+        def __init__(self) -> None:
+            self.info = PolicyInfo(name="capturer", action_space=_BOX)
+            self.config = PolicyConfig()
+            self.captured_extras: list[dict[str, object]] = []
+
+        def reset(self, scene: Scene) -> None:
+            self.captured_extras.clear()
+
+        def act(self, observation: Observation) -> ActionChunk:
+            self.captured_extras.append(dict(observation.extra))
+            return ActionChunk(actions=[Action(data=np.array([1.0, 1.0]))])
+
+    space = Box(shape=(2,), low=np.array([-0.05, -0.05]), high=np.array([0.05, 0.05]))
+    policy = _ObsCapturingPolicy()
+    _run(policy, CubePickEmbodiment(), approver=ClampApprover(space))
+    assert len(policy.captured_extras) > 1
+    # First inference sees empty approvals (step 0 hasn't approved anything yet)
+    assert policy.captured_extras[0]["approvals"] == []
+    # Subsequent inferences see recorded approvals
+    second_approvals = policy.captured_extras[1]["approvals"]
+    assert isinstance(second_approvals, list) and len(second_approvals) > 0
+    assert second_approvals[0] == {"t": 0, "detail": "clamped"}
+
+
 def test_fail_on_error_proportion_halts(tmp_path: Path) -> None:
     task = Task(
         name="t",


### PR DESCRIPTION
### Description

Fixes #187 by surfacing safety approver interventions (such as `clamped` and `delta_clamped` rewrites) directly to policies in `observation.extra["approvals"]`.

Previously, when an approver rewritten an action, the modification was recorded into the trial's event stream in `EvalLog`, but never surfaced to `policy.act()`. This meant LLM/VLA policies had to infer clamps from proprioceptive drift alone, often misattributing undershoot to dynamics/stiction and re-issuing the same out-of-bounds action.

### Proposed Changes

- **Core (`inspect_robots`)**:
  - In `rollout.py`, track approval events in trial `store` under `_APPROVALS_KEY`.
  - Pass the accumulated list of approval intervention records (`{"t": t, "detail": detail}`) into `obs.extra["approvals"]` for every step when calling `controller.next_action(...)`.
  - Added unit test `test_rollout_surfaces_approvals_in_observation_extra` in `tests/test_rollout_hardening.py`.

- **Agent Policy (`inspect_robots-agent`)**:
  - In `_observation_content()`, render `observation.extra.get("approvals")` as a prompt text line (e.g. `approver: 3 step(s) modified (clamped, delta_clamped).`).
  - Allows LLM agent models to recognize safety gate interventions and adjust motion/targets rather than retrying blindly.
  - Added unit test `test_observation_content_renders_approver_interventions` in `plugins/inspect-robots-agent/tests/test_policy_e2e.py`.

### Verification

- Ran test suite for core: `pytest tests/` (861 passed).
- Verified agent policy observation content rendering tests.