### PR TITLE
chore(agent): bump plugin to 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,13 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **Agent plugin (0.19.1):** the chat wire now round-trips Gemini's
+  `tool_calls[].extra_content` (`google.thought_signature`) into conversation
+  history. Dropping it made Gemini reject any request ending on a tool
+  message — e.g. after an `eef_pos` workspace-bounds rejection — with HTTP 400
+  "Function call is missing a thought_signature", erroring the trial (#229,
+  #230). Non-Gemini requests are unchanged.
+
 - **Task validation rejects boolean `max_steps` values** — `Task(max_steps=True)`
   now raises `ConfigError` instead of silently converting `True` to a 1-step
   horizon (`bool` is a subclass of `int` in Python).

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.19.0"
+version = "0.19.1"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,7 +6,7 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.19.0"
+    assert inspect_robots_agent.__version__ == "0.19.1"
     assert callable(inspect_robots_agent.agent_policy)
     assert inspect_robots_agent.__all__ == [
         "ENV_MODEL",

--- a/uv.lock
+++ b/uv.lock
@@ -225,7 +225,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -397,7 +397,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.19.0"
+version = "0.19.1"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Publishes the Gemini thought_signature round-trip fix (#229, #230) via the next release run's `publish-agent` job. Adds the missing changelog entry for the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)