### PR TITLE
fix(agent): permit re-revealing on_demand cameras when image_horizon …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@ All notable changes to this project are documented here. The format is based on
   413). Stored history, transcripts, and frame side-cars are unchanged.
   Restore the old unbounded behavior with `-P image_horizon=none` (#188).
 
+### Fixed
+
+- **Agent plugin:** `images=on_demand` mode now permits re-requesting a camera with `take_pic` if its frame was elided by `image_horizon`, preventing untrue "already shown" refusals (#192).
+
+
 ### Added
 
 - **Public user-defaults API:** `inspect_robots.defaults` lets plugin CLIs read

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -758,12 +758,10 @@ class LLMAgentPolicy(PolicyBase):
                                                 and part.get("type") == "text"
                                             ):
                                                 text = part.get("text", "")
-                                                if text.startswith("camera "):
-                                                    for term in text.split():
-                                                        if term.startswith(("'", '"')):
-                                                            active_camera_names.add(
-                                                                term.strip("'\"").rstrip(":")
-                                                            )
+                                                if text.startswith("camera '"):
+                                                    end_quote = text.find("'", 8)
+                                                    if end_quote != -1:
+                                                        active_camera_names.add(text[8:end_quote])
                                 self._revealed.intersection_update(active_camera_names)
 
                             skipped = tuple(name for name in requested if name in self._revealed)

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -745,20 +745,32 @@ class LLMAgentPolicy(PolicyBase):
                                 if result.capture is None
                                 else _unique_names(result.capture)
                             )
-                            # Exclude cameras from self._revealed if their image-bearing message was evicted by image_horizon
+                            # Exclude cameras from self._revealed if their image-bearing message
+                            # was evicted by image_horizon
                             if self._image_horizon is not None:
                                 active_camera_names: set[str] = set()
                                 for msg in outgoing:
-                                    if isinstance((cnt := msg.get("content")), list):
-                                        for part in cnt:
-                                            if isinstance(part, dict) and part.get("type") == "text":
+                                    content_list = msg.get("content")
+                                    if isinstance(content_list, list):
+                                        for part in content_list:
+                                            if (
+                                                isinstance(part, dict)
+                                                and part.get("type") == "text"
+                                            ):
                                                 text = part.get("text", "")
                                                 if text.startswith("camera "):
-                                                    # e.g. "camera 'top' (step 0):" or "camera 'front':" or "Camera top:"
                                                     for term in text.split():
-                                                        if (term.startswith("'") or term.startswith('"')):
-                                                            active_camera_names.add(term.strip("'\"").rstrip(":"))
-                                self._revealed.intersection_update(active_camera_names)
+                                                        if term.startswith(
+                                                            ("'", '"')
+                                                        ):
+                                                            active_camera_names.add(
+                                                                term.strip(
+                                                                    "'\""
+                                                                ).rstrip(":")
+                                                            )
+                                self._revealed.intersection_update(
+                                    active_camera_names
+                                )
 
                             skipped = tuple(name for name in requested if name in self._revealed)
                             immediate_frames = tuple(

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -745,6 +745,21 @@ class LLMAgentPolicy(PolicyBase):
                                 if result.capture is None
                                 else _unique_names(result.capture)
                             )
+                            # Exclude cameras from self._revealed if their image-bearing message was evicted by image_horizon
+                            if self._image_horizon is not None:
+                                active_camera_names: set[str] = set()
+                                for msg in outgoing:
+                                    if isinstance((cnt := msg.get("content")), list):
+                                        for part in cnt:
+                                            if isinstance(part, dict) and part.get("type") == "text":
+                                                text = part.get("text", "")
+                                                if text.startswith("camera "):
+                                                    # e.g. "camera 'top' (step 0):" or "camera 'front':" or "Camera top:"
+                                                    for term in text.split():
+                                                        if (term.startswith("'") or term.startswith('"')):
+                                                            active_camera_names.add(term.strip("'\"").rstrip(":"))
+                                self._revealed.intersection_update(active_camera_names)
+
                             skipped = tuple(name for name in requested if name in self._revealed)
                             immediate_frames = tuple(
                                 name for name in requested if name not in self._revealed

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -760,17 +760,11 @@ class LLMAgentPolicy(PolicyBase):
                                                 text = part.get("text", "")
                                                 if text.startswith("camera "):
                                                     for term in text.split():
-                                                        if term.startswith(
-                                                            ("'", '"')
-                                                        ):
+                                                        if term.startswith(("'", '"')):
                                                             active_camera_names.add(
-                                                                term.strip(
-                                                                    "'\""
-                                                                ).rstrip(":")
+                                                                term.strip("'\"").rstrip(":")
                                                             )
-                                self._revealed.intersection_update(
-                                    active_camera_names
-                                )
+                                self._revealed.intersection_update(active_camera_names)
 
                             skipped = tuple(name for name in requested if name in self._revealed)
                             immediate_frames = tuple(

--- a/plugins/inspect-robots-agent/tests/test_policy_eviction.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_eviction.py
@@ -405,7 +405,7 @@ def test_on_demand_allows_re_reveal_after_eviction() -> None:
                 }
             ]
         },
