### PR TITLE
view: accept a logs directory and render a browsable index of all runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- `inspect-robots view` now accepts a logs directory and incrementally renders
+  self-contained per-run reports plus a searchable browsable index, with
+  unreadable logs surfaced in place instead of aborting the whole directory
+  ([plan 0035](plans/0035-view-log-directory.md), #234).
+
 - Embodiments can contribute specialized approvers to the CLI's default
   guardrail chain through the new public `GuardrailContribution` API. Generic
   clamp and delta-limit gates remain first, contribution warnings stay visible,

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ inspect-robots "place the fork on the plate" --policy agent \
 Read the recorded agent conversation with
 `inspect-robots inspect LOG.json --transcript`, or open the HTML report with
 `inspect-robots view LOG.json`. For `--store-frames` runs it includes the
-camera frames the model saw.
+camera frames the model saw. Once a few runs have accumulated,
+`inspect-robots view logs/` renders them all and builds a browsable index.
 
 ### Fast Opus 5 streamed to a remote Rerun viewer
 
@@ -222,6 +223,21 @@ Render a saved eval log as a self-contained HTML report:
 ```bash
 inspect-robots view logs/cubepick-reach_*.json
 ```
+
+Browse a whole logs directory: pass the directory instead of a file and every
+log is rendered into `logs/html/` behind a filterable `index.html` — when,
+instruction, policy/model, status, metrics, termination, and error for each
+run, newest first, with rows linking to the per-log reports:
+
+```bash
+inspect-robots view logs/
+```
+
+Re-runs are incremental (only new or changed logs are re-rendered; `--force`
+re-renders everything, e.g. after changing `--no-frames` or
+`--frames-budget`). Open the index directly with `--open`, or serve it to
+another machine with any static file server, e.g.
+`python3 -m http.server -d logs/html`.
 
 Render a `--store-frames` run's camera frames to MP4 videos (needs the
 `ffmpeg` binary on PATH):

--- a/plans/0035-view-log-directory.md
+++ b/plans/0035-view-log-directory.md
@@ -34,7 +34,10 @@ renders logs to HTML" — with the argument deciding scope.
     `<dir>/html/index.html`. A log whose stem is exactly `index` renders to
     `html/index_log.html` — suffixed further (`index_log_2.html`, …) until
     free, so the remap cannot itself clobber another log's page (documented
-    in the subcommand help). If `<dir>/html` exists and is not a directory:
+    in the subcommand help). "Free" is resolved against the computed set of
+    target page names for this run, **not** against the filesystem —
+    probing disk would see run 1's own `index_log.html` as taken and orphan
+    a fresh page every incremental re-run. If `<dir>/html` exists and is not a directory:
     `SystemExit` with a clear message, before any rendering.
   - `-o PATH` (metavar changes from FILE to PATH): in single-file mode an
     output HTML file, exactly as today; in directory mode an output

--- a/plans/0035-view-log-directory.md
+++ b/plans/0035-view-log-directory.md
@@ -28,29 +28,48 @@ renders logs to HTML" — with the argument deciding scope.
   render a browsable index`.
 - Directory mode semantics:
   - Renders every top-level `*.json` in the directory (no recursion; frames/
-    transcript/wire subdirectories live below and are not logs).
+    transcript/wire/learnings subdirectories are not logs; the sink's atomic
+    `.json.tmp` + `os.replace` write means the glob never sees partials).
   - Per-log pages land in `<dir>/html/<log-stem>.html`; the index at
-    `<dir>/html/index.html`.
-  - `-o DIR` overrides the output directory (created if missing). `-o -` is
-    rejected in directory mode: there is no single document to stream.
+    `<dir>/html/index.html`. A log whose stem is exactly `index` renders to
+    `html/index_log.html` so it cannot clobber the index (documented in the
+    subcommand help). If `<dir>/html` exists and is not a directory:
+    `SystemExit` with a clear message, before any rendering.
+  - `-o PATH` (metavar changes from FILE to PATH): in single-file mode an
+    output HTML file, exactly as today; in directory mode an output
+    *directory*, created if missing, replacing the `<dir>/html` default. If
+    it exists and is a regular file in directory mode: `SystemExit`. The
+    existing "is a directory" guard applies only in single-file mode. `-o -`
+    is rejected in directory mode: there is no single document to stream.
   - `--open` opens `index.html`.
   - `--no-frames` / `--frames-budget` pass through to every per-log render.
+    The budget is **per page**; help text says so explicitly, since a
+    first render of a large directory multiplies it (the totals line reports
+    cumulative bytes written, so the cost is visible, and `--no-frames`
+    or a lower budget is the stated remedy).
   - New flag `--force`: re-render pages that already exist. Without it,
     rendering is incremental — a page is re-rendered only when missing or
     older than its log (mtime comparison), so re-running after a few new runs
-    is quick. `--force` is accepted and ignored in single-file mode (a single
-    render is always "forced"); documented as directory-mode only.
+    is quick. Changing `--frames-budget`/`--no-frames` between runs does not
+    invalidate existing pages; `--force` is the refresh path and its help
+    text says so. `--force` is accepted and ignored in single-file mode.
+    Incremental applies to page rendering only: index metadata still parses
+    every log each run (`read_eval_log` is O(log bytes)), which is fine for
+    v1 and stated here so nobody expects a no-op re-run to be free.
 - Progress goes to stderr (`[i/N] rendering <name>`), one line per log
   actually rendered, so a large first run is visibly alive while stdout stays
-  clean. A final line reports totals: `index: <path> (N logs, M pages)`.
-- Exit code 0 when the index is written, even if individual logs were
+  clean. The final totals line goes to stdout (mirroring plan 0022's `wrote`
+  line): `index: <path> (N logs, M pages, X MB)`.
+- Exit codes: 0 when the index is written, even if individual logs were
   unreadable — those are surfaced as error rows in the index and warnings on
-  stderr. (A directory with no `*.json` at all is a usage error: exit 2 with
-  a message, no empty index.)
+  stderr. A directory with no top-level `*.json` at all is a runtime usage
+  error: `SystemExit` with a message (exit 1, matching every other runtime
+  validation error in cli.py), no empty index.
 
 ### 2. Index rendering (`_html_index.py`)
 
-New private module, sibling to `_html.py`, exporting one function:
+New private module (naming per `_video.py`/`_summarize.py`), exporting one
+function:
 
 ```python
 def render_index(entries: Sequence[IndexEntry], *, title: str = "Inspect Robots runs") -> str
@@ -58,9 +77,10 @@ def render_index(entries: Sequence[IndexEntry], *, title: str = "Inspect Robots 
 
 with a small frozen dataclass `IndexEntry` carrying: `name` (log filename),
 `page` (relative href or None), `created`, `instruction`, `policy`, `model`,
-`status`, `errored` (bool), `reduced` (mapping), `termination`, `error`,
-`size_mb`. The CLI builds entries; the module renders. This keeps the module
-pure (string in, string out) and testable without touching the filesystem.
+`status` (display string), `status_class` (badge class), `metrics` (mapping,
+run-level), `termination`, `error`, `size_mb`. The CLI builds entries; the
+module renders. This keeps the module pure (string in, string out) and
+testable without touching the filesystem.
 
 Index page properties:
 
@@ -69,14 +89,24 @@ Index page properties:
   dark palette — same constraints `_html.py` already honors.
 - Table sorted newest-first by `created` (falling back to file mtime when a
   log is unreadable), columns: When, Instruction, Policy (policy / model
-  tail), Outcome, Score, Termination, Error, Log. Instruction and Log cells
+  tail), Status, Metrics, Termination, Error, Log. Instruction and Log cells
   link to the page when one exists.
-- Outcome badge derived in the CLI, not the template: `error` when the log
-  status is error or any trial errored; `cancelled`; else `success` /
-  `failure` from whether any reduced metric reaches 1.0; `?` when no reduced
-  metrics exist. (The reduced scorer metric is the task verdict; run status
-  only says the run completed. `operator_judgements` is not it either —
-  stock rollout never populates it.)
+- **Status, not verdict guessing.** The badge shows the run status through
+  the existing display mapping (`_display_status`): completed / error /
+  cancelled, with error also when any trial errored. The Metrics column
+  shows the **run-level** `log.results.metrics` (`name=value`, 4 sig figs) —
+  the same aggregate `run`/`inspect` print. No success/failure inference
+  from a 1.0 threshold: reduced values are epoch means (1-of-2 trials is
+  0.5) and metrics like `min_distance_to_goal` invert the scale, so any
+  threshold badge would contradict the repo's existing outcome vocabulary
+  (`_outcome_line`, `_display_status`). Users judge from the metrics they
+  chose; the report page has the full per-scene story.
+- **Multi-scene aware.** Instruction column: the shared instruction when all
+  scenes share one (the `shared` logic `_cmd_inspect` already applies);
+  otherwise `"<n> scenes"`. Termination column: the union of termination
+  reasons across all scenes, deduplicated, order-preserved. `log.samples`
+  may be empty (cancelled before the first trial): every per-sample access
+  is guarded and such logs still get a row (status badge carries the story).
 - A filter input that hides non-matching rows on substring match across the
   row text, persisted to `localStorage` so a reload keeps the filter.
 - All user-controlled strings HTML-escaped; errors truncated in-cell with the
