### PR TITLE
fix(agent): round-trip Gemini thought_signature on the chat wire

### DIFF
--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
@@ -137,6 +137,7 @@ class ToolCall:
     id: str
     name: str
     arguments: str
+    extra_content: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -156,6 +157,7 @@ class AssistantMessage:
                     "id": c.id,
                     "type": "function",
                     "function": {"name": c.name, "arguments": c.arguments},
+                    **({"extra_content": c.extra_content} if c.extra_content is not None else {}),
                 }
                 for c in self.tool_calls
             ]
@@ -266,6 +268,7 @@ def _parse_message(payload: dict[str, Any]) -> AssistantMessage:
             id=str(c["id"]),
             name=str(c["function"]["name"]),
             arguments=str(c["function"]["arguments"]),
+            extra_content=c.get("extra_content"),
         )
         for c in message.get("tool_calls") or []
     )

--- a/plugins/inspect-robots-agent/tests/test_llm.py
+++ b/plugins/inspect-robots-agent/tests/test_llm.py
@@ -264,6 +264,24 @@ def test_complete_sends_wire_format_and_parses_tool_calls() -> None:
     assert json.loads(call.arguments)["duration_s"] == 1.0
 
 
+def test_parse_message_preserves_tool_call_extra_content() -> None:
+    payload = _tool_call_response()
+    extra_content = {"google": {"thought_signature": "sig-blob"}}
+    payload["choices"][0]["message"]["tool_calls"][0]["extra_content"] = extra_content
+
+    message = llm_module._parse_message(payload)
+
+    (tool_call,) = message.raw()["tool_calls"]
+    assert tool_call["extra_content"] == extra_content
+
+
+def test_parse_message_omits_absent_tool_call_extra_content() -> None:
+    message = llm_module._parse_message(_tool_call_response())
+
+    (tool_call,) = message.raw()["tool_calls"]
+    assert "extra_content" not in tool_call
+
+
 def test_reasoning_effort_is_sent_when_set_and_omitted_when_none() -> None:
     bodies: list[dict[str, Any]] = []
 


### PR DESCRIPTION
Closes #229

Gemini's OpenAI-compat endpoint attaches `tool_calls[].extra_content.google.thought_signature` to every function call and requires it echoed back in history. `ToolCall`/`AssistantMessage.raw()` drop it, which hard-400s any run where a request ends on a tool message (current-turn strict validation) — reliably triggered in `eef_pos` mode by workspace-bounds rejections.

Fix: preserve `extra_content` as an opaque optional field on `ToolCall` and emit it in `raw()` only when the endpoint sent it, so non-Gemini providers see byte-identical requests.

- [ ] failing regression test (round-trip through parse → raw)
- [ ] fix
- [ ] full plugin test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)