### PR TITLE
setup wizard: interview plugin-declared option slots (auto_start)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- `OptionSlot` / `OPTION_SLOTS` (plan 0032): embodiment plugins can declare
+  boolean behavior toggles that `inspect-robots setup` interviews as yes/no
+  questions and writes into `[embodiment.args]`. First consumer:
+  inspect-robots-yam's `auto_start` (yam#87).
+
 - Policy connection failures now include an actionable action-server
   remediation hint in the recorded error message (#219).
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ uv pip install inspect-robots-yam   # provides the molmoact2 policy + yam_arms r
 inspect-robots setup
 ```
 
-The wizard picks your defaults and finds your cameras, then writes
-`~/.config/inspect-robots/config.ini`. On a different rig, install its plugin
-instead and type its component names at the prompts; to write the config file
-by hand, see [the CLI guide](https://inspectrobots.org/guide/cli/).
+The wizard picks your defaults, finds your cameras, and asks about behavior
+toggles declared by the embodiment plugin, such as yam's `auto_start`, then
+writes `~/.config/inspect-robots/config.ini`. On a different rig, install its
+plugin instead and type its component names at the prompts; to write the config
+file by hand, see [the CLI guide](https://inspectrobots.org/guide/cli/).
 
 The `molmoact2` policy is only a client: nothing moves until the MolmoAct2
 server is listening, and the server does not start itself or survive a

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -82,6 +82,28 @@ wizard probes and interviews slots in declaration order, then writes each
 selection to its `arg` key under `[embodiment.args]`. Slots with the same
 non-`None` `group` are all-or-none. Ungrouped slots remain independent.
 
+## Declare option slots
+
+Declare boolean behavior toggles on the registered embodiment factory. Import
+[`OptionSlot`](/api/#inspect_robots.conformance.OptionSlot) from the
+`inspect_robots.conformance` submodule:
+
+```python
+from inspect_robots.conformance import OptionSlot
+
+OPTION_SLOTS = (
+    OptionSlot(
+        arg="auto_start",
+        label="Skip the operator start prompts (auto_start)",
+    ),
+)
+```
+
+Each slot is one yes/no question in the setup wizard. Its `arg` is the
+`[embodiment.args]` key written as `true` or `false`. On re-runs, the carried
+config value is the suggested answer. A declaration is skipped when its `arg`
+collides with a device slot, a camera key, or an earlier option declaration.
+
 ## The conformance kit
 
 Add one test built on

--- a/plans/0032-wizard-option-slots.md
+++ b/plans/0032-wizard-option-slots.md
@@ -57,39 +57,44 @@ def test_option_slots_defaults_to_false() -> None:
     assert OptionSlot(arg="a", label="A").default is False
 
 
-def test_option_slots_absent_or_malformed_never_crash() -> None:
+def test_option_slots_none_and_absent_return_empty() -> None:
     class _Bare:
         pass
 
+    assert option_slots(None) == ()
+    assert option_slots(_Bare()) == ()
+
+
+def test_option_slots_malformed_never_crash() -> None:
     class _NotIterable:
-        OPTION_SLOTS = 7
+        OPTION_SLOTS: ClassVar[int] = 7
 
     class _MixedEntries:
-        OPTION_SLOTS = (OptionSlot(arg="ok", label="OK"), "junk", None)
+        OPTION_SLOTS: ClassVar[tuple[object, ...]] = (
+            OptionSlot(arg="ok", label="OK"),
+            "junk",
+            None,
+        )
+
+    class _RaisingIteration:
+        def __iter__(self) -> "Iterator[OptionSlot]":
+            raise RuntimeError("boom")
+
+    class _RaisingIterationFactory:
+        OPTION_SLOTS: ClassVar[object] = _RaisingIteration()
 
     class _RaisingGetattr:
         @property
         def OPTION_SLOTS(self) -> tuple[OptionSlot, ...]:
             raise RuntimeError("boom")
 
-    class _RaisingIteration:
-        class _Evil:
-            def __iter__(self) -> "_RaisingIteration._Evil":
-                return self
-
-            def __next__(self) -> OptionSlot:
-                raise RuntimeError("boom")
-
-        OPTION_SLOTS = _Evil()
-
-    assert option_slots(_Bare()) == ()
     assert option_slots(_NotIterable()) == ()
     assert option_slots(_MixedEntries()) == (OptionSlot(arg="ok", label="OK"),)
+    assert option_slots(_RaisingIterationFactory()) == ()
     assert option_slots(_RaisingGetattr()) == ()
-    assert option_slots(_RaisingIteration()) == ()
 ```
 
-Before finalizing, compare with how `tests/test_conformance.py` already exercises `device_slots`' defensive paths and match its idioms (it may already have equivalents of `_RaisingGetattr` etc. to crib; property-on-class raise only fires on instances, hence the instance calls above — keep whichever instantiation style the device_slots tests use).
+Before finalizing, compare with how `tests/test_conformance.py` already exercises `device_slots`' defensive paths (lines ~63-111) and match its idioms exactly: it annotates fixture class attributes with `ClassVar[...]`, breaks iteration by raising in `__iter__`, asserts `device_slots(None) == ()`, and parametrizes whole-value garbage — mirror whichever of those apply, reusing its parametrize lists where they fit, in preference to the sketch above where they differ.
 
 - [ ] **Step 2: Run tests to verify they fail**
 
@@ -178,7 +183,9 @@ def _register_option_slots(
     )
 ```
 
-Then tests, following the harness style of `test_run_setup_defaults_and_numbered_cameras_write_golden_config` (env with `XDG_CONFIG_HOME=tmp_path`, scripted answers list, `io.StringIO()` out, read back the written config with the existing raw-read helper or `configparser`). The scripted answer sequences must be derived from the ACTUAL prompt order in the current wizard (defaults prompts first, then the camera/device section, then options) — count the prompts in the existing golden test and extend its answer list; the factory here declares no `DEVICE_SLOTS`, so the camera path (`_camera_section`) runs, and its "Configure cameras?"-style question must be answered "n" (check the real prompt text in `_camera_section` before writing the list).
+Then tests, following the harness style of `test_run_setup_defaults_and_numbered_cameras_write_golden_config` (env with `XDG_CONFIG_HOME=tmp_path` and `DISPLAY: ":0"` — without DISPLAY the headless rerun note fires and flips the rerun suggestion, adding transcript noise; scripted answers via the harness's `_scripted_input`, which RECORDS every prompt string into a `prompts` list; `io.StringIO()` out; read back the written config with the same mechanism the golden test uses). The scripted answer sequences must be derived from the ACTUAL prompt order in the current wizard: `_prompt_defaults` asks exactly 6 questions (the `SUGGESTED` keys), then the camera/device section, then options. The options-only factory declares no `DEVICE_SLOTS`, so `_camera_section` runs and its "Configure cameras?" question must be answered "n" (check the real prompt text before writing the list).
+
+IMPORTANT: prompt strings (including the `[y/N]`/`[Y/n]` suffix) go to `input_fn`, NOT to `out` — all prompt assertions must target the recorded `prompts` list, the way existing tests assert on `prompts[6]` (see `test_setup.py` ~lines 1090-1128). Asserting prompt text "not in out" is vacuously true and guards nothing.
 
 ```python
 AUTO_START = OptionSlot(arg="auto_start", label="Skip the operator start prompts (auto_start)")
@@ -186,41 +193,68 @@ AUTO_START = OptionSlot(arg="auto_start", label="Skip the operator start prompts
 
 def test_run_setup_writes_declared_option_yes(tmp_path, monkeypatch) -> None:
     # embodiment answer must name the registered factory ("option-body");
-    # answer "y" at the option prompt -> auto_start = true in [embodiment.args].
+    # answer "y" at the option prompt -> auto_start = true in [embodiment.args];
+    # the option prompt (prompts[7], after 6 defaults + "Configure cameras?")
+    # contains AUTO_START.label.
     ...
 
 
 def test_run_setup_writes_declared_option_default_no(tmp_path, monkeypatch) -> None:
     # Enter at the option prompt with no carried value -> auto_start = false,
-    # and the prompt suffix shown in `out` is [y/N] (default False).
+    # and the recorded option prompt carries the "[y/N]" suffix (default False).
     ...
 
 
 def test_run_setup_option_suggestion_comes_from_carried_config(tmp_path, monkeypatch) -> None:
     # Pre-write a config with [embodiment.args] auto_start = true (and the
     # matching [defaults] embodiment = option-body so the same factory is
-    # suggested); Enter keeps it -> auto_start = true survives, prompt shows [Y/n].
+    # suggested); Enter keeps it -> auto_start = true survives, and the
+    # recorded option prompt carries "[Y/n]".
 
 
 def test_run_setup_option_carried_garbage_falls_back_to_default(tmp_path, monkeypatch) -> None:
-    # Pre-write auto_start = banana -> suggestion is the slot default (False).
+    # Pre-write auto_start = banana -> recorded option prompt carries "[y/N]"
+    # (the slot default), and Enter writes false.
 
 
 def test_run_setup_option_answer_overrides_carried_value_without_duplicate(tmp_path, monkeypatch) -> None:
-    # Pre-write auto_start = true; answer "n" -> written config contains
-    # exactly one auto_start line and it is false.
+    # Pre-write auto_start = true; answer "n" -> the written config text
+    # contains exactly one "auto_start" occurrence and it is false.
 
 
 def test_run_setup_abort_during_options_writes_nothing(tmp_path, monkeypatch) -> None:
     # input_fn raises EOFError at the option prompt -> exit code 1, no config file.
 
 
-def test_options_section_absent_when_no_declared_options(tmp_path, monkeypatch) -> None:
-    # _empty_registry / a factory without OPTION_SLOTS: no option prompt text
-    # in `out`; this is the regression guard for unchanged wizards.
+def test_run_setup_interviews_options_alongside_device_slots(tmp_path, monkeypatch) -> None:
+    # The real first-consumer shape (yam declares both): register ONE factory
+    # class carrying both DEVICE_SLOTS (a single "can" slot, following
+    # _register_device_slots) and OPTION_SLOTS = (AUTO_START,). Decline the
+    # device section ("n" at "Configure devices?", so _preserve_managed_args
+    # runs; pre-write the device arg in [embodiment.args] to assert it is
+    # preserved), then answer "y" at the option prompt. Assert both keys are
+    # written exactly once: the carried device value and auto_start = true.
+    ...
+
+
+def test_run_setup_option_colliding_with_managed_key_is_skipped(tmp_path, monkeypatch) -> None:
+    # A factory with no DEVICE_SLOTS but OPTION_SLOTS naming a camera key
+    # (OptionSlot(arg="top_cam_device", ...)) plus AUTO_START: the colliding
+    # option is never prompted (no prompt contains its label), only
+    # auto_start is interviewed, and the written config has no duplicate
+    # top_cam_device line. Also cover a duplicate arg WITHIN options
+    # ((AUTO_START, OptionSlot(arg="auto_start", label="dupe"))): one prompt,
+    # first declaration wins.
+
+
+def test_run_setup_no_declared_options_asks_nothing(tmp_path, monkeypatch) -> None:
+    # A factory without OPTION_SLOTS: the recorded prompts list contains no
+    # option-label text and has exactly the same length as before this
+    # feature (6 defaults + camera/device prompts) — the regression guard
+    # for unchanged wizards.
 ```
 
-Flesh each `...` into real code against the actual harness (the plan cannot transcribe the golden test's 30-line env scaffold; copy it from the file). Assert written-file contents via the same mechanism the golden test uses.
+Flesh each `...`/comment into real code against the actual harness (the plan cannot transcribe the golden test's env scaffold; copy it from the file). Assert written-file contents via the same mechanism the golden test uses.
 
 - [ ] **Step 2: Run tests to verify they fail**
 
@@ -266,14 +300,25 @@ def _options_section(
 3. In `run_setup`, alongside the `slots = device_slots(...)` computation, add the parallel `options = option_slots(embodiment_factories[configured_embodiment]) if configured_embodiment in embodiment_factories else ()` (keep the existing membership-test style). After the `if slots: ... else: ...` device/camera block, still inside the `try`:
 
 ```python
-        if options:
-            managed_args = managed_args + tuple(option.arg for option in options)
+        # Options whose arg collides with an already-managed key (a device
+        # slot or camera key) or repeats an earlier option are skipped:
+        # interviewing them would write the key twice, and a duplicate key
+        # makes configparser reject the whole file on the next setup run.
+        interviewed: list[OptionSlot] = []
+        taken = set(managed_args)
+        for option in options:
+            if option.arg in taken:
+                continue
+            taken.add(option.arg)
+            interviewed.append(option)
+        if interviewed:
+            managed_args = managed_args + tuple(option.arg for option in interviewed)
             embodiment_args.update(
-                _options_section(options, carried, input_fn=input_fn, out=out)
+                _options_section(tuple(interviewed), carried, input_fn=input_fn, out=out)
             )
 ```
 
-(`embodiment_args` is a plain dict in both branches; if either branch returns a mapping that must not be mutated, use `embodiment_args = {**embodiment_args, **_options_section(...)}` instead — check `_camera_section`/`_device_section`/`_preserve_managed_args` return values; `_preserve_managed_args` builds a fresh dict, so `update` is safe, but verify.)
+(`embodiment_args.update` is safe: `_device_section`, `_camera_section`, and `_preserve_managed_args` all return freshly built dicts, never references into `carried` — verify this still holds before relying on it.)
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -283,7 +328,7 @@ Expected: all PASS — new option tests and every pre-existing golden/scripted t
 - [ ] **Step 5: Full gate set**
 
 Run: `uv run ruff check . && uv run ruff format --check . && uv run mypy && uv run pytest --cov -q`
-Expected: clean, 100% coverage (both suggestion sources, both answers, garbage fallback, abort path, and the no-options fall-through are all exercised above).
+Expected: clean, 100% coverage (both suggestion sources, both answers, garbage fallback, abort path, the collision-skip `continue`, the combined device+option shape, and the no-options fall-through are all exercised above).
 
 - [ ] **Step 6: Commit**
 
@@ -298,13 +343,34 @@ git commit -m "setup: interview plugin-declared option slots (yam#87 auto_start)
 
 **Files:**
 - Modify: `README.md` (wizard description ~line 67)
-- Modify: `CHANGELOG.md` (`## Unreleased` → `### Added`; match the file's existing heading structure)
+- Modify: `CHANGELOG.md` (`## [Unreleased]` → `### Added`; match the file's existing heading structure)
+- Modify: `docs/guide/adapters.md` (the `DEVICE_SLOTS` section, ~lines 42-70)
+- Modify: `src/inspect_robots/CLAUDE.md` (module-map rows for `conformance.py` and `_setup.py`)
 
 - [ ] **Step 1: README**
 
 Extend the wizard sentence ("The wizard picks your defaults and finds your cameras, then writes...") with one clause noting it also asks about behavior toggles the embodiment plugin declares (e.g. yam's `auto_start`). Match the surrounding prose style; no em dashes if the README avoids them (check nearby prose and mirror it).
 
-- [ ] **Step 2: CHANGELOG**
+- [ ] **Step 2: adapters guide (`docs/guide/adapters.md`)**
+
+This is the plugin-author-facing protocol, so it needs the authoring docs. After the `DEVICE_SLOTS` section, add a parallel `OPTION_SLOTS` subsection in the same voice and format, with a minimal declaration example:
+
+```python
+from inspect_robots.conformance import OptionSlot
+
+
+class MyEmbodiment:
+    OPTION_SLOTS: ClassVar[tuple[OptionSlot, ...]] = (
+        OptionSlot(
+            arg="auto_start",
+            label="Skip the operator start prompts (auto_start)",
+        ),
+    )
+```
+
+State the contract in prose: each slot is one yes/no question; `arg` is the `[embodiment.args]` key written as `true`/`false`; the carried config value is the suggested answer on re-runs; declarations whose `arg` collides with a device slot, camera key, or earlier option are skipped. Adapt the example to the surrounding doc's actual class/ClassVar conventions.
+
+- [ ] **Step 3: CHANGELOG**
 
 ```markdown
 - `OptionSlot` / `OPTION_SLOTS` (plan 0032): embodiment plugins can declare
@@ -315,12 +381,16 @@ Extend the wizard sentence ("The wizard picks your defaults and finds your camer
 
 Match the existing entry indentation/format exactly.
 
-- [ ] **Step 3: Gates + commit**
+- [ ] **Step 4: Module map (`src/inspect_robots/CLAUDE.md`)**
+
+Extend the `conformance.py` row to mention `OptionSlot`/`option_slots` next to `DeviceSlot`/`device_slots`, and the `_setup.py` row to mention the option interview, matching each row's existing phrasing density.
+
+- [ ] **Step 5: Gates + commit**
 
 Run: `uv run pytest -q` (green tree), then:
 
 ```bash
-git add README.md CHANGELOG.md
+git add README.md CHANGELOG.md docs/guide/adapters.md src/inspect_robots/CLAUDE.md
 git commit -m "docs: describe wizard option-slot interviews"
 ```
 

--- a/plans/0032-wizard-option-slots.md
+++ b/plans/0032-wizard-option-slots.md
@@ -1,0 +1,333 @@
+# Wizard option slots Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let embodiment plugins declare boolean behavior toggles (first consumer: inspect-robots-yam's `auto_start`, yam#87) that the `inspect-robots setup` wizard interviews as yes/no questions and writes into `[embodiment.args]`.
+
+**Architecture:** Mirror the existing `DeviceSlot` / `DEVICE_SLOTS` protocol one-for-one: a frozen `OptionSlot` dataclass and a defensive `option_slots()` reader in `conformance.py`, plus a small `_options_section()` interview in `_setup.py` that runs after the device/camera section for the configured embodiment. Answered options become managed args (re-runs re-prompt with the carried value as the suggestion; `_render_config` writes them from the interview, not the carry-through). Plugins on older cores are unaffected; cores with no declaring plugin ask nothing.
+
+**Tech Stack:** Python 3.10+, stdlib only, pytest with injected `input_fn`/`out` seams.
+
+## Global Constraints
+
+- Gates (all blocking): `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` (strict), `uv run pytest --cov` at **100% coverage**.
+- Every public module/class/function needs a docstring; state the contract.
+- Repo root is the `wizard-auto-start` worktree at `.claude/worktrees/wizard-auto-start`; run everything via `uv run ...` there.
+- Wizard behavior for embodiments that declare no `OPTION_SLOTS` must be byte-for-byte unchanged (all existing golden-config tests must pass untouched).
+- Commit messages: imperative, scoped; reference yam#87 as motivation where apt.
+
+## Reference: current wiring
+
+- `conformance.py:32-70`: `@dataclass(frozen=True) class DeviceSlot` and `device_slots(factory)` — the defensive-reader pattern to copy (`getattr` in try/except, `Iterable` check, per-entry `isinstance` filter).
+- `_setup.py:130-147`: `_ask_yes_no(prompt, default, *, input_fn, out) -> bool` — the interview primitive; renders `[Y/n]`/`[y/N]`, Enter accepts the default.
+- `_setup.py:15`: `_parse_value` is already imported; it coerces `"true"`/`"false"` (any case) to bool and other strings to other scalars.
+- `_setup.py:1013-1043` (`run_setup`): computes `slots = device_slots(...)` for the configured embodiment, then either `_device_section` (sets `managed_args = tuple(slot.arg ...)`) or `_camera_section` (sets `managed_args = CAMERA_KEYS`). Everything interview-shaped sits inside the `try` whose `except (EOFError, KeyboardInterrupt)` aborts with nothing written.
+- `_setup.py:893-945` (`_render_config(defaults, embodiment_args, carried, managed_args)`): writes managed keys from `embodiment_args`, then carries any `[embodiment.args]` key NOT in `managed_args` verbatim — so once an option key is managed, the interview's answer wins over the carried line and there is no duplicate.
+- `tests/test_setup.py:122-138`: `_register_device_slots(monkeypatch, slots, name)` fakes `inspect_robots.registry.registered` with a `_Factory` class carrying `DEVICE_SLOTS`; the autouse `_empty_registry` fixture empties the registry otherwise. Scripted runs drive `run_setup` with `input_fn=iter(answers).__next__`-style callables and a `StringIO` out (see `test_run_setup_defaults_and_numbered_cameras_write_golden_config`, line 553, for the env/tmp_path harness to copy).
+
+---
+
+### Task 1: `OptionSlot` + `option_slots` in conformance.py
+
+**Files:**
+- Modify: `src/inspect_robots/conformance.py` (below `device_slots`, ~line 70)
+- Test: `tests/test_conformance.py`
+
+**Interfaces:**
+- Produces: `OptionSlot(arg: str, label: str, default: bool = False)` (frozen dataclass) and `option_slots(factory: object) -> tuple[OptionSlot, ...]`. Task 2 consumes both. Plugins import `OptionSlot` from `inspect_robots.conformance` (same path as `DeviceSlot`; not added to the package `__all__`, matching `DeviceSlot`, unless `DeviceSlot` IS in `__all__` — mirror whatever `DeviceSlot` does).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_conformance.py` (extend its conformance import line with `OptionSlot, option_slots`; `ClassVar` may need adding to the typing imports):
+
+```python
+def test_option_slots_reads_declared_tuple_in_order() -> None:
+    declared = (
+        OptionSlot(arg="auto_start", label="Skip the operator start prompts (auto_start)"),
+        OptionSlot(arg="verbose", label="Verbose", default=True),
+    )
+
+    class _Factory:
+        OPTION_SLOTS: ClassVar[tuple[OptionSlot, ...]] = declared
+
+    assert option_slots(_Factory) == declared
+
+
+def test_option_slots_defaults_to_false() -> None:
+    assert OptionSlot(arg="a", label="A").default is False
+
+
+def test_option_slots_absent_or_malformed_never_crash() -> None:
+    class _Bare:
+        pass
+
+    class _NotIterable:
+        OPTION_SLOTS = 7
+
+    class _MixedEntries:
+        OPTION_SLOTS = (OptionSlot(arg="ok", label="OK"), "junk", None)
+
+    class _RaisingGetattr:
+        @property
+        def OPTION_SLOTS(self) -> tuple[OptionSlot, ...]:
+            raise RuntimeError("boom")
+
+    class _RaisingIteration:
+        class _Evil:
+            def __iter__(self) -> "_RaisingIteration._Evil":
+                return self
+
+            def __next__(self) -> OptionSlot:
+                raise RuntimeError("boom")
+
+        OPTION_SLOTS = _Evil()
+
+    assert option_slots(_Bare()) == ()
+    assert option_slots(_NotIterable()) == ()
+    assert option_slots(_MixedEntries()) == (OptionSlot(arg="ok", label="OK"),)
+    assert option_slots(_RaisingGetattr()) == ()
+    assert option_slots(_RaisingIteration()) == ()
+```
+
+Before finalizing, compare with how `tests/test_conformance.py` already exercises `device_slots`' defensive paths and match its idioms (it may already have equivalents of `_RaisingGetattr` etc. to crib; property-on-class raise only fires on instances, hence the instance calls above — keep whichever instantiation style the device_slots tests use).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_conformance.py -k option_slot -v`
+Expected: FAIL at import (`ImportError: cannot import name 'OptionSlot'`).
+
+- [ ] **Step 3: Implement**
+
+In `src/inspect_robots/conformance.py`, directly after `device_slots`:
+
+```python
+@dataclass(frozen=True)
+class OptionSlot:
+    """One boolean behavior toggle the setup wizard interviews.
+
+    ``arg`` is the ``[embodiment.args]`` key to write (``true``/``false``);
+    ``label`` is the yes/no question shown to the operator ("Skip the
+    operator start prompts (auto_start)"); ``default`` is the suggested
+    answer when the key is absent from an existing config.
+    """
+
+    arg: str
+    label: str
+    default: bool = False
+
+
+def option_slots(factory: object) -> tuple[OptionSlot, ...]:
+    """The declared option slots, defensively read.
+
+    Reads ``OPTION_SLOTS`` off ``factory``; anything that is not an iterable
+    of ``OptionSlot`` instances has the offending entries ignored, never
+    crashes the wizard. Returns a tuple in declaration order.
+    """
+    try:
+        slots = getattr(factory, "OPTION_SLOTS", None)
+    except Exception:
+        return ()
+    if not isinstance(slots, Iterable):
+        return ()
+    try:
+        return tuple(slot for slot in slots if isinstance(slot, OptionSlot))
+    except Exception:
+        return ()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_conformance.py -v`
+Expected: PASS (new and existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/inspect_robots/conformance.py tests/test_conformance.py
+git commit -m "conformance: OptionSlot protocol for wizard-interviewed behavior toggles"
+```
+
+---
+
+### Task 2: wizard interviews declared options
+
+**Files:**
+- Modify: `src/inspect_robots/_setup.py` (import at line 14; new `_options_section` near `_device_section`; wiring in `run_setup` ~line 1013-1043)
+- Test: `tests/test_setup.py`
+
+**Interfaces:**
+- Consumes: `OptionSlot`, `option_slots` from Task 1; existing `_ask_yes_no`, `_parse_value`, `_render_config` managed-args semantics.
+- Produces: `_options_section(options, carried, *, input_fn, out) -> dict[str, str]` (private) and the run_setup behavior below.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_setup.py` a registrar mirroring `_register_device_slots` (import `OptionSlot` alongside `DeviceSlot`):
+
+```python
+def _register_option_slots(
+    monkeypatch: pytest.MonkeyPatch,
+    options: tuple[OptionSlot, ...],
+    name: str = "option-body",
+) -> None:
+    class _Factory:
+        OPTION_SLOTS: ClassVar[tuple[OptionSlot, ...]] = options
+
+    monkeypatch.setattr(
+        "inspect_robots.registry.registered",
+        lambda kind: {name: _Factory} if kind == "embodiment" else {},
+    )
+```
+
+Then tests, following the harness style of `test_run_setup_defaults_and_numbered_cameras_write_golden_config` (env with `XDG_CONFIG_HOME=tmp_path`, scripted answers list, `io.StringIO()` out, read back the written config with the existing raw-read helper or `configparser`). The scripted answer sequences must be derived from the ACTUAL prompt order in the current wizard (defaults prompts first, then the camera/device section, then options) — count the prompts in the existing golden test and extend its answer list; the factory here declares no `DEVICE_SLOTS`, so the camera path (`_camera_section`) runs, and its "Configure cameras?"-style question must be answered "n" (check the real prompt text in `_camera_section` before writing the list).
+
+```python
+AUTO_START = OptionSlot(arg="auto_start", label="Skip the operator start prompts (auto_start)")
+
+
+def test_run_setup_writes_declared_option_yes(tmp_path, monkeypatch) -> None:
+    # embodiment answer must name the registered factory ("option-body");
+    # answer "y" at the option prompt -> auto_start = true in [embodiment.args].
+    ...
+
+
+def test_run_setup_writes_declared_option_default_no(tmp_path, monkeypatch) -> None:
+    # Enter at the option prompt with no carried value -> auto_start = false,
+    # and the prompt suffix shown in `out` is [y/N] (default False).
+    ...
+
+
+def test_run_setup_option_suggestion_comes_from_carried_config(tmp_path, monkeypatch) -> None:
+    # Pre-write a config with [embodiment.args] auto_start = true (and the
+    # matching [defaults] embodiment = option-body so the same factory is
+    # suggested); Enter keeps it -> auto_start = true survives, prompt shows [Y/n].
+
+
+def test_run_setup_option_carried_garbage_falls_back_to_default(tmp_path, monkeypatch) -> None:
+    # Pre-write auto_start = banana -> suggestion is the slot default (False).
+
+
+def test_run_setup_option_answer_overrides_carried_value_without_duplicate(tmp_path, monkeypatch) -> None:
+    # Pre-write auto_start = true; answer "n" -> written config contains
+    # exactly one auto_start line and it is false.
+
+
+def test_run_setup_abort_during_options_writes_nothing(tmp_path, monkeypatch) -> None:
+    # input_fn raises EOFError at the option prompt -> exit code 1, no config file.
+
+
+def test_options_section_absent_when_no_declared_options(tmp_path, monkeypatch) -> None:
+    # _empty_registry / a factory without OPTION_SLOTS: no option prompt text
+    # in `out`; this is the regression guard for unchanged wizards.
+```
+
+Flesh each `...` into real code against the actual harness (the plan cannot transcribe the golden test's 30-line env scaffold; copy it from the file). Assert written-file contents via the same mechanism the golden test uses.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_setup.py -k option -v`
+Expected: FAIL — no option prompt is consumed, so scripted-answer counts and file contents mismatch (the abort test fails because setup completes instead of aborting).
+
+- [ ] **Step 3: Implement**
+
+In `src/inspect_robots/_setup.py`:
+
+1. Extend the conformance import: `from inspect_robots.conformance import DeviceSlot, OptionSlot, device_slots, option_slots`.
+
+2. Add after `_device_section` (module-private, docstringed):
+
+```python
+def _options_section(
+    options: tuple[OptionSlot, ...],
+    carried: dict[str, dict[str, str]],
+    *,
+    input_fn: Callable[[str], str],
+    out: IO[str],
+) -> dict[str, str]:
+    """Interview plugin-declared behavior toggles as yes/no questions.
+
+    The carried config value (parsed as a bool) is the suggested answer when
+    present and boolean; otherwise the slot's declared default. Answers are
+    written explicitly (``true``/``false``) so declining a previously enabled
+    toggle turns it off rather than silently carrying it forward.
+    """
+    existing_args = carried.get("embodiment.args", {})
+    answers: dict[str, str] = {}
+    for option in options:
+        suggested = option.default
+        if option.arg in existing_args:
+            parsed = _parse_value(existing_args[option.arg])
+            if isinstance(parsed, bool):
+                suggested = parsed
+        enabled = _ask_yes_no(option.label, suggested, input_fn=input_fn, out=out)
+        answers[option.arg] = "true" if enabled else "false"
+    return answers
+```
+
+3. In `run_setup`, alongside the `slots = device_slots(...)` computation, add the parallel `options = option_slots(embodiment_factories[configured_embodiment]) if configured_embodiment in embodiment_factories else ()` (keep the existing membership-test style). After the `if slots: ... else: ...` device/camera block, still inside the `try`:
+
+```python
+        if options:
+            managed_args = managed_args + tuple(option.arg for option in options)
+            embodiment_args.update(
+                _options_section(options, carried, input_fn=input_fn, out=out)
+            )
+```
+
+(`embodiment_args` is a plain dict in both branches; if either branch returns a mapping that must not be mutated, use `embodiment_args = {**embodiment_args, **_options_section(...)}` instead — check `_camera_section`/`_device_section`/`_preserve_managed_args` return values; `_preserve_managed_args` builds a fresh dict, so `update` is safe, but verify.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_setup.py -v`
+Expected: all PASS — new option tests and every pre-existing golden/scripted test unchanged.
+
+- [ ] **Step 5: Full gate set**
+
+Run: `uv run ruff check . && uv run ruff format --check . && uv run mypy && uv run pytest --cov -q`
+Expected: clean, 100% coverage (both suggestion sources, both answers, garbage fallback, abort path, and the no-options fall-through are all exercised above).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/inspect_robots/_setup.py tests/test_setup.py
+git commit -m "setup: interview plugin-declared option slots (yam#87 auto_start)"
+```
+
+---
+
+### Task 3: docs
+
+**Files:**
+- Modify: `README.md` (wizard description ~line 67)
+- Modify: `CHANGELOG.md` (`## Unreleased` → `### Added`; match the file's existing heading structure)
+
+- [ ] **Step 1: README**
+
+Extend the wizard sentence ("The wizard picks your defaults and finds your cameras, then writes...") with one clause noting it also asks about behavior toggles the embodiment plugin declares (e.g. yam's `auto_start`). Match the surrounding prose style; no em dashes if the README avoids them (check nearby prose and mirror it).
+
+- [ ] **Step 2: CHANGELOG**
+
+```markdown
+- `OptionSlot` / `OPTION_SLOTS` (plan 0032): embodiment plugins can declare
+  boolean behavior toggles that `inspect-robots setup` interviews as yes/no
+  questions and writes into `[embodiment.args]`. First consumer:
+  inspect-robots-yam's `auto_start` (yam#87).
+```
+
+Match the existing entry indentation/format exactly.
+
+- [ ] **Step 3: Gates + commit**
+
+Run: `uv run pytest -q` (green tree), then:
+
+```bash
+git add README.md CHANGELOG.md
+git commit -m "docs: describe wizard option-slot interviews"
+```
+
+---
+
+## Out of scope
+
+- Non-boolean option kinds (choice/text): YAGNI until a plugin needs one; the dataclass can grow a `kind` later without breaking declarers.
+- The yam-side `OPTION_SLOTS` declaration: separate PR in inspect-robots-yam after this ships in a core release (it needs the new dependency floor).
+- Prompting for options of unregistered embodiments: without the plugin installed there is no declaration to read; the wizard already warns about missing plugins.

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -20,7 +20,7 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `frames.py` | `FrameStore`/`FrameRef` — stream camera frames to disk (R5) |
 | `transcript.py` | typed event stream (reset/inference/step/approval/operator/error) |
 | `compat.py` | `check_compatibility`/`assert_compatible` — fail-fast before rollout |
-| `conformance.py` | adapter conformance kit: `check_embodiment`/`assert_embodiment_conformant` for declarative guardrail/agent readiness; `missing_runtime_requirements` provides runtime-dependency preflight; `DeviceSlot`/`device_slots` declare and defensively read embodiment device slots |
+| `conformance.py` | adapter conformance kit: `check_embodiment`/`assert_embodiment_conformant` for declarative guardrail/agent readiness; `missing_runtime_requirements` provides runtime-dependency preflight; `DeviceSlot`/`device_slots` and `OptionSlot`/`option_slots` declare and defensively read embodiment device and boolean option slots |
 | `errors.py` | error taxonomy (continue vs halt) |
 | `eval.py` | `eval()` / `eval_set()` orchestration |
 | `log.py` | immutable, schema-versioned `EvalLog` + `read_eval_log`, including per-trial policy transcripts parallel to epochs |
@@ -33,7 +33,7 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `_video.py` | `inspect-robots video`: reunite a log with its `FrameStore` side-cars and pipe them to the ffmpeg binary, one MP4 per (trial, camera) stream (plan 0016: stderr temp file not pipe, per-stream failure isolation, strict uint8) |
 | `defaults.py` | public reader for user default policy/embodiment (+ `--sim` counterpart): env vars > `~/.config/inspect-robots/config.ini` (INI — py3.10 has no tomllib; deliberately no project-local file); `_set_default` backs `config set` |
 | `_dotenv.py` | dependency-free `.env` parsing and working-directory auto-loading with real environment variables taking precedence |
-| `_setup.py` | the `inspect-robots setup` wizard (plans 0009 and 0011): IO-injected prompts for `[defaults]`, plugin-declared V4L2/CAN/serial device slots with unplug-to-identify and CAN udev guidance, fallback camera discovery, headless-rerun warning; renders config.ini itself (comments survive) and carries unmanaged sections/keys through raw |
+| `_setup.py` | the `inspect-robots setup` wizard (plans 0009, 0011, and 0032): IO-injected prompts for `[defaults]`, plugin-declared V4L2/CAN/serial device slots with unplug-to-identify and CAN udev guidance, boolean option interviews, fallback camera discovery, headless-rerun warning; renders config.ini itself (comments survive) and carries unmanaged sections/keys through raw |
 | `mock/` | dependency-free `CubePick` world + scripted/random/noop policies |
 
 ## Key invariants

--- a/src/inspect_robots/_setup.py
+++ b/src/inspect_robots/_setup.py
@@ -11,7 +11,7 @@ from functools import partial
 from pathlib import Path
 from typing import IO
 
-from inspect_robots.conformance import DeviceSlot, device_slots
+from inspect_robots.conformance import DeviceSlot, OptionSlot, device_slots, option_slots
 from inspect_robots.defaults import _parse_value, config_path
 
 # Same minimal-ANSI convention as cli.py (#37): plain when piped or NO_COLOR.
@@ -722,6 +722,33 @@ def _device_section(
     return assignments
 
 
+def _options_section(
+    options: tuple[OptionSlot, ...],
+    carried: dict[str, dict[str, str]],
+    *,
+    input_fn: Callable[[str], str],
+    out: IO[str],
+) -> dict[str, str]:
+    """Interview plugin-declared behavior toggles as yes/no questions.
+
+    The carried config value (parsed as a bool) is the suggested answer when
+    present and boolean; otherwise the slot's declared default. Answers are
+    written explicitly (``true``/``false``) so declining a previously enabled
+    toggle turns it off rather than silently carrying it forward.
+    """
+    existing_args = carried.get("embodiment.args", {})
+    answers: dict[str, str] = {}
+    for option in options:
+        suggested = option.default
+        if option.arg in existing_args:
+            parsed = _parse_value(existing_args[option.arg])
+            if isinstance(parsed, bool):
+                suggested = parsed
+        enabled = _ask_yes_no(option.label, suggested, input_fn=input_fn, out=out)
+        answers[option.arg] = "true" if enabled else "false"
+    return answers
+
+
 def _v4l2_color_capture(path: Path) -> bool | None:
     """Return whether a node captures color, or ``None`` when probing is inconclusive."""
     try:
@@ -1017,6 +1044,11 @@ def run_setup(
             if configured_embodiment in embodiment_factories
             else ()
         )
+        options = (
+            option_slots(embodiment_factories[configured_embodiment])
+            if configured_embodiment in embodiment_factories
+            else ()
+        )
         if slots:
             managed_args = tuple(slot.arg for slot in slots)
             embodiment_args = _device_section(
@@ -1039,6 +1071,22 @@ def run_setup(
                 by_path_dir,
                 input_fn=input_fn,
                 out=out,
+            )
+        # Options whose arg collides with an already-managed key (a device
+        # slot or camera key) or repeats an earlier option are skipped:
+        # interviewing them would write the key twice, and a duplicate key
+        # makes configparser reject the whole file on the next setup run.
+        interviewed: list[OptionSlot] = []
+        taken = set(managed_args)
+        for option in options:
+            if option.arg in taken:
+                continue
+            taken.add(option.arg)
+            interviewed.append(option)
+        if interviewed:
+            managed_args = managed_args + tuple(option.arg for option in interviewed)
+            embodiment_args.update(
+                _options_section(tuple(interviewed), carried, input_fn=input_fn, out=out)
             )
     except (EOFError, KeyboardInterrupt):
         print(_paint("setup aborted; nothing written", _YELLOW, out), file=out)

--- a/src/inspect_robots/conformance.py
+++ b/src/inspect_robots/conformance.py
@@ -70,6 +70,40 @@ def device_slots(factory: object) -> tuple[DeviceSlot, ...]:
         return ()
 
 
+@dataclass(frozen=True)
+class OptionSlot:
+    """One boolean behavior toggle the setup wizard interviews.
+
+    ``arg`` is the ``[embodiment.args]`` key to write (``true``/``false``);
+    ``label`` is the yes/no question shown to the operator ("Skip the
+    operator start prompts (auto_start)"); ``default`` is the suggested
+    answer when the key is absent from an existing config.
+    """
+
+    arg: str
+    label: str
+    default: bool = False
+
+
+def option_slots(factory: object) -> tuple[OptionSlot, ...]:
+    """The declared option slots, defensively read.
+
+    Reads ``OPTION_SLOTS`` off ``factory``; anything that is not an iterable
+    of ``OptionSlot`` instances has the offending entries ignored, never
+    crashes the wizard. Returns a tuple in declaration order.
+    """
+    try:
+        slots = getattr(factory, "OPTION_SLOTS", None)
+    except Exception:
+        return ()
+    if not isinstance(slots, Iterable):
+        return ()
+    try:
+        return tuple(slot for slot in slots if isinstance(slot, OptionSlot))
+    except Exception:
+        return ()
+
+
 def missing_runtime_requirements(factory: object) -> dict[str, str]:
     """The declared runtime modules that are not importable here.
 

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -9,10 +9,12 @@ import pytest
 
 from inspect_robots.conformance import (
     DeviceSlot,
+    OptionSlot,
     assert_embodiment_conformant,
     check_embodiment,
     device_slots,
     missing_runtime_requirements,
+    option_slots,
 )
 from inspect_robots.embodiment import EmbodimentInfo
 from inspect_robots.mock import CubePickEmbodiment
@@ -112,6 +114,71 @@ def test_device_slots_attribute_or_iteration_failure_is_empty() -> None:
 
     assert device_slots(_BrokenAttribute()) == ()
     assert device_slots(_Factory) == ()
+
+
+def test_option_slots_absent_attribute_is_empty() -> None:
+    class _Factory:
+        pass
+
+    assert option_slots(_Factory) == ()
+    assert option_slots(None) == ()
+
+
+def test_option_slots_valid_tuple_round_trips_in_order() -> None:
+    slots = (
+        OptionSlot(
+            arg="auto_start",
+            label="Skip the operator start prompts (auto_start)",
+        ),
+        OptionSlot(arg="verbose", label="Verbose", default=True),
+    )
+
+    class _Factory:
+        OPTION_SLOTS: ClassVar[tuple[OptionSlot, ...]] = slots
+
+    assert option_slots(_Factory) == slots
+
+
+def test_option_slots_default_is_false() -> None:
+    assert OptionSlot(arg="a", label="A").default is False
+
+
+def test_option_slots_accepts_lists_and_ignores_offending_entries() -> None:
+    valid = OptionSlot(arg="auto_start", label="Auto start")
+
+    class _Factory:
+        OPTION_SLOTS: ClassVar[list[object]] = [
+            "not a slot",
+            valid,
+            None,
+        ]
+
+    assert option_slots(_Factory) == (valid,)
+
+
+@pytest.mark.parametrize("garbage", [7, None])
+def test_option_slots_whole_value_garbage_is_empty(garbage: object) -> None:
+    class _Factory:
+        OPTION_SLOTS: ClassVar[object] = garbage
+
+    assert option_slots(_Factory) == ()
+
+
+def test_option_slots_attribute_or_iteration_failure_is_empty() -> None:
+    class _BrokenAttribute:
+        @property
+        def OPTION_SLOTS(self) -> object:
+            raise RuntimeError("broken descriptor")
+
+    class _BrokenIteration:
+        def __iter__(self) -> object:
+            raise RuntimeError("broken iterator")
+
+    class _Factory:
+        OPTION_SLOTS: ClassVar[object] = _BrokenIteration()
+
+    assert option_slots(_BrokenAttribute()) == ()
+    assert option_slots(_Factory) == ()
 
 
 def test_runtime_requirements_absent_attribute_is_empty() -> None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -29,7 +29,7 @@ from inspect_robots._setup import (
     _v4l2_color_capture,
     run_setup,
 )
-from inspect_robots.conformance import DeviceSlot
+from inspect_robots.conformance import DeviceSlot, OptionSlot
 
 
 def _scripted_input(
@@ -133,8 +133,28 @@ def _register_device_slots(
     )
 
 
+def _register_option_slots(
+    monkeypatch: pytest.MonkeyPatch,
+    options: tuple[OptionSlot, ...],
+    name: str = "option-body",
+) -> None:
+    class _Factory:
+        OPTION_SLOTS: ClassVar[tuple[OptionSlot, ...]] = options
+
+    monkeypatch.setattr(
+        "inspect_robots.registry.registered",
+        lambda kind: {name: _Factory} if kind == "embodiment" else {},
+    )
+
+
 def _slot_defaults(name: str = "slot-body") -> list[str]:
     return ["", name, "", "", "", ""]
+
+
+AUTO_START = OptionSlot(
+    arg="auto_start",
+    label="Skip the operator start prompts (auto_start)",
+)
 
 
 @pytest.fixture(autouse=True)
@@ -2171,6 +2191,271 @@ def test_run_setup_falls_back_to_cameras_without_registered_slots(
     assert result == 0
     assert any(prompt.startswith("Configure cameras?") for prompt in prompts)
     assert not any(prompt.startswith("Configure devices?") for prompt in prompts)
+
+
+def test_run_setup_writes_declared_option_yes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_option_slots(monkeypatch, (AUTO_START,))
+    input_fn, prompts = _scripted_input([*_slot_defaults("option-body"), "n", "y"])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path), "DISPLAY": ":0"},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert AUTO_START.label in prompts[7]
+    assert "auto_start = true" in text
+
+
+def test_run_setup_writes_declared_option_default_no(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_option_slots(monkeypatch, (AUTO_START,))
+    input_fn, prompts = _scripted_input([*_slot_defaults("option-body"), "n", ""])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path), "DISPLAY": ":0"},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert prompts[7] == f"{AUTO_START.label} [y/N] "
+    assert "auto_start = false" in text
+
+
+def test_run_setup_option_suggestion_comes_from_carried_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_option_slots(monkeypatch, (AUTO_START,))
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[defaults]\nembodiment = option-body\n\n[embodiment.args]\nauto_start = true\n",
+        encoding="utf-8",
+    )
+    input_fn, prompts = _scripted_input([*_slot_defaults("option-body"), "n", ""])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path), "DISPLAY": ":0"},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = path.read_text(encoding="utf-8")
+    assert result == 0
+    assert prompts[7] == f"{AUTO_START.label} [Y/n] "
+    assert "auto_start = true" in text
+
+
+def test_run_setup_option_carried_garbage_falls_back_to_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_option_slots(monkeypatch, (AUTO_START,))
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[defaults]\nembodiment = option-body\n\n[embodiment.args]\nauto_start = banana\n",
+        encoding="utf-8",
+    )
+    input_fn, prompts = _scripted_input([*_slot_defaults("option-body"), "n", ""])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path), "DISPLAY": ":0"},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = path.read_text(encoding="utf-8")
+    assert result == 0
+    assert prompts[7] == f"{AUTO_START.label} [y/N] "
+    assert "auto_start = false" in text
+    assert "banana" not in text
+
+
+def test_run_setup_option_answer_overrides_carried_value_without_duplicate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_option_slots(monkeypatch, (AUTO_START,))
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[defaults]\nembodiment = option-body\n\n[embodiment.args]\nauto_start = true\n",
+        encoding="utf-8",
+    )
+    input_fn, _ = _scripted_input([*_slot_defaults("option-body"), "n", "n"])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path), "DISPLAY": ":0"},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = path.read_text(encoding="utf-8")
+    assert result == 0
+    assert text.count("auto_start") == 1
+    assert "auto_start = false" in text
+
+
+def test_run_setup_abort_during_options_writes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_option_slots(monkeypatch, (AUTO_START,))
+    input_fn, _ = _scripted_input([*_slot_defaults("option-body"), "n", EOFError()])
+    out = io.StringIO()
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path), "DISPLAY": ":0"},
+        input_fn=input_fn,
+        out=out,
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 1
+    assert "setup aborted; nothing written" in out.getvalue()
+    assert not _config_path(tmp_path).exists()
+
+
+def test_run_setup_interviews_options_alongside_device_slots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _Factory:
+        DEVICE_SLOTS: ClassVar[tuple[DeviceSlot, ...]] = (
+            DeviceSlot("left_channel", "can", "left CAN channel"),
+        )
+        OPTION_SLOTS: ClassVar[tuple[OptionSlot, ...]] = (AUTO_START,)
+
+    monkeypatch.setattr(
+        "inspect_robots.registry.registered",
+        lambda kind: {"option-body": _Factory} if kind == "embodiment" else {},
+    )
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[defaults]\nembodiment = option-body\n\n[embodiment.args]\nleft_channel = can9\n",
+        encoding="utf-8",
+    )
+    input_fn, prompts = _scripted_input([*_slot_defaults("option-body"), "n", "y"])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path), "DISPLAY": ":0"},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        sysfs_net=tmp_path / "none-net",
+    )
+
+    text = path.read_text(encoding="utf-8")
+    assert result == 0
+    assert "Configure devices? [Y/n] " in prompts
+    assert AUTO_START.label in prompts[7]
+    assert text.count("left_channel = can9") == 1
+    assert text.count("auto_start = true") == 1
+
+
+def test_run_setup_option_colliding_with_managed_key_is_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    colliding = OptionSlot(arg="top_cam_device", label="Replace the top camera")
+    _register_option_slots(monkeypatch, (colliding, AUTO_START))
+    path = _config_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text(
+        "[defaults]\nembodiment = option-body\n\n"
+        "[embodiment.args]\ntop_cam_device = /dev/old-top\n",
+        encoding="utf-8",
+    )
+    input_fn, prompts = _scripted_input([*_slot_defaults("option-body"), "n", "y"])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path), "DISPLAY": ":0"},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = path.read_text(encoding="utf-8")
+    assert result == 0
+    assert not any(colliding.label in prompt for prompt in prompts)
+    assert sum(AUTO_START.label in prompt for prompt in prompts) == 1
+    assert text.count("top_cam_device = /dev/old-top") == 1
+    assert text.count("auto_start = true") == 1
+
+
+def test_run_setup_duplicate_option_arg_uses_first_declaration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    duplicate = OptionSlot(arg="auto_start", label="Duplicate auto start", default=True)
+    _register_option_slots(monkeypatch, (AUTO_START, duplicate))
+    input_fn, prompts = _scripted_input([*_slot_defaults("option-body"), "n", ""])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path), "DISPLAY": ":0"},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    text = _config_path(tmp_path).read_text(encoding="utf-8")
+    assert result == 0
+    assert sum(AUTO_START.label in prompt for prompt in prompts) == 1
+    assert not any(duplicate.label in prompt for prompt in prompts)
+    assert prompts[7] == f"{AUTO_START.label} [y/N] "
+    assert text.count("auto_start = false") == 1
+
+
+def test_run_setup_no_declared_options_asks_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _Factory:
+        pass
+
+    monkeypatch.setattr(
+        "inspect_robots.registry.registered",
+        lambda kind: {"option-body": _Factory} if kind == "embodiment" else {},
+    )
+    input_fn, prompts = _scripted_input([*_slot_defaults("option-body"), "n"])
+
+    result = run_setup(
+        {"XDG_CONFIG_HOME": str(tmp_path), "DISPLAY": ":0"},
+        input_fn=input_fn,
+        out=io.StringIO(),
+        interactive=True,
+        by_id_dir=tmp_path / "none-id",
+        by_path_dir=tmp_path / "none-path",
+    )
+
+    assert result == 0
+    assert len(prompts) == 7
+    assert prompts[6] == "Configure cameras? [y/N] "
+    assert not any(AUTO_START.label in prompt for prompt in prompts)
 
 
 def test_run_setup_device_gate_defaults_no_without_probe_or_existing_arg(


### PR DESCRIPTION
Lets embodiment plugins declare boolean behavior toggles the `inspect-robots setup` wizard interviews as yes/no questions and writes into `[embodiment.args]`, mirroring the `DeviceSlot`/`DEVICE_SLOTS` protocol: a frozen `OptionSlot` dataclass plus a defensive `option_slots()` reader in `conformance.py`, and an `_options_section()` interview in `_setup.py` that runs after the device/camera section. Answers are managed args: re-runs suggest the carried value, and declining a previously enabled toggle writes `false` instead of silently carrying it forward. Wizards for embodiments that declare nothing are byte-for-byte unchanged.

First consumer: inspect-robots-yam's `auto_start` (robocurve/inspect-robots-yam#87, shipped in yam 0.19.0), declared in a follow-up yam PR once this lands in a release.

Plan: `plans/0032-wizard-option-slots.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)