@@ -96,39 +126,46 @@ that `read_eval_log` rejects (truncated write, foreign JSON) contributes an
 index row with `error="unreadable: …"`, no page, and a stderr warning — one
 bad file must not sink the index.
 
-Entry metadata for readable logs comes from the parsed `EvalLog` (first
-sample's instruction, `eval.policy`, `policy_config["model"]`, reduced
-metrics of the first sample, termination reasons), mirroring what the per-log
-report shows.
-
 ### 4. Hints (cli.py)
 
-The two hint blocks gain one directory-level line, emitted only when the log's
-parent directory is plausible (always is — logs are written into a directory):
-
-- Post-run block (`hint: render videos with…` neighborhood):
+- Post-run block (`hint: render videos with…` neighborhood) gains, last (it
+  is the widest-scope hint):
   `hint: browse all logs: inspect-robots view <log_dir>`
-- Eval-set completion block: same line with the set's `log_dir`.
+- Eval-set completion block: the existing
+  `hint: HTML viewer: inspect-robots view {log_dir}/<task>_<id>.json`
+  placeholder line (which the user must hand-edit) is **replaced** by
+  `hint: browse all logs: inspect-robots view {log_dir}` — the directory form
+  strictly dominates it, and two adjacent view hints would be noise.
 
-Placed last in each block: it is the widest-scope hint.
+## Tests (tests/test_html_index.py + tests/test_registry_cli.py)
 
-## Tests (tests/test_html_index.py + additions to tests/test_cli_view.py area)
+`test_html_index.py` (pure renderer):
 
-- `render_index`: escaping (instruction with `<script>`), link vs no-link
-  rows, badge classes for each outcome, newest-first ordering, empty-entries
-  rejected upstream (never called with zero entries).
+- Escaping (instruction containing `<script>`), link vs no-link rows, badge
+  class per status, newest-first ordering, metrics formatting, filter JS and
+  localStorage key present in the document.
+
+`test_registry_cli.py` (CLI-level, alongside the existing `test_view_*`):
+
 - Directory mode end-to-end (tmp_path): two small synthetic logs → pages +
-  index exist, index references both; unreadable third file → warning row, no
-  page, exit 0.
-- Incremental behavior: second invocation renders nothing (mtimes honored);
-  touching a log re-renders its page; `--force` re-renders all.
-- Flag validation: `-o -` with a directory exits with a usage error; `--open`
-  targets index.html (monkeypatched webbrowser).
+  index exist, index references both; unreadable third file → error row, no
+  page, exit 0; multi-scene log shows shared instruction and run-level
+  metrics; empty-samples log gets a row without crashing.
+- Incremental behavior: second invocation renders nothing; a log made newer
+  than its page via explicit `os.utime` (not sleep — same-second mtimes on
+  coarse filesystems) re-renders exactly that page; `--force` re-renders all.
+- Collisions and flags: log named `index.json` → page at `index_log.html`,
+  index intact; `<dir>/html` as regular file → clean `SystemExit`; `-o -`
+  with a directory → clean `SystemExit`; `-o` pointing at an existing file in
+  directory mode → clean `SystemExit`; empty directory → clean `SystemExit`;
+  `--open` targets `index.html` (monkeypatched webbrowser).
 - Hint lines: post-run output includes the browse-all hint with the right
-  directory.
+  directory; eval-set output includes the directory hint and no longer the
+  placeholder per-file hint.
 
 ## Rollout
 
 Pure addition to the CLI + one new private module; no schema, wire, or plugin
-surface changes. Changelog entry under core. No version gate needed by
-downstream embodiment packages.
+surface changes. Changelog: `### Added` entry under `[Unreleased]` in the
+root `CHANGELOG.md` with the `(plan 0035, #234)` reference recent entries
+use. No version gate needed by downstream embodiment packages.

--- a/plans/0035-view-log-directory.md
+++ b/plans/0035-view-log-directory.md
@@ -32,8 +32,9 @@ renders logs to HTML" — with the argument deciding scope.
     `.json.tmp` + `os.replace` write means the glob never sees partials).
   - Per-log pages land in `<dir>/html/<log-stem>.html`; the index at
     `<dir>/html/index.html`. A log whose stem is exactly `index` renders to
-    `html/index_log.html` so it cannot clobber the index (documented in the
-    subcommand help). If `<dir>/html` exists and is not a directory:
+    `html/index_log.html` — suffixed further (`index_log_2.html`, …) until
+    free, so the remap cannot itself clobber another log's page (documented
+    in the subcommand help). If `<dir>/html` exists and is not a directory:
     `SystemExit` with a clear message, before any rendering.
   - `-o PATH` (metavar changes from FILE to PATH): in single-file mode an
     output HTML file, exactly as today; in directory mode an output
@@ -78,8 +79,8 @@ def render_index(entries: Sequence[IndexEntry], *, title: str = "Inspect Robots 
 with a small frozen dataclass `IndexEntry` carrying: `name` (log filename),
 `page` (relative href or None), `created`, `instruction`, `policy`, `model`,
 `status` (display string), `status_class` (badge class), `metrics` (mapping,
-run-level), `termination`, `error`, `size_mb`. The CLI builds entries; the
-module renders. This keeps the module pure (string in, string out) and
+run-level), `errored_trials` (int), `termination`, `error`. The CLI builds
+entries; the module renders. This keeps the module pure (string in, string out) and
 testable without touching the filesystem.
 
 Index page properties:
@@ -91,11 +92,15 @@ Index page properties:
   log is unreadable), columns: When, Instruction, Policy (policy / model
   tail), Status, Metrics, Termination, Error, Log. Instruction and Log cells
   link to the page when one exists.
-- **Status, not verdict guessing.** The badge shows the run status through
-  the existing display mapping (`_display_status`): completed / error /
-  cancelled, with error also when any trial errored. The Metrics column
-  shows the **run-level** `log.results.metrics` (`name=value`, 4 sig figs) —
-  the same aggregate `run`/`inspect` print. No success/failure inference
+- **Status, not verdict guessing.** The badge is strictly
+  `_display_status(log.status)`: completed / error / cancelled — never
+  rewritten by trial errors, matching how `run` and `inspect` keep the
+  persisted status intact and surface trial errors as an annotation
+  (`trials: N (M errored)`). The Metrics column shows the **run-level**
+  `log.results.metrics` (`name=value`, 4 sig figs) — the same aggregate
+  `run`/`inspect` print — followed by an `(M errored)` marker when
+  `errored_trials > 0`, styled as an error accent so mixed runs are visible
+  at a glance without misstating their status. No success/failure inference
   from a 1.0 threshold: reduced values are epoch means (1-of-2 trials is
   0.5) and metrics like `min_distance_to_goal` invert the scale, so any
   threshold badge would contradict the repo's existing outcome vocabulary
@@ -104,7 +109,10 @@ Index page properties:
 - **Multi-scene aware.** Instruction column: the shared instruction when all
   scenes share one (the `shared` logic `_cmd_inspect` already applies);
   otherwise `"<n> scenes"`. Termination column: the union of termination
-  reasons across all scenes, deduplicated, order-preserved. `log.samples`
+  reasons across all scenes, deduplicated, order-preserved, with `None`
+  entries skipped and each reason rendered through the `_OUTCOME_PHRASES`
+  mapping `_outcome_line` already uses (raw token as fallback), so the index
+  speaks the same vocabulary as `run`/`inspect`. `log.samples`
   may be empty (cancelled before the first trial): every per-sample access
   is guarded and such logs still get a row (status badge carries the story).
 - A filter input that hides non-matching rows on substring match across the
@@ -131,11 +139,14 @@ bad file must not sink the index.
 - Post-run block (`hint: render videos with…` neighborhood) gains, last (it
   is the widest-scope hint):
   `hint: browse all logs: inspect-robots view <log_dir>`
-- Eval-set completion block: the existing
+- Eval-set completion block **and** the eval-set `KeyboardInterrupt` path
+  (which prints the same placeholder because it holds no per-task sink
+  paths): the existing
   `hint: HTML viewer: inspect-robots view {log_dir}/<task>_<id>.json`
-  placeholder line (which the user must hand-edit) is **replaced** by
+  placeholder lines (which the user must hand-edit) are **replaced** by
   `hint: browse all logs: inspect-robots view {log_dir}` — the directory form
-  strictly dominates it, and two adjacent view hints would be noise.
+  strictly dominates them; on the interrupt path especially, the user holds a
+  directory of partial logs and knows no filenames.
 
 ## Tests (tests/test_html_index.py + tests/test_registry_cli.py)
 
@@ -150,7 +161,9 @@ bad file must not sink the index.
 - Directory mode end-to-end (tmp_path): two small synthetic logs → pages +
   index exist, index references both; unreadable third file → error row, no
   page, exit 0; multi-scene log shows shared instruction and run-level
-  metrics; empty-samples log gets a row without crashing.
+  metrics; empty-samples log gets a row without crashing; a completed run
+  with an errored trial keeps the completed badge and shows the
+  `(1 errored)` marker.
 - Incremental behavior: second invocation renders nothing; a log made newer
   than its page via explicit `os.utime` (not sleep — same-second mtimes on
   coarse filesystems) re-renders exactly that page; `--force` re-renders all.
