### PR TITLE
Fix agent/capx core floors: v0.29.0 predates max_step

### DIFF
--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 # the same "speak the protocol, don't import the package" doctrine as the
 # xpolicylab plugin.
 dependencies = [
-    "inspect-robots>=0.29",
+    "inspect-robots>=0.30",
     "numpy>=1.24",
     "httpx>=0.27",
 ]

--- a/plugins/inspect-robots-capx/pyproject.toml
+++ b/plugins/inspect-robots-capx/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 # CaP-X itself is intentionally not a dependency. The research checkout owns
 # the model servers; this adapter speaks their small HTTP protocol directly.
 dependencies = [
-    "inspect-robots>=0.29",
+    "inspect-robots>=0.30",
     "inspect-robots-agent>=0.12",
     "numpy>=1.24",
     "httpx>=0.27",


### PR DESCRIPTION
#224 bumped the agent and capx plugins' `inspect-robots` floor to `>=0.29` on the assumption that the next core release would be 0.29.0. v0.29.0 was cut this morning before #224 merged, so it does not contain `ActionSemantics.max_step`; the floors must be `>=0.30` or a new plugin wheel against core 0.29.0 fails at bind time — the exact partial-upgrade failure the floors guard against. Must land before the next release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)