### PR TITLE
Per-dimension max_step: embodiment-declared speed semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project are documented here. The format is based on
   absolute-control pacing and safety ceilings in native units. Default delta
   approval, agent-tool interpolation, and CaP-X motion queues honor mixed
   declared/range-derived limits while policy compatibility deliberately ignores
-  embodiment-only declarations ([plan 0033](plans/0033-per-dim-max-step.md)).
+  embodiment-only declarations ([plan 0033](plans/0033-per-dim-max-step.md), #223).
 
 - `OptionSlot` / `OPTION_SLOTS` (plan 0032): embodiment plugins can declare
   boolean behavior toggles that `inspect-robots setup` interviews as yes/no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- Per-dimension `ActionSemantics.max_step` declarations let embodiments set
+  absolute-control pacing and safety ceilings in native units. Default delta
+  approval, agent-tool interpolation, and CaP-X motion queues honor mixed
+  declared/range-derived limits while policy compatibility deliberately ignores
+  embodiment-only declarations ([plan 0033](plans/0033-per-dim-max-step.md)).
+
 - `OptionSlot` / `OPTION_SLOTS` (plan 0032): embodiment plugins can declare
   boolean behavior toggles that `inspect-robots setup` interviews as yes/no
   questions and writes into `[embodiment.args]`. First consumer:

--- a/plans/0033-per-dim-max-step.md
+++ b/plans/0033-per-dim-max-step.md
@@ -1,0 +1,249 @@
+# 0033 — Per-dimension `max_step`: embodiment-declared speed semantics
+
+## Problem
+
+The agent plugin paces every action dimension at `min(max_speed_frac / hz, 0.05) ×
+(high − low)` per control step, and `DeltaLimitApprover` derives its default
+per-step limit as `0.05 × (high − low)`. Both treat "fraction of declared range"
+as a proxy for safe speed. That heuristic is right for revolute joints (range
+2π rad → ~0.6 rad/s at defaults) and badly wrong for a normalized 0–1 gripper
+stroke, where the full range is a routine single motion: a full open↔close under
+agent control is paced at ~100 steps — 10 s at 10 Hz — while the hardware does
+it in well under a second. In fact at 10 Hz defaults a lone full stroke
+*exceeds* the 10 s playout cap (`headed_ratio ≈ 100.0001 > _max_steps = 100`),
+so the agent gets a "split the move into smaller motions" error and must burn
+extra LLM calls to close its own gripper; anything short of the full stroke
+crawls. Because interpolation step count is the max over named
+dimensions, a combined joints+gripper `move_joints` call drags the *joints* down
+to the gripper's crawl too.
+
+Neither layer can fix this alone: the toolset deliberately stays under the
+approver's derived ceiling (`native_backstop`), so raising toolset pacing without
+teaching the approver would just get clamped (or worse, silently halved).
+
+## Design
+
+One new optional declaration, honored by every layer that derives per-step
+limits from the range. Motion knowledge continues to flow from the embodiment
+via declarations; the agent plugin stays embodiment-agnostic.
+
+**Absolute modes only.** `max_step` is meaningful only for absolute-target
+control (`joint_pos`, `eef_abs_pose`). In displacement/rate modes the box
+*already is* the embodiment-authored per-step limit; a second channel for the
+same fact would create a toolset/approver asymmetry (the toolset splits deltas
+by the box side) and is rejected at construction.
+
+### 1. Core: `ActionSemantics.max_step`
+
+```python
+max_step: tuple[float | None, ...] | None = None
+```
+
+Per-dimension change limit, in the action space's native units **per control
+step**, that the embodiment author considers safe and normal. `None` (the
+default) or a `None` entry means "underived — use existing range-based
+defaults". Declared entries must be finite and > 0.
+
+Validation is split by what each type can see:
+
+- `ActionSemantics.__post_init__` (new): each entry `None` or finite-positive;
+  any non-`None` entry on a non-absolute `control_mode` raises `ValueError`
+  ("displacement boxes already declare per-step limits via low/high"). This
+  catches invalid declarations at their construction site — the yam builders
+  construct semantics detached from any box. The absolute-modes set becomes a
+  canonical `ABSOLUTE_CONTROL_MODES` frozenset in `spaces.py` (it cannot live
+  in `approver.py`, which imports `spaces`); `approver.py`, `conformance.py`,
+  and the agent plugin's `_tools.py` import it instead of keeping their three
+  private copies.
+- `Box.__post_init__`: length must equal `box.dim` (same as `dim_labels`), and
+  a declared entry on a dimension whose bounds pin it (`low == high`) raises
+  `ValueError` (contradictory declaration), so every consumer — not just the
+  agent policy at bind time — rejects it.
+
+`ActionSemantics` is `frozen` without `eq=False`; a tuple field keeps it
+hashable/comparable exactly like `dim_labels` already does. Compatibility
+checking (`compat.py`) compares semantics field-by-field (`control_mode`,
+`rotation_repr`, `gripper`, `frame`) and must **not** compare `max_step`:
+the embodiment declares motion limits; a policy-side semantics never needs to
+(see §4). Add a comment there stating this is deliberate.
+
+### 2. Core: `DeltaLimitApprover`
+
+Only default derivation changes; the explicit `max_delta` argument still wins
+outright — this matches today's contract where `--max-action-delta` replaces
+the derived 5% default entirely, and is a deliberate operator override. Add a
+both-present test locking that in.
+
+Absolute modes, no explicit `max_delta`: per-dim default = declared `max_step`
+where present, else `0.05 × (high − low)` as today. The finite-bounds
+requirement ("deriving a default needs finite low/high") now applies only to
+*undeclared* dims: a space whose every dim declares `max_step` needs no finite
+bounds for derivation. Arithmetic for undeclared dims stays in the box's native
+dtype (unchanged); declared entries are substituted per-dim in float64.
+
+Scope note: this relaxation is approver-only. `conformance.py` and both
+plugins' toolset/motion builders still require finite bounds for their own
+reasons and are not relaxed to match; only the standalone/CLI-guardrails
+approver path gains the capability.
+
+Displacement modes: unchanged (declarations cannot exist there, per §1).
+
+### 3. Agent plugin: toolset pacing (`_tools.py`)
+
+In `build_toolset`, for absolute modes:
+
+- **Undeclared dims**: unchanged — `min(max_speed_frac / hz, 0.05) × range`,
+  capped by `native_backstop`.
+- **Declared dims**: pacing = `max_step × min(max_speed_frac / _DEFAULT_SPEED_FRAC, 1.0)`
+  where `_DEFAULT_SPEED_FRAC = 0.1` (the policy's default `max_speed_frac`).
+  Rationale: at the default speed setting a declared dim moves exactly at its
+  declared limit; turning the global knob *down* slows declared dims
+  proportionally (an operator slowing the robot expects everything slower);
+  turning it *up* speeds only range-paced dims — declared dims are already at
+  the embodiment's stated ceiling and must not exceed the approver's default,
+  which equals the declared value. The existing `_RELATIVE_HEADROOM` keeps
+  emitted steps strictly below the limit, so the approver never clamps.
+- **Float-spacing guard**: the coarseness check compares grid spacing against
+  the per-dim *effective* budget (declared or backstop), not `native_backstop`
+  alone, preserving the "no silent truncation" invariant for declared dims.
+- **Fixed-dim detection and underflow guards**: declared-dim pacing is folded
+  into `step_limits` **before** the existing movable-zero-limit underflow
+  guard, which stays as-is and now also covers a declared pacing product that
+  underflows to exactly 0.0 (e.g. a subnormal `max_speed_frac` times a tiny
+  declared limit) — a zero entry would otherwise misreport a movable dim as
+  fixed. `Box` rejecting declarations on pinned (`low == high`) dims means no
+  *separate* contradiction check is needed, but the underflow guard must see
+  the final per-dim limits.
+
+Step-count cap (`_MAX_DURATION_S`), tool schemas, and result notes are
+unchanged.
+
+### 3b. Capx plugin: `MotionQueue` ceiling (`_motion.py`)
+
+Capx reproduces the approver's `0.05 × (high − low)` native-dtype arithmetic so
+its emitted chunks are never rewritten by the CLI's default delta backstop.
+That mirror must track the new default or its invariant breaks in both
+directions (a tighter declaration would clamp capx chunks; a looser one — the
+gripper case — would keep capx at the crawl). Capx gets the same two-part
+treatment as the agent toolset, since its pacing has the same shape
+(`step_limits = min(step_frac × range, ceiling)`, `max_speed_frac` default 0.1
+in its policy):
+
+- **Ceiling**: per-dim, declared `max_step` where present, else the existing
+  native-dtype 5% backstop (mirrors §2 exactly, so chunks are never rewritten
+  by the default approver in either direction).
+- **Pacing**: declared dims pace at
+  `max_step × min(max_speed_frac / _DEFAULT_SPEED_FRAC, 1.0)` per §3 —
+  ceiling-only would leave the capx gripper at the crawl (0.01/step from
+  `step_frac × range` regardless of ceiling). Undeclared dims unchanged.
+- **Float-spacing guard**: capx's copy of the coarseness guard also checks
+  against the per-dim effective budget, keeping the two mirrors symmetric.
+- Same guard-ordering rule as §3: pacing folds into the per-dim limits before
+  capx's movable-zero-limit underflow check.
+
+Test: `MotionQueue` chunks on a declaring space pass the default approver
+unmodified AND traverse a full 0–1 declared dim in the declared number of
+steps; undeclaring spaces byte-identical.
+
+### 4. Yam plugin (separate repo/PR): declare the gripper limit
+
+- New `YamConfig` field: `gripper_stroke_s: float = 1.0` — seconds for a full
+  0→1 stroke under agent pacing. Validation: finite, > 0.
+- Derived per-step limit: `min(1.0, 1.0 / (gripper_stroke_s × hz))` where
+  `hz = control_hz if control_hz > 0 else 10.0` — the same fallback the
+  embodiment already applies to `control_hz` (which `YamConfig` deliberately
+  does not validate). The derivation guards non-finite inputs and products
+  (`control_hz = inf`, or an overflowing `gripper_stroke_s × hz`) by declaring
+  **no** gripper limit in that case rather than crashing at semantics
+  construction — a config whose `embodiment.info` constructs today must keep
+  constructing. At defaults this is 0.1/step → 11 interpolation
+  steps for a full stroke (headroom ceil, see the table note) → ~1 s. The
+  `min` caps at full stroke in one step for absurdly small stroke times.
+- The semantics builders (`action_semantics()` and `action_box()`, which the
+  embodiment actually calls in `_action_space`) are shared by the embodiment
+  **and** the `/act` policy client, whose `ActServerConfig` has neither
+  `control_hz` nor the new field. Both builders gain an optional
+  `gripper_max_step: float | None = None` parameter, plumbed from `action_box`
+  into `action_semantics`: the embodiment passes the derived value
+  unconditionally; `action_semantics` applies it only when building an
+  **absolute**-mode semantics and ignores it for `joint_delta` (so a
+  delta-configured rig cannot trip the new construction-time validation). The
+  policy client passes nothing and declares no limits. The two sides' semantics then differ in `max_step` — safe because
+  `compat.py` compares field-by-field and deliberately excludes `max_step`
+  (§1); soften the builder docstring's "one function guarantees a clean check"
+  claim accordingly.
+- Declarations go on the two **absolute** interfaces only: `joint_pos`
+  (gripper indices 6 and 13 of the 14-D packing: `left_gripper`,
+  `right_gripper`) and `eef_abs_pose` (gripper indices 4 and 9 of
+  `EEF_DIM_LABELS`), `None` everywhere else. The `joint_delta` interface
+  cannot and does not declare (§1).
+- `pyproject.toml`: bump `inspect-robots` minimum to the release carrying
+  `max_step`.
+
+### Resulting behavior on a stock YAM rig (10 Hz, defaults)
+
+| Motion | Before (agent toolset) | After |
+|---|---|---|
+| Full gripper close (alone) | playout-cap error; forced split across ≥2 calls, ~10 s total | 11 steps, ~1 s |
+| 90% gripper close | 91 steps, ~9 s | 10 steps, ~1 s |
+| 1 rad joint reach (alone) | ~16 steps, 1.6 s | unchanged |
+| Joints + full gripper close together | playout-cap error | max(joint steps, 11) |
+
+(Counts include the `_RELATIVE_HEADROOM` ceil: a stroke at exactly N× the
+per-step limit rounds up one step so every emitted step stays strictly below
+the limit — tests assert 11, not 10, for the full stroke. The toolset's
+"before" full stroke is a cap error, not a 101-step chunk; the 101-step figure
+applies only to capx's `MotionQueue`, which has no duration cap.)
+
+Joints keep byte-identical pacing and approver limits.
+
+## Not doing (YAGNI)
+
+- No displacement-mode declarations (rejected at construction, see Design).
+- No per-dim `max_speed_frac` config plumbing in the policy — the declaration
+  makes per-rig tuning unnecessary, and `gripper_stroke_s` covers the yam knob.
+- No unit-string-driven inference (e.g. special-casing `"normalized"`): units
+  describe state, not sanctioned speeds, and inference re-introduces hidden
+  motion knowledge into the plugin.
+- No changes to `ClampApprover`, collision guardrails, or the CLI flag surface
+  (`--max-action-delta` still overrides everything as an explicit scalar).
+
+## Tests (core, 100% coverage per CONTRIBUTING)
+
+- `spaces`: valid declarations round-trip; wrong length, non-positive,
+  non-finite entries raise; `None` entries allowed; non-absolute mode with any
+  declared entry raises at `ActionSemantics` construction; declaration on a
+  pinned (`low == high`) dim raises at `Box` construction; semantics equality/
+  hash still work with the tuple field.
+- `approver` absolute: mixed declared/underived defaults per-dim; all-declared
+  space with non-finite bounds constructs; undeclared dim with non-finite
+  bounds still raises; explicit `max_delta` overrides declarations when both
+  are present; first-action passthrough and store semantics unchanged.
+- `toolset`: declared gripper dim paces at declared limit (11 steps for a full
+  stroke at defaults, per the headroom note above); undeclared dims unchanged
+  for the same space;
+  `max_speed_frac` below default slows declared dims proportionally, above
+  default does not raise them; combined move's step count is the per-dim max;
+  spacing guard uses the effective per-dim budget; emitted chunks pass a
+  default `DeltaLimitApprover` for the same space unmodified (the ceiling
+  invariant, as an explicit test).
+- `capx`: `MotionQueue` chunks on a declaring space pass the default approver
+  unmodified and traverse a declared dim at the declared pace; existing
+  behavior on undeclaring spaces byte-identical.
+- `compat`: embodiment-declares / policy-doesn't still passes compatibility.
+- Yam repo: config validation, derived limit arithmetic (incl. the 1-step cap),
+  declaration present on absolute interfaces only and only embodiment-side,
+  builder parameter default declares nothing.
+
+## Rollout
+
+1. Core PR (this repo): spaces + approver + agent toolset + capx motion queue
+   + tests + CHANGELOG; agent and capx plugin version bumps (follow the repo's
+   existing plugin-bump convention from prior PRs). Both plugins' stale
+   `inspect-robots>=0.4` dependency floors bump to the core version carrying
+   `max_step` — a new plugin wheel importing `ABSOLUTE_CONTROL_MODES` /
+   reading `max_step` against an older core would fail at bind time in
+   exactly the partial-venv-upgrade scenario rigs hit.
+2. Release core + agent (+ capx) to PyPI.
+3. Yam PR: config field + builder parameter + declaration + dep bump + tests.
+4. Rig enablement (venv upgrade) tracked separately, as with prior features.

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.18.0"
+version = "0.19.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"
@@ -25,7 +25,7 @@ classifiers = [
 # the same "speak the protocol, don't import the package" doctrine as the
 # xpolicylab plugin.
 dependencies = [
-    "inspect-robots>=0.4",
+    "inspect-robots>=0.29",
     "numpy>=1.24",
     "httpx>=0.27",
 ]

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -2,8 +2,8 @@
 
 Tools are generated from the embodiment's spaces, so the plugin never needs
 embodiment-specific motion knowledge. Absolute targets are interpolated with a
-per-step limit of ``min(max_speed_frac / hz, 0.05)`` times each dimension's
-range. Displacements are split by the available box side, which the plugin
+declared per-dimension limit where available and a range-derived backstop
+otherwise. Displacements are split by the available box side, which the plugin
 treats as the embodiment author's per-action limit.
 
 Tool mistakes come back as structured error strings the LLM can correct.
@@ -22,10 +22,14 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 
-from inspect_robots.spaces import CANONICAL_STATE_UNITS, Box, ObservationSpace
+from inspect_robots.spaces import (
+    ABSOLUTE_CONTROL_MODES,
+    CANONICAL_STATE_UNITS,
+    Box,
+    ObservationSpace,
+)
 from inspect_robots.types import Action, ActionChunk, Observation
 
-_ABSOLUTE_MODES = frozenset({"joint_pos", "eef_abs_pose"})
 _DISPLACEMENT_MODES = frozenset({"eef_delta_pos", "eef_delta_pose", "joint_delta"})
 _POSE_MODES = frozenset({"eef_abs_pose", "eef_delta_pose"})
 _SAFE_ROT = frozenset({"none", "rot6d"})
@@ -33,6 +37,7 @@ _SAFE_ROT = frozenset({"none", "rot6d"})
 _FALLBACK_HZ = 10.0
 _MAX_DURATION_S = 10.0
 _BACKSTOP_STEP_FRAC = 0.05
+_DEFAULT_SPEED_FRAC = 0.1
 _RELATIVE_HEADROOM = 1e-6
 
 #: A motion hook over the exact clipped absolute waypoints for one move call.
@@ -534,7 +539,7 @@ def build_toolset(
             f"rotation_repr {semantics.rotation_repr!r} cannot be driven per-dimension; "
             f"only {sorted(_SAFE_ROT)} are supported"
         )
-    if mode not in _ABSOLUTE_MODES | _DISPLACEMENT_MODES:
+    if mode not in ABSOLUTE_CONTROL_MODES | _DISPLACEMENT_MODES:
         raise ToolsetError(f"control_mode {mode!r} is not supported by the agent policy yet")
     if pre_check is not None and mode in _DISPLACEMENT_MODES:
         raise ToolsetError(
@@ -549,7 +554,7 @@ def build_toolset(
     resolved_hz = control_hz if control_hz is not None else _FALLBACK_HZ
     if not math.isfinite(_MAX_DURATION_S * resolved_hz):
         raise ToolsetError(f"control_hz {control_hz!r} is too large to derive a playout cap")
-    if max_speed_frac / resolved_hz == 0.0:
+    if mode in _DISPLACEMENT_MODES and max_speed_frac / resolved_hz == 0.0:
         raise ToolsetError(
             f"max_speed_frac {max_speed_frac!r} underflows to a zero per-step "
             f"limit at control_hz {resolved_hz!r}"
@@ -559,7 +564,7 @@ def build_toolset(
             f"only 1-D (vector) action spaces are supported, got shape {action_space.shape}"
         )
 
-    absolute = mode in _ABSOLUTE_MODES
+    absolute = mode in ABSOLUTE_CONTROL_MODES
     dim = action_space.dim
     state_key: str | None = None
     state_spec = observation_space.state
@@ -596,19 +601,27 @@ def build_toolset(
         raise ToolsetError("action-space range (high - low) overflows; bounds are too large")
     if not absolute and (bool(np.any(low64 > 0)) or bool(np.any(high64 < 0))):
         raise ToolsetError("displacement control bounds must contain zero in every dimension")
-    # DeltaLimitApprover derives its default limit in the box's native dtype;
-    # reproduce that arithmetic exactly so our ceiling can never exceed it.
+    # DeltaLimitApprover derives undeclared dimensions in the box's native
+    # dtype; reproduce that arithmetic exactly before substituting declarations.
     native_backstop = np.asarray(_BACKSTOP_STEP_FRAC * (high - low), dtype=np.float64)
     step_limits = np.zeros_like(high64)
     if absolute:
+        declared = semantics.max_step or (None,) * dim
+        declared_mask = np.fromiter(
+            (entry is not None for entry in declared), dtype=np.bool_, count=dim
+        )
+        effective_budget = native_backstop.copy()
+        for index, entry in enumerate(declared):
+            if entry is not None:
+                effective_budget[index] = entry
         # Interpolants snap to the float grid at the bounds' magnitude. If that
-        # grid is coarse relative to the backstop (offset boxes like
-        # [1e16, 1e16 + 2], or ranges whose 5% underflows to zero), emitted
-        # steps jump by more than the backstop allows and motions silently
+        # grid is coarse relative to the effective per-dimension budget (offset
+        # boxes like [1e16, 1e16 + 2], or ranges whose 5% underflows to zero),
+        # emitted steps jump by more than the budget allows and motions silently
         # truncate — the exact failure this plugin exists to remove.
         spacing = np.spacing(np.maximum(np.abs(low64), np.abs(high64)))
         movable = high64 > low64
-        if bool(np.any(movable & (spacing > 5e-7 * native_backstop))):
+        if bool(np.any(movable & (spacing > 5e-7 * effective_budget))):
             raise ToolsetError(
                 "bounds are too coarse at this magnitude for speed-limited "
                 "interpolation (float spacing exceeds the per-step budget)"
@@ -616,9 +629,11 @@ def build_toolset(
         resolved = control_hz if control_hz is not None else _FALLBACK_HZ
         step_frac = min(max_speed_frac / resolved, _BACKSTOP_STEP_FRAC)
         step_limits = np.minimum(step_frac * (high64 - low64), native_backstop)
+        declared_scale = min(max_speed_frac / _DEFAULT_SPEED_FRAC, 1.0)
+        step_limits[declared_mask] = effective_budget[declared_mask] * declared_scale
         # The frac/hz quotient can be nonzero yet still underflow to a zero
-        # limit once multiplied by a small range; a movable dimension with a
-        # zero limit would be misreported as fixed.
+        # limit once multiplied by a small range or declared max_step; a
+        # movable dimension with a zero limit would be misreported as fixed.
         if bool(np.any(movable & (step_limits == 0))):
             raise ToolsetError(
                 f"max_speed_frac {max_speed_frac!r} underflows the derived "

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,7 +6,7 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.18.0"
+    assert inspect_robots_agent.__version__ == "0.19.0"
     assert callable(inspect_robots_agent.agent_policy)
     assert inspect_robots_agent.__all__ == [
         "ENV_MODEL",

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -20,7 +20,7 @@ from inspect_robots.spaces import (
     StateField,
     StateSpec,
 )
-from inspect_robots.types import Observation
+from inspect_robots.types import Action, Observation
 from inspect_robots_agent._llm import ToolCall
 from inspect_robots_agent._tools import ToolResult, ToolsetError, build_toolset
 
@@ -61,6 +61,21 @@ def _absolute_space(
 
 def _absolute_obs_space(dim: int = 1, key: str = "q") -> ObservationSpace:
     return ObservationSpace(state=StateSpec(fields=(StateField(key=key, shape=(dim,)),)))
+
+
+def _declaring_space(
+    max_step: tuple[float | None, float | None] = (None, 0.1),
+) -> Box:
+    return Box(
+        shape=(2,),
+        low=np.array([-1.0, 0.0]),
+        high=np.array([1.0, 1.0]),
+        semantics=ActionSemantics(
+            "joint_pos",
+            dim_labels=("joint", "gripper"),
+            max_step=max_step,
+        ),
+    )
 
 
 def _camera_obs_space() -> ObservationSpace:
@@ -330,10 +345,18 @@ def test_build_rejects_degenerate_derivations() -> None:
     with pytest.raises(ToolsetError, match="too large to derive a playout cap"):
         build_toolset(_delta_space(), ObservationSpace(), control_hz=1e308)
 
-    with pytest.raises(ToolsetError, match="underflows to a zero per-step limit"):
+    with pytest.raises(ToolsetError, match="underflows the derived per-step limit"):
         build_toolset(
             _absolute_space(),
             _absolute_obs_space(),
+            control_hz=10.0,
+            max_speed_frac=5e-324,
+        )
+
+    with pytest.raises(ToolsetError, match="underflows to a zero per-step limit"):
+        build_toolset(
+            _delta_space(),
+            ObservationSpace(),
             control_hz=10.0,
             max_speed_frac=5e-324,
         )
@@ -401,6 +424,133 @@ def test_low_precision_bounds_never_outrun_native_backstop() -> None:
     store: dict[str, Any] = {}
     for action in result.chunk.actions:
         assert chain.review(action, store) is action
+
+
+def test_declared_step_paces_gripper_while_undeclared_joint_is_unchanged() -> None:
+    space = _declaring_space()
+    toolset = build_toolset(space, _absolute_obs_space(dim=2), control_hz=10.0)
+    observation = _obs({"q": np.array([0.0, 0.0])})
+
+    gripper = toolset.execute(
+        _call("move_joints", targets={"gripper": 1.0}),
+        observation,
+    )
+    joint = toolset.execute(
+        _call("move_joints", targets={"joint": 1.0}),
+        observation,
+    )
+
+    assert gripper.error is None and gripper.chunk is not None
+    assert len(gripper.chunk.actions) == 11
+    assert joint.error is None and joint.chunk is not None
+    assert len(joint.chunk.actions) == 51
+
+    undeclared = Box(
+        shape=(2,),
+        low=space.low,
+        high=space.high,
+        semantics=ActionSemantics("joint_pos", dim_labels=("joint", "gripper")),
+    )
+    old_toolset = build_toolset(undeclared, _absolute_obs_space(dim=2), control_hz=10.0)
+    old_full_stroke = old_toolset.execute(
+        _call("move_joints", targets={"gripper": 1.0}),
+        observation,
+    )
+    assert old_full_stroke.chunk is None
+    assert old_full_stroke.error is not None
+    assert "playout cap" in old_full_stroke.error
+
+
+@pytest.mark.parametrize(
+    ("max_speed_frac", "expected_steps"),
+    [(0.05, 21), (0.2, 11)],
+)
+def test_declared_step_scales_down_but_not_above_its_ceiling(
+    max_speed_frac: float,
+    expected_steps: int,
+) -> None:
+    toolset = build_toolset(
+        _declaring_space(),
+        _absolute_obs_space(dim=2),
+        control_hz=10.0,
+        max_speed_frac=max_speed_frac,
+    )
+    result = toolset.execute(
+        _call("move_joints", targets={"gripper": 1.0}),
+        _obs({"q": np.array([0.0, 0.0])}),
+    )
+
+    assert result.error is None and result.chunk is not None
+    assert len(result.chunk.actions) == expected_steps
+
+
+def test_combined_declared_move_uses_largest_per_dimension_step_count() -> None:
+    toolset = build_toolset(
+        _declaring_space(),
+        _absolute_obs_space(dim=2),
+        control_hz=10.0,
+    )
+    result = toolset.execute(
+        _call("move_joints", targets={"joint": 0.4, "gripper": 1.0}),
+        _obs({"q": np.array([0.0, 0.0])}),
+    )
+
+    assert result.error is None and result.chunk is not None
+    assert len(result.chunk.actions) == 21
+
+
+def test_declared_step_is_the_float_spacing_guard_budget() -> None:
+    space = Box(
+        shape=(1,),
+        low=np.array([1e9]),
+        high=np.array([1e9 + 100.0]),
+        semantics=ActionSemantics(
+            "joint_pos",
+            dim_labels=("joint",),
+            max_step=(0.1,),
+        ),
+    )
+
+    with pytest.raises(ToolsetError, match="too coarse at this magnitude"):
+        build_toolset(space, _absolute_obs_space(), control_hz=10.0)
+
+
+def test_declared_step_pacing_underflow_hits_movable_zero_limit_guard() -> None:
+    space = Box(
+        shape=(1,),
+        low=np.array([0.0]),
+        high=np.array([1e-300]),
+        semantics=ActionSemantics(
+            "joint_pos",
+            dim_labels=("joint",),
+            max_step=(1e-300,),
+        ),
+    )
+
+    with pytest.raises(ToolsetError, match="underflows the derived per-step limit"):
+        build_toolset(
+            space,
+            _absolute_obs_space(),
+            control_hz=10.0,
+            max_speed_frac=1e-300,
+        )
+
+
+def test_declared_step_chunks_pass_the_default_delta_approver_unmodified() -> None:
+    space = _declaring_space()
+    toolset = build_toolset(space, _absolute_obs_space(dim=2), control_hz=10.0)
+    start = np.array([0.0, 0.0])
+    result = toolset.execute(
+        _call("move_joints", targets={"gripper": 1.0}),
+        _obs({"q": start}),
+    )
+    assert result.chunk is not None
+
+    approver = DeltaLimitApprover(space)
+    store: dict[str, Any] = {}
+    approver.review(Action(data=start), store)
+    for action in result.chunk.actions:
+        assert approver.review(action, store) is action
 
 
 @pytest.mark.parametrize("max_speed_frac", [0.0, -0.1, float("inf"), float("nan")])

--- a/plugins/inspect-robots-capx/pyproject.toml
+++ b/plugins/inspect-robots-capx/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-capx"
-version = "0.1.0"
+version = "0.2.0"
 description = "Code-as-policy manipulation for Inspect Robots using CaP-X perception and IK servers."
 dynamic = ["readme"]
 requires-python = ">=3.10"
@@ -22,7 +22,7 @@ classifiers = [
 # CaP-X itself is intentionally not a dependency. The research checkout owns
 # the model servers; this adapter speaks their small HTTP protocol directly.
 dependencies = [
-    "inspect-robots>=0.4",
+    "inspect-robots>=0.29",
     "inspect-robots-agent>=0.12",
     "numpy>=1.24",
     "httpx>=0.27",

--- a/plugins/inspect-robots-capx/src/inspect_robots_capx/_motion.py
+++ b/plugins/inspect-robots-capx/src/inspect_robots_capx/_motion.py
@@ -1,9 +1,9 @@
 """Joint-space motion synthesis for model-generated policy code.
 
-The per-step ceiling reproduces ``DeltaLimitApprover``'s native-dtype
-``0.05 * (high - low)`` arithmetic. The speed fraction may make the ceiling
-tighter, but never looser, so actions within one returned chunk are not
-silently rewritten by the CLI's default delta backstop.
+The per-step ceiling reproduces ``DeltaLimitApprover``'s declared limit or
+native-dtype ``0.05 * (high - low)`` arithmetic. The speed fraction may make
+the ceiling tighter, but never looser, so actions within one returned chunk
+are not silently rewritten by the CLI's default delta backstop.
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ from inspect_robots.spaces import Box
 from inspect_robots.types import Action, ActionChunk
 
 _BACKSTOP_STEP_FRAC = 0.05
+_DEFAULT_SPEED_FRAC = 0.1
 _RELATIVE_HEADROOM = 1e-6
 
 
@@ -58,17 +59,31 @@ class MotionQueue:
         if not bool(np.all(np.isfinite(native_range)) and np.all(np.isfinite(float64_range))):
             raise ValueError("action-space range (high - low) overflows; bounds are too large")
         movable = high64 > low64
+        semantics = action_space.semantics
+        declared = semantics.max_step if semantics is not None else None
+        max_step = declared or (None,) * action_space.dim
+        declared_mask = np.fromiter(
+            (entry is not None for entry in max_step),
+            dtype=np.bool_,
+            count=action_space.dim,
+        )
+        effective_budget = native_backstop.copy()
+        for index, entry in enumerate(max_step):
+            if entry is not None:
+                effective_budget[index] = entry
         # Interpolants snap to the float grid at the bounds' magnitude; if that
-        # grid is coarse relative to the backstop (offset boxes like
+        # grid is coarse relative to the effective budget (offset boxes like
         # [1e16, 1e16 + 2]), emitted steps can exceed the approver's budget.
         spacing = np.spacing(np.maximum(np.abs(low64), np.abs(high64)))
-        if bool(np.any(movable & (spacing > 5e-7 * native_backstop))):
+        if bool(np.any(movable & (spacing > 5e-7 * effective_budget))):
             raise ValueError(
                 "bounds are too coarse at this magnitude for speed-limited "
                 "interpolation (float spacing exceeds the per-step budget)"
             )
         step_frac = min(max_speed_frac / control_hz, _BACKSTOP_STEP_FRAC)
         step_limits = np.minimum(step_frac * float64_range, native_backstop)
+        declared_scale = min(max_speed_frac / _DEFAULT_SPEED_FRAC, 1.0)
+        step_limits[declared_mask] = effective_budget[declared_mask] * declared_scale
         if bool(np.any(movable & (step_limits <= 0))):
             raise ValueError("speed fraction underflows the per-step limit for a movable dimension")
 

--- a/plugins/inspect-robots-capx/tests/test_motion.py
+++ b/plugins/inspect-robots-capx/tests/test_motion.py
@@ -26,6 +26,20 @@ def _space() -> Box:
     )
 
 
+def _declaring_space() -> Box:
+    return Box(
+        shape=(3,),
+        low=np.array([-1.0, -2.0, 0.0]),
+        high=np.array([1.0, 2.0, 1.0]),
+        semantics=ActionSemantics(
+            "joint_pos",
+            gripper="continuous",
+            dim_labels=("shoulder", "elbow", "gripper"),
+            max_step=(0.02, None, 0.1),
+        ),
+    )
+
+
 def _motion(
     *, control_hz: float = 10.0, max_speed_frac: float = 0.1, open_high: bool = True
 ) -> MotionQueue:
@@ -51,6 +65,12 @@ def test_speed_fraction_and_control_rate_set_per_step_interpolation() -> None:
     assert len(chunk.actions) == 11
     assert np.all(deltas <= np.array([0.02, 0.04, 0.01]))
     assert np.array_equal(chunk.actions[-1].data, np.array([0.2, -0.4, 1.0]))
+    target = np.array([0.2, -0.4, 1.0])
+    expected = np.stack(
+        [start + (target - start) * fraction for fraction in np.linspace(1.0 / 11, 1.0, 11)]
+    )
+    expected[-1] = target
+    assert np.array_equal(np.stack([action.data for action in chunk.actions]), expected)
     assert chunk.control_hz == 10.0
 
 
@@ -77,6 +97,51 @@ def test_low_control_rate_never_exceeds_delta_limit_approver_backstop() -> None:
     per_step = np.abs(np.diff(np.stack(points), axis=0))
     native_backstop = 0.05 * (space.high - space.low)  # type: ignore[operator]
     assert np.all(per_step <= native_backstop)
+
+
+def test_declared_step_chunks_traverse_at_pace_and_pass_default_approver() -> None:
+    space = _declaring_space()
+    motion = MotionQueue(
+        space,
+        control_hz=10.0,
+        max_speed_frac=0.1,
+        gripper_index=2,
+    )
+    start = np.array([0.0, 0.0, 1.0])
+    motion.begin_turn(start)
+    motion.close_gripper()
+    chunk = motion.take_chunk()
+
+    assert len(chunk.actions) == 11
+    points = np.stack([start, *(action.data for action in chunk.actions)])
+    assert np.all(np.abs(np.diff(points[:, 2])) < 0.1)
+    assert chunk.actions[-1].data[2] == 0.0
+
+    approver = DeltaLimitApprover(space)
+    store: dict[str, object] = {}
+    approver.review(Action(data=start), store)
+    for action in chunk.actions:
+        assert approver.review(action, store) is action
+
+
+@pytest.mark.parametrize(
+    ("max_speed_frac", "expected_steps"),
+    [(0.05, 21), (0.2, 11)],
+)
+def test_declared_step_pacing_scales_down_but_not_up(
+    max_speed_frac: float,
+    expected_steps: int,
+) -> None:
+    motion = MotionQueue(
+        _declaring_space(),
+        control_hz=10.0,
+        max_speed_frac=max_speed_frac,
+        gripper_index=2,
+    )
+    motion.begin_turn(np.array([0.0, 0.0, 1.0]))
+    motion.close_gripper()
+
+    assert len(motion.take_chunk().actions) == expected_steps
 
 
 def test_cursor_chains_across_arm_and_gripper_calls() -> None:
@@ -133,3 +198,42 @@ def test_offset_bounds_with_coarse_float_grid_are_rejected() -> None:
 
     with pytest.raises(ValueError, match="too coarse"):
         MotionQueue(space, control_hz=10.0, max_speed_frac=0.1, gripper_index=1)
+
+
+def test_declared_step_is_the_float_spacing_guard_budget() -> None:
+    space = Box(
+        shape=(2,),
+        low=np.array([1e9, 0.0]),
+        high=np.array([1e9 + 100.0, 1.0]),
+        semantics=ActionSemantics(
+            "joint_pos",
+            gripper="continuous",
+            dim_labels=("j0", "gripper"),
+            max_step=(0.1, None),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="too coarse"):
+        MotionQueue(space, control_hz=10.0, max_speed_frac=0.1, gripper_index=1)
+
+
+def test_declared_step_pacing_precedes_movable_zero_limit_guard() -> None:
+    space = Box(
+        shape=(2,),
+        low=np.array([0.0, 0.0]),
+        high=np.array([1e-300, 1.0]),
+        semantics=ActionSemantics(
+            "joint_pos",
+            gripper="continuous",
+            dim_labels=("j0", "gripper"),
+            max_step=(1e-300, None),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="underflows the per-step limit"):
+        MotionQueue(
+            space,
+            control_hz=10.0,
+            max_speed_frac=1e-300,
+            gripper_index=1,
+        )

--- a/src/inspect_robots/__init__.py
+++ b/src/inspect_robots/__init__.py
@@ -48,6 +48,7 @@ from inspect_robots.scorer import (
     success_at_end,
 )
 from inspect_robots.spaces import (
+    ABSOLUTE_CONTROL_MODES,
     ActionSemantics,
     Box,
     CameraSpec,
@@ -62,6 +63,7 @@ from inspect_robots.types import OPERATOR_END, Action, ActionChunk, Observation,
 # with ``_``) is private. Authoring a benchmark, policy, or embodiment should only
 # need these names.
 __all__ = [
+    "ABSOLUTE_CONTROL_MODES",
     "OPERATOR_END",
     "Action",
     "ActionChunk",

--- a/src/inspect_robots/approver.py
+++ b/src/inspect_robots/approver.py
@@ -197,6 +197,9 @@ class DeltaLimitApprover:
                 for index, entry in enumerate(declared):
                     if entry is not None:
                         self._delta[index] = entry
+                # review() clips against the action's own shape; a flat delta
+                # would fail to broadcast for multi-dimensional boxes.
+                self._delta = self._delta.reshape(action_space.shape)
         else:
             if explicit is None and (low is None or high is None):
                 raise ValueError(

--- a/src/inspect_robots/approver.py
+++ b/src/inspect_robots/approver.py
@@ -16,7 +16,7 @@ import numpy as np
 import numpy.typing as npt
 
 from inspect_robots.errors import SafetyAbort
-from inspect_robots.spaces import Box, RotationRepr
+from inspect_robots.spaces import ABSOLUTE_CONTROL_MODES, Box, RotationRepr
 from inspect_robots.types import Action
 
 
@@ -75,10 +75,6 @@ class ClampApprover:
         return replace(action, data=clamped, meta={**dict(action.meta), "clamped": True})
 
 
-# Control modes whose actions are absolute targets (delta-limited against the
-# last approved action) vs displacements/rates (the action *is* the per-step
-# change, limited directly). Together these cover every ControlMode literal.
-_ABSOLUTE_MODES = frozenset({"joint_pos", "eef_abs_pose"})
 _POSE_MODES = frozenset({"eef_abs_pose", "eef_delta_pose"})
 # Absolute pose modes only: clamping an absolute euler/quat orientation per
 # dimension has wraparound and axis-coupling problems, so those reps are
@@ -86,7 +82,7 @@ _POSE_MODES = frozenset({"eef_abs_pose", "eef_delta_pose"})
 # *deltas*, which mostly clamp per dimension like any other bounded
 # displacement — except reps whose no-op is not the origin (see
 # _DISPLACEMENT_POSE_UNSAFE_ROT below).
-_ABSOLUTE_POSE_MODES = _ABSOLUTE_MODES & _POSE_MODES
+_ABSOLUTE_POSE_MODES = ABSOLUTE_CONTROL_MODES & _POSE_MODES
 _DISPLACEMENT_POSE_MODES = _POSE_MODES - _ABSOLUTE_POSE_MODES
 # Rotation reps that survive independent per-dimension clamping of an absolute
 # orientation (same set the EnsemblingController accepts for per-dimension
@@ -118,7 +114,8 @@ class DeltaLimitApprover:
     dimension to at most ``max_delta`` away from the **last approved action**
     of the trial; the first action passes through un-delta-limited (there is
     no trustworthy reference yet — bounds clamping still applies upstream).
-    The derived default is 5% of ``high - low`` per step.
+    The derived default is a declared ``ActionSemantics.max_step`` where
+    present, otherwise 5% of ``high - low`` per step.
 
     Displacement/rate modes (``eef_delta_pos``, ``eef_delta_pose``,
     ``joint_delta``, ``joint_vel``) *are* the per-step change, so each
@@ -162,7 +159,7 @@ class DeltaLimitApprover:
                 f"origin, so per-dimension clamping distorts it instead of "
                 f"limiting it; only {sorted(_DISPLACEMENT_SAFE_ROT)} are safe here"
             )
-        self._absolute = sem.control_mode in _ABSOLUTE_MODES
+        self._absolute = sem.control_mode in ABSOLUTE_CONTROL_MODES
         dim = action_space.dim
         low, high = action_space.low, action_space.high
 
@@ -171,12 +168,35 @@ class DeltaLimitApprover:
             if explicit is not None:
                 self._delta = explicit
             else:
-                if low is None or high is None or not bool(np.all(np.isfinite(high - low))):
+                declared = sem.max_step or (None,) * dim
+                undeclared = np.fromiter(
+                    (entry is None for entry in declared), dtype=np.bool_, count=dim
+                )
+                if bool(np.any(undeclared)) and (low is None or high is None):
                     raise ValueError(
                         "DeltaLimitApprover: deriving a default needs finite low/high "
                         "bounds; pass max_delta explicitly"
                     )
-                self._delta = 0.05 * (high - low)
+                self._delta = np.empty(dim, dtype=np.float64)
+                if bool(np.any(undeclared)):
+                    assert low is not None and high is not None
+                    low_undeclared = low.reshape(-1)[undeclared]
+                    high_undeclared = high.reshape(-1)[undeclared]
+                    with np.errstate(over="ignore", invalid="ignore"):
+                        native_default = 0.05 * (high_undeclared - low_undeclared)
+                    if not bool(
+                        np.all(np.isfinite(low_undeclared))
+                        and np.all(np.isfinite(high_undeclared))
+                        and np.all(np.isfinite(native_default))
+                    ):
+                        raise ValueError(
+                            "DeltaLimitApprover: deriving a default needs finite low/high "
+                            "bounds; pass max_delta explicitly"
+                        )
+                    self._delta[undeclared] = native_default
+                for index, entry in enumerate(declared):
+                    if entry is not None:
+                        self._delta[index] = entry
         else:
             if explicit is None and (low is None or high is None):
                 raise ValueError(

--- a/src/inspect_robots/compat.py
+++ b/src/inspect_robots/compat.py
@@ -80,6 +80,8 @@ def _check_action_spaces(policy_box: Box, emb_box: Box, issues: list[CompatIssue
             )
         )
         return
+    # max_step is deliberately excluded: motion limits are embodiment-authored,
+    # and policy-side semantics do not need to duplicate them.
     if ps.control_mode != es.control_mode:
         issues.append(
             CompatIssue(

--- a/src/inspect_robots/conformance.py
+++ b/src/inspect_robots/conformance.py
@@ -25,8 +25,8 @@ from dataclasses import dataclass, field
 import numpy as np
 
 from inspect_robots.embodiment import EmbodimentInfo
+from inspect_robots.spaces import ABSOLUTE_CONTROL_MODES
 
-_ABSOLUTE_MODES = frozenset({"joint_pos", "eef_abs_pose"})
 DEVICE_KINDS = ("v4l2", "can", "serial")
 
 
@@ -213,7 +213,7 @@ def check_embodiment(info: EmbodimentInfo) -> ConformanceReport:
         elif len(set(labels)) != len(labels):
             error("dim_labels", "dim_labels contains duplicates")
 
-        if semantics.control_mode in _ABSOLUTE_MODES:
+        if semantics.control_mode in ABSOLUTE_CONTROL_MODES:
             spec = info.observation_space.state
             matching = [f.key for f in spec.fields if f.shape == (space.dim,)] if spec else []
             if len(matching) != 1:

--- a/src/inspect_robots/spaces.py
+++ b/src/inspect_robots/spaces.py
@@ -14,6 +14,7 @@ layered on in a later step without changing these signatures.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -39,6 +40,9 @@ RotationRepr = Literal[
 GripperKind = Literal["none", "continuous", "binary"]
 Frame = Literal["base", "world", "camera"]
 
+#: Control modes whose actions name absolute targets rather than per-step changes.
+ABSOLUTE_CONTROL_MODES = frozenset({"joint_pos", "eef_abs_pose"})
+
 
 @dataclass(frozen=True)
 class ActionSemantics:
@@ -49,6 +53,12 @@ class ActionSemantics:
     LLM agent policies, logging, visualization — can address dimensions by
     name. Length is validated against the owning box in ``Box.__post_init__``
     (the semantics/shape pairing is only visible there).
+
+    ``max_step`` optionally declares the safe per-control-step change for each
+    absolute-target dimension in the action space's native units. A ``None``
+    entry leaves that dimension to range-based defaults. Displacement and rate
+    boxes already declare per-step limits through their bounds, so declarations
+    are rejected for those modes.
     """
 
     control_mode: ControlMode
@@ -56,6 +66,21 @@ class ActionSemantics:
     gripper: GripperKind = "none"
     frame: Frame = "base"
     dim_labels: tuple[str, ...] | None = None
+    max_step: tuple[float | None, ...] | None = None
+
+    def __post_init__(self) -> None:
+        if self.max_step is None:
+            return
+        for entry in self.max_step:
+            if entry is not None and (not math.isfinite(entry) or entry <= 0):
+                raise ValueError("ActionSemantics.max_step entries must be finite and > 0 or None")
+        if self.control_mode not in ABSOLUTE_CONTROL_MODES and any(
+            entry is not None for entry in self.max_step
+        ):
+            raise ValueError(
+                "ActionSemantics.max_step is only valid for absolute control modes; "
+                "displacement boxes already declare per-step limits via low/high"
+            )
 
 
 @dataclass(frozen=True, eq=False)
@@ -82,6 +107,22 @@ class Box:
                 f"ActionSemantics.dim_labels has {len(labels)} entries but the box "
                 f"has {self.dim} dimensions"
             )
+        max_step = self.semantics.max_step if self.semantics is not None else None
+        if max_step is not None:
+            if len(max_step) != self.dim:
+                raise ValueError(
+                    f"ActionSemantics.max_step has {len(max_step)} entries but the box "
+                    f"has {self.dim} dimensions"
+                )
+            if self.low is not None and self.high is not None:
+                pinned = np.asarray(self.low == self.high).reshape(-1)
+                if any(
+                    step is not None and bool(pinned[index]) for index, step in enumerate(max_step)
+                ):
+                    raise ValueError(
+                        "ActionSemantics.max_step cannot be declared for a pinned "
+                        "dimension whose low == high"
+                    )
 
     @property
     def dim(self) -> int:

--- a/tests/test_api_snapshot.py
+++ b/tests/test_api_snapshot.py
@@ -42,6 +42,7 @@ EXPECTED = {
     "EmbodimentBase",
     "EmbodimentInfo",
     # types & spaces
+    "ABSOLUTE_CONTROL_MODES",
     "Observation",
     "Action",
     "ActionChunk",

--- a/tests/test_approvers.py
+++ b/tests/test_approvers.py
@@ -164,6 +164,24 @@ def test_absolute_derived_default_is_five_percent_of_range() -> None:
     assert np.allclose(out.data, [0.1, 0.45])  # 0.05 * (high - low) per dim
 
 
+def test_absolute_derived_default_keeps_the_box_shape_for_multi_d_boxes() -> None:
+    # The derived delta must broadcast against multi-dimensional actions; a
+    # flat (dim,) delta would raise in review() for a (2, 3) box.
+    space = Box(
+        shape=(2, 3),
+        low=np.zeros((2, 3)),
+        high=np.full((2, 3), 2.0),
+        semantics=ActionSemantics("joint_pos", max_step=(None, None, None, None, None, 0.5)),
+    )
+    approver = DeltaLimitApprover(space)
+    store: dict[str, object] = {}
+    approver.review(Action(data=np.zeros((2, 3))), store)
+    out = approver.review(Action(data=np.full((2, 3), 2.0)), store)
+    # Undeclared dims clamp to 5% of range (0.1); the flat declaration maps to
+    # the last element of the flattened box (0.5).
+    assert np.allclose(out.data, [[0.1, 0.1, 0.1], [0.1, 0.1, 0.5]])
+
+
 def test_absolute_derived_default_mixes_declared_and_native_range_limits() -> None:
     low = np.array([-1.0, 0.0], dtype=np.float16)
     high = np.array([1.0, 1.0], dtype=np.float16)

--- a/tests/test_approvers.py
+++ b/tests/test_approvers.py
@@ -164,6 +164,60 @@ def test_absolute_derived_default_is_five_percent_of_range() -> None:
     assert np.allclose(out.data, [0.1, 0.45])  # 0.05 * (high - low) per dim
 
 
+def test_absolute_derived_default_mixes_declared_and_native_range_limits() -> None:
+    low = np.array([-1.0, 0.0], dtype=np.float16)
+    high = np.array([1.0, 1.0], dtype=np.float16)
+    space = Box(
+        shape=(2,),
+        low=low,
+        high=high,
+        semantics=ActionSemantics("joint_pos", max_step=(None, 0.2)),
+    )
+    approver = DeltaLimitApprover(space)
+    store: dict[str, object] = {}
+    approver.review(Action(data=np.array([0.0, 0.0])), store)
+    out = approver.review(Action(data=np.array([1.0, 1.0])), store)
+    native_default = np.asarray(0.05 * (high - low), dtype=np.float64)
+
+    assert np.array_equal(out.data, np.array([native_default[0], 0.2]))
+
+
+def test_all_declared_absolute_space_needs_no_finite_bounds() -> None:
+    space = Box(
+        shape=(2,),
+        low=np.array([float("-inf"), float("nan")]),
+        high=np.array([float("inf"), float("nan")]),
+        semantics=ActionSemantics("joint_pos", max_step=(0.1, 0.2)),
+    )
+    DeltaLimitApprover(space)
+
+
+def test_undeclared_absolute_dimension_still_needs_finite_bounds() -> None:
+    space = Box(
+        shape=(2,),
+        low=np.array([float("-inf"), 0.0]),
+        high=np.array([float("inf"), float("inf")]),
+        semantics=ActionSemantics("joint_pos", max_step=(0.1, None)),
+    )
+    with pytest.raises(ValueError, match="finite low/high bounds"):
+        DeltaLimitApprover(space)
+
+
+def test_explicit_max_delta_overrides_declarations() -> None:
+    space = Box(
+        shape=(1,),
+        low=np.array([0.0]),
+        high=np.array([1.0]),
+        semantics=ActionSemantics("joint_pos", max_step=(0.01,)),
+    )
+    approver = DeltaLimitApprover(space, max_delta=0.5)
+    store: dict[str, object] = {}
+    approver.review(Action(data=np.array([0.0])), store)
+    within_override = Action(data=np.array([0.4]))
+
+    assert approver.review(within_override, store) is within_override
+
+
 def test_stores_are_isolated_per_trial() -> None:
     approver = DeltaLimitApprover(_abs_space(), max_delta=0.1)
     trial_a: dict[str, object] = {}

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -70,6 +70,30 @@ def test_control_mode_mismatch_is_error() -> None:
     assert any(i.code == "control_mode" for i in report.errors)
 
 
+def test_embodiment_only_max_step_declaration_is_compatible() -> None:
+    policy = _StubPolicy(
+        PolicyInfo(
+            name="absolute-policy",
+            action_space=Box(
+                shape=(2,),
+                semantics=ActionSemantics(control_mode="joint_pos"),
+            ),
+        )
+    )
+    embodiment = CubePickEmbodiment()
+    embodiment.info = replace(
+        embodiment.info,
+        action_space=Box(
+            shape=(2,),
+            low=np.zeros(2),
+            high=np.ones(2),
+            semantics=ActionSemantics(control_mode="joint_pos", max_step=(None, 0.1)),
+        ),
+    )
+
+    assert check_compatibility(policy, embodiment).ok
+
+
 def test_missing_required_state_is_error() -> None:
     policy = _StubPolicy(
         PolicyInfo(

--- a/tests/test_types_spaces.py
+++ b/tests/test_types_spaces.py
@@ -10,6 +10,7 @@ import pytest
 from inspect_robots.embodiment import EmbodimentInfo
 from inspect_robots.mock import CubePickEmbodiment
 from inspect_robots.spaces import (
+    ABSOLUTE_CONTROL_MODES,
     ActionSemantics,
     Box,
     CameraSpec,
@@ -84,6 +85,8 @@ def test_action_semantics_defaults() -> None:
     assert sem.rotation_repr == "none"
     assert sem.gripper == "none"
     assert sem.frame == "base"
+    assert sem.max_step is None
+    assert {"joint_pos", "eef_abs_pose"} == ABSOLUTE_CONTROL_MODES
 
 
 def test_action_semantics_joint_delta_and_dim_labels() -> None:
@@ -100,6 +103,72 @@ def test_box_validates_dim_labels_length() -> None:
     assert Box(shape=(3,), semantics=labeled).dim == 3
     # No labels: any dim is fine.
     Box(shape=(2,), semantics=ActionSemantics(control_mode="joint_pos"))
+
+
+def test_action_semantics_max_step_round_trips_with_value_semantics() -> None:
+    sem = ActionSemantics(
+        control_mode="joint_pos",
+        dim_labels=("joint", "gripper"),
+        max_step=(None, 0.1),
+    )
+    same = ActionSemantics(
+        control_mode="joint_pos",
+        dim_labels=("joint", "gripper"),
+        max_step=(None, 0.1),
+    )
+    different = dataclasses.replace(sem, max_step=(None, 0.2))
+    box = Box(
+        shape=(2,),
+        low=np.array([-1.0, 0.0]),
+        high=np.array([1.0, 1.0]),
+        semantics=sem,
+    )
+
+    assert box.semantics is sem
+    assert sem.max_step == (None, 0.1)
+    assert sem == same
+    assert hash(sem) == hash(same)
+    assert sem != different
+
+
+def test_box_validates_max_step_length() -> None:
+    semantics = ActionSemantics(control_mode="joint_pos", max_step=(0.1,))
+    with pytest.raises(ValueError, match=r"max_step has 1 entries.*2 dimensions"):
+        Box(shape=(2,), semantics=semantics)
+    assert Box(shape=(1,), semantics=semantics).dim == 1
+
+
+@pytest.mark.parametrize("entry", [0.0, -0.1, float("nan"), float("inf"), float("-inf")])
+def test_action_semantics_rejects_invalid_max_step_entries(entry: float) -> None:
+    with pytest.raises(ValueError, match="max_step entries must be finite and > 0"):
+        ActionSemantics(control_mode="joint_pos", max_step=(entry,))
+
+
+def test_action_semantics_allows_none_max_step_entries() -> None:
+    assert ActionSemantics(control_mode="joint_pos", max_step=(None, 0.1)).max_step == (
+        None,
+        0.1,
+    )
+    assert ActionSemantics(control_mode="joint_delta", max_step=(None,)).max_step == (None,)
+
+
+def test_action_semantics_rejects_declared_step_for_non_absolute_mode() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"displacement boxes already declare per-step limits via low/high",
+    ):
+        ActionSemantics(control_mode="joint_delta", max_step=(None, 0.1))
+
+
+def test_box_rejects_max_step_on_pinned_dimension() -> None:
+    semantics = ActionSemantics(control_mode="joint_pos", max_step=(None, 0.1))
+    with pytest.raises(ValueError, match=r"pinned dimension.*low == high"):
+        Box(
+            shape=(2,),
+            low=np.array([-1.0, 0.0]),
+            high=np.array([1.0, 0.0]),
+            semantics=semantics,
+        )
 
 
 def test_observation_space_derives_state_keys_from_spec() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },
@@ -428,7 +428,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "inspect-robots-capx"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "plugins/inspect-robots-capx" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #223

Adds optional per-dimension `ActionSemantics.max_step` (native units per control step) so embodiments can declare safe per-step speeds for dimensions where fraction-of-range pacing is wrong — most importantly normalized 0–1 gripper strokes, which today crawl at ~10 s per full stroke under the agent policy (and trip the playout cap outright).

Honored by:
- `DeltaLimitApprover` default derivation (declared where present, else 5% of range as today)
- agent toolset pacing (`plugins/inspect-robots-agent`)
- capx `MotionQueue` ceiling + pacing mirror (`plugins/inspect-robots-capx`)

Undeclared dimensions keep byte-identical behavior; joints are untouched. Design + full details in `plans/0033-per-dim-max-step.md` (5-round critique). Follow-up: yam plugin PR declaring ~1 s full stroke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)