### PR TITLE
Embodiment-contributed guardrails: CLI hook for plugin safety approvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- Embodiments can contribute specialized approvers to the CLI's default
+  guardrail chain through the new public `GuardrailContribution` API. Generic
+  clamp and delta-limit gates remain first, contribution warnings stay visible,
+  and `DeltaLimitApprover.rewind_reference` safely supports hold substitutions.
+  The new public API is the rationale for the 0.31.0 minor release
+  ([plan 0034](plans/0034-embodiment-contributed-guardrails.md), #232).
+
 - Per-dimension `ActionSemantics.max_step` declarations let embodiments set
   absolute-control pacing and safety ceilings in native units. Default delta
   approval, agent-tool interpolation, and CaP-X motion queues honor mixed

--- a/README.md
+++ b/README.md
@@ -388,8 +388,9 @@ camera configuration, and reset behavior are documented in the
 [ROS plugin README](plugins/inspect-robots-ros/).
 
 Safety guardrails (a bounds clamp plus a per-step delta limit derived from
-the embodiment's action space) are wired into every CLI run by default, for
-every policy. Turning them off requires an explicit `--disable-guardrails`.
+the embodiment's action space, followed by any specialized guardrails the
+embodiment contributes) are wired into every CLI run by default, for every
+policy. Turning them off requires an explicit `--disable-guardrails`.
 Persist your usual setup once with `inspect-robots config set embodiment NAME`
 and `inspect-robots config set policy NAME`, then a bare
 `inspect-robots "wipe the table"` does the rest.

--- a/plans/0034-embodiment-contributed-guardrails.md
+++ b/plans/0034-embodiment-contributed-guardrails.md
@@ -55,6 +55,40 @@ newline (they land in a one-line banner); approvers must satisfy the
 `Approver` protocol shape (`callable review` attribute), checked with the same
 lenience the chain itself applies. Exported from `inspect_robots.approver`.
 
+The docstring also states the **behavioral contract** a contributed approver
+must honor as a chain member (today implicit in core's internals):
+
+- *Identity preservation*: return the incoming `Action` object itself when
+  approving unmodified — rollout detects modification by identity
+  (`ChainApprover` docstring); a fresh equal-valued object corrupts approval
+  events.
+- *Reference rewind on substitution*: an approver that substitutes a
+  different target (hold semantics) must rewind the delta limiter's reference
+  via `DeltaLimitApprover.rewind_reference` (below), or the limiter keeps
+  rating subsequent deltas against a target that never executed — permitting
+  a single-step jump from the real pose far larger than `max_delta`.
+- *Veto = `SafetyAbort`*: rejecting outright means raising `SafetyAbort`;
+  any other exception is treated as a bug and propagates.
+
+### 1b. Public store seam: `DeltaLimitApprover.rewind_reference`
+
+The delta limiter's store key is module-private (`_LAST_APPROVED_KEY`), and
+the first real contribution (yam's `CollisionApprover`) currently duplicates
+the string literal to rewind it — a silent-desync hazard: if core renames the
+key, the rewind becomes a no-op with no warning and the jump hazard above
+goes live. Since this plan creates the seam that invites third-party
+approvers behind the limiter, it also makes the interaction point public:
+
+```python
+@staticmethod
+def rewind_reference(store: dict[str, Any], pose: npt.NDArray[np.float64]) -> None:
+    """Reset the limiter's reference to ``pose`` if a reference exists."""
+```
+
+documented for exactly this substitution case, with a test pinning the
+store-key/helper coupling so a rename fails loudly. Yam plan 0017 switches
+`CollisionApprover` to call it.
+
 ### 2. The embodiment method (documented protocol, duck-typed)
 
 ```python
@@ -65,9 +99,18 @@ def contribute_guardrails(self, action_space: Box) -> GuardrailContribution: ...
   working, zero migration).
 - Instance method, not ClassVar: whether and how to contribute depends on the
   embodiment's runtime config (control interface, user opt-out flag).
-- Documented on the `Embodiment` protocol in `types.py` alongside `info`, with
-  the conformance suite gaining a shape check: *if* the attribute exists it
-  must be callable, and its result must be a `GuardrailContribution`.
+- Follows the `bind_task` precedent exactly (`embodiment.py`): documented in
+  the `Embodiment` Protocol docstring, deliberately **not** a Protocol
+  member, so existing embodiments remain `isinstance(x, Embodiment)`-
+  conformant under `runtime_checkable`.
+- Conformance: `check_embodiment` stays purely declarative and untouched (it
+  receives an `EmbodimentInfo`, cannot see instance methods, and must never
+  execute plugin code — `doctor` runs it against every installed adapter). A
+  new opt-in `check_guardrail_contribution(embodiment, action_space)` joins
+  `conformance.py` for adapter CI to call with an instance it constructed:
+  documented as allowed to execute plugin code, it asserts the attribute (if
+  present) is callable, the result is a `GuardrailContribution`, and the
+  contribution validates.
 - The contract mirrors `_build_guardrails`' own degrade philosophy: an
   embodiment that cannot contribute in the current mode returns a warning
   entry, never raises for "not applicable". Raising is reserved for actual
@@ -88,11 +131,15 @@ After the existing clamp/delta assembly:
 
 - `hook = getattr(embodiment, "contribute_guardrails", None)`; if absent →
   done (exact current behavior).
-- If present but not callable → warning
-  `"embodiment guardrails skipped: contribute_guardrails is not callable"`.
-- If calling it returns a non-`GuardrailContribution` → warning naming the
-  actual type (defensive: a plugin built against a newer/older core must
-  degrade visibly, not crash the banner).
+- If present but not callable, or if calling it returns anything that is not
+  a `GuardrailContribution` → **hard error** (`SystemExit` naming the
+  embodiment and the actual type). There is no legitimate version skew that
+  produces this: a plugin new enough to define the hook imports
+  `GuardrailContribution` from the installed core (same class object), and a
+  core too old to have the class never calls the hook. The branch catches
+  exactly plugin bugs, and a bug in a safety component halts the run — the
+  same stance as §2's "raising propagates". Degrading here would let a
+  default-on guardrail vanish behind a stderr warning.
 - Otherwise append each contributed approver to `parts`, its display name to
   `active`, and extend `warnings` with the contribution's warnings.
 
@@ -126,21 +173,34 @@ in-bounds.
 
 ## Tests
 
-`tests/test_cli_guardrails.py` (extending the existing `_build_guardrails`
-coverage):
+In `tests/test_registry_cli.py`, where the existing `_build_guardrails`
+coverage lives, plus `tests/test_approver.py` for the store seam:
 
 - No method → identical chain and banner to today (regression).
 - Contribution with one approver → appended after delta-limit, name in
   `active`, banner string exact.
+- Two contributed approvers → declaration order preserved in both chain and
+  banner; a contribution with both `approvers` and `warnings` non-empty
+  surfaces both.
 - Contribution with warnings only → warnings printed, chain unchanged.
-- Non-callable attribute / wrong return type → visible warning, generic chain
-  intact.
+- Non-callable attribute / wrong return type → `SystemExit` naming the
+  embodiment and type.
 - Contribution while clamp+delta are both skipped (unbounded space) → chain is
   contribution-only, `AutoApprover` fallback not taken.
 - `--disable-guardrails` with a contributing embodiment → no approver, no
   contribution call (method not invoked; assert via spy).
-- Conformance: embodiment with `contribute_guardrails` returning a wrong type
-  fails the shape check; absent attribute passes.
+- `rewind_reference`: rewinds an existing reference; no-op without one; a
+  test pinning it to the limiter's actual store key (rename fails loudly);
+  substitution scenario — approver behind the limiter holds an earlier pose,
+  rewinds, next delta is rated against the held pose.
+- Conformance: `check_guardrail_contribution` passes an absent attribute,
+  fails a non-callable one and a wrong return type; `check_embodiment`
+  behavior unchanged.
+
+A `ValueError` escaping a contribution (e.g. a mis-measured rig model
+rejected at approver construction) intentionally surfaces as a traceback
+rather than the friendly `SystemExit` used for embodiment construction
+errors: it is a bug-loudness path, not an operator-input path.
 
 ## Release
 

--- a/plans/0034-embodiment-contributed-guardrails.md
+++ b/plans/0034-embodiment-contributed-guardrails.md
@@ -1,0 +1,149 @@
+# 0034 — Embodiment-contributed guardrails
+
+Issue: #232. Sibling: inspect-robots-yam#93 / its plan 0017.
+
+## Problem
+
+The default CLI safety chain (`_build_guardrails`, plan 0008 §3e) is fixed:
+bounds clamp + per-step delta limit. Both are generic — they know the action
+space, not the robot. Embodiment plugins can ship materially stronger,
+embodiment-specific approvers: inspect-robots-yam's MuJoCo collision guardrail
+(yam #85/#86) predicts bimanual self-, cross-arm, and table collisions and
+holds at the last safe pose — complete, tested, and released. But no run path
+can activate it:
+
+- `_build_guardrails` builds only the two generic approvers; nothing consults
+  the embodiment.
+- The agent plugin's `pre_check` hook (#210) is programmatic-only by design
+  ("-P CLI flags cannot carry callables") — and it protects only the agent
+  policy, not scripted or learned policies, and sits *above* the approver
+  layer rather than below it.
+
+So a bimanual rig runs `clamp + delta-limit` while a purpose-built collision
+guardrail sits unreachable in the installed wheel. The gap is a missing seam,
+not a missing feature.
+
+## Design
+
+One optional, duck-typed embodiment method, consulted by `_build_guardrails`,
+appending embodiment-contributed approvers to the default chain. Contributions
+are **additive only**: the generic clamp + delta-limit stay exactly as they
+are, in front, so the CLI is never less protective with a contribution than
+without one. `--disable-guardrails` continues to disable the entire chain,
+contributions included.
+
+### 1. `GuardrailContribution` (approver.py)
+
+```python
+@dataclass(frozen=True)
+class GuardrailContribution:
+    """Approvers an embodiment adds to the CLI's default guardrail chain.
+
+    ``approvers`` pairs a short display name (shown in the ``guardrails:``
+    banner, e.g. ``"yam-collision"``) with the approver to append.
+    ``warnings`` name contributions the embodiment declined to make and why
+    (mode unsupported, optional dependency missing) — printed like the
+    builder's own skip warnings, so a declined contribution is always visible.
+    """
+
+    approvers: tuple[tuple[str, Approver], ...] = ()
+    warnings: tuple[str, ...] = ()
+```
+
+Validation in `__post_init__`: display names must be non-empty and contain no
+newline (they land in a one-line banner); approvers must satisfy the
+`Approver` protocol shape (`callable review` attribute), checked with the same
+lenience the chain itself applies. Exported from `inspect_robots.approver`.
+
+### 2. The embodiment method (documented protocol, duck-typed)
+
+```python
+def contribute_guardrails(self, action_space: Box) -> GuardrailContribution: ...
+```
+
+- Optional: absence means no contribution (every existing embodiment keeps
+  working, zero migration).
+- Instance method, not ClassVar: whether and how to contribute depends on the
+  embodiment's runtime config (control interface, user opt-out flag).
+- Documented on the `Embodiment` protocol in `types.py` alongside `info`, with
+  the conformance suite gaining a shape check: *if* the attribute exists it
+  must be callable, and its result must be a `GuardrailContribution`.
+- The contract mirrors `_build_guardrails`' own degrade philosophy: an
+  embodiment that cannot contribute in the current mode returns a warning
+  entry, never raises for "not applicable". Raising is reserved for actual
+  bugs and propagates — a safety component that fails unexpectedly must be
+  loud, not silently skipped.
+
+### 3. `_build_guardrails` (cli.py)
+
+Signature gains the embodiment:
+
+```python
+def _build_guardrails(
+    space: Box, max_action_delta: float | None, embodiment: Embodiment | None = None
+) -> tuple[Approver, list[str], list[str]]:
+```
+
+After the existing clamp/delta assembly:
+
+- `hook = getattr(embodiment, "contribute_guardrails", None)`; if absent →
+  done (exact current behavior).
+- If present but not callable → warning
+  `"embodiment guardrails skipped: contribute_guardrails is not callable"`.
+- If calling it returns a non-`GuardrailContribution` → warning naming the
+  actual type (defensive: a plugin built against a newer/older core must
+  degrade visibly, not crash the banner).
+- Otherwise append each contributed approver to `parts`, its display name to
+  `active`, and extend `warnings` with the contribution's warnings.
+
+`_build_and_announce_guardrails` passes `resolved.embodiment` through from
+both call sites (single-task and eval-set paths); the banner then reads e.g.
+`guardrails: clamp + delta-limit + yam-collision`. The `AutoApprover`
+fallback branch ("no guardrails are active…") is unreachable when a
+contribution exists, and the fallback message stays accurate: contributions
+append to `parts`, so `parts` non-empty ⇒ chain built.
+
+`--disable-guardrails` already returns before `_build_guardrails` is invoked;
+contributions are therefore disabled with everything else, and the
+`--max-action-delta`/`--disable-guardrails` conflict check is untouched.
+
+### 4. Ordering
+
+Chain order is `clamp → delta-limit → contributions…` (declaration order
+within a contribution). Contributed approvers see targets already clamped and
+rate-limited — the cheap generic gates run first, the expensive
+embodiment-specific ones last, and a contribution can rely on its input being
+in-bounds.
+
+## Not in scope
+
+- Contributions replacing or reordering the generic chain (additive only).
+- A CLI flag to disable a single contribution (opt-out belongs to the
+  embodiment's own config, where the wizard can interview it — see yam plan
+  0017).
+- Plumbing contributions into programmatic `eval()` callers: `eval()` already
+  accepts any `approver`; callers compose their own chain.
+
+## Tests
+
+`tests/test_cli_guardrails.py` (extending the existing `_build_guardrails`
+coverage):
+
+- No method → identical chain and banner to today (regression).
+- Contribution with one approver → appended after delta-limit, name in
+  `active`, banner string exact.
+- Contribution with warnings only → warnings printed, chain unchanged.
+- Non-callable attribute / wrong return type → visible warning, generic chain
+  intact.
+- Contribution while clamp+delta are both skipped (unbounded space) → chain is
+  contribution-only, `AutoApprover` fallback not taken.
+- `--disable-guardrails` with a contributing embodiment → no approver, no
+  contribution call (method not invoked; assert via spy).
+- Conformance: embodiment with `contribute_guardrails` returning a wrong type
+  fails the shape check; absent attribute passes.
+
+## Release
+
+Minor bump (new public API `GuardrailContribution`): core `0.31.0`. The yam
+plugin's floor bumps to `>=0.31` in its own PR (yam #93), which imports the
+dataclass.

--- a/plans/0034-embodiment-contributed-guardrails.md
+++ b/plans/0034-embodiment-contributed-guardrails.md
@@ -114,9 +114,10 @@ def contribute_guardrails(self, action_space: Box) -> GuardrailContribution: ...
   gains a default `contribute_guardrails` returning an empty
   `GuardrailContribution()` (bind_task has a no-op base default too);
   subclasses override to contribute.
-- Conformance: `check_embodiment` stays purely declarative and untouched (it
-  receives an `EmbodimentInfo`, cannot see instance methods, and must never
-  execute plugin code — `doctor` runs it against every installed adapter). A
+- Conformance: `check_embodiment` stays purely declarative and untouched: it
+  receives an `EmbodimentInfo` and cannot see instance methods, and `doctor`
+  — which runs it on the resolved adapter after a construct-only step — must
+  never be forced to invoke arbitrary plugin methods. A
   new opt-in `check_guardrail_contribution(embodiment, action_space)` joins
   `conformance.py` for adapter CI to call with an instance it constructed:
   documented as allowed to execute plugin code, it checks the attribute (if

--- a/plans/0034-embodiment-contributed-guardrails.md
+++ b/plans/0034-embodiment-contributed-guardrails.md
@@ -41,9 +41,11 @@ class GuardrailContribution:
 
     ``approvers`` pairs a short display name (shown in the ``guardrails:``
     banner, e.g. ``"yam-collision"``) with the approver to append.
-    ``warnings`` name contributions the embodiment declined to make and why
-    (mode unsupported, optional dependency missing) — printed like the
-    builder's own skip warnings, so a declined contribution is always visible.
+    ``warnings`` name contributions the embodiment declined to make or made
+    in a degraded state, and why (mode unsupported, optional dependency
+    missing, unmeasured configuration) — printed like the builder's own skip
+    warnings, so neither a declined nor a degraded contribution is ever
+    invisible. Warnings may accompany active approvers.
     """
 
     approvers: tuple[tuple[str, Approver], ...] = ()

--- a/plans/0034-embodiment-contributed-guardrails.md
+++ b/plans/0034-embodiment-contributed-guardrails.md
@@ -52,8 +52,8 @@ class GuardrailContribution:
 
 Validation in `__post_init__`: display names must be non-empty and contain no
 newline (they land in a one-line banner); approvers must satisfy the
-`Approver` protocol shape (`callable review` attribute), checked with the same
-lenience the chain itself applies. Exported from `inspect_robots.approver`.
+`Approver` protocol shape (a callable `review` attribute). Exported from
+`inspect_robots.approver`.
 
 The docstring also states the **behavioral contract** a contributed approver
 must honor as a chain member (today implicit in core's internals):
@@ -69,6 +69,11 @@ must honor as a chain member (today implicit in core's internals):
   a single-step jump from the real pose far larger than `max_delta`.
 - *Veto = `SafetyAbort`*: rejecting outright means raising `SafetyAbort`;
   any other exception is treated as a bug and propagates.
+- *Validate your own input*: a contribution must reject non-finite values
+  itself (`SafetyAbort`) and must not assume upstream clamping occurred —
+  on a degraded chain (unbounded space, both generic gates skipped) the
+  contribution is the first and only gate between raw policy output and
+  hardware.
 
 ### 1b. Public store seam: `DeltaLimitApprover.rewind_reference`
 
@@ -85,9 +90,10 @@ def rewind_reference(store: dict[str, Any], pose: npt.NDArray[np.float64]) -> No
     """Reset the limiter's reference to ``pose`` if a reference exists."""
 ```
 
-documented for exactly this substitution case, with a test pinning the
-store-key/helper coupling so a rename fails loudly. Yam plan 0017 switches
-`CollisionApprover` to call it.
+documented for exactly this substitution case — it **stores a copy** of the
+pose (callers must not end up aliasing the limiter's reference to a live
+array) — with a test pinning the store-key/helper coupling so a rename fails
+loudly. Yam plan 0017 switches `CollisionApprover` to call it.
 
 ### 2. The embodiment method (documented protocol, duck-typed)
 
@@ -99,18 +105,23 @@ def contribute_guardrails(self, action_space: Box) -> GuardrailContribution: ...
   working, zero migration).
 - Instance method, not ClassVar: whether and how to contribute depends on the
   embodiment's runtime config (control interface, user opt-out flag).
-- Follows the `bind_task` precedent exactly (`embodiment.py`): documented in
-  the `Embodiment` Protocol docstring, deliberately **not** a Protocol
-  member, so existing embodiments remain `isinstance(x, Embodiment)`-
-  conformant under `runtime_checkable`.
+- Follows the `bind_task` precedent (`embodiment.py`): documented in the
+  `Embodiment` Protocol docstring, deliberately **not** a Protocol member,
+  so existing embodiments remain `isinstance(x, Embodiment)`-conformant
+  under `runtime_checkable`. Completing the precedent, `EmbodimentBase`
+  gains a default `contribute_guardrails` returning an empty
+  `GuardrailContribution()` (bind_task has a no-op base default too);
+  subclasses override to contribute.
 - Conformance: `check_embodiment` stays purely declarative and untouched (it
   receives an `EmbodimentInfo`, cannot see instance methods, and must never
   execute plugin code — `doctor` runs it against every installed adapter). A
   new opt-in `check_guardrail_contribution(embodiment, action_space)` joins
   `conformance.py` for adapter CI to call with an instance it constructed:
-  documented as allowed to execute plugin code, it asserts the attribute (if
-  present) is callable, the result is a `GuardrailContribution`, and the
-  contribution validates.
+  documented as allowed to execute plugin code, it checks the attribute (if
+  present) is callable and the result is a valid `GuardrailContribution`. It
+  returns a `ConformanceReport` in the `check_embodiment` style, with an
+  `assert_guardrail_contribution_conformant` raising wrapper mirroring the
+  existing pair — so both CI idioms keep working.
 - The contract mirrors `_build_guardrails`' own degrade philosophy: an
   embodiment that cannot contribute in the current mode returns a warning
   entry, never raises for "not applicable". Raising is reserved for actual
@@ -157,10 +168,12 @@ contributions are therefore disabled with everything else, and the
 ### 4. Ordering
 
 Chain order is `clamp → delta-limit → contributions…` (declaration order
-within a contribution). Contributed approvers see targets already clamped and
-rate-limited — the cheap generic gates run first, the expensive
-embodiment-specific ones last, and a contribution can rely on its input being
-in-bounds.
+within a contribution). When the generic gates are active, contributed
+approvers see targets already clamped and rate-limited — cheap generic gates
+first, expensive embodiment-specific ones last. On a degraded chain (both
+generic gates skipped for an unbounded space) the contribution sees raw
+policy output, which is why the §1 contract requires contributions to
+validate their own input.
 
 ## Not in scope
 
@@ -174,7 +187,7 @@ in-bounds.
 ## Tests
 
 In `tests/test_registry_cli.py`, where the existing `_build_guardrails`
-coverage lives, plus `tests/test_approver.py` for the store seam:
+coverage lives, plus `tests/test_approvers.py` for the store seam:
 
 - No method → identical chain and banner to today (regression).
 - Contribution with one approver → appended after delta-limit, name in
@@ -189,13 +202,17 @@ coverage lives, plus `tests/test_approver.py` for the store seam:
   contribution-only, `AutoApprover` fallback not taken.
 - `--disable-guardrails` with a contributing embodiment → no approver, no
   contribution call (method not invoked; assert via spy).
-- `rewind_reference`: rewinds an existing reference; no-op without one; a
-  test pinning it to the limiter's actual store key (rename fails loudly);
-  substitution scenario — approver behind the limiter holds an earlier pose,
-  rewinds, next delta is rated against the held pose.
+- `rewind_reference`: rewinds an existing reference; no-op without one;
+  stores a copy (mutating the caller's array afterward must not move the
+  reference); a test pinning it to the limiter's actual store key (rename
+  fails loudly); substitution scenario — approver behind the limiter holds
+  an earlier pose, rewinds, next delta is rated against the held pose.
+- `EmbodimentBase` default returns an empty `GuardrailContribution()`; the
+  CLI treats it identically to an absent attribute (banner unchanged).
 - Conformance: `check_guardrail_contribution` passes an absent attribute,