@@ -160,8 +173,8 @@ bad file must not sink the index.
   directory mode → clean `SystemExit`; empty directory → clean `SystemExit`;
   `--open` targets `index.html` (monkeypatched webbrowser).
 - Hint lines: post-run output includes the browse-all hint with the right
-  directory; eval-set output includes the directory hint and no longer the
-  placeholder per-file hint.
+  directory; eval-set completion and interrupt outputs include the directory
+  hint and no longer the placeholder per-file hint.
 
 ## Rollout
 

--- a/plans/0035-view-log-directory.md
+++ b/plans/0035-view-log-directory.md
@@ -1,0 +1,134 @@
+# 0035 — `view` on a logs directory: browsable index of all runs
+
+Issue: #234.
+
+## Problem
+
+`inspect-robots view` renders exactly one log to one self-contained HTML
+report. A working `logs/` directory accumulates hundreds of runs, and the
+package offers no way to browse them: which runs happened, with which policy,
+which succeeded, which errored, and where the report for each one is. Users
+hand-roll index builders that shell out to `view` per log (the rig carries a
+~170-line `build_log_index.py` doing exactly this).
+
+The post-run hint block advertises `inspect`, `view`, and `video` for the log
+just written, but nothing points at the directory-level story, because none
+exists.
+
+## Design
+
+Directory support folds into the existing subcommand rather than adding a new
+one: `inspect-robots view logs/`. One command, one mental model — "view
+renders logs to HTML" — with the argument deciding scope.
+
+### 1. CLI surface (cli.py)
+
+- `view` positional `log` accepts either an EvalLog JSON file (unchanged) or a
+  directory. Help text: `path to an EvalLog JSON file, or a logs directory to
+  render a browsable index`.
+- Directory mode semantics:
+  - Renders every top-level `*.json` in the directory (no recursion; frames/
+    transcript/wire subdirectories live below and are not logs).
+  - Per-log pages land in `<dir>/html/<log-stem>.html`; the index at
+    `<dir>/html/index.html`.
+  - `-o DIR` overrides the output directory (created if missing). `-o -` is
+    rejected in directory mode: there is no single document to stream.
+  - `--open` opens `index.html`.
+  - `--no-frames` / `--frames-budget` pass through to every per-log render.
+  - New flag `--force`: re-render pages that already exist. Without it,
+    rendering is incremental — a page is re-rendered only when missing or
+    older than its log (mtime comparison), so re-running after a few new runs
+    is quick. `--force` is accepted and ignored in single-file mode (a single
+    render is always "forced"); documented as directory-mode only.
+- Progress goes to stderr (`[i/N] rendering <name>`), one line per log
+  actually rendered, so a large first run is visibly alive while stdout stays
+  clean. A final line reports totals: `index: <path> (N logs, M pages)`.
+- Exit code 0 when the index is written, even if individual logs were
+  unreadable — those are surfaced as error rows in the index and warnings on
+  stderr. (A directory with no `*.json` at all is a usage error: exit 2 with
+  a message, no empty index.)
+
+### 2. Index rendering (`_html_index.py`)
+
+New private module, sibling to `_html.py`, exporting one function:
+
+```python
+def render_index(entries: Sequence[IndexEntry], *, title: str = "Inspect Robots runs") -> str
+```
+
+with a small frozen dataclass `IndexEntry` carrying: `name` (log filename),
+`page` (relative href or None), `created`, `instruction`, `policy`, `model`,
+`status`, `errored` (bool), `reduced` (mapping), `termination`, `error`,
+`size_mb`. The CLI builds entries; the module renders. This keeps the module
+pure (string in, string out) and testable without touching the filesystem.
+
+Index page properties:
+
+- Single self-contained document: inline CSS + a few lines of inline JS, no
+  external assets, `color-scheme: light dark` with a `prefers-color-scheme`
+  dark palette — same constraints `_html.py` already honors.
+- Table sorted newest-first by `created` (falling back to file mtime when a
+  log is unreadable), columns: When, Instruction, Policy (policy / model
+  tail), Outcome, Score, Termination, Error, Log. Instruction and Log cells
+  link to the page when one exists.
+- Outcome badge derived in the CLI, not the template: `error` when the log
+  status is error or any trial errored; `cancelled`; else `success` /
+  `failure` from whether any reduced metric reaches 1.0; `?` when no reduced
+  metrics exist. (The reduced scorer metric is the task verdict; run status
+  only says the run completed. `operator_judgements` is not it either —
+  stock rollout never populates it.)
+- A filter input that hides non-matching rows on substring match across the
+  row text, persisted to `localStorage` so a reload keeps the filter.
+- All user-controlled strings HTML-escaped; errors truncated in-cell with the
+  full text in `title=`.
+
+Non-goals, deliberately: no serve/watch mode, no auto-refresh meta tag (the
+index is a static artifact; serving it is the user's business), no pagination
+(a table of a few hundred rows is fine), no camera-grid changes to the per-log
+report (separate concern, separate issue if wanted).
+
+### 3. Per-log rendering in directory mode (cli.py)
+
+Reuses the exact single-file path: `read_eval_log` → `resolve_frames_dir`
+(unless `--no-frames`) → `render_html` → write UTF-8. Factored so both modes
+call one helper rather than duplicating the frames-dir/budget handling. A log
+that `read_eval_log` rejects (truncated write, foreign JSON) contributes an
+index row with `error="unreadable: …"`, no page, and a stderr warning — one
+bad file must not sink the index.
+
+Entry metadata for readable logs comes from the parsed `EvalLog` (first
+sample's instruction, `eval.policy`, `policy_config["model"]`, reduced
+metrics of the first sample, termination reasons), mirroring what the per-log
+report shows.
+
+### 4. Hints (cli.py)
+
+The two hint blocks gain one directory-level line, emitted only when the log's
+parent directory is plausible (always is — logs are written into a directory):
+
+- Post-run block (`hint: render videos with…` neighborhood):
+  `hint: browse all logs: inspect-robots view <log_dir>`
+- Eval-set completion block: same line with the set's `log_dir`.
+
+Placed last in each block: it is the widest-scope hint.
+
+## Tests (tests/test_html_index.py + additions to tests/test_cli_view.py area)
+
+- `render_index`: escaping (instruction with `<script>`), link vs no-link
+  rows, badge classes for each outcome, newest-first ordering, empty-entries
+  rejected upstream (never called with zero entries).
+- Directory mode end-to-end (tmp_path): two small synthetic logs → pages +
+  index exist, index references both; unreadable third file → warning row, no
+  page, exit 0.
+- Incremental behavior: second invocation renders nothing (mtimes honored);
+  touching a log re-renders its page; `--force` re-renders all.
+- Flag validation: `-o -` with a directory exits with a usage error; `--open`
+  targets index.html (monkeypatched webbrowser).
+- Hint lines: post-run output includes the browse-all hint with the right
+  directory.
+
+## Rollout
+
+Pure addition to the CLI + one new private module; no schema, wire, or plugin
+surface changes. Changelog entry under core. No version gate needed by
+downstream embodiment packages.

--- a/src/inspect_robots/_html_index.py
+++ b/src/inspect_robots/_html_index.py
@@ -192,16 +192,14 @@ def _row(entry: IndexEntry) -> str:
     )
 
 