-        # Call 5: move_by
+        # Call 5: take_pic left again (still visible; should be refused)
         {
             "choices": [
                 {
@@ -415,6 +415,29 @@ def test_on_demand_allows_re_reveal_after_eviction() -> None:
                         "tool_calls": [
                             {
                                 "id": "call_5",
+                                "type": "function",
+                                "function": {
+                                    "name": "take_pic",
+                                    "arguments": json.dumps(
+                                        {"cameras": ["left"], "note": "Check left again"}
+                                    ),
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        },
+        # Call 6: move_by
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_6",
                                 "type": "function",
                                 "function": {
                                     "name": "move_by",
@@ -444,8 +467,27 @@ def test_on_demand_allows_re_reveal_after_eviction() -> None:
     policy.bind(embodiment.info)
     scene = Scene(id="s0", instruction="reach")
     policy.reset(scene)
-    observation = embodiment.reset(scene, seed=0)
 
-    # Should complete without error / refusal when re-requesting 'top' after eviction
+    import numpy as np
+
+    from inspect_robots.types import Observation
+
+    images = {
+        name: np.full((2, 2, 3), i, dtype=np.uint8)
+        for i, name in enumerate(["top", "front", "left"], start=1)
+    }
+    observation = Observation(state={"q": np.array([0.0])}, images=images, extra={"env_step": 0})
+
     chunk = policy.act(observation)
     assert chunk is not None
+
+    tool_results = [
+        message["content"] for message in policy._messages if message.get("role") == "tool"
+    ]
+    assert tool_results[:4] == [
+        "captured 1 frame(s): 'top'",
+        "captured 1 frame(s): 'front'",
+        "captured 1 frame(s): 'left'",
+        "captured 1 frame(s): 'top'",
+    ]
+    assert tool_results[4].startswith("already shown for this observation: 'left'")

--- a/plugins/inspect-robots-agent/tests/test_policy_eviction.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_eviction.py
@@ -449,4 +449,3 @@ def test_on_demand_allows_re_reveal_after_eviction() -> None:
     # Should complete without error / refusal when re-requesting 'top' after eviction
     chunk = policy.act(observation)
     assert chunk is not None
-

--- a/plugins/inspect-robots-agent/tests/test_policy_eviction.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_eviction.py
@@ -309,3 +309,134 @@ def test_eviction_boundary_and_already_stubbed_prefix_are_byte_stable() -> None:
             if message_index in stub_indices(body)
         }
         assert len(stable_forms) == 1
+
+
+def test_on_demand_allows_re_reveal_after_eviction() -> None:
+    responses = [
+        # Call 1: take_pic top
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "take_pic",
+                                    "arguments": json.dumps({"cameras": ["top"], "note": "Check top view"}),
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        },
+        # Call 2: take_pic front
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_2",
+                                "type": "function",
+                                "function": {
+                                    "name": "take_pic",
+                                    "arguments": json.dumps({"cameras": ["front"], "note": "Check front view"}),
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        },
+        # Call 3: take_pic left
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_3",
+                                "type": "function",
+                                "function": {
+                                    "name": "take_pic",
+                                    "arguments": json.dumps({"cameras": ["left"], "note": "Check left view"}),
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        },
+        # Call 4: take_pic top again (was evicted since image_horizon=2)
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_4",
+                                "type": "function",
+                                "function": {
+                                    "name": "take_pic",
+                                    "arguments": json.dumps({"cameras": ["top"], "note": "Check top view again"}),
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        },
+        # Call 5: move_by
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_5",
+                                "type": "function",
+                                "function": {
+                                    "name": "move_by",
+                                    "arguments": json.dumps({"deltas": {"dx": 0.01}, "note": "Move"}),
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        },
+    ]
+
+    response_iter = iter(responses)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=next(response_iter))
+
+    embodiment = CubePickEmbodiment()
+    policy = _policy(
+        images="on_demand",
+        image_horizon=2,
+        transport=httpx.MockTransport(handler),
+    )
+    policy.bind(embodiment.info)
+    scene = Scene(id="s0", instruction="reach")
+    policy.reset(scene)
+    observation = embodiment.reset(scene, seed=0)
+
+    # Should complete without error / refusal when re-requesting 'top' after eviction
+    chunk = policy.act(observation)
+    assert chunk is not None
+

--- a/plugins/inspect-robots-agent/tests/test_policy_eviction.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_eviction.py
@@ -326,7 +326,9 @@ def test_on_demand_allows_re_reveal_after_eviction() -> None:
                                 "type": "function",
                                 "function": {
                                     "name": "take_pic",
-                                    "arguments": json.dumps({"cameras": ["top"], "note": "Check top view"}),
+                                    "arguments": json.dumps(
+                                        {"cameras": ["top"], "note": "Check top"}
+                                    ),
                                 },
                             }
                         ],
@@ -347,7 +349,9 @@ def test_on_demand_allows_re_reveal_after_eviction() -> None:
                                 "type": "function",
                                 "function": {
                                     "name": "take_pic",
-                                    "arguments": json.dumps({"cameras": ["front"], "note": "Check front view"}),
+                                    "arguments": json.dumps(
+                                        {"cameras": ["front"], "note": "Check front"}
+                                    ),
                                 },
                             }
                         ],