-  fails a non-callable one and a wrong return type; `check_embodiment`
-  behavior unchanged.
+  fails a non-callable one and a wrong return type, and the
+  `assert_guardrail_contribution_conformant` wrapper raises on failure;
+  `check_embodiment` behavior unchanged.
 
 A `ValueError` escaping a contribution (e.g. a mis-measured rig model
 rejected at approver construction) intentionally surfaces as a traceback

--- a/plans/0034-embodiment-contributed-guardrails.md
+++ b/plans/0034-embodiment-contributed-guardrails.md
@@ -143,8 +143,11 @@ def _build_guardrails(
 
 After the existing clamp/delta assembly:
 
-- `hook = getattr(embodiment, "contribute_guardrails", None)`; if absent →
-  done (exact current behavior).
+- `hook = getattr(embodiment, "contribute_guardrails", missing)` with a
+  sentinel (not `None`): a genuinely absent attribute → done (exact current
+  behavior), while an attribute explicitly set to `None` is present-and-not-
+  callable and takes the hard-error path below — a default-on guardrail must
+  not vanish because a subclass nulled the hook.
 - If present but not callable, or if calling it returns anything that is not
   a `GuardrailContribution` → **hard error** (`SystemExit` naming the
   embodiment and the actual type). There is no legitimate version skew that

--- a/src/inspect_robots/approver.py
+++ b/src/inspect_robots/approver.py
@@ -9,7 +9,7 @@ passes everything through; clamping/operator approval land in rollout hardening.
 
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from typing import Any, Protocol, get_args, runtime_checkable
 
 import numpy as np
@@ -31,6 +31,36 @@ class Approver(Protocol):
     def review(self, action: Action, store: dict[str, Any]) -> Action:
         """Return the action to execute, or raise ``SafetyAbort`` to halt the evaluation."""
         ...
+
+
+@dataclass(frozen=True)
+class GuardrailContribution:
+    """Approvers an embodiment adds to the CLI's default guardrail chain.
+
+    ``approvers`` pairs a short display name (shown in the ``guardrails:``
+    banner) with each approver to append. ``warnings`` names contributions
+    the embodiment declined to make or made in a degraded state, and why, so
+    neither condition is invisible. Warnings may accompany active approvers.
+
+    A contributed approver must preserve the incoming ``Action`` object's
+    identity when approving it unmodified. If it substitutes another target,
+    such as holding an earlier pose, it must call
+    ``DeltaLimitApprover.rewind_reference`` with that executed pose so later
+    deltas are measured from reality. It vetoes by raising ``SafetyAbort``;
+    other exceptions are bugs and propagate. It must validate its own input,
+    rejecting non-finite values with ``SafetyAbort`` rather than assuming an
+    upstream clamp exists, because it may be the only active gate.
+    """
+
+    approvers: tuple[tuple[str, Approver], ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        for name, approver in self.approvers:
+            if not name or "\n" in name or "\r" in name:
+                raise ValueError("guardrail display names must be non-empty and newline-free")
+            if not callable(getattr(approver, "review", None)):
+                raise ValueError(f"guardrail approver {name!r} must have a callable review")
 
 
 class AutoApprover:
@@ -208,6 +238,18 @@ class DeltaLimitApprover:
                 )
             self._low = low if explicit is None else _intersect(low, -explicit, np.maximum)
             self._high = high if explicit is None else _intersect(high, explicit, np.minimum)
+
+    @staticmethod
+    def rewind_reference(store: dict[str, Any], pose: npt.NDArray[np.float64]) -> None:
+        """Reset an existing limiter reference to a copy of an executed pose.
+
+        A downstream approver that substitutes a target, such as holding an
+        earlier safe pose, must use this before the next action is reviewed so
+        the limiter measures subsequent deltas from the pose that actually ran.
+        If the limiter has not established a reference, this is a no-op.
+        """
+        if _LAST_APPROVED_KEY in store:
+            store[_LAST_APPROVED_KEY] = pose.copy()
 
     def review(self, action: Action, store: dict[str, Any]) -> Action:
         """Limit per-step change, retaining absolute-mode history in trial state."""

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -73,6 +73,7 @@ from inspect_robots.types import OPERATOR_END
 
 if TYPE_CHECKING:
     from inspect_robots.approver import Approver
+    from inspect_robots.embodiment import Embodiment
     from inspect_robots.log import EvalLog
     from inspect_robots.logging.sink import LogSink
     from inspect_robots.rollout import TrialRecord
@@ -533,7 +534,9 @@ def _resolve_or_exit(
 
 
 def _build_guardrails(
-    space: Box, max_action_delta: float | None
+    space: Box,
+    max_action_delta: float | None,
+    embodiment: Embodiment | None = None,
 ) -> tuple[Approver, list[str], list[str]]:
     """The default CLI safety chain for an action space (plan 0008 §3e).
 
@@ -548,6 +551,7 @@ def _build_guardrails(
         ChainApprover,
         ClampApprover,
         DeltaLimitApprover,
+        GuardrailContribution,
     )
 
     parts: list[Approver] = []
@@ -565,6 +569,28 @@ def _build_guardrails(
         active.append("delta-limit")
     except ValueError as exc:
         warnings.append(f"delta limit skipped: {exc}")
+
+    missing = object()
+    hook = getattr(embodiment, "contribute_guardrails", missing)
+    if hook is not missing:
+        if not callable(hook):
+            assert embodiment is not None
+            raise SystemExit(
+                f"embodiment {embodiment.info.name!r} contribute_guardrails is "
+                f"not callable (got {type(hook).__name__})"
+            )
+        contribution = hook(space)
+        if not isinstance(contribution, GuardrailContribution):
+            assert embodiment is not None
+            raise SystemExit(
+                f"embodiment {embodiment.info.name!r} contribute_guardrails returned "
+                f"{type(contribution).__name__}, expected GuardrailContribution"
+            )
+        for name, approver in contribution.approvers:
+            parts.append(approver)
+            active.append(name)
+        warnings.extend(contribution.warnings)
+
     if not parts:
         warnings.append(
             "no guardrails are active for this action space; declare bounds/semantics "
@@ -1103,7 +1129,9 @@ def _announce_components(resolved: _ResolvedComponents) -> None:
     print(f"embodiment: {resolved.embodiment_name} ({resolved.embodiment_source})")
 
 
-def _build_and_announce_guardrails(args: argparse.Namespace, action_space: Box) -> Approver | None:
+def _build_and_announce_guardrails(
+    args: argparse.Namespace, action_space: Box, embodiment: Embodiment
+) -> Approver | None:
     """Build the default guardrail chain for a run, announcing what is active.
 
     Guardrails are on by default (plan 0008 §3e): the approver chain sits below
@@ -1119,7 +1147,9 @@ def _build_and_announce_guardrails(args: argparse.Namespace, action_space: Box) 
         )
         print("guardrails: disabled (--disable-guardrails)")
         return None
-    approver, active, guard_warnings = _build_guardrails(action_space, args.max_action_delta)
+    approver, active, guard_warnings = _build_guardrails(
+        action_space, args.max_action_delta, embodiment
+    )
     for warning in guard_warnings:
         print(f"guardrails warning: {warning}", file=sys.stderr)
     print(f"guardrails: {' + '.join(active) if active else 'none active'}")
@@ -1185,7 +1215,9 @@ def _cmd_run(args: argparse.Namespace) -> int:
                 raise SystemExit(f"--epochs: {exc}") from exc
 
         _announce_components(resolved)
-        approver = _build_and_announce_guardrails(args, embodiment.info.action_space)
+        approver = _build_and_announce_guardrails(
+            args, embodiment.info.action_space, resolved.embodiment
+        )
 
         before_scoring = None
         if _attended(args):
@@ -1322,7 +1354,9 @@ def _cmd_eval_set(args: argparse.Namespace) -> int:
     try:
         _announce_components(resolved)
         print(f"tasks: {', '.join(task_names)}")
-        approver = _build_and_announce_guardrails(args, embodiment.info.action_space)
+        approver = _build_and_announce_guardrails(
+            args, embodiment.info.action_space, resolved.embodiment
+        )
         before_scoring = None
         if _attended(args):
             # Registered tasks only here: prompt for exactly the trials a human

--- a/src/inspect_robots/conformance.py
+++ b/src/inspect_robots/conformance.py
@@ -9,11 +9,12 @@ requirements into a checkable report so adapter repos can enforce them in CI
 (one test: ``assert_embodiment_conformant(MyEmbodiment().info)``) and users
 can audit an installed adapter via ``inspect-robots doctor``.
 
-The checks are purely declarative — nothing here touches hardware — which is
-also their limit: conformance proves an adapter is *guardrail-ready and
-agent-ready*, not that its declarations are honest (a delta rig declaring
-absolute-sized per-step bounds type-checks fine). The adapter authoring
-guide covers the human half.
+``check_embodiment`` is purely declarative and touches no hardware. The
+separate, opt-in ``check_guardrail_contribution`` executes plugin code to
+validate the optional runtime contribution hook. Conformance proves an
+adapter is *guardrail-ready and agent-ready*, not that its declarations are
+honest (a delta rig declaring absolute-sized per-step bounds type-checks
+fine). The adapter authoring guide covers the human half.
 """
 
 from __future__ import annotations
@@ -24,8 +25,9 @@ from dataclasses import dataclass, field
 
 import numpy as np
 
-from inspect_robots.embodiment import EmbodimentInfo
-from inspect_robots.spaces import ABSOLUTE_CONTROL_MODES
+from inspect_robots.approver import GuardrailContribution
+from inspect_robots.embodiment import Embodiment, EmbodimentInfo
+from inspect_robots.spaces import ABSOLUTE_CONTROL_MODES, Box
 
 DEVICE_KINDS = ("v4l2", "can", "serial")
 
@@ -246,5 +248,43 @@ def check_embodiment(info: EmbodimentInfo) -> ConformanceReport:
 def assert_embodiment_conformant(info: EmbodimentInfo) -> None:
     """Pytest-friendly wrapper: raise ``AssertionError`` with the full summary."""
     report = check_embodiment(info)
+    if not report.ok:
+        raise AssertionError(report.summary())
+
+
+def check_guardrail_contribution(embodiment: Embodiment, action_space: Box) -> ConformanceReport:
+    """Validate an optional contribution hook by executing plugin code.
+
+    An absent attribute passes. A present attribute must be callable and must
+    return ``GuardrailContribution``. Exceptions raised by the hook propagate
+    as plugin bugs. Unlike ``check_embodiment``, callers must opt in knowing
+    this check can run arbitrary adapter code.
+    """
+    missing = object()
+    hook = getattr(embodiment, "contribute_guardrails", missing)
+    if hook is missing:
+        return ConformanceReport(embodiment=embodiment.info.name)
+    if not callable(hook):
+        issue = ConformanceIssue(
+            "error",
+            "guardrail_contribution",
+            f"contribute_guardrails is not callable (got {type(hook).__name__})",
+        )
+        return ConformanceReport(embodiment=embodiment.info.name, issues=(issue,))
+    contribution = hook(action_space)
+    if not isinstance(contribution, GuardrailContribution):
+        issue = ConformanceIssue(
+            "error",
+            "guardrail_contribution",
+            f"contribute_guardrails returned {type(contribution).__name__}, "
+            "expected GuardrailContribution",
+        )
+        return ConformanceReport(embodiment=embodiment.info.name, issues=(issue,))
+    return ConformanceReport(embodiment=embodiment.info.name)
+
+
+def assert_guardrail_contribution_conformant(embodiment: Embodiment, action_space: Box) -> None:
+    """Raise ``AssertionError`` with the full contribution report on failure."""
+    report = check_guardrail_contribution(embodiment, action_space)
     if not report.ok:
         raise AssertionError(report.summary())

--- a/src/inspect_robots/embodiment.py
+++ b/src/inspect_robots/embodiment.py
@@ -22,6 +22,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+from inspect_robots.approver import GuardrailContribution
 from inspect_robots.scene import Scene
 from inspect_robots.spaces import Box, ObservationSpace
 from inspect_robots.types import Action, Observation, StepResult
@@ -80,6 +81,15 @@ class Embodiment(Protocol):
     fires once per ``eval()``, which can be several times over an embodiment's
     lifetime; each call replaces the previous envelope. ``EmbodimentBase``
     ships a no-op default.
+
+    Embodiments may also define an **optional**
+    ``contribute_guardrails(self, action_space: Box) -> GuardrailContribution``
+    hook, likewise omitted from this Protocol so existing implementations
+    remain runtime-conformant. The CLI calls it with the resolved action space
+    and appends its contribution after the generic clamp and delta limiter.
+    Direct ``rollout()`` and programmatic ``eval()`` callers compose their own
+    approvers, so the hook is CLI input rather than a universal callback.
+    ``EmbodimentBase`` returns an empty contribution by default.
     """
 
     info: EmbodimentInfo
@@ -118,6 +128,10 @@ class EmbodimentBase(ABC):
 
     def bind_task(self, envelope: TaskEnvelope) -> None:  # noqa: B027 - no-op default
         """Default: embodiments with nothing to display or pre-allocate ignore it."""
+
+    def contribute_guardrails(self, action_space: Box) -> GuardrailContribution:
+        """Default: embodiments without specialized safety gates contribute nothing."""
+        return GuardrailContribution()
 
     def close(self) -> None:  # noqa: B027 - intentional no-op default
         """Default: nothing to release."""

--- a/tests/test_approvers.py
+++ b/tests/test_approvers.py
@@ -8,10 +8,18 @@ bounds, or unaverageable rotation reps refuse loudly.
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 
-from inspect_robots.approver import ChainApprover, ClampApprover, DeltaLimitApprover
+from inspect_robots.approver import (
+    AutoApprover,
+    ChainApprover,
+    ClampApprover,
+    DeltaLimitApprover,
+    GuardrailContribution,
+)
 from inspect_robots.errors import SafetyAbort
 from inspect_robots.spaces import ActionSemantics, Box, RotationRepr
 from inspect_robots.types import Action
@@ -156,6 +164,77 @@ def test_absolute_reference_is_the_approved_action_not_the_request() -> None:
     assert np.allclose(out.data, [0.2, 0.0])  # walks, one clamped step at a time
 
 
+def test_rewind_reference_changes_an_existing_reference() -> None:
+    approver = DeltaLimitApprover(_abs_space(), max_delta=0.1)
+    store: dict[str, object] = {}
+    approver.review(Action(data=np.array([0.0, 0.0])), store)
+
+    DeltaLimitApprover.rewind_reference(store, np.array([0.5, 0.5]))
+    out = approver.review(Action(data=np.array([0.8, 0.8])), store)
+
+    assert np.allclose(out.data, [0.6, 0.6])
+
+
+def test_rewind_reference_is_a_noop_without_a_limiter_reference() -> None:
+    store: dict[str, object] = {"other": np.array([0.0, 0.0])}
+
+    DeltaLimitApprover.rewind_reference(store, np.array([0.5, 0.5]))
+
+    assert set(store) == {"other"}
+
+
+def test_rewind_reference_stores_a_copy() -> None:
+    approver = DeltaLimitApprover(_abs_space(), max_delta=0.1)
+    store: dict[str, object] = {}
+    approver.review(Action(data=np.array([0.0, 0.0])), store)
+    held = np.array([0.4, 0.4])
+
+    DeltaLimitApprover.rewind_reference(store, held)
+    held[:] = 0.9
+    out = approver.review(Action(data=np.array([0.8, 0.8])), store)
+
+    assert np.allclose(out.data, [0.5, 0.5])
+
+
+def test_rewind_reference_uses_the_limiter_store_key() -> None:
+    approver = DeltaLimitApprover(_abs_space(), max_delta=0.1)
+    store: dict[str, object] = {}
+    approver.review(Action(data=np.array([0.0, 0.0])), store)
+
+    assert set(store) == {"delta_limit:last"}
+    DeltaLimitApprover.rewind_reference(store, np.array([0.3, 0.4]))
+    reference = store["delta_limit:last"]
+    assert isinstance(reference, np.ndarray)
+    assert np.array_equal(reference, np.array([0.3, 0.4]))
+
+
+def test_substitution_rewinds_the_next_delta_reference() -> None:
+    held = Action(data=np.array([0.0, 0.0]))
+
+    class _HoldSecondTarget:
+        def __init__(self) -> None:
+            self._calls = 0
+
+        def review(self, action: Action, store: dict[str, Any]) -> Action:
+            self._calls += 1
+            if self._calls == 2:
+                DeltaLimitApprover.rewind_reference(store, np.asarray(held.data, dtype=np.float64))
+                return held
+            return action
+
+    chain = ChainApprover(
+        DeltaLimitApprover(_abs_space(), max_delta=0.1),
+        _HoldSecondTarget(),
+    )
+    store: dict[str, object] = {}
+    assert chain.review(held, store) is held
+    assert chain.review(Action(data=np.array([0.1, 0.0])), store) is held
+
+    out = chain.review(Action(data=np.array([0.2, 0.0])), store)
+
+    assert np.allclose(out.data, [0.1, 0.0])
+
+
 def test_absolute_derived_default_is_five_percent_of_range() -> None:
     approver = DeltaLimitApprover(_abs_space())  # ranges: 2.0 and 1.0
     store: dict[str, object] = {}
@@ -285,6 +364,21 @@ def test_nan_raises_safety_abort_in_both_branches() -> None:
         approver = DeltaLimitApprover(space, max_delta=0.1)
         with pytest.raises(SafetyAbort, match="NaN"):
             approver.review(Action(data=np.array([float("nan"), 0.0])), {})
+
+
+@pytest.mark.parametrize("name", ["", "line\nbreak", "line\rbreak"])
+def test_guardrail_contribution_rejects_invalid_display_names(name: str) -> None:
+    with pytest.raises(ValueError, match="display names"):
+        GuardrailContribution(approvers=((name, AutoApprover()),))
+
+
+def test_guardrail_contribution_requires_callable_review() -> None:
+    class _NotAnApprover:
+        review = 7
+
+    broken: Any = _NotAnApprover()
+    with pytest.raises(ValueError, match="callable review"):
+        GuardrailContribution(approvers=(("broken", broken),))
 
 
 def test_chain_runs_approvers_in_order() -> None:

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -6,7 +6,7 @@ import dataclasses
 import json
 import sys
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import pytest
 
@@ -3421,6 +3421,282 @@ def test_build_guardrails_full_chain_on_bounded_displacement_space() -> None:
     assert warnings == []
     out = approver.review(Action(data=np.array([5.0, 5.0])), {})
     assert out.meta.get("clamped") is True  # box bounds enforced
+
+
+def test_contributed_guardrail_follows_delta_limit_and_has_exact_banner(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import argparse
+
+    import numpy as np
+
+    from inspect_robots.approver import GuardrailContribution
+    from inspect_robots.cli import _build_and_announce_guardrails
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.spaces import Box
+    from inspect_robots.types import Action
+
+    seen: list[float] = []
+
+    class _Observer:
+        def review(self, action: Action, store: dict[str, Any]) -> Action:
+            seen.append(float(action.data[0]))
+            return action
+
+    class _ContributingEmbodiment(CubePickEmbodiment):
+        def contribute_guardrails(self, action_space: Box) -> GuardrailContribution:
+            return GuardrailContribution(approvers=(("collision", _Observer()),))
+
+    embodiment = _ContributingEmbodiment()
+    args = argparse.Namespace(disable_guardrails=False, max_action_delta=0.05)
+    approver = _build_and_announce_guardrails(args, embodiment.info.action_space, embodiment)
+    assert approver is not None
+    approver.review(Action(data=np.array([0.08, 0.0])), {})
+
+    assert seen == [0.05]
+    assert capsys.readouterr().out == "guardrails: clamp + delta-limit + collision\n"
+
+
+def test_contributed_approvers_keep_declaration_order_and_warnings() -> None:
+    import numpy as np
+
+    from inspect_robots.approver import GuardrailContribution
+    from inspect_robots.cli import _build_guardrails
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.spaces import Box
+    from inspect_robots.types import Action
+
+    calls: list[str] = []
+
+    class _Recorder:
+        def __init__(self, name: str) -> None:
+            self._name = name
+
+        def review(self, action: Action, store: dict[str, Any]) -> Action:
+            calls.append(self._name)
+            return action
+
+    class _ContributingEmbodiment(CubePickEmbodiment):
+        def contribute_guardrails(self, action_space: Box) -> GuardrailContribution:
+            return GuardrailContribution(
+                approvers=(
+                    ("first", _Recorder("first")),
+                    ("second", _Recorder("second")),
+                ),
+                warnings=("collision model is running without table geometry",),
+            )
+
+    embodiment = _ContributingEmbodiment()
+    approver, active, warnings = _build_guardrails(embodiment.info.action_space, None, embodiment)
+    approver.review(Action(data=np.array([0.01, 0.01])), {})
+
+    assert calls == ["first", "second"]
+    assert active == ["clamp", "delta-limit", "first", "second"]
+    assert warnings == ["collision model is running without table geometry"]
+
+
+def test_warnings_only_contribution_keeps_the_generic_chain(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import argparse
+
+    import numpy as np
+
+    from inspect_robots.approver import GuardrailContribution
+    from inspect_robots.cli import _build_and_announce_guardrails
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.spaces import Box
+    from inspect_robots.types import Action
+
+    class _WarningEmbodiment(CubePickEmbodiment):
+        def contribute_guardrails(self, action_space: Box) -> GuardrailContribution:
+            return GuardrailContribution(warnings=("collision guardrail unavailable",))
+
+    embodiment = _WarningEmbodiment()
+    args = argparse.Namespace(disable_guardrails=False, max_action_delta=None)
+    approver = _build_and_announce_guardrails(args, embodiment.info.action_space, embodiment)
+    assert approver is not None
+    action = Action(data=np.array([0.01, 0.01]))
+
+    assert approver.review(action, {}) is action
+    captured = capsys.readouterr()
+    assert captured.out == "guardrails: clamp + delta-limit\n"
+    assert captured.err == "guardrails warning: collision guardrail unavailable\n"
+
+
+def test_non_callable_guardrail_hook_is_a_hard_error() -> None:
+    from inspect_robots.cli import _build_guardrails
+    from inspect_robots.mock import CubePickEmbodiment
+
+    class _BrokenEmbodiment(CubePickEmbodiment):
+        contribute_guardrails = 7
+
+    embodiment = _BrokenEmbodiment()
+    with pytest.raises(SystemExit, match=r"cubepick.*int"):
+        _build_guardrails(embodiment.info.action_space, None, embodiment)
+
+
+def test_none_guardrail_hook_is_a_hard_error() -> None:
+    from inspect_robots.cli import _build_guardrails
+    from inspect_robots.mock import CubePickEmbodiment
+
+    class _BrokenEmbodiment(CubePickEmbodiment):
+        contribute_guardrails = None
+
+    embodiment = _BrokenEmbodiment()
+    with pytest.raises(SystemExit, match=r"cubepick.*NoneType"):
+        _build_guardrails(embodiment.info.action_space, None, embodiment)
+
+
+def test_wrong_guardrail_contribution_type_is_a_hard_error() -> None:
+    from inspect_robots.cli import _build_guardrails
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.spaces import Box
+
+    class _BrokenEmbodiment(CubePickEmbodiment):
+        def contribute_guardrails(self, action_space: Box) -> object:
+            return "not a contribution"
+
+    embodiment = _BrokenEmbodiment()
+    with pytest.raises(SystemExit, match=r"cubepick.*str"):
+        _build_guardrails(embodiment.info.action_space, None, embodiment)
+
+
+def test_contribution_is_the_only_gate_for_an_unbounded_space() -> None:
+    import numpy as np
+
+    from inspect_robots.approver import ChainApprover, GuardrailContribution
+    from inspect_robots.cli import _build_guardrails
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.spaces import Box
+    from inspect_robots.types import Action
+
+    calls: list[Action] = []
+
+    class _OnlyGate:
+        def review(self, action: Action, store: dict[str, Any]) -> Action:
+            calls.append(action)
+            return action
+
+    class _ContributingEmbodiment(CubePickEmbodiment):
+        def contribute_guardrails(self, action_space: Box) -> GuardrailContribution:
+            return GuardrailContribution(approvers=(("only-gate", _OnlyGate()),))
+
+    embodiment = _ContributingEmbodiment()
+    space = Box(shape=(2,))
+    approver, active, warnings = _build_guardrails(space, None, embodiment)
+    action = Action(data=np.array([4.0, 5.0]))
+
+    assert isinstance(approver, ChainApprover)
+    assert approver.review(action, {}) is action
+    assert calls == [action]
+    assert active == ["only-gate"]
+    assert not any("no guardrails" in warning for warning in warnings)
+
+
+def test_disable_guardrails_does_not_invoke_contribution(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import argparse
+
+    from inspect_robots.approver import GuardrailContribution
+    from inspect_robots.cli import _build_and_announce_guardrails
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.spaces import Box
+
+    calls: list[Box] = []
+
+    class _ContributingEmbodiment(CubePickEmbodiment):
+        def contribute_guardrails(self, action_space: Box) -> GuardrailContribution:
+            calls.append(action_space)
+            return GuardrailContribution()
+
+    embodiment = _ContributingEmbodiment()
+    args = argparse.Namespace(disable_guardrails=True, max_action_delta=None)
+
+    approver = _build_and_announce_guardrails(args, embodiment.info.action_space, embodiment)
+    assert approver is None
+    assert calls == []
+    assert "guardrails: disabled" in capsys.readouterr().out
+
+
+def test_embodiment_base_default_matches_an_absent_hook() -> None:
+    from inspect_robots.approver import GuardrailContribution
+    from inspect_robots.cli import _build_guardrails
+    from inspect_robots.embodiment import EmbodimentBase
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.scene import Scene
+    from inspect_robots.types import Action, Observation, StepResult
+
+    class _BaseEmbodiment(EmbodimentBase):
+        def __init__(self) -> None:
+            self._delegate = CubePickEmbodiment()
+            self.info = self._delegate.info
+
+        def reset(self, scene: Scene, *, seed: int | None = None) -> Observation:
+            return self._delegate.reset(scene, seed=seed)
+
+        def step(self, action: Action) -> StepResult:
+            return self._delegate.step(action)
+
+    absent = CubePickEmbodiment()
+    base = _BaseEmbodiment()
+
+    _, absent_active, absent_warnings = _build_guardrails(absent.info.action_space, None, absent)
+    _, base_active, base_warnings = _build_guardrails(base.info.action_space, None, base)
+
+    assert base.contribute_guardrails(base.info.action_space) == GuardrailContribution()
+    assert (base_active, base_warnings) == (absent_active, absent_warnings)
+
+
+def test_guardrail_contribution_conformance_passes_absent_and_valid_hooks() -> None:
+    from inspect_robots.approver import GuardrailContribution
+    from inspect_robots.conformance import (
+        assert_guardrail_contribution_conformant,
+        check_guardrail_contribution,
+    )
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.spaces import Box
+
+    class _ValidEmbodiment(CubePickEmbodiment):
+        def contribute_guardrails(self, action_space: Box) -> GuardrailContribution:
+            return GuardrailContribution()
+
+    absent = CubePickEmbodiment()
+    valid = _ValidEmbodiment()
+
+    assert check_guardrail_contribution(absent, absent.info.action_space).ok
+    assert check_guardrail_contribution(valid, valid.info.action_space).ok
+    assert_guardrail_contribution_conformant(valid, valid.info.action_space)
+
+
+def test_guardrail_contribution_conformance_reports_bad_hooks() -> None:
+    from inspect_robots.conformance import (
+        assert_guardrail_contribution_conformant,
+        check_guardrail_contribution,
+    )
+    from inspect_robots.mock import CubePickEmbodiment
+    from inspect_robots.spaces import Box
+
+    class _NonCallableEmbodiment(CubePickEmbodiment):
+        contribute_guardrails = 7
+
+    class _WrongTypeEmbodiment(CubePickEmbodiment):
+        def contribute_guardrails(self, action_space: Box) -> object:
+            return "not a contribution"
+
+    non_callable = _NonCallableEmbodiment()
+    wrong_type = _WrongTypeEmbodiment()
+
+    report = check_guardrail_contribution(non_callable, non_callable.info.action_space)
+    assert not report.ok
+    assert "int" in report.summary()
+
+    report = check_guardrail_contribution(wrong_type, wrong_type.info.action_space)
+    assert not report.ok
+    assert "str" in report.summary()
+    with pytest.raises(AssertionError, match="GuardrailContribution"):
+        assert_guardrail_contribution_conformant(wrong_type, wrong_type.info.action_space)
 
 
 def test_build_guardrails_threads_max_action_delta() -> None:


### PR DESCRIPTION
Closes #232.

Adds an optional, duck-typed `contribute_guardrails(action_space)` embodiment method consulted by `_build_guardrails`, so embodiment plugins can append purpose-built approvers (e.g. yam's MuJoCo collision guardrail, robocurve/inspect-robots-yam#93) to the default clamp + delta-limit chain — visible in the `guardrails:` banner, degrading with visible warnings, disabled by `--disable-guardrails` like everything else.

Plan: `plans/0034-embodiment-contributed-guardrails.md` (critique loop in progress; implementation follows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)