-def render_index(
-    entries: Sequence[IndexEntry], *, title: str = "Inspect Robots runs"
-) -> str:
+def render_index(entries: Sequence[IndexEntry], *, title: str = "Inspect Robots runs") -> str:
     """Return one self-contained HTML document indexing evaluation logs."""
     ordered = sorted(entries, key=lambda entry: entry.created, reverse=True)
     rows = "".join(_row(entry) for entry in ordered)
     empty = (
         ""
         if rows
-        else '<tr><td class="empty" colspan="8">no evaluation logs found</td></tr>'
+        else '<tr class="empty"><td class="empty" colspan="8">no evaluation logs found</td></tr>'
     )
     return f"""<!doctype html>
 <html lang="en">

--- a/src/inspect_robots/_html_index.py
+++ b/src/inspect_robots/_html_index.py
@@ -1,0 +1,246 @@
+"""Render a directory of evaluation logs as a self-contained HTML index.
+
+The CLI owns filesystem discovery and log parsing; this module accepts plain
+row data and returns one dependency-free document. Keeping that boundary
+pure makes escaping, ordering, and presentation independently testable.
+"""
+
+from __future__ import annotations
+
+import html
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class IndexEntry:
+    """One evaluation-log row in the directory index."""
+
+    name: str
+    page: str | None
+    created: str
+    instruction: str
+    policy: str
+    model: str | None
+    status: str
+    status_class: str
+    metrics: Mapping[str, float]
+    errored_trials: int
+    termination: str
+    error: str | None
+
+
+_STYLES = """
+:root {
+  color-scheme: light dark;
+  --bg: #f7f8fa;
+  --panel: #ffffff;
+  --text: #20242b;
+  --muted: #68707d;
+  --line: #dfe3e8;
+  --link: #245ca6;
+  --green: #19723b;
+  --green-bg: #e9f6ed;
+  --red: #a12a2a;
+  --red-bg: #fbecec;
+  --grey: #626a75;
+  --grey-bg: #eef0f2;
+  --neutral: #45546a;
+  --neutral-bg: #edf1f6;
+}
+@media (prefers-color-scheme: light) {
+  :root { color-scheme: light; }
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #111419;
+    --panel: #191d24;
+    --text: #e7eaf0;
+    --muted: #a4acb8;
+    --line: #343a45;
+    --link: #8ebcff;
+    --green: #7ed99a;
+    --green-bg: #193b27;
+    --red: #ff9b9b;
+    --red-bg: #492323;
+    --grey: #c0c5cd;
+    --grey-bg: #343943;
+    --neutral: #b9c9df;
+    --neutral-bg: #293342;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+header { border-bottom: 1px solid var(--line); background: var(--panel); }
+.header-inner, main { width: min(1500px, calc(100% - 32px)); margin: auto; }
+.header-inner { padding: 26px 0 20px; }
+h1 { margin: 0; font-size: 24px; font-weight: 650; }
+.meta { color: var(--muted); margin-top: 7px; }
+main { margin-bottom: 64px; }
+.toolbar { margin: 22px 0 14px; }
+label { display: block; color: var(--muted); font-size: 12px; margin-bottom: 5px; }
+input {
+  width: min(460px, 100%);
+  padding: 9px 11px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--text);
+  font: inherit;
+}
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+table { width: 100%; border-collapse: collapse; }
+th, td { padding: 10px 12px; text-align: left; vertical-align: top; }
+th {
+  color: var(--muted);
+  border-bottom: 1px solid var(--line);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+td { border-top: 1px solid var(--line); }
+tbody tr:first-child td { border-top: 0; }
+tbody tr:hover { background: var(--bg); }
+a { color: var(--link); }
+.when, .policy, .metrics, .termination, .log { white-space: nowrap; }
+.instruction { min-width: 230px; max-width: 440px; }
+.error-cell { color: var(--red); min-width: 150px; max-width: 280px; overflow-wrap: anywhere; }
+.badge {
+  display: inline-block;
+  border-radius: 999px;
+  padding: 2px 9px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+.status-completed { color: var(--green); background: var(--green-bg); }
+.status-error { color: var(--red); background: var(--red-bg); }
+.status-cancelled { color: var(--grey); background: var(--grey-bg); }
+.status-neutral { color: var(--neutral); background: var(--neutral-bg); }
+.errored { color: var(--red); font-weight: 650; white-space: nowrap; }
+.muted, .empty { color: var(--muted); }
+.empty { padding: 28px 12px; text-align: center; }
+""".strip()
+
+_ERROR_LIMIT = 160
+_FILTER_KEY = "inspect-robots-index-filter"
+
+
+def _escape(value: object) -> str:
+    """Escape one foreign value at its HTML interpolation boundary."""
+    return html.escape(str(value), quote=True)
+
+
+def _number(value: int | float) -> str:
+    """Format numeric log values compactly before their interpolation boundary."""
+    return f"{value:.4g}"
+
+
+def _link(page: str | None, content: str) -> str:
+    """Wrap escaped cell content in a relative report link when one exists."""
+    if page is None:
+        return content
+    return f'<a href="{_escape(page)}">{content}</a>'
+
+
+def _error_cell(error: str | None) -> str:
+    """Render a compact error with its complete value available as a tooltip."""
+    if not error:
+        return ""
+    short = error if len(error) <= _ERROR_LIMIT else f"{error[: _ERROR_LIMIT - 1]}…"
+    return f'<span title="{_escape(error)}">{_escape(short)}</span>'
+
+
+def _row(entry: IndexEntry) -> str:
+    """Render one fully escaped table row."""
+    model_tail = "" if entry.model is None else entry.model.rsplit("/", 1)[-1]
+    policy = _escape(entry.policy)
+    if model_tail:
+        policy += f' <span class="muted">/ {_escape(model_tail)}</span>'
+    metrics = ", ".join(
+        f"{_escape(name)}={_escape(_number(value))}"
+        for name, value in sorted(entry.metrics.items())
+    )
+    if entry.errored_trials:
+        marker = f'<span class="errored">({_escape(entry.errored_trials)} errored)</span>'
+        metrics = f"{metrics} {marker}" if metrics else marker
+    instruction = _link(entry.page, _escape(entry.instruction))
+    log_name = _link(entry.page, _escape(entry.name))
+    return (
+        "<tr>"
+        f'<td class="when"><time>{_escape(entry.created)}</time></td>'
+        f'<td class="instruction">{instruction}</td>'
+        f'<td class="policy">{policy}</td>'
+        f'<td><span class="badge {_escape(entry.status_class)}">'
+        f"{_escape(entry.status)}</span></td>"
+        f'<td class="metrics">{metrics}</td>'
+        f'<td class="termination">{_escape(entry.termination)}</td>'
+        f'<td class="error-cell">{_error_cell(entry.error)}</td>'
+        f'<td class="log">{log_name}</td>'
+        "</tr>"
+    )
+
+
+def render_index(
+    entries: Sequence[IndexEntry], *, title: str = "Inspect Robots runs"
+) -> str:
+    """Return one self-contained HTML document indexing evaluation logs."""
+    ordered = sorted(entries, key=lambda entry: entry.created, reverse=True)
+    rows = "".join(_row(entry) for entry in ordered)
+    empty = (
+        ""
+        if rows
+        else '<tr><td class="empty" colspan="8">no evaluation logs found</td></tr>'
+    )
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{_escape(title)}</title>
+<style>{_STYLES}</style>
+</head>
+<body>
+<header><div class="header-inner">
+  <h1>{_escape(title)}</h1>
+  <div class="meta">{len(entries)} logs</div>
+</div></header>
+<main>
+  <div class="toolbar">
+    <label for="filter">Filter runs</label>
+    <input id="filter" type="search" placeholder="instruction, policy, status, metric…">
+  </div>
+  <div class="table-wrap"><table>
+    <thead><tr>
+      <th>When</th><th>Instruction</th><th>Policy</th><th>Status</th>
+      <th>Metrics</th><th>Termination</th><th>Error</th><th>Log</th>
+    </tr></thead>
+    <tbody>{rows}{empty}</tbody>
+  </table></div>
+</main>
+<script>
+const key = "{_FILTER_KEY}", input = document.querySelector("#filter");
+const rows = document.querySelectorAll("tbody tr:not(.empty)");
+function applyFilter() {{
+  const query = input.value.toLocaleLowerCase();
+  rows.forEach(row => row.hidden = !row.textContent.toLocaleLowerCase().includes(query));
+  try {{ localStorage.setItem(key, input.value); }} catch (_) {{}}
+}}
+try {{ input.value = localStorage.getItem(key) || ""; }} catch (_) {{}}
+input.addEventListener("input", applyFilter);
+applyFilter();
+</script>
+</body>
+</html>
+"""

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -354,8 +354,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="PATH",
         help=(
-            "output HTML file, or output directory in directory mode "
-            "(defaults: LOG.html or LOG_DIR/html; - writes one file to stdout)"
+            "output HTML file for one log (default: LOG.html; - writes to stdout), "
+            "or output directory for a logs directory (default: LOG_DIR/html)"
         ),
     )
     p_view.add_argument(
@@ -374,8 +374,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=50,
         metavar="MB",
         help=(
-            "maximum inline frame payload in decimal MB per page in directory mode "
-            "(default: 50; 0 is unlimited)"
+            "maximum inline frame payload in decimal MB, applied to each rendered "
+            "page (default: 50; 0 is unlimited)"
         ),
     )
     p_view.add_argument(
@@ -1525,16 +1525,14 @@ def _write_html(document: str, out_path: Path | None) -> int:
 
 
 def _render_log_page(
+    log: EvalLog,
     log_path: Path,
     out_path: Path | None,
     *,
     no_frames: bool,
     frames_budget: float,
-) -> tuple[EvalLog, int]:
-    """Read and render one log through the shared single-page pipeline."""
-    from inspect_robots import read_eval_log
-
-    log = read_eval_log(str(log_path))
+) -> int:
+    """Render one already-parsed log through the shared single-page pipeline."""
     frames_dir = None
     if not no_frames and log.stats.frames_dir is not None:
         from inspect_robots._video import resolve_frames_dir
@@ -1547,7 +1545,7 @@ def _render_log_page(
         frames_dir=frames_dir,
         frames_budget_bytes=int(frames_budget * 1_000_000),
     )
-    return log, _write_html(document, out_path)
+    return _write_html(document, out_path)
 
 
 def _open_html(path: Path) -> None:
@@ -1567,7 +1565,10 @@ def _index_instruction(log: EvalLog) -> str:
     """Return the shared instruction or the multi-scene fallback."""
     instructions = {scene.instruction for scene in log.samples}
     shared = next(iter(instructions)) if len(instructions) == 1 else None
-    return shared if shared else f"{len(log.samples)} scenes"
+    if shared:
+        return shared
+    count = len(log.samples)
+    return f"{count} scene" if count == 1 else f"{count} scenes"
 
 
 def _index_termination(log: EvalLog) -> str:
@@ -1651,52 +1652,51 @@ def _cmd_view_directory(args: argparse.Namespace, log_dir: Path) -> int:
     if args.out == "-":
         raise SystemExit("-o - cannot be used with a logs directory; pass an output directory")
 
-    log_paths = sorted(log_dir.glob("*.json"))
+    log_paths = sorted(path for path in log_dir.glob("*.json") if path.is_file())
     if not log_paths:
         raise SystemExit(f"no top-level *.json logs found in {log_dir}")
 
     out_dir = log_dir / "html" if args.out is None else Path(args.out)
     if (out_dir.exists() or out_dir.is_symlink()) and not out_dir.is_dir():
-        raise SystemExit(f"--out {out_dir} is not a directory; pass an output directory")
+        if args.out is not None:
+            raise SystemExit(f"--out {out_dir} is not a directory; pass an output directory")
+        raise SystemExit(
+            f"default output path {out_dir} exists and is not a directory; move it or pass -o DIR"
+        )
     out_dir.mkdir(parents=True, exist_ok=True)
 
     page_names = _directory_page_names(log_paths)
-    parsed: dict[Path, EvalLog | Exception] = {}
-    for log_path in log_paths:
-        try:
-            parsed[log_path] = read_eval_log(str(log_path))
-        except Exception as exc:
-            parsed[log_path] = exc
-            print(f"warning: could not read {log_path.name}: {exc}", file=sys.stderr)
-
     entries: list[IndexEntry] = []
     pages_written = 0
     bytes_written = 0
     total = len(log_paths)
+    # One pass, one parse per log, nothing retained beyond its row: a log that
+    # fails to read or render (e.g. replaced mid-run by a concurrent writer)
+    # becomes an error row instead of sinking the index.
     for index, log_path in enumerate(log_paths, start=1):
-        parsed_log = parsed[log_path]
-        if isinstance(parsed_log, Exception):
-            entries.append(_unreadable_index_entry(log_path, parsed_log))
-            continue
-
         page_name = page_names[log_path]
         page_path = out_dir / page_name
-        render_page = (
-            args.force
-            or not page_path.exists()
-            or page_path.stat().st_mtime < log_path.stat().st_mtime
-        )
-        if render_page:
-            print(f"[{index}/{total}] rendering {log_path.name}", file=sys.stderr)
-            parsed_log, page_bytes = _render_log_page(
-                log_path,
-                page_path,
-                no_frames=args.no_frames,
-                frames_budget=args.frames_budget,
+        try:
+            log = read_eval_log(str(log_path))
+            render_page = (
+                args.force
+                or not page_path.exists()
+                or page_path.stat().st_mtime < log_path.stat().st_mtime
             )
-            pages_written += 1
-            bytes_written += page_bytes
-        entries.append(_index_entry(parsed_log, log_path, page_name))
+            if render_page:
+                print(f"[{index}/{total}] rendering {log_path.name}", file=sys.stderr)
+                bytes_written += _render_log_page(
+                    log,
+                    log_path,
+                    page_path,
+                    no_frames=args.no_frames,
+                    frames_budget=args.frames_budget,
+                )
+                pages_written += 1
+            entries.append(_index_entry(log, log_path, page_name))
+        except Exception as exc:
+            print(f"warning: could not read or render {log_path.name}: {exc}", file=sys.stderr)
+            entries.append(_unreadable_index_entry(log_path, exc))
 
     index_path = out_dir / "index.html"
     bytes_written += _write_html(render_index(entries), index_path)
@@ -1732,7 +1732,10 @@ def _cmd_view(args: argparse.Namespace) -> int:
         # The one data-loss path in this command: rendering over the log it reads.
         raise SystemExit(f"--out {out_path} would overwrite the input log; pass a different path")
 
-    _log, document_size = _render_log_page(
+    from inspect_robots import read_eval_log
+
+    document_size = _render_log_page(
+        read_eval_log(str(log_path)),
         log_path,
         out_path,
         no_frames=args.no_frames,
@@ -1742,9 +1745,7 @@ def _cmd_view(args: argparse.Namespace) -> int:
         return 0
 
     file_path = cast(Path, out_path)
-    size_suffix = (
-        f" ({document_size / 1_000_000:.1f} MB)" if document_size > 1_000_000 else ""
-    )
+    size_suffix = f" ({document_size / 1_000_000:.1f} MB)" if document_size > 1_000_000 else ""
     print(f"wrote {file_path}{size_suffix}")
     if args.open:
         _open_html(file_path)

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -17,8 +17,8 @@ Subcommands:
   saved eval log and optionally append policy conversations or captured wire calls.
 - ``inspect-robots summarize LOG.json [--model M]`` — distill a saved eval log
   into a deterministic digest or model-written learnings file.
-- ``inspect-robots view LOG.json [-o OUT.html] [--open]`` — render a saved eval log
-  as a self-contained HTML report.
+- ``inspect-robots view LOG.json|LOG_DIR [-o PATH] [--open]`` — render one saved
+  eval log or a browsable directory index as self-contained HTML.
 - ``inspect-robots video LOG.json`` — render a ``--store-frames`` run's stored
   camera frames to one MP4 per (trial, camera) stream via the ffmpeg binary.
 - ``inspect-robots setup`` — interactively configure defaults and camera devices.
@@ -45,6 +45,7 @@ import sys
 import tempfile
 from collections.abc import Sequence
 from contextlib import suppress
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
@@ -54,8 +55,10 @@ from inspect_robots._html import (
     _chat_content,
     _display_status,
     _is_chat_transcript,
+    _status_class,
     render_html,
 )
+from inspect_robots._html_index import IndexEntry, render_index
 from inspect_robots._pointers import derive_blob_dir, read_jsonl_prefix, resolve_log_pointer
 from inspect_robots.defaults import (
     _ADHOC_MAX_STEPS_FALLBACK,
@@ -332,14 +335,28 @@ def build_parser() -> argparse.ArgumentParser:
         help="output markdown file (default: LOG_DIR/learnings/LOG_STEM.md; - writes stdout)",
     )
 
-    p_view = sub.add_parser("view", help="render a saved eval log as a self-contained HTML report")
-    p_view.add_argument("log", help="path to an EvalLog JSON file")
+    p_view = sub.add_parser(
+        "view",
+        help="render saved eval logs as self-contained HTML reports",
+        description=(
+            "Render one EvalLog JSON file, or every top-level *.json in a logs "
+            "directory with a browsable index. A directory log named index.json "
+            "uses index_log.html (or the next collision-free suffix)."
+        ),
+    )
+    p_view.add_argument(
+        "log",
+        help="path to an EvalLog JSON file, or a logs directory to render a browsable index",
+    )
     p_view.add_argument(
         "-o",
         "--out",
         default=None,
-        metavar="FILE",
-        help="output HTML file (default: LOG with an .html suffix; - writes to stdout)",
+        metavar="PATH",
+        help=(
+            "output HTML file, or output directory in directory mode "
+            "(defaults: LOG.html or LOG_DIR/html; - writes one file to stdout)"
+        ),
     )
     p_view.add_argument(
         "--open",
@@ -356,7 +373,18 @@ def build_parser() -> argparse.ArgumentParser:
         type=float,
         default=50,
         metavar="MB",
-        help="maximum inline frame payload in decimal MB (default: 50; 0 is unlimited)",
+        help=(
+            "maximum inline frame payload in decimal MB per page in directory mode "
+            "(default: 50; 0 is unlimited)"
+        ),
+    )
+    p_view.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "re-render existing pages in directory mode; use after changing "
+            "--no-frames or --frames-budget (ignored for one file)"
+        ),
     )
 
     p_video = sub.add_parser(
@@ -1040,6 +1068,8 @@ def _print_run_summary(log: EvalLog, log_path: str, is_adhoc: bool) -> None:
         root = resolve_frames_dir(log.stats.frames_dir, Path(log_path))
         if root is not None and count_frames(root):
             print(_styled(f"hint: render videos with: inspect-robots video {log_path}", _DIM))
+    log_dir = Path(log_path).parent
+    print(_styled(f"hint: browse all logs: inspect-robots view {log_dir}", _DIM))
 
 
 class _ResolvedComponents(NamedTuple):
@@ -1312,12 +1342,7 @@ def _print_eval_set_summary(success: bool, logs: Sequence[EvalLog], log_dir: str
                 _DIM,
             )
         )
-    print(
-        _styled(
-            f"hint: HTML viewer: inspect-robots view {log_dir}/<task>_<id>.json",
-            _DIM,
-        )
-    )
+    print(_styled(f"hint: browse all logs: inspect-robots view {log_dir}", _DIM))
 
 
 def _cmd_eval_set(args: argparse.Namespace) -> int:
@@ -1393,7 +1418,7 @@ def _cmd_eval_set(args: argparse.Namespace) -> int:
             )
             print(
                 _styled(
-                    f"hint: HTML viewer: inspect-robots view {args.log_dir}/<task>_<id>.json",
+                    f"hint: browse all logs: inspect-robots view {args.log_dir}",
                     _DIM,
                 )
             )
@@ -1487,17 +1512,215 @@ def _cmd_inspect(
     return 0 if log.status == "success" else 1
 
 
-def _cmd_view(args: argparse.Namespace) -> int:
-    """Render a saved log to a UTF-8 HTML artifact and optionally open it."""
+def _write_html(document: str, out_path: Path | None) -> int:
+    """Write one document as UTF-8, returning the encoded byte count."""
+    encoded = document.encode("utf-8", errors="replace")
+    if out_path is None:
+        sys.stdout.write(encoded.decode("utf-8"))
+        return len(encoded)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8", errors="replace") as handle:
+        handle.write(document)
+    return len(encoded)
+
+
+def _render_log_page(
+    log_path: Path,
+    out_path: Path | None,
+    *,
+    no_frames: bool,
+    frames_budget: float,
+) -> tuple[EvalLog, int]:
+    """Read and render one log through the shared single-page pipeline."""
+    from inspect_robots import read_eval_log
+
+    log = read_eval_log(str(log_path))
+    frames_dir = None
+    if not no_frames and log.stats.frames_dir is not None:
+        from inspect_robots._video import resolve_frames_dir
+
+        frames_dir = resolve_frames_dir(log.stats.frames_dir, log_path)
+    document = render_html(
+        log,
+        title=f"{log.eval.task} - {log_path.name}",
+        log_path=log_path,
+        frames_dir=frames_dir,
+        frames_budget_bytes=int(frames_budget * 1_000_000),
+    )
+    return log, _write_html(document, out_path)
+
+
+def _open_html(path: Path) -> None:
+    """Open one rendered artifact, degrading browser failures to warnings."""
     import webbrowser
 
+    try:
+        opened = webbrowser.open(path.resolve().as_uri())
+    except Exception as exc:
+        print(f"warning: could not open browser for {path}: {exc}", file=sys.stderr)
+    else:
+        if not opened:
+            print(f"warning: could not open browser for {path}", file=sys.stderr)
+
+
+def _index_instruction(log: EvalLog) -> str:
+    """Return the shared instruction or the multi-scene fallback."""
+    instructions = {scene.instruction for scene in log.samples}
+    shared = next(iter(instructions)) if len(instructions) == 1 else None
+    return shared if shared else f"{len(log.samples)} scenes"
+
+
+def _index_termination(log: EvalLog) -> str:
+    """Return the order-preserved union of human-facing termination reasons."""
+    seen: set[str] = set()
+    phrases: list[str] = []
+    for scene in log.samples:
+        for reason in scene.termination_reasons:
+            if reason is None:
+                continue
+            text = str(reason)
+            if text in seen:
+                continue
+            seen.add(text)
+            phrases.append(_OUTCOME_PHRASES.get(text, text))
+    return ", ".join(phrases)
+
+
+def _index_entry(log: EvalLog, log_path: Path, page: str) -> IndexEntry:
+    """Build one directory-index row from a successfully parsed log."""
+    model = log.eval.policy_config.get("model")
+    return IndexEntry(
+        name=log_path.name,
+        page=page,
+        created=log.eval.created,
+        instruction=_index_instruction(log),
+        policy=log.eval.policy,
+        model=None if model is None else str(model),
+        status=_display_status(log.status),
+        status_class=_status_class(log.status),
+        metrics=log.results.metrics,
+        errored_trials=log.results.errored_trials,
+        termination=_index_termination(log),
+        error=log.error,
+    )
+
+
+def _unreadable_index_entry(log_path: Path, error: Exception) -> IndexEntry:
+    """Build an error row for a file that is not a readable EvalLog."""
+    try:
+        created = datetime.fromtimestamp(log_path.stat().st_mtime, tz=timezone.utc).isoformat()
+    except OSError:
+        created = ""
+    return IndexEntry(
+        name=log_path.name,
+        page=None,
+        created=created,
+        instruction="",
+        policy="",
+        model=None,
+        status="error",
+        status_class="status-error",
+        metrics={},
+        errored_trials=0,
+        termination="",
+        error=f"unreadable: {error}",
+    )
+
+
+def _directory_page_names(log_paths: Sequence[Path]) -> dict[Path, str]:
+    """Assign collision-free report names without consulting existing files."""
+    names = {path: f"{path.stem}.html" for path in log_paths if path.stem != "index"}
+    reserved = set(names.values())
+    for path in log_paths:
+        if path.stem != "index":
+            continue
+        candidate = "index_log.html"
+        suffix = 2
+        while candidate in reserved:
+            candidate = f"index_log_{suffix}.html"
+            suffix += 1
+        names[path] = candidate
+        reserved.add(candidate)
+    return names
+
+
+def _cmd_view_directory(args: argparse.Namespace, log_dir: Path) -> int:
+    """Render a logs directory incrementally and write its browsable index."""
     from inspect_robots import read_eval_log
+
+    if args.out == "-":
+        raise SystemExit("-o - cannot be used with a logs directory; pass an output directory")
+
+    log_paths = sorted(log_dir.glob("*.json"))
+    if not log_paths:
+        raise SystemExit(f"no top-level *.json logs found in {log_dir}")
+
+    out_dir = log_dir / "html" if args.out is None else Path(args.out)
+    if (out_dir.exists() or out_dir.is_symlink()) and not out_dir.is_dir():
+        raise SystemExit(f"--out {out_dir} is not a directory; pass an output directory")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    page_names = _directory_page_names(log_paths)
+    parsed: dict[Path, EvalLog | Exception] = {}
+    for log_path in log_paths:
+        try:
+            parsed[log_path] = read_eval_log(str(log_path))
+        except Exception as exc:
+            parsed[log_path] = exc
+            print(f"warning: could not read {log_path.name}: {exc}", file=sys.stderr)
+
+    entries: list[IndexEntry] = []
+    pages_written = 0
+    bytes_written = 0
+    total = len(log_paths)
+    for index, log_path in enumerate(log_paths, start=1):
+        parsed_log = parsed[log_path]
+        if isinstance(parsed_log, Exception):
+            entries.append(_unreadable_index_entry(log_path, parsed_log))
+            continue
+
+        page_name = page_names[log_path]
+        page_path = out_dir / page_name
+        render_page = (
+            args.force
+            or not page_path.exists()
+            or page_path.stat().st_mtime < log_path.stat().st_mtime
+        )
+        if render_page:
+            print(f"[{index}/{total}] rendering {log_path.name}", file=sys.stderr)
+            parsed_log, page_bytes = _render_log_page(
+                log_path,
+                page_path,
+                no_frames=args.no_frames,
+                frames_budget=args.frames_budget,
+            )
+            pages_written += 1
+            bytes_written += page_bytes
+        entries.append(_index_entry(parsed_log, log_path, page_name))
+
+    index_path = out_dir / "index.html"
+    bytes_written += _write_html(render_index(entries), index_path)
+    print(
+        f"index: {index_path} "
+        f"({total} logs, {pages_written} pages, {bytes_written / 1_000_000:.1f} MB)"
+    )
+    if args.open:
+        _open_html(index_path)
+    return 0
+
+
+def _cmd_view(args: argparse.Namespace) -> int:
+    """Render one saved log or a logs directory to UTF-8 HTML artifacts."""
+    if not (math.isfinite(args.frames_budget) and args.frames_budget >= 0):
+        raise SystemExit("--frames-budget must be a non-negative finite number")
+
+    log_path = Path(args.log)
+    if log_path.is_dir():
+        return _cmd_view_directory(args, log_path)
 
     stdout_mode = args.out == "-"
     if stdout_mode and args.open:
         raise SystemExit("--open cannot be used with -o -: no file to open")
-
-    log_path = Path(args.log)
     out_path = (
         None
         if stdout_mode
@@ -1509,43 +1732,22 @@ def _cmd_view(args: argparse.Namespace) -> int:
         # The one data-loss path in this command: rendering over the log it reads.
         raise SystemExit(f"--out {out_path} would overwrite the input log; pass a different path")
 
-    log = read_eval_log(args.log)
-    if not (math.isfinite(args.frames_budget) and args.frames_budget >= 0):
-        raise SystemExit("--frames-budget must be a non-negative finite number")
-    frames_dir = None
-    if not args.no_frames and log.stats.frames_dir is not None:
-        from inspect_robots._video import resolve_frames_dir
-
-        frames_dir = resolve_frames_dir(log.stats.frames_dir, log_path)
-    document = render_html(
-        log,
-        title=f"{log.eval.task} - {log_path.name}",
-        log_path=log_path,
-        frames_dir=frames_dir,
-        frames_budget_bytes=int(args.frames_budget * 1_000_000),
+    _log, document_size = _render_log_page(
+        log_path,
+        out_path,
+        no_frames=args.no_frames,
+        frames_budget=args.frames_budget,
     )
     if stdout_mode:
-        degraded = document.encode("utf-8", errors="replace").decode("utf-8")
-        sys.stdout.write(degraded)
         return 0
 
     file_path = cast(Path, out_path)
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    with file_path.open("w", encoding="utf-8", errors="replace") as handle:
-        handle.write(document)
-    document_size = len(document.encode("utf-8", errors="replace"))
-    size_suffix = f" ({document_size / 1_000_000:.1f} MB)" if document_size > 1_000_000 else ""
+    size_suffix = (
+        f" ({document_size / 1_000_000:.1f} MB)" if document_size > 1_000_000 else ""
+    )
     print(f"wrote {file_path}{size_suffix}")
-
     if args.open:
-        uri = file_path.resolve().as_uri()
-        try:
-            opened = webbrowser.open(uri)
-        except Exception as exc:
-            print(f"warning: could not open browser for {file_path}: {exc}", file=sys.stderr)
-        else:
-            if not opened:
-                print(f"warning: could not open browser for {file_path}", file=sys.stderr)
+        _open_html(file_path)
     return 0
 
 

--- a/tests/test_html_index.py
+++ b/tests/test_html_index.py
@@ -1,0 +1,116 @@
+"""Pure rendering tests for the self-contained eval-log directory index."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from inspect_robots._html_index import IndexEntry, render_index
+
+
+def _entry(
+    name: str,
+    *,
+    page: str | None = "run.html",
+    created: str = "2026-07-30T12:00:00Z",
+    instruction: str = "pick up the cube",
+    status: str = "completed",
+    status_class: str = "status-completed",
+    metrics: dict[str, float] | None = None,
+    errored_trials: int = 0,
+) -> IndexEntry:
+    return IndexEntry(
+        name=name,
+        page=page,
+        created=created,
+        instruction=instruction,
+        policy="agent",
+        model="provider/models/claude-test",
+        status=status,
+        status_class=status_class,
+        metrics={"success_at_end": 0.75} if metrics is None else metrics,
+        errored_trials=errored_trials,
+        termination="succeeded",
+        error=None,
+    )
+
+
+def test_escaping_and_link_vs_no_link_rows() -> None:
+    document = render_index(
+        [
+            _entry("linked.json", instruction="<script>alert(1)</script>"),
+            _entry("broken.json", page=None),
+        ]
+    )
+
+    assert "<script>alert(1)</script>" not in document
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in document
+    assert '<a href="run.html">linked.json</a>' in document
+    assert '<a href="run.html">&lt;script&gt;' in document
+    assert ">broken.json</a>" not in document
+
+
+def test_badge_classes_are_used_verbatim_for_display_status() -> None:
+    document = render_index(
+        [
+            _entry("complete.json"),
+            _entry("error.json", status="error", status_class="status-error"),
+            _entry(
+                "cancelled.json",
+                status="cancelled",
+                status_class="status-cancelled",
+            ),
+        ]
+    )
+
+    assert '<span class="badge status-completed">completed</span>' in document
+    assert '<span class="badge status-error">error</span>' in document
+    assert '<span class="badge status-cancelled">cancelled</span>' in document
+
+
+def test_rows_are_newest_first_and_metrics_use_four_significant_figures() -> None:
+    document = render_index(
+        [
+            _entry(
+                "old.json",
+                created="2026-07-29T12:00:00Z",
+                metrics={"distance": 0.0123456},
+            ),
+            _entry(
+                "new.json",
+                created="2026-07-30T12:00:00Z",
+                metrics={"success": 0.666666},
+                errored_trials=1,
+            ),
+        ]
+    )
+
+    assert document.index("new.json") < document.index("old.json")
+    assert "distance=0.01235" in document
+    assert "success=0.6667" in document
+    assert '<span class="errored">(1 errored)</span>' in document
+    assert "agent <span class=\"muted\">/ claude-test</span>" in document
+
+
+def test_filter_script_and_persisted_key_are_present() -> None:
+    document = render_index([_entry("run.json")])
+
+    assert 'id="filter"' in document
+    assert "row.textContent.toLocaleLowerCase().includes(query)" in document
+    assert "localStorage.setItem" in document
+    assert "localStorage.getItem" in document
+    assert "inspect-robots-index-filter" in document
+
+
+def test_long_error_is_truncated_with_full_escaped_tooltip() -> None:
+    error = 'failed <badly> "' + "x" * 200
+    entry = replace(
+        _entry("broken.json"),
+        status="error",
+        status_class="status-error",
+        error=error,
+    )
+
+    document = render_index([entry])
+
+    assert f'title="failed &lt;badly&gt; &quot;{"x" * 200}"' in document
+    assert "…" in document

--- a/tests/test_html_index.py
+++ b/tests/test_html_index.py
@@ -88,7 +88,7 @@ def test_rows_are_newest_first_and_metrics_use_four_significant_figures() -> Non
     assert "distance=0.01235" in document
     assert "success=0.6667" in document
     assert '<span class="errored">(1 errored)</span>' in document
-    assert "agent <span class=\"muted\">/ claude-test</span>" in document
+    assert 'agent <span class="muted">/ claude-test</span>' in document
 
 
 def test_filter_script_and_persisted_key_are_present() -> None:

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -1546,7 +1546,7 @@ def test_view_directory_end_to_end_and_unreadable_log(
     assert "foreign.json" in index and "unreadable:" in index
     assert out.out.startswith(f"index: {html_dir / 'index.html'} (3 logs, 2 pages, ")
     assert "[1/3] rendering foreign.json" not in out.err
-    assert "warning: could not read foreign.json" in out.err
+    assert "warning: could not read or render foreign.json" in out.err
     assert out.err.count(" rendering ") == 2
 
 
@@ -1712,7 +1712,7 @@ def test_view_directory_rejects_default_html_regular_file(tmp_path: Path) -> Non
     _write_log(_directory_view_log(created="2026-07-30T12:00:00Z"), logs, "run.json")
     (logs / "html").write_text("occupied", encoding="utf-8")
 
-    with pytest.raises(SystemExit, match="is not a directory; pass an output directory"):
+    with pytest.raises(SystemExit, match="exists and is not a directory; move it or pass -o DIR"):
         main(["view", str(logs)])
 
 
@@ -1734,6 +1734,22 @@ def test_view_directory_rejects_existing_output_file(tmp_path: Path) -> None:
 
     with pytest.raises(SystemExit, match="is not a directory; pass an output directory"):
         main(["view", str(logs), "-o", str(output)])
+
+
+def test_view_directory_out_dir_replaces_html_default(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_log(_directory_view_log(created="2026-07-30T12:00:00Z"), logs, "run.json")
+    output = tmp_path / "reports" / "nested"
+
+    assert main(["view", str(logs), "-o", str(output)]) == 0
+
+    assert (output / "run.html").is_file()
+    assert (output / "index.html").is_file()
+    assert not (logs / "html").exists()
+    assert capsys.readouterr().out.startswith(f"index: {output / 'index.html'} (1 logs, 1 pages, ")
 
 
 def test_view_directory_empty_is_runtime_error(tmp_path: Path) -> None:

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -1752,6 +1752,14 @@ def test_view_directory_out_dir_replaces_html_default(
     assert capsys.readouterr().out.startswith(f"index: {output / 'index.html'} (1 logs, 1 pages, ")
 
 
+def test_unreadable_index_entry_tolerates_vanished_file(tmp_path: Path) -> None:
+    entry = cli._unreadable_index_entry(tmp_path / "gone.json", ValueError("boom"))
+
+    assert entry.created == ""
+    assert entry.error == "unreadable: boom"
+    assert entry.page is None
+
+
 def test_view_directory_empty_is_runtime_error(tmp_path: Path) -> None:
     logs = tmp_path / "logs"
     logs.mkdir()

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any, ClassVar
@@ -118,7 +119,9 @@ def test_cli_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     # A clean run teaches both terminal and browser read-back commands.
     assert f"hint: inspect it with: inspect-robots inspect {written}" in out
     assert f"hint: HTML viewer: inspect-robots view {written}" in out
-    assert out.count("hint:") == 2
+    assert f"hint: browse all logs: inspect-robots view {tmp_path}" in out
+    assert out.count("hint:") == 3
+    assert out.rstrip().endswith(f"hint: browse all logs: inspect-robots view {tmp_path}")
 
 
 @pytest.mark.parametrize(
@@ -476,7 +479,8 @@ def test_cli_eval_set_runs_multiple_exact_tasks(
     assert "[completed] kb/a" in out
     assert "[completed] kb/b" in out
     assert out.count("log dir:") == 1  # one shared line, not one per task
-    assert "hint: HTML viewer: inspect-robots view" in out
+    assert f"hint: browse all logs: inspect-robots view {tmp_path}" in out
+    assert "HTML viewer: inspect-robots view" not in out
     assert len(list(tmp_path.glob("*.json"))) == 2
 
 
@@ -980,7 +984,8 @@ def test_cli_eval_set_ctrl_c_reports_partial_logs_and_exits_130(
     out = capsys.readouterr().out
     assert f"cancelled: partial logs are under {tmp_path}" in out
     assert "inspect-robots inspect" in out
-    assert "inspect-robots view" in out
+    assert f"hint: browse all logs: inspect-robots view {tmp_path}" in out
+    assert "HTML viewer: inspect-robots view" not in out
 
 
 def test_cli_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
@@ -1206,6 +1211,38 @@ def _write_view_frame_fixture(tmp_path: Path) -> tuple[Path, Path]:
     recorded = str(tmp_path / "old-machine" / "run-stamp")
     path = _write_log(_view_frame_log(recorded), log_dir, "run.json")
     return path, frames_dir
+
+
+def _directory_view_log(
+    *,
+    created: str,
+    instruction: str = "pick up the cube",
+    status: str = "success",
+    metrics: dict[str, float] | None = None,
+    errored_trials: int = 0,
+) -> EvalLog:
+    log = _step_limit_log(reasons=("success",))
+    scene = dataclasses.replace(
+        log.samples[0],
+        status=status,
+        instruction=instruction,
+        termination_reasons=("success",),
+    )
+    return dataclasses.replace(
+        log,
+        status=status,
+        eval=dataclasses.replace(
+            log.eval,
+            created=created,
+            policy_config={"model": "provider/models/claude-test"},
+        ),
+        results=dataclasses.replace(
+            log.results,
+            metrics={"success_at_end": 1.0} if metrics is None else metrics,
+            errored_trials=errored_trials,
+        ),
+        samples=(scene,),
+    )
 
 
 @pytest.mark.parametrize("name", ["run.json", "run"])
@@ -1474,6 +1511,260 @@ def test_view_exit_code_reports_artifact_production_not_eval_status(
 
     assert main(["view", str(path)]) == 0
     capsys.readouterr()
+
+
+def test_view_directory_end_to_end_and_unreadable_log(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_log(
+        _directory_view_log(created="2026-07-29T12:00:00Z"),
+        logs,
+        "older.json",
+    )
+    _write_log(
+        _directory_view_log(
+            created="2026-07-30T12:00:00Z",
+            instruction="place the cube",
+        ),
+        logs,
+        "newer.json",
+    )
+    (logs / "foreign.json").write_text("{not json", encoding="utf-8")
+
+    assert main(["view", str(logs)]) == 0
+
+    out = capsys.readouterr()
+    html_dir = logs / "html"
+    assert (html_dir / "older.html").is_file()
+    assert (html_dir / "newer.html").is_file()
+    assert not (html_dir / "foreign.html").exists()
+    index = (html_dir / "index.html").read_text(encoding="utf-8")
+    assert index.index("newer.json") < index.index("older.json")
+    assert 'href="newer.html"' in index and 'href="older.html"' in index
+    assert "foreign.json" in index and "unreadable:" in index
+    assert out.out.startswith(f"index: {html_dir / 'index.html'} (3 logs, 2 pages, ")
+    assert "[1/3] rendering foreign.json" not in out.err
+    assert "warning: could not read foreign.json" in out.err
+    assert out.err.count(" rendering ") == 2
+
+
+def test_view_directory_multi_scene_metrics_empty_samples_and_errored_trials(
+    tmp_path: Path,
+) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    base = _directory_view_log(
+        created="2026-07-30T12:00:00Z",
+        metrics={"mean_score": 0.333333},
+        errored_trials=1,
+    )
+    first = dataclasses.replace(
+        base.samples[0],
+        scene_id="first",
+        instruction="shared instruction",
+        termination_reasons=("success", None),
+    )
+    second = dataclasses.replace(
+        base.samples[0],
+        scene_id="second",
+        instruction="shared instruction",
+        termination_reasons=("max_steps", "success"),
+    )
+    multi = dataclasses.replace(
+        base,
+        results=dataclasses.replace(base.results, total_scenes=2, total_trials=4),
+        samples=(first, second),
+    )
+    empty = dataclasses.replace(
+        _directory_view_log(
+            created="2026-07-29T12:00:00Z",
+            status="cancelled",
+            metrics={},
+        ),
+        results=EvalResults(total_scenes=0, total_trials=0, metrics={}),
+        samples=(),
+    )
+    _write_log(multi, logs, "multi.json")
+    _write_log(empty, logs, "empty.json")
+
+    assert main(["view", str(logs)]) == 0
+
+    index = (logs / "html" / "index.html").read_text(encoding="utf-8")
+    assert "shared instruction" in index
+    assert "mean_score=0.3333" in index
+    assert "succeeded, hit step limit" in index
+    assert '<span class="badge status-completed">completed</span>' in index
+    assert '<span class="errored">(1 errored)</span>' in index
+    assert "0 scenes" in index
+    assert '<span class="badge status-cancelled">cancelled</span>' in index
+
+
+def test_view_directory_incremental_mtime_and_force(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    first = _write_log(
+        _directory_view_log(created="2026-07-29T12:00:00Z"),
+        logs,
+        "a.json",
+    )
+    _write_log(
+        _directory_view_log(created="2026-07-30T12:00:00Z"),
+        logs,
+        "b.json",
+    )
+
+    assert main(["view", str(logs)]) == 0
+    capsys.readouterr()
+
+    assert main(["view", str(logs)]) == 0
+    second = capsys.readouterr()
+    assert " rendering " not in second.err
+    assert "(2 logs, 0 pages, " in second.out
+
+    from inspect_robots._html import render_html
+
+    calls: list[str] = []
+
+    def record_render(
+        log: EvalLog,
+        *,
+        title: str,
+        log_path: Path,
+        frames_dir: Path | None,
+        frames_budget_bytes: int,
+    ) -> str:
+        calls.append(log.eval.created)
+        return render_html(
+            log,
+            title=title,
+            log_path=log_path,
+            frames_dir=frames_dir,
+            frames_budget_bytes=frames_budget_bytes,
+        )
+
+    monkeypatch.setattr(cli, "render_html", record_render)
+    page_mtime = (logs / "html" / "a.html").stat().st_mtime
+    os.utime(first, (page_mtime + 10, page_mtime + 10))
+
+    assert main(["view", str(logs)]) == 0
+    refreshed = capsys.readouterr()
+    assert calls == ["2026-07-29T12:00:00Z"]
+    assert refreshed.err.count(" rendering ") == 1
+    assert "rendering a.json" in refreshed.err
+
+    calls.clear()
+    assert main(["view", str(logs), "--force"]) == 0
+    forced = capsys.readouterr()
+    assert len(calls) == 2
+    assert forced.err.count(" rendering ") == 2
+    assert "(2 logs, 2 pages, " in forced.out
+
+
+def test_view_directory_index_log_uses_collision_free_page(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_log(
+        _directory_view_log(created="2026-07-30T12:00:00Z"),
+        logs,
+        "index.json",
+    )
+
+    assert main(["view", str(logs)]) == 0
+
+    html_dir = logs / "html"
+    assert (html_dir / "index.html").is_file()
+    assert (html_dir / "index_log.html").is_file()
+    assert 'href="index_log.html"' in (html_dir / "index.html").read_text(encoding="utf-8")
+
+
+def test_view_directory_index_log_suffix_uses_run_targets_not_filesystem(
+    tmp_path: Path,
+) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_log(
+        _directory_view_log(created="2026-07-30T12:00:00Z"),
+        logs,
+        "index.json",
+    )
+    _write_log(
+        _directory_view_log(created="2026-07-29T12:00:00Z"),
+        logs,
+        "index_log.json",
+    )
+
+    assert main(["view", str(logs)]) == 0
+    assert (logs / "html" / "index_log_2.html").is_file()
+
+    assert main(["view", str(logs)]) == 0
+    assert not (logs / "html" / "index_log_3.html").exists()
+
+
+def test_view_directory_rejects_default_html_regular_file(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_log(_directory_view_log(created="2026-07-30T12:00:00Z"), logs, "run.json")
+    (logs / "html").write_text("occupied", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="is not a directory; pass an output directory"):
+        main(["view", str(logs)])
+
+
+def test_view_directory_rejects_stdout_output(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_log(_directory_view_log(created="2026-07-30T12:00:00Z"), logs, "run.json")
+
+    with pytest.raises(SystemExit, match="cannot be used with a logs directory"):
+        main(["view", str(logs), "-o", "-"])
+
+
+def test_view_directory_rejects_existing_output_file(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_log(_directory_view_log(created="2026-07-30T12:00:00Z"), logs, "run.json")
+    output = tmp_path / "reports"
+    output.write_text("occupied", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="is not a directory; pass an output directory"):
+        main(["view", str(logs), "-o", str(output)])
+
+
+def test_view_directory_empty_is_runtime_error(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+
+    with pytest.raises(SystemExit, match=r"no top-level \*\.json") as excinfo:
+        main(["view", str(logs)])
+
+    assert excinfo.value.code
+    assert not (logs / "html" / "index.html").exists()
+
+
+def test_view_directory_open_targets_index(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_log(_directory_view_log(created="2026-07-30T12:00:00Z"), logs, "run.json")
+    opened: list[str] = []
+
+    def open_browser(uri: str) -> bool:
+        opened.append(uri)
+        return True
+
+    monkeypatch.setattr("webbrowser.open", open_browser)
+
+    assert main(["view", str(logs), "--open"]) == 0
+
+    assert opened == [(logs / "html" / "index.html").resolve().as_uri()]
 
 
 def test_run_outcome_shows_timeout_without_a_count(


### PR DESCRIPTION
Closes #234.

`inspect-robots view logs/` renders every eval log in the directory to `logs/html/<log>.html` plus a filterable `index.html` (when, instruction, policy/model, outcome badge, score, termination, error — newest first, rows linking to the per-log reports). Incremental by mtime with `--force` to re-render; single-file mode unchanged. The post-run and eval-set hint blocks gain `hint: browse all logs: inspect-robots view <log_dir>`.

Plan: `plans/0035-view-log-directory.md` (critique loop in progress; implementation to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)