@@ -368,7 +372,9 @@ def test_on_demand_allows_re_reveal_after_eviction() -> None:
                                 "type": "function",
                                 "function": {
                                     "name": "take_pic",
-                                    "arguments": json.dumps({"cameras": ["left"], "note": "Check left view"}),
+                                    "arguments": json.dumps(
+                                        {"cameras": ["left"], "note": "Check left"}
+                                    ),
                                 },
                             }
                         ],
@@ -389,7 +395,9 @@ def test_on_demand_allows_re_reveal_after_eviction() -> None:
                                 "type": "function",
                                 "function": {
                                     "name": "take_pic",
-                                    "arguments": json.dumps({"cameras": ["top"], "note": "Check top view again"}),
+                                    "arguments": json.dumps(
+                                        {"cameras": ["top"], "note": "Check top again"}
+                                    ),
                                 },
                             }
                         ],
@@ -410,7 +418,9 @@ def test_on_demand_allows_re_reveal_after_eviction() -> None:
                                 "type": "function",
                                 "function": {
                                     "name": "move_by",
-                                    "arguments": json.dumps({"deltas": {"dx": 0.01}, "note": "Move"}),
+                                    "arguments": json.dumps(
+                                        {"deltas": {"dx": 0.01}, "note": "Move"}
+                                    ),
                                 },
                             }
                         ],


### PR DESCRIPTION
### Description

Fixes #192 where in `images="on_demand"` mode, taking multiple single-camera pictures under an `image_horizon` evicted earlier revealed frames from the active context window, but left their camera names registered in `self._revealed`. 

When the model subsequently attempted to re-reveal an evicted frame, `LLMAgentPolicy` refused the request with `"already shown for this observation ... the view cannot change until the robot moves"`, leaving the model with an untrue refusal text and no way to recover the frame until taking a motion step.

### Proposed Changes

- **Agent Policy (`plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py`)**:
  - In `LLMAgentPolicy.act()`, inspect the active `outgoing` view (post `_evicted_view()`) before processing duplicate camera capture refusals.
  - Update `self._revealed` by keeping only camera names whose frame messages are still present in the outgoing payload.
  - If a frame message was stubbed/evicted due to `image_horizon`, re-requesting `take_pic` for that camera is now permitted.

- **Tests (`plugins/inspect-robots-agent/tests/test_policy_eviction.py`)**:
  - Added `test_on_demand_allows_re_reveal_after_eviction()` to verify that sequential single-camera reveals exceeding `image_horizon` permit re-revealing aged-out frames.

### Verification

- Ran `pytest plugins/inspect-robots-agent/tests/test_policy_eviction.py` (17 passed).