### PR TITLE
agent: gemini-live wire — Gemini Robotics ER 2 over the Live API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- **Agent plugin (0.20.0):** `-P wire=gemini-live` now serves
+  `google/gemini-robotics-er-2-streaming-preview` through Google's stateful
+  v1beta Live API. The sync websocket client streams only new observations,
+  preserves exact tool-response ordering, recovers expired or dropped
+  sessions from the image-free transcript, and captures each socket attempt
+  with content-addressed frame blobs (plan 0039, #252).
+
 - `inspect-robots view --serve` now serves a rendered logs directory, refreshes
   it incrementally as new runs arrive, and supports explicit host/port binding
   for local or remote browsing (plan 0037, #241)

--- a/plans/0039-gemini-live-wire.md
+++ b/plans/0039-gemini-live-wire.md
@@ -1,0 +1,408 @@
+# 0039 — `-P wire=gemini-live`: Gemini Robotics ER 2 over the Live API
+
+Issue: #252. PR: #227. Revised after critiques R1 (13 findings) and R2
+(10 findings); all resolved below.
+
+## Problem
+
+Google's guidance for Gemini Robotics ER 2 is the Live API: "Gemini Robotics
+ER 2 integrates into the Gemini Live API, using a bidirectional streaming
+endpoint optimized for latency-sensitive tasks" (launch post, confirmed by its
+author). The Live-served model is a distinct id,
+`gemini-robotics-er-2-streaming-preview`, which supports only
+`bidiGenerateContent`: it cannot be reached by any HTTP wire the agent plugin
+speaks today. Conversely the chat-wire id (`gemini-robotics-er-2-preview`) is
+rejected on the socket, so this is not a transport preference; it is a
+different serving surface.
+
+On the chat wire every step re-uploads the whole multi-image transcript. A
+real-rig rollout is one motion per LLM call, so per-call overhead dominates
+wall-clock rig time. A Live session holds conversation state server-side:
+after setup, each step sends only the new observation and tool result.
+
+All protocol facts below were verified against the live socket on 2026-08-01
+(spike transcript in issue #252). Where the public docs and the socket
+disagreed, the socket won.
+
+## Design
+
+One new wire, `gemini-live`, in `inspect-robots-agent`. Raw
+`BidiGenerateContent` JSON over WSS, no google SDK — the same
+speak-the-protocol doctrine as the other wires, and the same `websockets>=12`
+sync-client dependency and stub-server test pattern the xpolicylab plugin
+already established in this repo.
+
+### Verified protocol facts (socket, v1beta, 2026-08-01)
+
+- Endpoint: `wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=<KEY>`.
+- Setup accepts `model` (sent as `models/<bare-id>`), `systemInstruction`,
+  `tools`, `generationConfig`. `toolConfig` is **rejected at the protocol
+  level** ("Unknown name \"toolConfig\" at 'setup'"): there is no
+  config-forced tool choice on this surface. Prompt-level forcing produced
+  well-formed motion tool calls (with `note` args) in 4/4 spike sessions; the
+  policy's existing no-tool-call nudge/retry path is the backstop.
+- Camera frames work as `inlineData` parts inside `clientContent` turns —
+  verified for both `image/jpeg` and `image/png` (the policy emits PNG).
+- Lockstep sequencing (the eval-semantics requirement that the model acts on
+  the *fresh* observation): sending `toolResponse` alone resumes generation
+  immediately and the model emits its next action **without** new frames.
+  Buffering the new user content first (`turnComplete: false`), then sending
+  the `toolResponse`, yields an **empty** resumed turn instead of a
+  stale-state action; a final empty `clientContent {"turnComplete": true}`
+  then fires generation on the buffered content.
+- `functionResponses` entries carrying `id`, `name`, and an object-valued
+  `response` are accepted (the spike always sent all three; the client always
+  will too).
+- `sessionResumptionUpdate` messages arrive unprompted and must be drained;
+  `GoAway` carries `timeLeft` before server-side termination.
+- Server envelopes the client and stub must both speak, as parsed
+  successfully against the real socket by the spike:
+  `{"setupComplete": {}}`;
+  `{"serverContent": {"modelTurn": {"parts": [{"text": "..."}]}}}` and
+  `{"serverContent": {"turnComplete": true}}` (the empty resumed turn is
+  exactly this, with no `modelTurn`);
+  `{"toolCall": {"functionCalls": [{"name": "move_joints", "args": {...},
+  "id": "fc_15275099834869453056"}]}}` — note `args` is a JSON object, not
+  a string, hence the re-serialization when building `ToolCall.arguments`.
+
+### `wire` param and per-wire defaults
+
+`_WIRE_FORMATS` grows to `{"chat", "responses", "anthropic", "gemini-live"}`.
+
+`effort` and `image_horizon` currently have non-None constructor defaults
+(`"low"`, `2`), so "reject when explicitly set" cannot be expressed with the
+`speed`/`max_output_tokens` pattern (those default to `None`). Both switch to
+an out-of-band sentinel that no CLI or config value can produce (in-band
+sentinels like `"default"`/`0` would legalize inputs that are rejected today
+— `tests/test_policy_eviction.py` pins the `image_horizon=0` rejection):
+
+```python
+class _Unset:
+    """Marker type for constructor defaults resolved per wire."""
+
+_UNSET: Final = _Unset()
+```
+
+- `effort: str | None | _Unset = _UNSET` — resolves to `"low"` on
+  `chat`/`responses`/`anthropic`, `None` on `gemini-live` (bidi
+  `generationConfig` has no effort/thinking field on v1beta). An explicit
+  effort level with `wire=gemini-live` is a guided `ConfigError` (fix: drop
+  `-P effort=`); explicit `None` ("omit the field") equals this wire's
+  resolved value and passes.
+- `image_horizon: int | None | _Unset = _UNSET` — resolves to `2` on the
+  HTTP wires, `None` on `gemini-live`. An explicit `int >= 1` with
+  `wire=gemini-live` is a guided `ConfigError` (we cannot evict what we
+  already streamed; the Live API's own context-window compression is the
+  equivalent mechanism, and the fix line says so); explicit `None` ("full
+  history") passes.
+
+Validation order: the `wire` membership check runs before sentinel resolution
+and the per-wire rejections (today the `_EFFORT_LEVELS` check at
+policy.py:318 precedes the wire check at :328 — it moves after; its
+user-facing message is unchanged since `_UNSET` is not user-expressible).
+All existing rejections (`image_horizon=0`, `effort="default"`, booleans)
+behave exactly as today — including on `gemini-live`, where the generic
+`image_horizon=0` message suggests `-P image_horizon=N` and the wire then
+rejects `N >= 1`; the two-bounce error path is accepted (both messages are
+guided, and special-casing one invalid input per wire isn't worth it).
+`AgentPolicyConfig` keeps its `str | None` / `int | None` field types and
+records the *resolved* values. A bare `-P wire=gemini-live` run constructs
+successfully (regression test).
+
+Other params: `temperature` passes through as `generationConfig.temperature`.
+`speed`/`max_output_tokens` stay anthropic-only (unchanged checks).
+`wire_capture`, `images=always|on_demand`, `depth`, `replan_interval`,
+`max_llm_calls`, and `transcript_echo` work unchanged — they live in the
+policy loop, which this wire does not touch.
+
+### Provider resolution and endpoint derivation
+
+`resolve_provider` is untouched, but `gemini-live` adds a wrong-provider
+guard in `__init__` (the analog of the anthropic-wire guard at
+policy.py:393-440): without an explicit `base_url`, resolution must land on
+the google direct provider — i.e. a `google/*` model with `$GEMINI_API_KEY`
+set. Otherwise (OpenRouter fallback, other prefixes) a guided `ConfigError`
+(fix: use `-P model=google/...` and set `$GEMINI_API_KEY`), which also
+guarantees an OpenRouter secret is never placed in a Google `?key=` query.
+
+- Default endpoint: the wss URL above; the key is appended as `?key=` at
+  connect time only, and only when non-empty.
+- An explicit `base_url` starting with `ws://` or `wss://` wins (this is how
+  tests reach the stub). With a ws(s) `base_url`, `api_key_env` defaults to
+  `GEMINI_API_KEY` (not the OpenRouter default `resolve_provider` would
+  pick); a missing key is allowed (stubs are keyless). `wire=gemini-live`
+  with an `http(s)://` `base_url` is a guided `ConfigError`.
+- Setup `model` is always `models/<bare-id>`, where the bare id strips a
+  leading `google/` when present — this normalizes both paths (the direct
+  provider already strips; the explicit-base_url path of `_llm.py:111-113`
+  does not). Asserted in the setup round-trip test.
+- `AgentPolicyConfig.base_url` records the derived ws(s) endpoint **without**
+  the key. The key must never appear in config, capture rows, transcripts, or
+  exception text: connect/send/recv errors are wrapped and re-raised with the
+  query string stripped before they can carry the URL upward.
+
+### `GeminiLiveClient` (new module `_gemini_live.py`)
+
+Implements the same duck interface as the other three clients —
+`complete(messages, tools, temperature, reasoning_effort) -> AssistantMessage`
+and `close()` — so `policy.py` changes are confined to validation, client
+selection, and one lifecycle hook (below). The client is stateful where the
+others are stateless; the policy's append-only chat-format message list is
+the source of truth, and the client keeps **a list of references to the
+message dicts it has streamed** (the cursor). Synchronous
+`websockets.sync.client`, matching the blocking policy loop.
+
+**Invariant:** on this wire the resolved `image_horizon` is always `None`,
+so `complete()` receives `self._messages` itself — never an `_evicted_view`
+copy — and the identity cursor is sound. Guard: if the prefix check fails
+while `messages[0] is streamed[0]`, that is a view-not-reset bug (a real
+`reset()` replaces the system message too) and the client raises
+`RuntimeError` instead of silently re-sessioning every call.
+
+Session/cursor rules, in order, on each `complete(messages, ...)`:
+
+1. **Prefix check by identity.** If any streamed reference is not `is`-equal
+   to the message at its position (or the list is shorter), this is a new
+   trial (`reset()` rebuilt the list — value equality is unsafe: re-running
+   the same scene rebuilds a byte-identical prefix): close the socket and
+   start fresh. Object identity is O(1) per message and immune to that
+   collision.
+2. **Open lazily.** If no session is open: setup from the leading `system`
+   message (`systemInstruction`) plus `tools` as `functionDeclarations` and
+   `generationConfig` (temperature when set); wait for `setupComplete`. On a
+   *reconnect* (mid-trial recovery), the send is the recovery send defined
+   below, not the normal suffix send.
+3. **Send the un-streamed suffix.** Message classes:
+   - `assistant` messages generated by the currently open session are
+     advanced past without sending — the server already holds them as its
+     own turns; re-sending would duplicate them in server context. (The
+     suffix after a normal step is `[assistant, tool, user]`: the assistant
+     entry is the `raw()` echo of what this session just produced.)
+   - `user` messages → `clientContent` turns; plain-string content becomes
+     a single text part, text parts pass through, `image_url` data-URI
+     parts become `inlineData` (mime from the URI header), and any other
+     part type raises `RuntimeError` (only text and `image_url` occur in
+     this plugin; silently dropping or forwarding unverified constructs is
+     worse than failing loudly).
+   - `tool` messages: **all consecutive un-streamed tool messages aggregate
+     into one `toolResponse`**, `functionResponses` entries in list order,
+     every issued call id answered (the loop appends one tool message per
+     call, so `[assistant, tool, tool, user]` is a real normal-step suffix —
+     ignored-second-call results and motion+queued-`take_pic` pairs). Each
+     entry carries the original `toolCall` `id`, the `name` from the
+     client's id→name map (recorded when the `toolCall` message was
+     received — chat-format tool messages carry no name), and
+     `response={"output": <the string content>}`.
+
+   The generation trigger depends on the suffix class:
+
+   | suffix contains | send order | trigger |
+   |---|---|---|
+   | user only (first call: `[system, user(goal), user(obs)]`; nudge) | `clientContent` turns | `turnComplete: true` set on the **final content turn** itself |
+   | tool + user (normal step; on-demand `take_pic`) | user turns with `turnComplete: false`, then `toolResponse` | trailing **empty** `clientContent {"turnComplete": true}` |
+   | tool only (in-step tool-error retry) | `toolResponse` | the `toolResponse` itself — **no** turn-complete (one would fire a second, stray generation and desync the next read) |
+
+   Advance the cursor only after the full send completes.
+4. **Read** with a 120 s per-message timeout (the `timeout_s` the HTTP wires
+   use) and a drain cap of 64 messages per exchange, draining
+   `sessionResumptionUpdate` and empty/interim turns, until either a
+   `toolCall` (→ `AssistantMessage` with the calls, `args` re-serialized as
+   JSON text; multiple `functionCalls` become multiple `ToolCall`s; ids and
+   names recorded in the id→name map) or a completed text turn
+   (→ `AssistantMessage(content=text, tool_calls=())`, which lands in the
+   policy's existing nudge path). Timeout or cap exhaustion → recovery
+   (below). `usageMetadata` is summed across **all** messages in the
+   exchange and normalized (`promptTokenCount` → `input_tokens`,
+   `candidatesTokenCount` → `output_tokens`, `totalTokenCount` →
+   `total_tokens`). This is billing truth: a normal step comprises two
+   generations (the empty resumed turn plus the triggered one), so
+   `input_tokens` reads higher than single-generation wires; the README
+   note says so. Messages received on an attempt that later fails mid-read
+   (recovery follows) still count — they were billed. Pinned by a stub test
+   with `usageMetadata` on two messages of one exchange.
+
+The suffix shapes in the table are exhaustive for the current policy loop
+(`act()` appends `user(observation)` before its first `complete()`; tool
+results are appended as they execute; the nudge appends a bare user turn;
+on-demand `take_pic` appends `[tool(result), user(images)]`;
+`_forced_give_up` constructs its chunk without calling `complete()`).
+The stub tests pin each shape.
+
+### Recovery (always a fresh session; text prologue; no handles)
+
+v1 does **not** use `sessionResumption` handles: after a mid-step transport
+failure the client cannot know how much of the send the server absorbed, so
+resuming server state risks double-delivering an observation or answering an
+already-answered call. Handles are drained and discarded. Recovery never
+depends on Google keeping state.
+
+Triggers: socket close, connect/send/recv transport error, read timeout,
+drain-cap exhaustion. On `GoAway`: finish the current exchange normally (the
+server keeps it alive for `timeLeft`), mark the session, and reconnect at
+the next `complete()` boundary before sending.
+
+The recovery send, on the fresh session (after setup):
+
+- **Everything except the newest user content is folded into one text
+  prologue** — streamed history *and* any un-streamed assistant/tool
+  messages alike. Model-role `clientContent` turns and `toolResponse`s for
+  call ids the new session never issued are unverified constructs on this
+  surface; the prologue uses only verified ones, and it also preserves the
+  dead session's assistant turns that rule 3 would otherwise skip.
+- Prologue format (concrete): a single `user` turn whose text is
+  `"Recovered session. Conversation so far, oldest first, one JSON object
+  per line:"` followed by the `_sanitize`-rendered messages (`_sanitize`
+  lives in `policy.py`, which imports the client module — use a deferred
+  function-level import inside the recovery path to avoid the circular
+  top-level import) (the exact
+  JSONL rendering `on_trial_end` already writes; image parts become
+  `_sanitize`'s literal `"[image omitted: streamed camera frame]"` text
+  stubs, with camera names surviving in the adjacent label parts) for every
+  message being folded, then `"Continue the task from the latest
+  observation below."`.
+- The anchor is the **newest `user` message, images or not** (under
+  `images=on_demand` observation turns usually carry no frames, and a
+  camera-less embodiment never has any): it is excluded from the prologue
+  and sent as a normal `clientContent` turn, with its images intact when it
+  has them — exactly one copy (in the mid-step case the pending observation
+  and the anchor are the same message, so nothing is double-sent). Older
+  image-bearing messages (e.g. stale `take_pic` deliveries) always fold
+  into the prologue as stubs — stale frames are never re-sent.
+- The final content turn carries `turnComplete: true`. A recovery send
+  never contains a `toolResponse`.
+- Afterwards the cursor marks the entire list streamed, and the id→name map
+  is cleared (no live call ids can span sessions).
+
+Bounded by the same retry discipline as `ChatClient` (3 attempts,
+exponential backoff); persistent failure raises `RuntimeError`, which the
+rollout wraps as `PolicyError`. This is also the session-lifetime answer: a
+`max_steps=1200` rollout that outlives any single Live session survives on
+recoveries.
+
+### Lifecycle
+
+`policy.on_trial_end` closes the live session (an `isinstance` check, the
+`mark_anchor` precedent): trials never share sessions anyway (identity rule),
+this stops a session idling through scoring until the server `GoAway`s it,
+and nothing else would ever close the final trial's socket (`eval()` closes
+only the embodiment). Closing is **best-effort**: `GeminiLiveClient.close()`
+swallows all transport/close exceptions — the sessions most likely to be
+closed here are half-dead (post-`GoAway`, server already gone), and an
+exception escaping `on_trial_end` would flip a successful trial to `"error"`
+(eval.py:428-442). Stub test: server drops the connection, `on_trial_end`
+still returns cleanly.
+
+### Capture and transcript
+
+One `WireCapture.record` row per socket exchange **attempt** (recovery
+attempts get their own rows, matching the one-row-per-attempt contract):
+`endpoint="bidi"`, `request={"messages": [...]}` (a dict, as `record`'s
+signature requires) containing the client messages sent in that attempt —
+including `setup` when the attempt opened a session — and
+`response_text=json.dumps({"messages": [...]})` for the received messages.
+The object wrapper matters: `_capture._response_value` stores parsed JSON
+only when it is a dict and truncates anything else to 2000 chars, which
+would silently lose multi-message exchanges. `_replace_blobs` gains an
+`inlineData` branch (Gemini parts have no `type` key) so frames dedupe into
+content-addressed blobs like the HTTP wires.
+
+The client-side message list remains the authoritative transcript exactly as
+on the HTTP wires — deliberate: with server-held state and context
+compression, our side is the only complete record, and `on_trial_end`
+already persists it.
+
+## Tests (`tests/test_gemini_live.py` + `tests/_stub_bidi_server.py`)
+
+Stub `BidiGenerateContent` server on `websockets.sync.server` (xpolicylab's
+`_stub_server.py` pattern: free port, thread, steerable failure modes,
+recorded inbound messages exposed for order assertions), speaking exact
+v1beta JSON:
+
+- setup round-trip over the stub (explicit ws base_url, including with a
+  `google/`-prefixed model): `models/<bare-id>`, systemInstruction from the
+  system message, functionDeclarations from toolset schemas, temperature
+  when set; asserts `toolConfig` absent. The no-base_url `google/*` path is
+  asserted **socketlessly** — `AgentPolicyConfig.base_url` records the
+  derived wss endpoint and the client's pending setup payload carries
+  `models/<bare-id>` — since the default endpoint is the real Google URL
+  and the client has no HTTP-style `transport=` seam (the socket opens
+  lazily inside `complete()`).
+- suffix-shape sequencing, one test per table row, with stub-side order
+  assertions: first-call (`[system, user, user]` → content turns with
+  `turnComplete: true` on the final content turn, no empty third message,
+  no toolResponse); normal step (obs turn `turnComplete: false` **before**
+  the `toolResponse`, empty turn-complete last); nudge (no toolResponse);
+  in-step tool-error retry (toolResponse only, **no** trailing
+  turn-complete); on-demand `take_pic` (`[tool, user]` → three-part
+  sequence).
+- `functionResponses` shape: id echoed, `name` recovered from the earlier
+  `toolCall`, `response == {"output": <string>}`; two `functionCalls` in
+  one `toolCall` message → two `ToolCall`s, and their two tool-result
+  messages aggregate into **one** `toolResponse` with entries in list
+  order.
+- assistant turns never re-sent mid-session (stub asserts no model-role
+  content between setup and trial end).
+- image translation: PNG data-URI part → `inlineData` with `image/png`.
+- text-only completed turn → nudge path end-to-end (next exchange returns a
+  tool call).
+- drain behavior: interleaved `sessionResumptionUpdate` and empty turns
+  before the `toolCall`; drain-cap exhaustion → recovery, then
+  `RuntimeError` after retries.
+- usage: `usageMetadata` on two messages of one exchange → summed,
+  normalized keys.
+- recovery: server drops between `clientContent` and `toolResponse`
+  (mid-step) and separately sends `GoAway`; fresh session gets a text
+  prologue (stub asserts: no model-role turns, no toolResponse, exactly one
+  copy of the newest observation's images, older images as `_sanitize`'s
+  `"[image omitted: streamed camera frame]"` stubs, prologue lines parse as
+  JSONL) and the step completes; a server that keeps dropping exhausts
+  retries into `RuntimeError`; an `images=on_demand` recovery (anchor user
+  message carries no frames) completes with a frameless anchor turn.
+- new-trial detection: `reset()` to a byte-identical scene still produces a
+  fresh session (identity check, not value equality); view-not-reset guard
+  raises `RuntimeError`.
+- lifecycle: `on_trial_end` closes the socket (stub observes the close);
+  next trial reopens lazily; with the server already gone, `on_trial_end`
+  still returns cleanly (best-effort close).
+- validation: bare `wire=gemini-live` with `google/*` + key constructs and
+  resolves `effort=None`/`image_horizon=None`; explicit `effort=low` and
+  explicit `image_horizon=2` → guided `ConfigError`s; explicit
+  `effort=none`/`image_horizon=none` pass; sentinel resolution on the HTTP
+  wires still lands on `"low"`/`2`, and `image_horizon=0`/`effort=default`
+  are still rejected with today's messages (regressions); non-google model
+  without ws base_url, OpenRouter-fallback (no `GEMINI_API_KEY`,
+  `OPENROUTER_API_KEY` set — message must not leak the key), and `http://`
+  base_url → guided `ConfigError`s.
+- capture: one row per attempt including the recovery attempt; setup in the
+  opening row; a long multi-message response survives un-truncated (object
+  wrapper); `inlineData` frames deduped to blobs; no key material in rows.
+- key redaction: transport error whose exception text contains the URL
+  surfaces without the `?key=` query.
+
+Existing pinned tests updated: `test_package.py` version pin → `0.20.0` and
+`__all__` gains `GeminiLiveClient` (also exported from `__init__.py`, the
+`AnthropicClient`/`ResponsesClient` precedent). `test_llm.py` is untouched
+(provider resolution unchanged). Note the agent plugin's CI coverage is
+report-only (`--cov-fail-under=0`, ci.yml:327-331) — the exhaustive test
+list above is the real gate, not a coverage number.
+
+## Docs
+
+`plugins/inspect-robots-agent/README.md`: add the `gemini-live` row to the
+wire table ("Google's Live API — required for the `-streaming-` robotics
+model ids"); replace the interim ER 2 paragraph from the docs commit with a
+short "Gemini Robotics ER 2" subsection covering both ids —
+`gemini-robotics-er-2-preview` on the default chat wire,
+`gemini-robotics-er-2-streaming-preview` via `-P wire=gemini-live` — the
+one-liner example, and the per-wire notes (no `effort`, no `image_horizon`,
+Live context compression instead; usage counts include two generations per
+step). The paragraph's "Interactions API" fallback note is superseded and
+dropped. CHANGELOG entry under the plugin.
+
+## Version
+
+`inspect-robots-agent` 0.19.1 → 0.20.0 (new wire, new dependency
+`websockets>=12`; the `_UNSET` sentinel change is behavior-preserving for
+every expressible input). Core is untouched — no core version bump.
+`uv lock` run and committed for the plugin dependency addition (CI installs
+`--locked`).

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -45,14 +45,25 @@ Providers resolved directly by prefix:
 | `mistralai/*` | `MISTRAL_API_KEY` | Mistral |
 | `deepseek/*` | `DEEPSEEK_API_KEY` | DeepSeek |
 
-Robotics-tuned models resolve the same way:
-`-P model=google/gemini-robotics-er-2-preview` drives the embodiment with
-Gemini Robotics ER 2, Google's embodied-reasoning VLM, over the compat
-endpoint on the default `chat` wire. Verified against the live API
-(2026-07-30): camera frames, forced tool calls, and every `effort` level work.
-Google documents the Interactions API as the primary surface for the ER
-models, so if the compat endpoint ever stops serving them, that is the wire
-to add here.
+### Gemini Robotics ER 2:
+
+Google serves two Gemini Robotics ER 2 model ids. Use
+`google/gemini-robotics-er-2-preview` on the default `chat` wire. The
+latency-oriented `google/gemini-robotics-er-2-streaming-preview` id requires
+the stateful Live API wire:
+
+```bash
+inspect-robots "pick up the cube" --policy agent \
+    -P model=google/gemini-robotics-er-2-streaming-preview \
+    -P wire=gemini-live --embodiment cubepick
+```
+
+The Live wire does not accept `effort` and does not use `image_horizon`.
+Leave both unset. Google's own Live context-window compression is the
+equivalent history mechanism because frames already streamed into a session
+cannot be evicted by the client. Live usage counts include the empty resumed
+generation and the observation-triggered generation on a normal step, so
+input token totals cover two generations per step.
 
 The wire format defaults to Chat Completions for broad OpenAI-compatible
 endpoint support:
@@ -62,6 +73,7 @@ endpoint support:
 | `chat` (default) | `/chat/completions` | Anything OpenAI-compatible: OpenRouter, vLLM, Ollama, the Anthropic and Gemini compat endpoints |
 | `responses` | `/responses` | A direct OpenAI or compatible endpoint requires the Responses API |
 | `anthropic` | `/messages` | Driving Claude natively, which is what fast mode needs |
+| `gemini-live` | `BidiGenerateContent` (WSS) | Google's Live API: required for the `-streaming-` robotics model ids |
 
 ## How it works
 
@@ -236,15 +248,15 @@ either on another wire is an error rather than a silent no-op.
 | Image option | Default | Behavior |
 |---|---|---|
 | `-P images=` | `always` | Attach every observation's frames; use `on_demand` for model-requested frames |
-| `-P image_horizon=` | `2` | Keep frames from the newest two image-bearing messages in each outgoing request |
+| `-P image_horizon=` | `2` on HTTP wires | Keep frames from the newest two image-bearing messages in each outgoing request; unset on `gemini-live` |
 
-Set `-P image_horizon=none` to send the full image history. Do not use a bare
-`-P image_horizon=`: the CLI parses it as an empty string, which the policy
-rejects. Full history grows request bodies by about 420 KB per observation
-with three cameras and can reach a 413 response around 85 observations. The
-default replaces older outgoing camera parts with deterministic text stubs;
-the saved conversation, transcript, and separately stored frames remain
-complete and unchanged.
+On the HTTP wires, set `-P image_horizon=none` to send the full image history.
+Do not use a bare `-P image_horizon=`: the CLI parses it as an empty string,
+which the policy rejects. Full history grows request bodies by about 420 KB
+per observation with three cameras and can reach a 413 response around 85
+observations. The HTTP default replaces older outgoing camera parts with
+deterministic text stubs; the saved conversation, transcript, and separately
+stored frames remain complete and unchanged.
 
 Set `-P prior_learnings=path/to/learnings.md` to append a nonempty UTF-8 notes
 file to the system prompt after any embodiment notes. The file is read once
@@ -261,8 +273,8 @@ Camera labels such as `camera 'top_cam' (step 480):` provide the join key from a
 Live Rerun transcript streaming happens automatically when a Rerun sink is attached.
 
 Wire capture is on by default (`-P wire_capture=false` to disable): every
-request attempt each wire client posts — tool schemas, evicted view, depth
-composites, cache breakpoints — and every response land in
+request attempt each wire client sends (tool schemas, evicted view, depth
+composites, and cache breakpoints) and every response land in
 `wire/<run_id>/<trial_id>/calls.jsonl` under the log directory, with image
 payloads deduplicated as `$blob:<sha256>` references into
 `wire/<run_id>/blobs/`. The format contract lives in the
@@ -275,16 +287,17 @@ integer token counters returned by the wire. The native Anthropic wire
 includes input, output, cache-creation, and cache-read tokens; other wires
 currently record `llm_calls` only. Trials with no LLM calls omit the key.
 
-Reasoning effort defaults to `low`: robot control is latency-sensitive (the
-arm stands still while the model thinks), safety guardrails sit below the
-model either way, and frontier models at low effort remain strong at this
-task shape. Raise it for hard manipulation problems (`-P effort=high`) or
-pass `-P effort=none` to omit the parameter for endpoints that reject it
-(the CLI reads a bare `none` as null). To send the literal wire value
-`none` and disable reasoning, quote it: `-P effort="'none'"`. GPT-5.x on
-chat completions requires the literal `none` when function tools are in
-play (any other value, or omitting the field, is a 400). In Python,
-`effort=None` omits the field and `effort="none"` sends the wire value.
+Reasoning effort defaults to `low` on the HTTP wires: robot control is
+latency-sensitive (the arm stands still while the model thinks), safety
+guardrails sit below the model either way, and frontier models at low effort
+remain strong at this task shape. Raise it for hard manipulation problems
+(`-P effort=high`) or pass `-P effort=none` to omit the parameter for
+endpoints that reject it (the CLI reads a bare `none` as null). To send the
+literal wire value `none` and disable reasoning, quote it:
+`-P effort="'none'"`. GPT-5.x on chat completions requires the literal `none`
+when function tools are in play (any other value, or omitting the field, is a
+400). In Python, `effort=None` omits the field and `effort="none"` sends the
+wire value. Gemini Live has no effort field, so leave it unset on that wire.
 
 ## Depth rendering
 

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -45,7 +45,7 @@ Providers resolved directly by prefix:
 | `mistralai/*` | `MISTRAL_API_KEY` | Mistral |
 | `deepseek/*` | `DEEPSEEK_API_KEY` | DeepSeek |
 
-### Gemini Robotics ER 2:
+### Gemini Robotics ER 2
 
 Google serves two Gemini Robotics ER 2 model ids. Use
 `google/gemini-robotics-er-2-preview` on the default `chat` wire. The

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -45,6 +45,15 @@ Providers resolved directly by prefix:
 | `mistralai/*` | `MISTRAL_API_KEY` | Mistral |
 | `deepseek/*` | `DEEPSEEK_API_KEY` | DeepSeek |
 
+Robotics-tuned models resolve the same way:
+`-P model=google/gemini-robotics-er-2-preview` drives the embodiment with
+Gemini Robotics ER 2, Google's embodied-reasoning VLM, over the compat
+endpoint on the default `chat` wire. Verified against the live API
+(2026-07-30): camera frames, forced tool calls, and every `effort` level work.
+Google documents the Interactions API as the primary surface for the ER
+models, so if the compat endpoint ever stops serving them, that is the wire
+to add here.
+
 The wire format defaults to Chat Completions for broad OpenAI-compatible
 endpoint support:
 

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.19.1"
+version = "0.20.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"
@@ -20,14 +20,15 @@ classifiers = [
     "Typing :: Typed",
 ]
 # NOTE: no provider SDKs. The adapters speak raw OpenAI wire formats over
-# httpx. Chat Completions remains the broad-compatibility default, while the
-# Responses wire is available for direct endpoints that serve it. This keeps
-# the same "speak the protocol, don't import the package" doctrine as the
-# xpolicylab plugin.
+# httpx and Gemini Live over websockets. Chat Completions remains the
+# broad-compatibility default, while provider-native wires cover capabilities
+# their compatibility endpoints do not expose. This keeps the same "speak the
+# protocol, don't import the package" doctrine as the xpolicylab plugin.
 dependencies = [
     "inspect-robots>=0.30",
     "numpy>=1.24",
     "httpx>=0.27",
+    "websockets>=12",
 ]
 
 [project.optional-dependencies]

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/__init__.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/__init__.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from importlib.metadata import version
 
 from inspect_robots_agent._anthropic import AnthropicClient
+from inspect_robots_agent._gemini_live import GeminiLiveClient
 from inspect_robots_agent._llm import (
     ENV_MODEL,
     AssistantMessage,
@@ -43,6 +44,7 @@ __all__ = [
     "AnthropicClient",
     "AssistantMessage",
     "ChatClient",
+    "GeminiLiveClient",
     "LLMAgentPolicy",
     "Provider",
     "ResponsesClient",

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_capture.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_capture.py
@@ -11,12 +11,12 @@ that parses as a JSON object is stored as that object at any HTTP status;
 non-object or invalid JSON is stored as its first 2000 text characters, and a
 missing response is stored as null.
 
-Inline PNG payloads in supported chat, Responses, and Anthropic image parts are
-replaced in a deep copy of the request by ``$blob:<sha256>``. Data-URL prefixes
-and all other part keys remain intact. Readers find references by scanning
-string values for the unanchored pattern ``\\$blob:[0-9a-f]{64}`` and restore
-them by replacing the sentinel with base64 of the corresponding decoded PNG
-blob.
+Inline PNG payloads in supported chat, Responses, Anthropic, and Gemini Live
+image parts are replaced in a deep copy of the request by
+``$blob:<sha256>``. Data-URL prefixes and all other part keys remain intact.
+Readers find references by scanning string values for the unanchored pattern
+``\\$blob:[0-9a-f]{64}`` and restore them by replacing the sentinel with base64
+of the corresponding decoded PNG blob.
 
 Capture is best-effort and cannot fail an evaluation. The first failure in a
 trial emits one stderr warning, disables that trial's sink, and is never
@@ -186,6 +186,11 @@ class WireCapture:
 
     def _replace_blobs(self, value: Any) -> None:
         if isinstance(value, dict):
+            inline_data = value.get("inlineData")
+            if isinstance(inline_data, dict):
+                payload = inline_data.get("data")
+                if isinstance(payload, str):
+                    inline_data["data"] = self._store_blob(payload)
             part_type = value.get("type")
             if part_type == "image_url":
                 image_url = value.get("image_url")

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_gemini_live.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_gemini_live.py
@@ -105,10 +105,14 @@ class GeminiLiveClient:
                     attempt, sent, received, last_error, t_start, time.time() - t_start
                 )
                 self._abandon()
-                self._needs_recovery = True
+                # A first-call failure has no absorbed state to fold: retry as
+                # a plain suffix send. A pending goAway died with the socket.
+                self._needs_recovery = bool(self._streamed)
+                self._go_away = False
             except Exception as exc:
                 error = _redact_query(str(exc), self._provider.base_url)
                 self._record_attempt(attempt, sent, received, error, t_start, time.time() - t_start)
+                self._abandon()
                 raise
             else:
                 self._record_attempt(attempt, sent, received, None, t_start, time.time() - t_start)
@@ -273,7 +277,10 @@ class GeminiLiveClient:
         # Deferred to avoid policy.py -> _gemini_live.py -> policy.py at import.
         from inspect_robots_agent.policy import _sanitize
 
-        folded = _sanitize(messages[:anchor_index] + messages[anchor_index + 1 :])
+        # The fresh session already carries a leading system message as its
+        # systemInstruction; folding it again would duplicate the prompt.
+        start = 1 if messages[0].get("role") == "system" else 0
+        folded = _sanitize(messages[start:anchor_index] + messages[anchor_index + 1 :])
         lines = [
             _RECOVERY_PROLOGUE,
             *(json.dumps(message) for message in folded),

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_gemini_live.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_gemini_live.py
@@ -1,0 +1,459 @@
+"""Stateful Gemini Live wire client with bounded fresh-session recovery.
+
+The policy's append-only chat-format list remains the conversation source of
+truth. This boundary streams only new list entries, tracks the streamed prefix
+by object identity, and folds that source of truth into a text prologue when a
+socket must be replaced mid-trial.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from typing import TYPE_CHECKING, Any
+from urllib.parse import quote_plus
+
+from websockets.exceptions import WebSocketException
+from websockets.sync.client import connect as ws_connect
+
+from inspect_robots_agent._llm import AssistantMessage, Provider, ToolCall
+
+from ._capture import WireCapture
+
+if TYPE_CHECKING:
+    from websockets.sync.client import ClientConnection
+
+_CONNECTION_ERRORS = (WebSocketException, OSError, EOFError, TimeoutError)
+_RECOVERY_PROLOGUE = (
+    "Recovered session. Conversation so far, oldest first, one JSON object per line:"
+)
+_RECOVERY_CONTINUATION = "Continue the task from the latest observation below."
+_DRAIN_CAP = 64
+
+
+class _RecoverableError(Exception):
+    """A transport or liveness failure that requires a fresh Live session."""
+
+
+class GeminiLiveClient:
+    """Stream append-only chat history over one recoverable Gemini Live session.
+
+    The streamed cursor contains references, not copied values. A changed
+    prefix therefore means a new trial even when two scenes produce
+    byte-identical prompts.
+    """
+
+    def __init__(
+        self,
+        provider: Provider,
+        *,
+        timeout_s: float = 120.0,
+        max_retries: int = 3,
+        backoff_s: float = 1.0,
+        capture: WireCapture | None = None,
+    ) -> None:
+        self._provider = provider
+        self._timeout_s = timeout_s
+        self._max_retries = max_retries
+        self._backoff_s = backoff_s
+        self._capture = capture
+        bare_model = provider.model.removeprefix("google/")
+        self._model_resource = f"models/{bare_model}"
+        # Kept as pending state so configuration tests can verify model
+        # normalization without opening the real endpoint.
+        self._setup: dict[str, Any] = {"model": self._model_resource}
+        self._ws: ClientConnection | None = None
+        self._streamed: list[dict[str, Any]] = []
+        self._call_names: dict[str, str] = {}
+        self._needs_recovery = False
+        self._go_away = False
+
+    def complete(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        temperature: float | None = None,
+        reasoning_effort: str | None = None,
+    ) -> AssistantMessage:
+        """Return one assistant turn after streaming only the unseen suffix."""
+        del reasoning_effort
+        self._check_identity_prefix(messages)
+        if self._go_away:
+            self._abandon()
+            self._needs_recovery = bool(self._streamed)
+            self._go_away = False
+
+        usage: dict[str, int] = {}
+        last_error = "unknown error"
+        for attempt in range(self._max_retries):
+            sent: list[dict[str, Any]] = []
+            received: list[dict[str, Any]] = []
+            t_start = time.time() if self._capture is not None else 0.0
+            try:
+                if self._ws is None:
+                    self._open(messages, tools, temperature, sent, received, usage)
+                if self._needs_recovery:
+                    self._send_recovery(messages, sent)
+                    self._needs_recovery = False
+                else:
+                    self._send_suffix(messages, sent)
+                result = self._read_exchange(received, usage)
+            except _RecoverableError as exc:
+                last_error = _redact_query(str(exc), self._provider.base_url)
+                self._record_attempt(
+                    attempt, sent, received, last_error, t_start, time.time() - t_start
+                )
+                self._abandon()
+                self._needs_recovery = True
+            except Exception as exc:
+                error = _redact_query(str(exc), self._provider.base_url)
+                self._record_attempt(attempt, sent, received, error, t_start, time.time() - t_start)
+                raise
+            else:
+                self._record_attempt(attempt, sent, received, None, t_start, time.time() - t_start)
+                return AssistantMessage(
+                    content=result.content,
+                    tool_calls=result.tool_calls,
+                    usage=usage or None,
+                )
+            if attempt + 1 < self._max_retries:
+                time.sleep(self._backoff_s * 2**attempt)
+
+        raise RuntimeError(f"LLM request failed after {self._max_retries} attempts — {last_error}")
+
+    def close(self) -> None:
+        """Drop the Live socket without allowing close failures to escape."""
+        self._abandon()
+        self._needs_recovery = bool(self._streamed)
+        self._go_away = False
+
+    def _check_identity_prefix(self, messages: list[dict[str, Any]]) -> None:
+        prefix_matches = len(messages) >= len(self._streamed) and all(
+            messages[index] is streamed for index, streamed in enumerate(self._streamed)
+        )
+        if prefix_matches:
+            return
+        if messages and self._streamed and messages[0] is self._streamed[0]:
+            raise RuntimeError(
+                "Gemini Live received a rewritten conversation view without a trial reset"
+            )
+        self._abandon()
+        self._streamed.clear()
+        self._call_names.clear()
+        self._needs_recovery = False
+        self._go_away = False
+
+    def _open(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        temperature: float | None,
+        sent: list[dict[str, Any]],
+        received: list[dict[str, Any]],
+        usage: dict[str, int],
+    ) -> None:
+        url = self._provider.base_url
+        if self._provider.api_key:
+            url = f"{url}?key={quote_plus(self._provider.api_key)}"
+        try:
+            self._ws = ws_connect(url, max_size=None, open_timeout=self._timeout_s)
+        except _CONNECTION_ERRORS as exc:
+            raise _RecoverableError(_redact_query(str(exc), self._provider.base_url)) from exc
+
+        setup: dict[str, Any] = {"model": self._model_resource}
+        if messages and messages[0].get("role") == "system":
+            setup["systemInstruction"] = {"parts": [{"text": str(messages[0].get("content", ""))}]}
+        if tools:
+            declarations: list[dict[str, Any]] = []
+            for tool in tools:
+                function = tool["function"]
+                declarations.append(
+                    {
+                        "name": function["name"],
+                        "description": function["description"],
+                        "parameters": function["parameters"],
+                    }
+                )
+            setup["tools"] = [{"functionDeclarations": declarations}]
+        if temperature is not None:
+            setup["generationConfig"] = {"temperature": temperature}
+        self._setup = setup
+        self._send_message({"setup": setup}, sent)
+
+        for _ in range(_DRAIN_CAP):
+            message = self._recv_message(received, usage)
+            if "setupComplete" in message:
+                return
+            if "goAway" in message:
+                self._go_away = True
+        raise _RecoverableError("Gemini Live setup drain cap exhausted after 64 messages")
+
+    def _send_suffix(
+        self,
+        messages: list[dict[str, Any]],
+        sent: list[dict[str, Any]],
+    ) -> None:
+        suffix = messages[len(self._streamed) :]
+        users: list[dict[str, Any]] = []
+        tool_runs: list[list[dict[str, Any]]] = []
+        current_tools: list[dict[str, Any]] = []
+        for message in suffix:
+            role = message.get("role")
+            if role == "tool":
+                current_tools.append(message)
+                continue
+            if current_tools:
+                tool_runs.append(current_tools)
+                current_tools = []
+            if role == "user":
+                users.append(message)
+            elif role in {"assistant", "system"}:
+                continue
+            else:
+                raise RuntimeError(f"unsupported chat message role {role!r}")
+        if current_tools:
+            tool_runs.append(current_tools)
+
+        has_tools = bool(tool_runs)
+        for index, message in enumerate(users):
+            final_user_only = not has_tools and index == len(users) - 1
+            self._send_message(
+                _client_content(message, turn_complete=final_user_only),
+                sent,
+            )
+        for run in tool_runs:
+            self._send_message(self._tool_response(run), sent)
+        if has_tools and users:
+            self._send_message({"clientContent": {"turnComplete": True}}, sent)
+        if not users and not has_tools:
+            raise RuntimeError("Gemini Live has no un-streamed user or tool message to send")
+
+        # A partial send cannot move the cursor: recovery must fold every
+        # possibly absorbed message from the authoritative source list.
+        self._streamed.extend(suffix)
+
+    def _tool_response(self, messages: list[dict[str, Any]]) -> dict[str, Any]:
+        responses: list[dict[str, Any]] = []
+        for message in messages:
+            call_id = str(message["tool_call_id"])
+            name = self._call_names.get(call_id)
+            if name is None:
+                raise RuntimeError(
+                    f"Gemini Live has no function name recorded for tool call {call_id!r}"
+                )
+            content = message.get("content")
+            if not isinstance(content, str):
+                raise RuntimeError(f"Gemini Live tool result {call_id!r} content must be a string")
+            responses.append(
+                {
+                    "id": call_id,
+                    "name": name,
+                    "response": {"output": content},
+                }
+            )
+        return {"toolResponse": {"functionResponses": responses}}
+
+    def _send_recovery(
+        self,
+        messages: list[dict[str, Any]],
+        sent: list[dict[str, Any]],
+    ) -> None:
+        anchor_index = next(
+            (
+                index
+                for index in range(len(messages) - 1, -1, -1)
+                if messages[index].get("role") == "user"
+            ),
+            None,
+        )
+        if anchor_index is None:
+            raise RuntimeError("Gemini Live recovery requires at least one user message")
+
+        # Deferred to avoid policy.py -> _gemini_live.py -> policy.py at import.
+        from inspect_robots_agent.policy import _sanitize
+
+        folded = _sanitize(messages[:anchor_index] + messages[anchor_index + 1 :])
+        lines = [
+            _RECOVERY_PROLOGUE,
+            *(json.dumps(message) for message in folded),
+            _RECOVERY_CONTINUATION,
+        ]
+        prologue = {"role": "user", "content": "\n".join(lines)}
+        self._send_message(_client_content(prologue, turn_complete=False), sent)
+        self._send_message(_client_content(messages[anchor_index], turn_complete=True), sent)
+        self._streamed = list(messages)
+        self._call_names.clear()
+
+    def _read_exchange(
+        self,
+        received: list[dict[str, Any]],
+        usage: dict[str, int],
+    ) -> AssistantMessage:
+        text_parts: list[str] = []
+        for _ in range(_DRAIN_CAP):
+            message = self._recv_message(received, usage)
+            if "goAway" in message:
+                self._go_away = True
+
+            tool_call = message.get("toolCall")
+            if isinstance(tool_call, dict):
+                calls: list[ToolCall] = []
+                for function_call in tool_call.get("functionCalls") or []:
+                    call_id = str(function_call["id"])
+                    name = str(function_call["name"])
+                    self._call_names[call_id] = name
+                    calls.append(
+                        ToolCall(
+                            id=call_id,
+                            name=name,
+                            arguments=json.dumps(function_call.get("args") or {}),
+                        )
+                    )
+                if calls:
+                    return AssistantMessage(content=None, tool_calls=tuple(calls))
+
+            server_content = message.get("serverContent")
+            if not isinstance(server_content, dict):
+                continue
+            model_turn = server_content.get("modelTurn")
+            if isinstance(model_turn, dict):
+                for part in model_turn.get("parts") or []:
+                    if isinstance(part, dict) and "text" in part:
+                        text_parts.append(str(part["text"]))
+            if server_content.get("turnComplete"):
+                if text_parts:
+                    return AssistantMessage(content="".join(text_parts), tool_calls=())
+                # The buffered toolResponse generation completes empty before
+                # the final clientContent trigger produces the useful turn.
+                text_parts.clear()
+        raise _RecoverableError("Gemini Live drain cap exhausted after 64 messages")
+
+    def _send_message(
+        self,
+        message: dict[str, Any],
+        sent: list[dict[str, Any]],
+    ) -> None:
+        ws = self._ws
+        if ws is None:
+            raise _RecoverableError("Gemini Live socket is not connected")
+        sent.append(message)
+        try:
+            ws.send(json.dumps(message))
+        except _CONNECTION_ERRORS as exc:
+            raise _RecoverableError(_redact_query(str(exc), self._provider.base_url)) from exc
+
+    def _recv_message(
+        self,
+        received: list[dict[str, Any]],
+        usage: dict[str, int],
+    ) -> dict[str, Any]:
+        ws = self._ws
+        if ws is None:
+            raise _RecoverableError("Gemini Live socket is not connected")
+        try:
+            raw = ws.recv(timeout=self._timeout_s)
+        except _CONNECTION_ERRORS as exc:
+            message = "Gemini Live read timed out" if isinstance(exc, TimeoutError) else str(exc)
+            raise _RecoverableError(_redact_query(message, self._provider.base_url)) from exc
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise RuntimeError(f"Gemini Live returned invalid JSON: {str(raw)[:200]}") from exc
+        if not isinstance(parsed, dict):
+            raise RuntimeError("Gemini Live returned a non-object JSON message")
+        received.append(parsed)
+        _add_usage(parsed, usage)
+        return parsed
+
+    def _record_attempt(
+        self,
+        attempt: int,
+        sent: list[dict[str, Any]],
+        received: list[dict[str, Any]],
+        error: str | None,
+        t_start: float,
+        duration_s: float,
+    ) -> None:
+        if self._capture is None:
+            return
+        self._capture.record(
+            attempt=attempt,
+            endpoint="bidi",
+            request={"messages": sent},
+            status=None,
+            response_text=json.dumps({"messages": received}),
+            error=error,
+            t_start=t_start,
+            duration_s=duration_s,
+        )
+
+    def _abandon(self) -> None:
+        ws = self._ws
+        self._ws = None
+        if ws is None:
+            return
+        try:
+            ws.close()
+        except Exception:
+            return
+
+
+def _client_content(message: dict[str, Any], *, turn_complete: bool) -> dict[str, Any]:
+    """Translate one chat user message into a verified Live content turn."""
+    content = message.get("content")
+    if isinstance(content, str):
+        parts = [{"text": content}]
+    elif isinstance(content, list):
+        parts = [_content_part(part) for part in content]
+    else:
+        raise RuntimeError(f"unsupported Gemini Live user content {content!r}")
+    return {
+        "clientContent": {
+            "turns": [{"role": "user", "parts": parts}],
+            "turnComplete": turn_complete,
+        }
+    }
+
+
+def _content_part(part: Any) -> dict[str, Any]:
+    """Translate text and data-URI image parts without accepting other shapes."""
+    if not isinstance(part, dict):
+        raise RuntimeError(f"unsupported content part type {type(part).__name__!r}")
+    part_type = part.get("type")
+    if part_type == "text":
+        return {"text": part["text"]}
+    if part_type == "image_url":
+        url = str(part.get("image_url", {}).get("url", ""))
+        header, separator, data = url.partition(",")
+        if not separator or not header.startswith("data:") or not header.endswith(";base64"):
+            raise RuntimeError(f"image content part is not a base64 data URI: {url[:60]!r}")
+        mime_type = header[len("data:") : -len(";base64")]
+        if not mime_type:
+            raise RuntimeError(f"image content part has no data-URI MIME type: {url[:60]!r}")
+        return {"inlineData": {"mimeType": mime_type, "data": data}}
+    raise RuntimeError(f"unsupported content part type {part_type!r}")
+
+
+def _add_usage(message: dict[str, Any], totals: dict[str, int]) -> None:
+    """Add one Live envelope's billing counters to normalized exchange totals."""
+    usage = message.get("usageMetadata")
+    if not isinstance(usage, dict):
+        return
+    keys = {
+        "promptTokenCount": "input_tokens",
+        "candidatesTokenCount": "output_tokens",
+        "totalTokenCount": "total_tokens",
+    }
+    for source, target in keys.items():
+        value = usage.get(source)
+        if isinstance(value, int) and not isinstance(value, bool):
+            totals[target] = totals.get(target, 0) + value
+
+
+def _redact_query(message: str, base_url: str) -> str:
+    """Remove the Live credential query from transport diagnostics."""
+    redacted = re.sub(r"\?key=[^\s'\"),]+", "", message)
+    return re.sub(re.escape(base_url) + r"\?[^\s'\"),]+", base_url, redacted)

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -17,9 +17,10 @@ import json
 import os
 import sys
 from collections.abc import Mapping
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 import httpx
 import numpy as np
@@ -36,11 +37,13 @@ if TYPE_CHECKING:
     from inspect_robots.rollout import TrialRecord
 from inspect_robots_agent._anthropic import _DEFAULT_MAX_OUTPUT_TOKENS, AnthropicClient
 from inspect_robots_agent._depth import depth_parts, resolve_depth
+from inspect_robots_agent._gemini_live import GeminiLiveClient
 from inspect_robots_agent._llm import (
     _DIRECT_PROVIDERS,
     _OPENROUTER_BASE,
     ENV_MODEL,
     ChatClient,
+    Provider,
     ToolCall,
     _has_openrouter_variant,
     resolve_provider,
@@ -56,16 +59,32 @@ _MAX_CONSECUTIVE_FAILURES = 3
 #: The only endpoint that serves /v1/messages without an explicit base_url.
 _ANTHROPIC_BASE = _DIRECT_PROVIDERS["anthropic"].base_url
 
+#: The HTTP endpoint resolution must land on before it can be upgraded to Live.
+_GOOGLE_BASE = _DIRECT_PROVIDERS["google"].base_url
+
+#: Key-free endpoint recorded in policy configuration and capture rows.
+_GEMINI_LIVE_BASE = (
+    "wss://generativelanguage.googleapis.com/ws/"
+    "google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
+)
+
 # reasoning_effort values accepted across OpenAI-compatible endpoints
 # (Anthropic compat maps these to thinking effort; OpenRouter forwards them).
 # The native wire reuses the set as output_config.effort, where "none" and
 # "minimal" are rejected and xhigh/max need a cap this client cannot stream;
 # both surface as a guided 400 rather than a per-wire allowlist (plan 0026).
 _EFFORT_LEVELS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max"})
-_WIRE_FORMATS = frozenset({"chat", "responses", "anthropic"})
+_WIRE_FORMATS = frozenset({"chat", "responses", "anthropic", "gemini-live"})
 _SPEEDS = frozenset({"fast"})
 _IMAGE_MODES = frozenset({"always", "on_demand"})
 _DEPTH_MODES = frozenset({"render", "off"})
+
+
+class _Unset:
+    """Marker type for constructor defaults resolved per wire."""
+
+
+_UNSET: Final = _Unset()
 
 # Duplicated in inspect_robots_capx/policy.py; keep both limits in sync.
 _PRIOR_LEARNINGS_TEXT_LIMIT = 32 * 1024
@@ -245,12 +264,12 @@ class LLMAgentPolicy(PolicyBase):
         max_output_tokens: int | None = None,
         max_llm_calls: int = 100,
         temperature: float | None = None,
-        effort: str | None = "low",
+        effort: str | None | _Unset = _UNSET,
         max_speed_frac: float = 0.1,
         transcript_echo: bool = False,
         images: str = "always",
         depth: str = "render",
-        image_horizon: int | None = 2,
+        image_horizon: int | None | _Unset = _UNSET,
         prior_learnings: str | None = None,
         transport: httpx.BaseTransport | None = None,
         env: dict[str, str] | None = None,
@@ -315,11 +334,6 @@ class LLMAgentPolicy(PolicyBase):
             raise ConfigError("max_speed_frac must be finite and > 0")
         if max_llm_calls < 1:
             raise ConfigError("max_llm_calls must be >= 1")
-        if effort is not None and effort not in _EFFORT_LEVELS:
-            raise ConfigError(
-                f"effort must be one of {sorted(_EFFORT_LEVELS)}, or None to omit "
-                f"the field, got {effort!r}"
-            )
         # Order matters from here down (plan 0026): wire is validated before
         # the params that are only legal on one wire, the api_key_env default
         # is applied before resolution, and the OpenRouter check after it.
@@ -327,6 +341,18 @@ class LLMAgentPolicy(PolicyBase):
         # guided message instead of a traceback (#168).
         if wire not in _WIRE_FORMATS:
             raise ConfigError(f"wire must be one of {sorted(_WIRE_FORMATS)}, got {wire!r}")
+        if effort is not _UNSET and effort is not None and effort not in _EFFORT_LEVELS:
+            raise ConfigError(
+                f"effort must be one of {sorted(_EFFORT_LEVELS)}, or None to omit "
+                f"the field, got {effort!r}"
+            )
+        resolved_effort: str | None = None if wire == "gemini-live" else "low"
+        if not isinstance(effort, _Unset):
+            resolved_effort = effort
+        if wire == "gemini-live" and effort is not _UNSET and effort is not None:
+            raise ConfigError(
+                "effort is not supported on wire='gemini-live'.\nfix: drop -P effort="
+            )
         if speed is not None and speed not in _SPEEDS:
             raise ConfigError(f"speed must be one of {sorted(_SPEEDS)}, or None, got {speed!r}")
         if images not in _IMAGE_MODES:
@@ -360,14 +386,35 @@ class LLMAgentPolicy(PolicyBase):
             or max_output_tokens < 1
         ):
             raise ConfigError("max_output_tokens must be an int >= 1")
-        if image_horizon is not None and (
-            isinstance(image_horizon, bool)
-            or not isinstance(image_horizon, int)
-            or image_horizon < 1
+        if (
+            image_horizon is not _UNSET
+            and image_horizon is not None
+            and (
+                isinstance(image_horizon, bool)
+                or not isinstance(image_horizon, int)
+                or image_horizon < 1
+            )
         ):
             raise ConfigError(
                 "image_horizon must be an int >= 1, or None to send full image history.\n"
                 "fix: pass -P image_horizon=N or -P image_horizon=none"
+            )
+        resolved_image_horizon: int | None = None if wire == "gemini-live" else 2
+        if not isinstance(image_horizon, _Unset):
+            resolved_image_horizon = image_horizon
+        if wire == "gemini-live" and image_horizon is not _UNSET and image_horizon is not None:
+            raise ConfigError(
+                "image_horizon is not supported on wire='gemini-live'.\n"
+                "fix: drop -P image_horizon=; the Live API's own context-window "
+                "compression is the equivalent mechanism because already-streamed "
+                "frames cannot be evicted"
+            )
+
+        if wire == "gemini-live" and base_url and not base_url.startswith(("ws://", "wss://")):
+            raise ConfigError(
+                "wire='gemini-live' requires a ws:// or wss:// base_url, got "
+                f"{base_url!r}.\nfix: drop -P base_url= to use Google's Live API, "
+                "or pass a websocket endpoint"
             )
 
         environ = dict(os.environ) if env is None else env
@@ -383,13 +430,23 @@ class LLMAgentPolicy(PolicyBase):
         effective_key_env = api_key_env
         if wire == "anthropic" and base_url and not api_key_env:
             effective_key_env = "ANTHROPIC_API_KEY"
+        if wire == "gemini-live" and base_url and not api_key_env:
+            effective_key_env = "GEMINI_API_KEY"
         requested_model = model or environ.get(ENV_MODEL)
-        provider = resolve_provider(
-            model=requested_model,
-            base_url=base_url,
-            api_key_env=effective_key_env,
-            env=environ,
-        )
+        try:
+            provider = resolve_provider(
+                model=requested_model,
+                base_url=base_url,
+                api_key_env=effective_key_env,
+                env=environ,
+            )
+        except ConfigError as exc:
+            if wire != "gemini-live" or base_url:
+                raise
+            raise ConfigError(
+                "wire='gemini-live' needs Google's direct Live API provider.\n"
+                "fix: use -P model=google/... and set $GEMINI_API_KEY"
+            ) from exc
         if wire == "anthropic" and not base_url and provider.base_url != _ANTHROPIC_BASE:
             # Only Anthropic's own endpoint serves /v1/messages. Resolution can
             # land elsewhere two ways: the OpenRouter fallback, or another
@@ -438,6 +495,17 @@ class LLMAgentPolicy(PolicyBase):
                 f"{asked!r} resolved to {where}, which does not serve one.\n"
                 f"{fix}, or pass -P base_url=... for a gateway that serves /v1/messages"
             )
+        if wire == "gemini-live" and not base_url:
+            if provider.base_url != _GOOGLE_BASE:
+                raise ConfigError(
+                    "wire='gemini-live' needs Google's direct Live API provider.\n"
+                    "fix: use -P model=google/... and set $GEMINI_API_KEY"
+                )
+            provider = Provider(
+                base_url=_GEMINI_LIVE_BASE,
+                api_key=provider.api_key,
+                model=provider.model,
+            )
 
         resolved_max_output_tokens = (
             (max_output_tokens if max_output_tokens is not None else _DEFAULT_MAX_OUTPUT_TOKENS)
@@ -445,7 +513,7 @@ class LLMAgentPolicy(PolicyBase):
             else None
         )
         self._capture = WireCapture() if wire_capture else None
-        self._client: ChatClient | ResponsesClient | AnthropicClient
+        self._client: ChatClient | ResponsesClient | AnthropicClient | GeminiLiveClient
         if wire == "anthropic":
             assert resolved_max_output_tokens is not None
             self._client = AnthropicClient(
@@ -457,6 +525,8 @@ class LLMAgentPolicy(PolicyBase):
             )
         elif wire == "responses":
             self._client = ResponsesClient(provider, transport=transport, capture=self._capture)
+        elif wire == "gemini-live":
+            self._client = GeminiLiveClient(provider, capture=self._capture)
         else:
             self._client = ChatClient(provider, transport=transport, capture=self._capture)
         self._max_llm_calls = max_llm_calls
@@ -464,12 +534,12 @@ class LLMAgentPolicy(PolicyBase):
         # Robot control is latency-sensitive: default to low reasoning effort
         # (the arm stands still while the model thinks; safety guardrails sit
         # below the model, so effort trades thinking time, not safety).
-        self._effort = effort
+        self._effort = resolved_effort
         self._max_speed_frac = max_speed_frac
         self._transcript_echo = transcript_echo
         self._images = images
         self._depth = depth
-        self._image_horizon = image_horizon
+        self._image_horizon = resolved_image_horizon
         self._prior_learnings_text = prior_learnings_text
         self._pre_check = pre_check
         self.config = AgentPolicyConfig(
@@ -482,12 +552,12 @@ class LLMAgentPolicy(PolicyBase):
             speed=speed,
             max_output_tokens=resolved_max_output_tokens,
             max_llm_calls=max_llm_calls,
-            effort=effort,
+            effort=resolved_effort,
             max_speed_frac=max_speed_frac,
             transcript_echo=transcript_echo,
             images=images,
             depth=depth,
-            image_horizon=image_horizon,
+            image_horizon=resolved_image_horizon,
             prior_learnings=prior_learnings_path,
             prior_learnings_sha256=prior_learnings_sha256,
             pre_check=pre_check_identity,
@@ -565,6 +635,11 @@ class LLMAgentPolicy(PolicyBase):
 
     def on_trial_end(self, record: TrialRecord, log_dir: str, run_id: str) -> None:
         """Persist wire capture and the transcript at the end of the trial."""
+        if isinstance(self._client, GeminiLiveClient):
+            # Trial finalization must stay successful even if a half-dead Live
+            # transport violates close()'s own best-effort contract.
+            with suppress(Exception):
+                self._client.close()
         if self._capture is not None:
             capture_path = self._capture.end_trial()
             if capture_path is not None:

--- a/plugins/inspect-robots-agent/tests/_stub_bidi_server.py
+++ b/plugins/inspect-robots-agent/tests/_stub_bidi_server.py
@@ -1,0 +1,162 @@
+"""An in-process v1beta BidiGenerateContent server for Live wire tests.
+
+The server acknowledges setup, records every decoded client envelope by
+connection, and emits queued response batches whenever a generation trigger
+arrives. Tests may also provide a callback to close a connection or inject
+messages at any exact inbound boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+
+from websockets.exceptions import ConnectionClosed
+from websockets.sync.server import Server, ServerConnection, serve
+
+MessageHook = Callable[["StubBidiServer", ServerConnection, int, dict[str, Any]], bool]
+
+
+class StubBidiServer:
+    """Serve a steerable Gemini Live JSON endpoint on a free local port."""
+
+    def __init__(
+        self,
+        responses: list[list[dict[str, Any]]] | None = None,
+        *,
+        hook: MessageHook | None = None,
+    ) -> None:
+        self.connections: list[list[dict[str, Any]]] = []
+        self.closed_connections: list[int] = []
+        self._responses = list(responses or [])
+        self._hook = hook
+        self._lock = threading.Lock()
+        self._stopped = False
+        self._server: Server = serve(self._handler, "127.0.0.1", 0, max_size=None)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def url(self) -> str:
+        """Return the free-port websocket URL accepted by the policy seam."""
+        port = self._server.socket.getsockname()[1]
+        return f"ws://127.0.0.1:{port}"
+
+    @property
+    def messages(self) -> list[dict[str, Any]]:
+        """Return all inbound envelopes in connection and arrival order."""
+        with self._lock:
+            return [message for connection in self.connections for message in connection]
+
+    def wait_for_connections(self, count: int, timeout_s: float = 2.0) -> None:
+        """Wait until at least ``count`` websocket sessions have opened."""
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            with self._lock:
+                if len(self.connections) >= count:
+                    return
+            time.sleep(0.005)
+        raise AssertionError(f"expected {count} connections, saw {len(self.connections)}")
+
+    def wait_for_closed(self, count: int, timeout_s: float = 2.0) -> None:
+        """Wait until at least ``count`` handlers have observed socket closure."""
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            with self._lock:
+                if len(self.closed_connections) >= count:
+                    return
+            time.sleep(0.005)
+        raise AssertionError(
+            f"expected {count} closed connections, saw {len(self.closed_connections)}"
+        )
+
+    def stop(self) -> None:
+        """Stop accepting connections and join the background server thread."""
+        if self._stopped:
+            return
+        self._stopped = True
+        self._server.shutdown()
+        self._thread.join(timeout=5)
+
+    def send(self, ws: ServerConnection, *messages: dict[str, Any]) -> bool:
+        """Return false if the peer closes before the full batch is sent."""
+        try:
+            for message in messages:
+                ws.send(json.dumps(message))
+        except ConnectionClosed:
+            return False
+        return True
+
+    def _handler(self, ws: ServerConnection) -> None:
+        with self._lock:
+            connection_index = len(self.connections)
+            self.connections.append([])
+        try:
+            for raw in ws:
+                if isinstance(raw, bytes):
+                    raw = raw.decode("utf-8")
+                message = json.loads(raw)
+                if not isinstance(message, dict):
+                    continue
+                with self._lock:
+                    self.connections[connection_index].append(message)
+                if self._hook is not None and self._hook(self, ws, connection_index, message):
+                    # Every terminating failure hook closes the connection.
+                    # Returning here prevents already-buffered client frames
+                    # from consuming a response meant for the recovery socket.
+                    return
+                if "setup" in message:
+                    if not self.send(ws, {"setupComplete": {}}):
+                        return
+                elif _is_generation_trigger(message):
+                    batch: list[dict[str, Any]] | None = None
+                    with self._lock:
+                        if self._responses:
+                            batch = self._responses[0]
+                    if batch is not None:
+                        if not self.send(ws, *batch):
+                            return
+                        with self._lock:
+                            if self._responses and self._responses[0] is batch:
+                                self._responses.pop(0)
+        finally:
+            with self._lock:
+                self.closed_connections.append(connection_index)
+
+
+def _is_generation_trigger(message: dict[str, Any]) -> bool:
+    """Return whether one client envelope asks the server to generate."""
+    if "toolResponse" in message:
+        return True
+    content = message.get("clientContent")
+    return isinstance(content, dict) and content.get("turnComplete") is True
+
+
+def tool_call(
+    call_id: str = "fc_1",
+    name: str = "done",
+    args: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one exact v1beta toolCall server envelope."""
+    return {
+        "toolCall": {
+            "functionCalls": [
+                {
+                    "name": name,
+                    "args": {"summary": "ok"} if args is None else args,
+                    "id": call_id,
+                }
+            ]
+        }
+    }
+
+
+def completed_text(text: str) -> list[dict[str, Any]]:
+    """Build a model text turn followed by its v1beta completion envelope."""
+    return [
+        {"serverContent": {"modelTurn": {"parts": [{"text": text}]}}},
+        {"serverContent": {"turnComplete": True}},
+    ]

--- a/plugins/inspect-robots-agent/tests/test_capture.py
+++ b/plugins/inspect-robots-agent/tests/test_capture.py
@@ -79,6 +79,14 @@ def test_extracts_all_wire_image_shapes_without_mutating_request(tmp_path: Path)
                 "cache_control": {"type": "ephemeral"},
                 "vendor": "anthropic",
             },
+            {
+                "inlineData": {
+                    "mimeType": "image/png",
+                    "data": _PAYLOAD,
+                    "vendor": "gemini-source",
+                },
+                "vendor": "gemini-live",
+            },
         ]
     }
     original = json.loads(json.dumps(request))
@@ -116,6 +124,14 @@ def test_extracts_all_wire_image_shapes_without_mutating_request(tmp_path: Path)
         },
         "cache_control": {"type": "ephemeral"},
         "vendor": "anthropic",
+    }
+    assert parts[3] == {
+        "inlineData": {
+            "mimeType": "image/png",
+            "data": sentinel,
+            "vendor": "gemini-source",
+        },
+        "vendor": "gemini-live",
     }
     assert request == original
     assert re.fullmatch(r"\$blob:[0-9a-f]{64}", sentinel)

--- a/plugins/inspect-robots-agent/tests/test_gemini_live.py
+++ b/plugins/inspect-robots-agent/tests/test_gemini_live.py
@@ -1,0 +1,893 @@
+"""Gemini Live v1beta wire behavior and policy integration (plan 0039)."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from _stub_bidi_server import StubBidiServer, completed_text, tool_call
+from websockets.sync.server import ServerConnection
+
+import inspect_robots_agent._gemini_live as live_module
+from inspect_robots.errors import ConfigError
+from inspect_robots.mock import CubePickEmbodiment
+from inspect_robots.rollout import TrialRecord
+from inspect_robots.scene import Scene
+from inspect_robots_agent import GeminiLiveClient, LLMAgentPolicy
+from inspect_robots_agent._capture import WireCapture
+from inspect_robots_agent._gemini_live import (
+    _RECOVERY_CONTINUATION,
+    _RECOVERY_PROLOGUE,
+)
+from inspect_robots_agent._llm import Provider
+from inspect_robots_agent.policy import _GEMINI_LIVE_BASE, AgentPolicyConfig
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\ngemini-live-test"
+_PNG_PAYLOAD = base64.b64encode(_PNG_BYTES).decode("ascii")
+
+
+@pytest.fixture
+def server_factory() -> Iterator[Callable[..., StubBidiServer]]:
+    servers: list[StubBidiServer] = []
+
+    def make(*args: Any, **kwargs: Any) -> StubBidiServer:
+        server = StubBidiServer(*args, **kwargs)
+        servers.append(server)
+        return server
+
+    yield make
+    for server in servers:
+        server.stop()
+
+
+def _client(
+    server: StubBidiServer,
+    *,
+    model: str = "gemini-robotics-er-2-streaming-preview",
+    api_key: str = "",
+    capture: WireCapture | None = None,
+    max_retries: int = 3,
+) -> GeminiLiveClient:
+    return GeminiLiveClient(
+        Provider(base_url=server.url, api_key=api_key, model=model),
+        timeout_s=1.0,
+        backoff_s=0.0,
+        max_retries=max_retries,
+        capture=capture,
+    )
+
+
+def _messages(*users: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {"role": "system", "content": "drive safely"},
+        {"role": "user", "content": "Goal: inspect"},
+        *users,
+    ]
+
+
+def _observation(text: str = "observation") -> dict[str, Any]:
+    return {"role": "user", "content": [{"type": "text", "text": text}]}
+
+
+def _image_observation(text: str, payload: str = _PNG_PAYLOAD) -> dict[str, Any]:
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": text},
+            {"type": "text", "text": "camera 'top':"},
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{payload}"},
+            },
+        ],
+    }
+
+
+def _schema(name: str = "done") -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": f"{name} the task",
+            "parameters": {
+                "type": "object",
+                "properties": {"summary": {"type": "string"}},
+            },
+        },
+    }
+
+
+def _tool_message(call_id: str, output: str) -> dict[str, Any]:
+    return {"role": "tool", "tool_call_id": call_id, "content": output}
+
+
+def _content_messages(server: StubBidiServer, connection: int = 0) -> list[dict[str, Any]]:
+    return [
+        message
+        for message in server.connections[connection]
+        if "clientContent" in message or "toolResponse" in message
+    ]
+
+
+def _wire_rows(tmp_path: Path) -> list[dict[str, Any]]:
+    path = tmp_path / "wire/run-1/scene-e0/calls.jsonl"
+    return [cast(dict[str, Any], json.loads(line)) for line in path.read_text().splitlines()]
+
+
+def test_setup_round_trip_and_first_call_suffix_shape(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    server = server_factory([[tool_call()]])
+    client = _client(server, model="google/gemini-robotics-er-2-streaming-preview")
+    messages = _messages(_observation())
+
+    client.complete(messages, [_schema()], temperature=0.2)
+
+    setup = server.connections[0][0]["setup"]
+    assert setup == {
+        "model": "models/gemini-robotics-er-2-streaming-preview",
+        "systemInstruction": {"parts": [{"text": "drive safely"}]},
+        "tools": [
+            {
+                "functionDeclarations": [
+                    {
+                        "name": "done",
+                        "description": "done the task",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"summary": {"type": "string"}},
+                        },
+                    }
+                ]
+            }
+        ],
+        "generationConfig": {"temperature": 0.2},
+    }
+    assert "toolConfig" not in setup
+    content = _content_messages(server)
+    assert len(content) == 2
+    assert content[0]["clientContent"]["turnComplete"] is False
+    assert content[1]["clientContent"]["turnComplete"] is True
+    assert content[0]["clientContent"]["turns"][0]["parts"] == [{"text": "Goal: inspect"}]
+    assert "turns" in content[1]["clientContent"]
+    assert all("toolResponse" not in message for message in content)
+
+
+def test_default_endpoint_and_pending_setup_are_socketless() -> None:
+    policy = LLMAgentPolicy(
+        model="google/gemini-robotics-er-2-streaming-preview",
+        wire="gemini-live",
+        wire_capture=False,
+        env={"GEMINI_API_KEY": "secret"},
+    )
+
+    assert isinstance(policy.config, AgentPolicyConfig)
+    assert policy.config.base_url == _GEMINI_LIVE_BASE
+    assert isinstance(policy._client, GeminiLiveClient)
+    assert policy._client._setup == {"model": "models/gemini-robotics-er-2-streaming-preview"}
+    assert "secret" not in json.dumps(policy.config.__dict__)
+
+
+def test_normal_step_orders_observation_before_tool_response_and_empty_trigger(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    empty = {"serverContent": {"turnComplete": True}}
+    server = server_factory([[tool_call("fc_1")], [empty], [tool_call("fc_2")]])
+    client = _client(server)
+    history = _messages(_observation("old"))
+    first = client.complete(history, [])
+    history.extend(
+        [
+            first.raw(),
+            _tool_message("fc_1", "motion played"),
+            _observation("fresh"),
+        ]
+    )
+
+    client.complete(history, [])
+
+    tail = _content_messages(server)[-3:]
+    assert tail[0]["clientContent"]["turnComplete"] is False
+    assert tail[0]["clientContent"]["turns"][0]["parts"] == [{"text": "fresh"}]
+    assert tail[1] == {
+        "toolResponse": {
+            "functionResponses": [
+                {
+                    "id": "fc_1",
+                    "name": "done",
+                    "response": {"output": "motion played"},
+                }
+            ]
+        }
+    }
+    assert tail[2] == {"clientContent": {"turnComplete": True}}
+
+
+def test_nudge_is_user_only_without_tool_response(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    server = server_factory([completed_text("describe"), [tool_call("fc_2")]])
+    client = _client(server)
+    history = _messages(_observation())
+    first = client.complete(history, [])
+    history.extend(
+        [
+            first.raw(),
+            {"role": "user", "content": "Respond with exactly one tool call."},
+        ]
+    )
+
+    client.complete(history, [])
+
+    tail = _content_messages(server)[-1]
+    assert tail["clientContent"]["turnComplete"] is True
+    assert tail["clientContent"]["turns"][0]["parts"] == [
+        {"text": "Respond with exactly one tool call."}
+    ]
+    assert "toolResponse" not in tail
+
+
+def test_tool_only_retry_has_no_trailing_turn_complete(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    server = server_factory([[tool_call("fc_1")], [tool_call("fc_2")]])
+    client = _client(server)
+    history = _messages(_observation())
+    first = client.complete(history, [])
+    history.extend([first.raw(), _tool_message("fc_1", "pre-check rejected")])
+
+    client.complete(history, [])
+
+    assert _content_messages(server)[-1] == {
+        "toolResponse": {
+            "functionResponses": [
+                {
+                    "id": "fc_1",
+                    "name": "done",
+                    "response": {"output": "pre-check rejected"},
+                }
+            ]
+        }
+    }
+
+
+def test_on_demand_tool_and_image_message_use_three_part_sequence(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    empty = {"serverContent": {"turnComplete": True}}
+    server = server_factory([[tool_call("pic", "take_pic")], [empty], [tool_call("move")]])
+    client = _client(server)
+    history = _messages(_observation())
+    first = client.complete(history, [])
+    history.extend(
+        [
+            first.raw(),
+            _tool_message("pic", "captured 1 frame(s): 'top'"),
+            _image_observation("camera delivery"),
+        ]
+    )
+
+    client.complete(history, [])
+
+    tail = _content_messages(server)[-3:]
+    assert tail[0]["clientContent"]["turnComplete"] is False
+    assert "inlineData" in tail[0]["clientContent"]["turns"][0]["parts"][-1]
+    assert "toolResponse" in tail[1]
+    assert tail[2] == {"clientContent": {"turnComplete": True}}
+
+
+def test_multiple_function_calls_aggregate_ordered_function_responses(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    two_calls = {
+        "toolCall": {
+            "functionCalls": [
+                {"name": "move_joints", "args": {"x": 1}, "id": "move"},
+                {"name": "take_pic", "args": {"camera": "top"}, "id": "pic"},
+            ]
+        }
+    }
+    server = server_factory([[two_calls], [tool_call("next")]])
+    client = _client(server)
+    history = _messages(_observation())
+
+    first = client.complete(history, [])
+
+    assert [call.id for call in first.tool_calls] == ["move", "pic"]
+    assert [json.loads(call.arguments) for call in first.tool_calls] == [
+        {"x": 1},
+        {"camera": "top"},
+    ]
+    history.extend(
+        [
+            first.raw(),
+            _tool_message("move", "executed"),
+            _tool_message("pic", "queued"),
+        ]
+    )
+    client.complete(history, [])
+    response = _content_messages(server)[-1]["toolResponse"]["functionResponses"]
+    assert response == [
+        {
+            "id": "move",
+            "name": "move_joints",
+            "response": {"output": "executed"},
+        },
+        {"id": "pic", "name": "take_pic", "response": {"output": "queued"}},
+    ]
+    assert sum("toolResponse" in message for message in _content_messages(server)) == 1
+
+
+def test_assistant_turns_are_never_resent_as_client_content(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    server = server_factory([completed_text("thinking"), [tool_call()]])
+    client = _client(server)
+    history = _messages(_observation())
+    first = client.complete(history, [])
+    history.extend([first.raw(), {"role": "user", "content": "nudge"}])
+
+    client.complete(history, [])
+
+    turns = [
+        turn
+        for message in _content_messages(server)
+        for turn in message.get("clientContent", {}).get("turns", [])
+    ]
+    assert all(turn["role"] == "user" for turn in turns)
+    assert "thinking" not in json.dumps(turns)
+
+
+def test_png_data_uri_translates_to_inline_data(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    server = server_factory([[tool_call()]])
+
+    _client(server).complete(_messages(_image_observation("look")), [])
+
+    parts = _content_messages(server)[-1]["clientContent"]["turns"][0]["parts"]
+    assert parts[-1] == {"inlineData": {"mimeType": "image/png", "data": _PNG_PAYLOAD}}
+
+
+def test_unknown_user_part_fails_loudly(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    server = server_factory()
+    history = _messages({"role": "user", "content": [{"type": "audio", "data": "x"}]})
+
+    with pytest.raises(RuntimeError, match="unsupported content part type 'audio'"):
+        _client(server, max_retries=1).complete(history, [])
+
+
+def test_policy_text_turn_takes_existing_nudge_path_end_to_end(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    server = server_factory(
+        [completed_text("I should use a tool"), [tool_call("done", "done", {"summary": "ok"})]]
+    )
+    policy = LLMAgentPolicy(
+        model="test/model",
+        base_url=server.url,
+        wire="gemini-live",
+        wire_capture=False,
+        env={},
+    )
+    embodiment = CubePickEmbodiment()
+    policy.bind(embodiment.info)
+    scene = Scene(id="s0", instruction="inspect")
+    policy.reset(scene)
+
+    chunk = policy.act(embodiment.reset(scene, seed=0))
+
+    assert chunk.actions[0].meta["request_stop"] is True
+    assert chunk.actions[0].meta["stop_reason"] == "done"
+    assert any(
+        message.get("clientContent", {}).get("turns", [{}])[0].get("parts", [{}])[0].get("text")
+        == "Respond with exactly one tool call."
+        for message in _content_messages(server)
+        if message.get("clientContent", {}).get("turns")
+    )
+
+
+def test_drain_resumption_and_empty_turn_before_tool_call(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    server = server_factory(
+        [
+            [
+                {"sessionResumptionUpdate": {"newHandle": "discard-me"}},
+                {"serverContent": {"turnComplete": True}},
+                tool_call(),
+            ]
+        ]
+    )
+
+    message = _client(server).complete(_messages(_observation()), [])
+
+    assert message.tool_calls[0].id == "fc_1"
+
+
+def test_drain_cap_exhaustion_recovers_then_raises(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    noise = [{"sessionResumptionUpdate": {"newHandle": str(index)}} for index in range(64)]
+    server = server_factory([noise, noise, noise])
+
+    with pytest.raises(RuntimeError, match=r"failed after 3 attempts.*drain cap exhausted"):
+        _client(server).complete(_messages(_observation()), [])
+
+    assert len(server.connections) == 3
+
+
+def test_usage_metadata_is_summed_and_normalized(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    server = server_factory(
+        [
+            [
+                {
+                    "sessionResumptionUpdate": {},
+                    "usageMetadata": {
+                        "promptTokenCount": 3,
+                        "candidatesTokenCount": 5,
+                        "totalTokenCount": 8,
+                    },
+                },
+                {
+                    **tool_call(),
+                    "usageMetadata": {
+                        "promptTokenCount": 7,
+                        "candidatesTokenCount": 11,
+                        "totalTokenCount": 18,
+                    },
+                },
+            ]
+        ]
+    )
+
+    result = _client(server).complete(_messages(_observation()), [])
+
+    assert result.usage == {"input_tokens": 10, "output_tokens": 16, "total_tokens": 26}
+
+
+def test_usage_from_failed_attempt_survives_recovery(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    def hook(
+        server: StubBidiServer,
+        ws: ServerConnection,
+        connection: int,
+        message: dict[str, Any],
+    ) -> bool:
+        if connection == 0 and message.get("clientContent", {}).get("turnComplete") is True:
+            server.send(
+                ws,
+                {
+                    "sessionResumptionUpdate": {},
+                    "usageMetadata": {"promptTokenCount": 9},
+                },
+            )
+            ws.close()
+            return True
+        return False
+
+    server = server_factory(
+        [[{**tool_call(), "usageMetadata": {"promptTokenCount": 4}}]],
+        hook=hook,
+    )
+
+    result = _client(server).complete(_messages(_observation()), [])
+
+    assert result.usage == {"input_tokens": 13}
+
+
+def test_mid_step_drop_recovers_with_sanitized_jsonl_and_one_anchor_image(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    old_payload = base64.b64encode(b"old-image").decode("ascii")
+
+    def hook(
+        server: StubBidiServer,
+        ws: ServerConnection,
+        connection: int,
+        message: dict[str, Any],
+    ) -> bool:
+        content = message.get("clientContent")
+        if connection == 0 and isinstance(content, dict) and content.get("turns"):
+            text = json.dumps(content["turns"])
+            if "newest observation" in text and content.get("turnComplete") is False:
+                ws.close()
+                return True
+        return False
+
+    server = server_factory([[tool_call("old")], [tool_call("recovered")]], hook=hook)
+    client = _client(server)
+    history = _messages(_image_observation("older observation", old_payload))
+    first = client.complete(history, [])
+    history.extend(
+        [
+            first.raw(),
+            _tool_message("old", "played"),
+            _image_observation("newest observation"),
+        ]
+    )
+
+    result = client.complete(history, [])
+
+    assert result.tool_calls[0].id == "recovered"
+    recovery = server.connections[1]
+    assert all("toolResponse" not in message for message in recovery)
+    assert all(
+        turn.get("role") != "model"
+        for message in recovery
+        for turn in message.get("clientContent", {}).get("turns", [])
+    )
+    wire = json.dumps(recovery)
+    assert wire.count(_PNG_PAYLOAD) == 1
+    assert old_payload not in wire
+    assert "[image omitted: streamed camera frame]" in wire
+    content = _content_messages(server, 1)
+    prologue = content[0]["clientContent"]["turns"][0]["parts"][0]["text"]
+    lines = prologue.splitlines()
+    assert lines[0] == _RECOVERY_PROLOGUE
+    assert lines[-1] == _RECOVERY_CONTINUATION
+    assert all(isinstance(json.loads(line), dict) for line in lines[1:-1])
+    anchor = content[1]["clientContent"]
+    assert anchor["turnComplete"] is True
+    assert "newest observation" in json.dumps(anchor)
+
+
+def test_go_away_finishes_exchange_then_recovers_at_next_boundary(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    server = server_factory(
+        [
+            [{"goAway": {"timeLeft": "5s"}}, tool_call("old")],
+            [tool_call("new")],
+        ]
+    )
+    client = _client(server)
+    history = _messages(_observation("old observation"))
+    first = client.complete(history, [])
+    history.extend([first.raw(), _tool_message("old", "played"), _observation("new observation")])
+
+    result = client.complete(history, [])
+
+    assert result.tool_calls[0].id == "new"
+    assert len(server.connections) == 2
+    assert all("toolResponse" not in message for message in server.connections[1])
+
+
+def test_persistent_drop_exhausts_retries(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    def hook(
+        server: StubBidiServer,
+        ws: ServerConnection,
+        connection: int,
+        message: dict[str, Any],
+    ) -> bool:
+        del server, connection
+        if message.get("clientContent", {}).get("turnComplete") is True:
+            ws.close()
+            return True
+        return False
+
+    server = server_factory(hook=hook)
+
+    with pytest.raises(RuntimeError, match="failed after 3 attempts"):
+        _client(server).complete(_messages(_observation()), [])
+
+    assert len(server.connections) == 3
+
+
+def test_on_demand_frameless_anchor_recovers(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    def hook(
+        server: StubBidiServer,
+        ws: ServerConnection,
+        connection: int,
+        message: dict[str, Any],
+    ) -> bool:
+        del server
+        content = message.get("clientContent")
+        if (
+            connection == 0
+            and isinstance(content, dict)
+            and content.get("turnComplete") is False
+            and "frameless anchor" in json.dumps(content)
+        ):
+            ws.close()
+            return True
+        return False
+
+    server = server_factory([[tool_call("pic", "take_pic")], [tool_call("new")]], hook=hook)
+    client = _client(server)
+    history = _messages(_observation())
+    first = client.complete(history, [])
+    history.extend(
+        [first.raw(), _tool_message("pic", "no frame"), _observation("frameless anchor")]
+    )
+
+    result = client.complete(history, [])
+
+    assert result.tool_calls[0].id == "new"
+    anchor = _content_messages(server, 1)[1]
+    assert "inlineData" not in json.dumps(anchor)
+    assert anchor["clientContent"]["turnComplete"] is True
+
+
+def test_byte_identical_new_trial_reopens_by_identity(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    server = server_factory([[tool_call("first")], [tool_call("second")]])
+    client = _client(server)
+    first_history = _messages(_observation("same"))
+    second_history = json.loads(json.dumps(first_history))
+
+    client.complete(first_history, [])
+    client.complete(second_history, [])
+
+    assert len(server.connections) == 2
+    assert server.connections[1][0]["setup"]["model"].startswith("models/")
+
+
+def test_rewritten_view_with_same_system_identity_raises_guard(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    server = server_factory([[tool_call()]])
+    client = _client(server)
+    history = _messages(_observation())
+    client.complete(history, [])
+    view = [history[0], *json.loads(json.dumps(history[1:]))]
+
+    with pytest.raises(RuntimeError, match="rewritten conversation view"):
+        client.complete(view, [])
+
+
+def test_policy_trial_end_closes_and_next_trial_reopens_lazily(
+    tmp_path: Path,
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    server = server_factory([[tool_call("first")], [tool_call("second")]])
+    policy = LLMAgentPolicy(
+        model="test/model",
+        base_url=server.url,
+        wire="gemini-live",
+        wire_capture=False,
+        env={},
+    )
+    assert isinstance(policy._client, GeminiLiveClient)
+    policy._client.complete(_messages(_observation("same")), [])
+    policy.on_trial_end(
+        TrialRecord(scene_id="s0", epoch=0, seed=0, status="success"),
+        str(tmp_path),
+        "run",
+    )
+    server.wait_for_closed(1)
+    assert len(server.connections) == 1
+
+    policy._client.complete(_messages(_observation("same")), [])
+
+    assert len(server.connections) == 2
+
+
+def test_trial_end_is_clean_when_server_is_already_gone(
+    tmp_path: Path,
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    server = server_factory([[tool_call()]])
+    policy = LLMAgentPolicy(
+        model="test/model",
+        base_url=server.url,
+        wire="gemini-live",
+        wire_capture=False,
+        env={},
+    )
+    assert isinstance(policy._client, GeminiLiveClient)
+    policy._client.complete(_messages(_observation()), [])
+    server.stop()
+
+    policy.on_trial_end(
+        TrialRecord(scene_id="s0", epoch=0, seed=0, status="success"),
+        str(tmp_path),
+        "run",
+    )
+
+
+def test_per_wire_default_resolution_and_explicit_none() -> None:
+    live = LLMAgentPolicy(
+        model="google/gemini-robotics-er-2-streaming-preview",
+        wire="gemini-live",
+        wire_capture=False,
+        env={"GEMINI_API_KEY": "g"},
+    )
+    explicit_none = LLMAgentPolicy(
+        model="m",
+        base_url="ws://stub.test",
+        wire="gemini-live",
+        effort=None,
+        image_horizon=None,
+        wire_capture=False,
+        env={},
+    )
+    chat = LLMAgentPolicy(model="m", base_url="http://stub.test", wire_capture=False, env={})
+    responses = LLMAgentPolicy(
+        model="m",
+        base_url="http://stub.test",
+        wire="responses",
+        wire_capture=False,
+        env={},
+    )
+    anthropic = LLMAgentPolicy(
+        model="m",
+        base_url="http://stub.test",
+        wire="anthropic",
+        wire_capture=False,
+        env={},
+    )
+
+    assert isinstance(live.config, AgentPolicyConfig)
+    assert isinstance(explicit_none.config, AgentPolicyConfig)
+    assert isinstance(chat.config, AgentPolicyConfig)
+    assert isinstance(responses.config, AgentPolicyConfig)
+    assert isinstance(anthropic.config, AgentPolicyConfig)
+    assert (live.config.effort, live.config.image_horizon) == (None, None)
+    assert (explicit_none.config.effort, explicit_none.config.image_horizon) == (
+        None,
+        None,
+    )
+    assert (chat.config.effort, chat.config.image_horizon) == ("low", 2)
+    assert (responses.config.effort, responses.config.image_horizon) == ("low", 2)
+    assert (anthropic.config.effort, anthropic.config.image_horizon) == ("low", 2)
+
+
+def test_live_rejects_explicit_effort_and_image_horizon_with_guidance() -> None:
+    common: dict[str, Any] = {
+        "model": "m",
+        "base_url": "ws://stub.test",
+        "wire": "gemini-live",
+        "wire_capture": False,
+        "env": {},
+    }
+    with pytest.raises(ConfigError) as effort_error:
+        LLMAgentPolicy(**common, effort="low")
+    assert str(effort_error.value) == (
+        "effort is not supported on wire='gemini-live'.\nfix: drop -P effort="
+    )
+    with pytest.raises(ConfigError) as horizon_error:
+        LLMAgentPolicy(**common, image_horizon=2)
+    assert "Live API's own context-window compression is the equivalent mechanism" in str(
+        horizon_error.value
+    )
+    assert "already-streamed frames cannot be evicted" in str(horizon_error.value)
+
+
+def test_existing_invalid_effort_and_horizon_messages_are_preserved() -> None:
+    common: dict[str, Any] = {
+        "model": "m",
+        "base_url": "ws://stub.test",
+        "wire": "gemini-live",
+        "env": {},
+    }
+    with pytest.raises(ConfigError) as effort_error:
+        LLMAgentPolicy(**common, effort="default")
+    assert str(effort_error.value) == (
+        "effort must be one of ['high', 'low', 'max', 'medium', 'minimal', 'none', "
+        "'xhigh'], or None to omit the field, got 'default'"
+    )
+    with pytest.raises(ConfigError) as horizon_error:
+        LLMAgentPolicy(**common, image_horizon=0)
+    assert str(horizon_error.value) == (
+        "image_horizon must be an int >= 1, or None to send full image history.\n"
+        "fix: pass -P image_horizon=N or -P image_horizon=none"
+    )
+    with pytest.raises(ConfigError, match="image_horizon must be an int"):
+        LLMAgentPolicy(**common, image_horizon=True)
+
+
+def test_wrong_provider_openrouter_and_http_base_url_are_guided_without_key_leak() -> None:
+    expected_fix = "fix: use -P model=google/... and set $GEMINI_API_KEY"
+    with pytest.raises(ConfigError) as foreign:
+        LLMAgentPolicy(
+            model="openai/gpt-test",
+            wire="gemini-live",
+            env={"OPENAI_API_KEY": "openai-secret"},
+        )
+    assert expected_fix in str(foreign.value)
+
+    with pytest.raises(ConfigError) as router:
+        LLMAgentPolicy(
+            model="google/gemini-test",
+            wire="gemini-live",
+            env={"OPENROUTER_API_KEY": "router-secret"},
+        )
+    assert expected_fix in str(router.value)
+    assert "router-secret" not in str(router.value)
+
+    with pytest.raises(ConfigError) as http_error:
+        LLMAgentPolicy(
+            model="google/gemini-test",
+            base_url="http://stub.test",
+            wire="gemini-live",
+            env={},
+        )
+    assert "requires a ws:// or wss:// base_url" in str(http_error.value)
+    assert "fix:" in str(http_error.value)
+
+
+def test_capture_rows_attempts_responses_blobs_and_key_redaction(
+    tmp_path: Path,
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+
+    def hook(
+        server: StubBidiServer,
+        ws: ServerConnection,
+        connection: int,
+        message: dict[str, Any],
+    ) -> bool:
+        if connection == 0 and message.get("clientContent", {}).get("turnComplete") is True:
+            server.send(ws, {"sessionResumptionUpdate": {"padding": "x" * 3000}})
+            ws.close()
+            return True
+        return False
+
+    long_batch = [
+        {"sessionResumptionUpdate": {"padding": str(index) + "y" * 200}} for index in range(20)
+    ] + [tool_call("recovered")]
+    server = server_factory([long_batch], hook=hook)
+    client = _client(server, api_key="capture-secret", capture=capture)
+
+    client.complete(_messages(_image_observation("anchor")), [])
+    capture.end_trial()
+
+    rows = _wire_rows(tmp_path)
+    assert len(rows) == 2
+    assert [row["attempt"] for row in rows] == [0, 1]
+    assert [row["call"] for row in rows] == [0, 0]
+    assert all(row["endpoint"] == "bidi" for row in rows)
+    assert "setup" in rows[0]["request"]["messages"][0]
+    assert "setup" in rows[1]["request"]["messages"][0]
+    assert len(rows[1]["response"]["messages"]) == 22
+    assert len(rows[0]["response"]["messages"][1]["sessionResumptionUpdate"]["padding"]) == 3000
+    serialized = json.dumps(rows)
+    assert "capture-secret" not in serialized
+    assert _PNG_PAYLOAD not in serialized
+    digest = hashlib.sha256(_PNG_BYTES).hexdigest()
+    assert f"$blob:{digest}" in serialized
+    assert (tmp_path / f"wire/run-1/blobs/{digest}.png").read_bytes() == _PNG_BYTES
+
+
+def test_transport_error_url_is_redacted_before_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    endpoint = "wss://live.test/BidiGenerateContent"
+    secret = "never-print-this"
+
+    def fail_connect(url: str, **kwargs: Any) -> None:
+        del kwargs
+        raise OSError(f"cannot connect to {url}")
+
+    monkeypatch.setattr(live_module, "ws_connect", fail_connect)
+    client = GeminiLiveClient(
+        Provider(base_url=endpoint, api_key=secret, model="google/model"),
+        max_retries=1,
+        backoff_s=0.0,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        client.complete(_messages(_observation()), [])
+
+    message = str(exc_info.value)
+    assert endpoint in message
+    assert "?key=" not in message
+    assert secret not in message

--- a/plugins/inspect-robots-agent/tests/test_gemini_live.py
+++ b/plugins/inspect-robots-agent/tests/test_gemini_live.py
@@ -189,8 +189,9 @@ def test_normal_step_orders_observation_before_tool_response_and_empty_trigger(
         ]
     )
 
-    client.complete(history, [])
+    second = client.complete(history, [])
 
+    assert second.tool_calls[0].id == "fc_2"
     tail = _content_messages(server)[-3:]
     assert tail[0]["clientContent"]["turnComplete"] is False
     assert tail[0]["clientContent"]["turns"][0]["parts"] == [{"text": "fresh"}]
@@ -272,8 +273,9 @@ def test_on_demand_tool_and_image_message_use_three_part_sequence(
         ]
     )
 
-    client.complete(history, [])
+    second = client.complete(history, [])
 
+    assert second.tool_calls[0].id == "move"
     tail = _content_messages(server)[-3:]
     assert tail[0]["clientContent"]["turnComplete"] is False
     assert "inlineData" in tail[0]["clientContent"]["turns"][0]["parts"][-1]
@@ -537,6 +539,9 @@ def test_mid_step_drop_recovers_with_sanitized_jsonl_and_one_anchor_image(
     assert lines[0] == _RECOVERY_PROLOGUE
     assert lines[-1] == _RECOVERY_CONTINUATION
     assert all(isinstance(json.loads(line), dict) for line in lines[1:-1])
+    # The fresh session re-sends the system prompt as systemInstruction;
+    # folding it into the prologue too would duplicate it.
+    assert all(json.loads(line).get("role") != "system" for line in lines[1:-1])
     anchor = content[1]["clientContent"]
     assert anchor["turnComplete"] is True
     assert "newest observation" in json.dumps(anchor)
@@ -561,6 +566,67 @@ def test_go_away_finishes_exchange_then_recovers_at_next_boundary(
     assert result.tool_calls[0].id == "new"
     assert len(server.connections) == 2
     assert all("toolResponse" not in message for message in server.connections[1])
+
+
+def test_go_away_then_drop_recovers_once_without_stale_flag(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    def hook(
+        server: StubBidiServer,
+        ws: ServerConnection,
+        connection: int,
+        message: dict[str, Any],
+    ) -> bool:
+        if connection == 0 and message.get("clientContent", {}).get("turnComplete") is True:
+            server.send(ws, {"goAway": {"timeLeft": "1s"}})
+            ws.close()
+            return True
+        return False
+
+    server = server_factory([[tool_call("recovered")], [tool_call("next")]], hook=hook)
+    client = _client(server)
+    history = _messages(_observation("first observation"))
+
+    first = client.complete(history, [])
+
+    assert first.tool_calls[0].id == "recovered"
+    history.extend(
+        [first.raw(), _tool_message("recovered", "played"), _observation("second observation")]
+    )
+
+    second = client.complete(history, [])
+
+    # The goAway died with its socket: the recovered session must survive the
+    # next boundary instead of being torn down by the stale flag.
+    assert second.tool_calls[0].id == "next"
+    assert len(server.connections) == 2
+
+
+def test_first_call_transient_failure_retries_without_recovery_prologue(
+    server_factory: Callable[..., StubBidiServer],
+) -> None:
+    def hook(
+        server: StubBidiServer,
+        ws: ServerConnection,
+        connection: int,
+        message: dict[str, Any],
+    ) -> bool:
+        del server
+        if connection == 0 and "setup" in message:
+            ws.close()
+            return True
+        return False
+
+    server = server_factory([[tool_call("fc_1")]], hook=hook)
+
+    result = _client(server).complete(_messages(_observation()), [])
+
+    assert result.tool_calls[0].id == "fc_1"
+    assert len(server.connections) == 2
+    retry_wire = json.dumps(server.connections[1])
+    assert _RECOVERY_PROLOGUE not in retry_wire
+    tail = _content_messages(server, 1)[-1]["clientContent"]
+    assert tail["turnComplete"] is True
 
 
 def test_persistent_drop_exhausts_retries(

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,7 +6,7 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.19.1"
+    assert inspect_robots_agent.__version__ == "0.20.0"
     assert callable(inspect_robots_agent.agent_policy)
     assert inspect_robots_agent.__all__ == [
         "ENV_MODEL",
@@ -14,6 +14,7 @@ def test_package_imports_and_exports() -> None:
         "AnthropicClient",
         "AssistantMessage",
         "ChatClient",
+        "GeminiLiveClient",
         "LLMAgentPolicy",
         "Provider",
         "ResponsesClient",

--- a/uv.lock
+++ b/uv.lock
@@ -397,13 +397,14 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.19.1"
+version = "0.20.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },
     { name = "inspect-robots" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -423,6 +424,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
+    { name = "websockets", specifier = ">=12" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
Closes #252

Adds a fourth wire to the agent plugin: `-P wire=gemini-live`, speaking the raw `BidiGenerateContent` WebSocket protocol so Gemini Robotics ER 2 runs over the surface Google recommends for latency-sensitive robotics (`gemini-robotics-er-2-streaming-preview`), instead of re-uploading the full multi-image transcript over the chat wire every step.

Protocol facts were verified by a live socket spike (see issue): distinct streaming model id, no `toolConfig` in bidi setup (prompt-level tool forcing), images as `inlineData` parts, and the lockstep sequencing that makes the model act on fresh observations (`turnComplete:false` observation, `toolResponse`, empty `turnComplete:true`).

Plan: `plans/0039-gemini-live-wire.md` (critique-gated). This PR started as the ER2 chat-wire docs note and was taken over for the full wire implementation; the README section it touched is rewritten here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)