### PR TITLE
docs: add fast Opus 5 + rerun-connect example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,3 +444,17 @@ If you use Inspect Robots in your research, please cite it:
 ## License
 
 [MIT](LICENSE)
+
+## Example: fast Opus 5 streamed to a remote Rerun viewer
+
+Run Claude Opus 5 in
+[fast mode](plugins/inspect-robots-agent/README.md#fast-mode-on-claude) at
+high thinking effort, streaming the rollout live to a Rerun viewer on your
+laptop (`rerun` locally, then `ssh -R 9876:localhost:9876 <robot>` for the
+tunnel):
+
+```bash
+inspect-robots "place the fork on the plate" --policy agent --rerun-connect \
+    -P model=anthropic/claude-opus-5 -P wire=anthropic -P speed=fast \
+    -P effort=high
+```


### PR DESCRIPTION
Adds a worked example at the very end of the README: Claude Opus 5 in fast mode (`-P wire=anthropic -P speed=fast`) at high thinking effort (`-P effort=high`), streaming the rollout to a remote Rerun viewer with `--rerun-connect`, using the instruction "place the fork on the plate".

🤖 Generated with [Claude Code](https://claude.com/claude-code)