### PR TITLE
view: lay out camera frames as a grid row per observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- Camera frames in HTML reports now render as captioned responsive grid rows,
+  with click-to-expand cells for closer inspection (plan 0036, #239).
 - **Task horizon binding now follows compatibility checking.** An
   embodiment's optional `bind_task()` hook receives the resolved step envelope
   only after the policy/embodiment/task triple is known to be compatible. This

--- a/plans/0036-frame-grid.md
+++ b/plans/0036-frame-grid.md
@@ -79,10 +79,11 @@ appending the label text + bare `<img>`:
 
 `auto-fit` + `minmax` handles any camera count and viewport: 3 cameras sit
 3-up at the report's 1120px main width, degrading to fewer columns on
-narrow screens. Stored frames are capped at 448px on their longest side
-(`_FRAME_MAX_SIDE`), so `max-width: 448px` keeps a single-camera row at
-today's natural-size look instead of upscaling a 448px image to the full
-column. The `.wide` expand deliberately lifts that cap: an expanded cell is
+narrow screens. Stored frames are downsampled to at most 448px on their longest side
+(`_FRAME_MAX_SIDE`, never upsampled), so `max-width: 448px` keeps a
+single-camera row at today's capped-size look instead of upscaling to the
+full column (a natively-smaller frame does stretch up to 448px — accepted;
+real frames sit at the cap). The `.wide` expand deliberately lifts that cap: an expanded cell is
 an upscaled (soft) image, same trade the current full-width-on-request
 behavior would make — bigger beats sharper when a human is squinting at a
 gripper. The existing `img.frame` rule (natural size, `max-width: 100%`)
@@ -93,8 +94,9 @@ still governs images outside rows, e.g. wire-blob embeds.
 Frames in a 3-up row are a third of their old size, so one interaction is
 justified: clicking a frame toggles `wide` on its figure (`grid-column: 1 /
 -1` — full row width, in place, no overlay). One small event-delegated
-inline script in the document (the report currently ships zero JS; this adds
-a 4-line click handler on `document`, no per-image listeners). The handler
+inline script in the document `<head>` (active before the multi-MB body
+finishes parsing; the report currently ships zero JS and this adds a 4-line
+delegated click handler on `document`, no per-image listeners). The handler
 matches `event.target.closest('.frame-cell')` and no-ops otherwise —
 wire-blob images (which also carry `img.frame`) and arbitrary clicks are
 untouched. The report stays fully readable with JS disabled (grid and
@@ -129,6 +131,13 @@ directory index page (plan 0035) is untouched.
   alt.
 - The click script (`closest('.frame-cell')` delegation) and
   `.frame-cell.wide` rule are present in the document.
+- **Deliberate invariant replacement:** `test_header_status_metrics_and_scene_content`
+  currently asserts `"<script" not in document` (5-way parametrized) — that
+  zero-JS guarantee is retired, but its injection-guard role is preserved,
+  not dropped: the replacement asserts the document contains **exactly one**
+  `<script` occurrence and that it is the known first-party literal, and the
+  existing escaping test (`<script>alert(1)</script>` appears only escaped)
+  stays green — no foreign script survives unescaped.
 
 ## Rollout
 

--- a/plans/0036-frame-grid.md
+++ b/plans/0036-frame-grid.md
@@ -35,18 +35,36 @@ appending the label text + bare `<img>`:
 ```
 
 - The caption text is the matched label line minus its trailing colon,
-  escaped. It is **removed from the buffered text run** (it currently
-  arrives as the run's last line): the label's whole content lives in the
-  figcaption, never duplicated.
-- Consecutive figures with no intervening text join one
-  `<div class="frame-row">`; any non-empty text run in between closes the
-  current row. One observation's cameras (label/placeholder pairs
-  back-to-back in the message parts) therefore form exactly one row.
+  escaped, and **deleted from the buffered run by index**: `pending` grows to
+  `(name, step, label_index)` where `label_index = len(buffered)` recorded
+  when the label is appended, and a successful embed does
+  `del buffered[label_index]`. The index cannot dangle: `pending` is always
+  consumed (embed or overwrite) before any flush empties the buffer. This is
+  the mechanism, not "pop the last line" — parts may intervene between label
+  and placeholder (text, `[image]` placeholders), the embed still fires, and
+  those parts must survive in the text run. When they do intervene, they
+  render in the pre-figure text run, so their text appears before the figure
+  whose caption is the (earlier) label — a deliberate, accepted reordering
+  for a degenerate input.
+- Two labels before one placeholder: the later label drives the embed (it
+  overwrote `pending`, today's behavior) and becomes the caption; the
+  earlier label line simply stays in the text run.
+- **Empty runs are never emitted.** The pre-figure flush emits a
+  `<div class="content">` only when the label-stripped join is non-empty —
+  the canonical `[label, placeholder]` observation strips down to an empty
+  buffer and must not produce `<div class="content"></div>` (the suite's
+  existing invariant, `test_stored_frame_embeds_between_escaped_text_runs`).
+  Same guard on the final flush when `embedded > 0`; the `embedded == 0`
+  text-only path keeps today's semantics exactly.
+- Consecutive figures join one `<div class="frame-row">`; the row closes
+  when a non-empty text run is flushed between embeds. A run that strips or
+  joins to empty (e.g. a stray `""` part) flushes nothing and does not close
+  the row. Observations in separate messages always get separate rows —
+  each `_render_frame_parts` call emits its own.
 - A frame that fails to embed (budget, missing artifact) keeps today's
-  behavior exactly: its label stays in the text run, no figure, no empty
-  cell. `--no-frames` placeholders are untouched.
-- The buffered-text flush logic (`embedded == 0 or buffered`) keeps its
-  current semantics for text-only runs.
+  behavior exactly: label and placeholder stay in the text run, no figure,
+  no empty cell, no row. `--no-frames` (`frame_ctx is None`) never reaches
+  this code and is untouched.
 
 ### 2. CSS
 
@@ -54,16 +72,21 @@ appending the label text + bare `<img>`:
 .frame-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 8px; margin: 6px 0; }
 .frame-cell { margin: 0; min-width: 0; }
 .frame-cell figcaption { font-size: 12px; color: var(--muted); margin-bottom: 2px; overflow-wrap: anywhere; }
-.frame-cell img.frame { width: 100%; margin: 0; cursor: zoom-in; }
+.frame-cell img.frame { width: 100%; max-width: 448px; margin: 0; cursor: zoom-in; }
 .frame-cell.wide { grid-column: 1 / -1; }
-.frame-cell.wide img.frame { cursor: zoom-out; }
+.frame-cell.wide img.frame { max-width: none; cursor: zoom-out; }
 ```
 
 `auto-fit` + `minmax` handles any camera count and viewport: 3 cameras sit
-side by side on a normal window, degrade to fewer columns on narrow screens,
-and a single camera fills the row (matching today's full-width look). The
-existing `img.frame` rule keeps `max-width: 100%` for any image outside a
-row (none are emitted today, but the rule stays as a safety net).
+3-up at the report's 1120px main width, degrading to fewer columns on
+narrow screens. Stored frames are capped at 448px on their longest side
+(`_FRAME_MAX_SIDE`), so `max-width: 448px` keeps a single-camera row at
+today's natural-size look instead of upscaling a 448px image to the full
+column. The `.wide` expand deliberately lifts that cap: an expanded cell is
+an upscaled (soft) image, same trade the current full-width-on-request
+behavior would make — bigger beats sharper when a human is squinting at a
+gripper. The existing `img.frame` rule (natural size, `max-width: 100%`)
+still governs images outside rows, e.g. wire-blob embeds.
 
 ### 3. Expand on click
 
@@ -71,9 +94,11 @@ Frames in a 3-up row are a third of their old size, so one interaction is
 justified: clicking a frame toggles `wide` on its figure (`grid-column: 1 /
 -1` — full row width, in place, no overlay). One small event-delegated
 inline script in the document (the report currently ships zero JS; this adds
-a 4-line click handler on `document`, no per-image listeners, so page weight
-and parse cost stay negligible). No other behavior changes; the report stays
-fully readable with JS disabled (grid and captions are pure CSS/markup).
+a 4-line click handler on `document`, no per-image listeners). The handler
+matches `event.target.closest('.frame-cell')` and no-ops otherwise —
+wire-blob images (which also carry `img.frame`) and arbitrary clicks are
+untouched. The report stays fully readable with JS disabled (grid and
+captions are pure CSS/markup; only the expand toggle needs JS).
 
 ## Non-goals
 
@@ -86,15 +111,24 @@ directory index page (plan 0035) is untouched.
 - One observation with three frames renders one `.frame-row` containing
   three `figure.frame-cell`s, each figcaption carrying its camera label
   (colon stripped), images in part order; the label line no longer appears
-  in the preceding `.content` text.
-- Two observations in one transcript yield two separate rows.
-- Intervening non-empty text between embeds splits rows.
+  in the preceding `.content` text; `<div class="content"></div>` count is
+  zero (the suite's existing invariant, asserted again here).
+- Two observations (separate user messages) yield two separate rows.
+- Intervening non-empty text between embeds splits rows; a stray `""` text
+  part between embeds does not (one row, no empty div).
+- Text between a label and its placeholder: embed still happens, the
+  intervening text stays in the pre-figure run, the caption is the label.
+- Two labels before one placeholder: later label captions the figure,
+  earlier label line survives in the text run.
 - Single-frame observation: row + one cell (no special case).
-- Failed embed (budget truncation path) leaves the label in the text run
-  and emits no figure/row — assert today's exact fallback.
+- Failed embed (budget truncation path) leaves label and placeholder in the
+  text run and emits no figure/row — assert today's exact fallback; the
+  existing `test_all_frame_misses_are_byte_identical_to_frames_off` must
+  stay green unmodified (CSS/script ship unconditionally in both renders).
 - Escaping: camera name containing `<b>` is escaped in both figcaption and
   alt.
-- The click script and `.frame-cell.wide` rule are present in the document.
+- The click script (`closest('.frame-cell')` delegation) and
+  `.frame-cell.wide` rule are present in the document.
 
 ## Rollout
 

--- a/plans/0036-frame-grid.md
+++ b/plans/0036-frame-grid.md
@@ -1,0 +1,104 @@
+# 0036 — view: camera frames as a grid row per observation
+
+Issue: #239.
+
+## Problem
+
+`view` reports render each embedded camera frame as a full-width block image.
+The renderer's own structure makes the layout worse than it needs to be: in
+`_render_frame_parts`, the `camera '<name>' (step N):` label line is just the
+tail of the buffered text run, so each frame arrives as
+`…text ending in label</div><img>` — one image per row, label/image
+association implicit. On a 3-camera rig every observation costs three screens
+of scrolling.
+
+The rig works around it by post-patching rendered pages with an end-of-body
+script that regroups the DOM — which visibly re-flows the page once the
+multi-MB document finishes parsing. The renderer already holds the label
+(`_FRAME_LABEL_RE` matched, name and step in hand) at the moment it embeds
+the image; it can emit the right markup in the first place.
+
+## Design
+
+All changes in `_html.py`; no CLI surface, no schema, no new module.
+
+### 1. Markup (`_render_frame_parts`)
+
+When a frame embeds successfully, emit a captioned figure instead of
+appending the label text + bare `<img>`:
+
+```html
+<figure class="frame-cell">
+  <figcaption>camera 'top_cam' (step 0)</figcaption>
+  <img class="frame" loading="lazy" alt="camera top_cam step 0" src="…">
+</figure>
+```
+
+- The caption text is the matched label line minus its trailing colon,
+  escaped. It is **removed from the buffered text run** (it currently
+  arrives as the run's last line): the label's whole content lives in the
+  figcaption, never duplicated.
+- Consecutive figures with no intervening text join one
+  `<div class="frame-row">`; any non-empty text run in between closes the
+  current row. One observation's cameras (label/placeholder pairs
+  back-to-back in the message parts) therefore form exactly one row.
+- A frame that fails to embed (budget, missing artifact) keeps today's
+  behavior exactly: its label stays in the text run, no figure, no empty
+  cell. `--no-frames` placeholders are untouched.
+- The buffered-text flush logic (`embedded == 0 or buffered`) keeps its
+  current semantics for text-only runs.
+
+### 2. CSS
+
+```css
+.frame-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 8px; margin: 6px 0; }
+.frame-cell { margin: 0; min-width: 0; }
+.frame-cell figcaption { font-size: 12px; color: var(--muted); margin-bottom: 2px; overflow-wrap: anywhere; }
+.frame-cell img.frame { width: 100%; margin: 0; cursor: zoom-in; }
+.frame-cell.wide { grid-column: 1 / -1; }
+.frame-cell.wide img.frame { cursor: zoom-out; }
+```
+
+`auto-fit` + `minmax` handles any camera count and viewport: 3 cameras sit
+side by side on a normal window, degrade to fewer columns on narrow screens,
+and a single camera fills the row (matching today's full-width look). The
+existing `img.frame` rule keeps `max-width: 100%` for any image outside a
+row (none are emitted today, but the rule stays as a safety net).
+
+### 3. Expand on click
+
+Frames in a 3-up row are a third of their old size, so one interaction is
+justified: clicking a frame toggles `wide` on its figure (`grid-column: 1 /
+-1` — full row width, in place, no overlay). One small event-delegated
+inline script in the document (the report currently ships zero JS; this adds
+a 4-line click handler on `document`, no per-image listeners, so page weight
+and parse cost stay negligible). No other behavior changes; the report stays
+fully readable with JS disabled (grid and captions are pure CSS/markup).
+
+## Non-goals
+
+Lightbox/overlay zoom, keyboard navigation, per-camera column ordering,
+frame diffing, and any change to `--no-frames`/budget semantics. The
+directory index page (plan 0035) is untouched.
+
+## Tests (tests/test_html_view.py)
+
+- One observation with three frames renders one `.frame-row` containing
+  three `figure.frame-cell`s, each figcaption carrying its camera label
+  (colon stripped), images in part order; the label line no longer appears
+  in the preceding `.content` text.
+- Two observations in one transcript yield two separate rows.
+- Intervening non-empty text between embeds splits rows.
+- Single-frame observation: row + one cell (no special case).
+- Failed embed (budget truncation path) leaves the label in the text run
+  and emits no figure/row — assert today's exact fallback.
+- Escaping: camera name containing `<b>` is escaped in both figcaption and
+  alt.
+- The click script and `.frame-cell.wide` rule are present in the document.
+
+## Rollout
+
+Pure rendering change in one module. Changelog `### Added` (or `### Changed`
+— it alters default report layout) under `[Unreleased]` with
+`(plan 0036, #239)`. After the next release, the rig deletes its local
+`ensure_camgrid` patch.

--- a/src/inspect_robots/_html.py
+++ b/src/inspect_robots/_html.py
@@ -31,6 +31,11 @@ _BLOB_SENTINEL_RE = re.compile(r"\$blob:([^\s]+)")
 _BLOB_SHA_RE = re.compile(r"[0-9a-f]{64}")
 _MISSING = object()
 
+_FRAME_CLICK_SCRIPT = """document.addEventListener('click', (event) => {
+  const cell = event.target.closest('.frame-cell');
+  if (cell) cell.classList.toggle('wide');
+});"""
+
 
 @dataclass
 class _FrameBudget:
@@ -179,6 +184,17 @@ img.frame {
   display: block; max-width: 100%; height: auto; margin: 6px 0;
   border: 1px solid var(--line); border-radius: 6px;
 }
+.frame-row {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 8px; margin: 6px 0;
+}
+.frame-cell { margin: 0; min-width: 0; }
+.frame-cell figcaption {
+  font-size: 12px; color: var(--muted); margin-bottom: 2px; overflow-wrap: anywhere;
+}
+.frame-cell img.frame { width: 100%; max-width: 448px; margin: 0; cursor: zoom-in; }
+.frame-cell.wide { grid-column: 1 / -1; }
+.frame-cell.wide img.frame { max-width: none; cursor: zoom-out; }
 .system-message {
   margin: 13px 0; padding: 0 0 0 13px; border: 0;
   border-left: 3px solid var(--system);
@@ -369,8 +385,9 @@ def _render_frame_parts(parts: list[object], frame_ctx: _FrameContext) -> str:
     """Render user content parts as text runs split only by successful frame embeds."""
     runs: list[str] = []
     buffered: list[str] = []
-    pending: tuple[str, int] | None = None
+    pending: tuple[str, int, int] | None = None
     embedded = 0
+    row_open = False
     for part in parts:
         if isinstance(part, dict) and part.get("type") == "text":
             raw_text = part.get("text", "")
@@ -378,15 +395,35 @@ def _render_frame_parts(parts: list[object], frame_ctx: _FrameContext) -> str:
             if isinstance(raw_text, str):
                 label = _FRAME_LABEL_RE.fullmatch(raw_text)
                 if label is not None:
-                    pending = (label.group("name"), int(label.group("step")))
+                    label_index = len(buffered)
+                    buffered.append(part_text)
+                    pending = (
+                        label.group("name"),
+                        int(label.group("step")),
+                        label_index,
+                    )
+                    continue
                 elif raw_text == _FRAME_PLACEHOLDER and pending is not None:
-                    name, step = pending
+                    name, step, label_index = pending
                     pending = None
                     image = _frame_image(frame_ctx, name, step)
                     if image is not None:
-                        text = _escape("\n".join(buffered))
-                        runs.append(f'<div class="content">{text}</div>')
-                        runs.append(image)
+                        caption = buffered[label_index][:-1]
+                        del buffered[label_index]
+                        joined = "\n".join(buffered)
+                        if joined:
+                            if row_open:
+                                runs.append("</div>")
+                                row_open = False
+                            runs.append(f'<div class="content">{_escape(joined)}</div>')
+                        if not row_open:
+                            runs.append('<div class="frame-row">')
+                            row_open = True
+                        runs.append(
+                            '<figure class="frame-cell">'
+                            f"<figcaption>{_escape(caption)}</figcaption>"
+                            f"{image}</figure>"
+                        )
                         buffered = []
                         embedded += 1
                         continue
@@ -394,8 +431,14 @@ def _render_frame_parts(parts: list[object], frame_ctx: _FrameContext) -> str:
         else:
             buffered.append("[image]")
     if embedded == 0 or buffered:
-        text = _escape("\n".join(buffered))
-        runs.append(f'<div class="content">{text}</div>')
+        joined = "\n".join(buffered)
+        if embedded == 0 or joined:
+            if row_open:
+                runs.append("</div>")
+                row_open = False
+            runs.append(f'<div class="content">{_escape(joined)}</div>')
+    if row_open:
+        runs.append("</div>")
     return "".join(runs)
 
 
@@ -888,6 +931,7 @@ def render_html(
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{_escape(title)}</title>
 <style>{_STYLES}</style>
+<script>{_FRAME_CLICK_SCRIPT}</script>
 </head>
 <body>
 <header><div class="header-inner">

--- a/tests/test_html_view.py
+++ b/tests/test_html_view.py
@@ -16,7 +16,11 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
-from inspect_robots._html import _JSON_STRING_LIMIT, _render_chat_transcript, render_html
+from inspect_robots._html import (
+    _JSON_STRING_LIMIT,
+    _render_chat_transcript,
+    render_html,
+)
 from inspect_robots._pngenc import png_data_url
 from inspect_robots.frames import _safe
 from inspect_robots.log import EvalLog, EvalResults, EvalSpec, EvalStats, SceneResult
@@ -171,7 +175,15 @@ def test_header_status_metrics_and_scene_content(status: str, label: str, badge_
     assert document.count(">n/a</span>") == 2
     assert "prefers-color-scheme: light" in document
     assert "prefers-color-scheme: dark" in document
-    assert "<script" not in document
+    assert document.count("<script") == 1
+    # The literal is duplicated here on purpose: an independent copy is what
+    # makes this an injection guard rather than a tautology.
+    assert (
+        "<script>document.addEventListener('click', (event) => {\n"
+        "  const cell = event.target.closest('.frame-cell');\n"
+        "  if (cell) cell.classList.toggle('wide');\n"
+        "});</script>" in document
+    )
 
 
 def test_absent_optional_fields_and_empty_scene_sequences_are_omitted() -> None:
@@ -483,9 +495,12 @@ def test_stored_frame_embeds_between_escaped_text_runs(tmp_path: Path) -> None:
     document = render_html(_frame_log(parts), title="frames", frames_dir=tmp_path)
 
     assert document.count('<img class="frame"') == 1
+    assert document.count('<div class="frame-row">') == 1
+    assert document.count('<figure class="frame-cell">') == 1
     assert 'loading="lazy"' in document
     assert 'src="data:image/png;base64,' in document
     assert 'alt="camera cam &lt;wide&gt; step 7"' in document
+    assert "<figcaption>camera &#x27;cam &lt;wide&gt;&#x27; (step 7)</figcaption>" in document
     assert document.index("caption &lt;before&gt;") < document.index('<img class="frame"')
     assert document.index('<img class="frame"') < document.index("after frame")
     assert "[image omitted: streamed camera frame]" not in document
@@ -703,9 +718,146 @@ def test_three_camera_pairs_embed_in_part_order(tmp_path: Path) -> None:
 
     document = render_html(_frame_log(parts), title="three", frames_dir=tmp_path)
 
+    assert document.count('<div class="frame-row">') == 1
+    assert document.count('<figure class="frame-cell">') == 3
     assert document.count('<img class="frame"') == 3
+    assert document.count("<figcaption>") == 3
+    assert "<figcaption>camera &#x27;left&#x27; (step 1)</figcaption>" in document
+    assert "<figcaption>camera &#x27;top&#x27; (step 2)</figcaption>" in document
+    assert "<figcaption>camera &#x27;right&#x27; (step 3)</figcaption>" in document
     assert document.index("camera left step 1") < document.index("camera top step 2")
     assert document.index("camera top step 2") < document.index("camera right step 3")
+    assert "camera &#x27;left&#x27; (step 1):" not in document
+    assert "camera &#x27;top&#x27; (step 2):" not in document
+    assert "camera &#x27;right&#x27; (step 3):" not in document
+    assert document.count('<div class="content"></div>') == 0
+
+
+def test_separate_user_observations_render_separate_frame_rows(tmp_path: Path) -> None:
+    _save_frame(tmp_path, "first", 1, np.zeros((2, 2, 3), dtype=np.uint8))
+    _save_frame(tmp_path, "second", 2, np.ones((2, 2, 3), dtype=np.uint8))
+    transcript = _chat(
+        {"role": "user", "content": _parts("first", 1)},
+        {"role": "user", "content": _parts("second", 2)},
+    )
+
+    document = render_html(_log(transcripts=(transcript,)), title="two rows", frames_dir=tmp_path)
+
+    assert document.count('<div class="frame-row">') == 2
+    assert document.count('<figure class="frame-cell">') == 2
+
+
+def test_non_empty_text_between_frames_splits_rows(tmp_path: Path) -> None:
+    parts = [*_parts("first", 1), {"type": "text", "text": "between"}, *_parts("second", 2)]
+    _save_frame(tmp_path, "first", 1, np.zeros((2, 2, 3), dtype=np.uint8))
+    _save_frame(tmp_path, "second", 2, np.ones((2, 2, 3), dtype=np.uint8))
+
+    document = render_html(_frame_log(parts), title="split rows", frames_dir=tmp_path)
+
+    assert document.count('<div class="frame-row">') == 2
+    assert document.count('<figure class="frame-cell">') == 2
+    assert '</div><div class="content">between</div><div class="frame-row">' in document
+
+
+def test_empty_text_between_frames_does_not_split_row(tmp_path: Path) -> None:
+    parts = [*_parts("first", 1), {"type": "text", "text": ""}, *_parts("second", 2)]
+    _save_frame(tmp_path, "first", 1, np.zeros((2, 2, 3), dtype=np.uint8))
+    _save_frame(tmp_path, "second", 2, np.ones((2, 2, 3), dtype=np.uint8))
+
+    document = render_html(_frame_log(parts), title="one row", frames_dir=tmp_path)
+
+    assert document.count('<div class="frame-row">') == 1
+    assert document.count('<figure class="frame-cell">') == 2
+    assert document.count('<div class="content"></div>') == 0
+
+
+def test_trailing_empty_text_after_embed_emits_no_div(tmp_path: Path) -> None:
+    parts = [*_parts("solo", 3), {"type": "text", "text": ""}]
+    _save_frame(tmp_path, "solo", 3, np.zeros((2, 2, 3), dtype=np.uint8))
+
+    document = render_html(_frame_log(parts), title="trailing", frames_dir=tmp_path)
+
+    assert document.count('<figure class="frame-cell">') == 1
+    assert document.count('<div class="content"></div>') == 0
+
+
+def test_text_between_label_and_placeholder_precedes_captioned_frame(tmp_path: Path) -> None:
+    parts = [
+        {"type": "text", "text": "camera 'top_cam' (step 4):"},
+        {"type": "text", "text": "intervening text"},
+        {"type": "text", "text": "[image omitted: streamed camera frame]"},
+    ]
+    _save_frame(tmp_path, "top_cam", 4, np.zeros((2, 2, 3), dtype=np.uint8))
+
+    document = render_html(_frame_log(parts), title="intervening", frames_dir=tmp_path)
+
+    content = '<div class="content">intervening text</div>'
+    caption = "<figcaption>camera &#x27;top_cam&#x27; (step 4)</figcaption>"
+    assert document.index(content) < document.index(caption)
+    assert document.count('<figure class="frame-cell">') == 1
+    assert "camera &#x27;top_cam&#x27; (step 4):" not in document
+
+
+def test_later_label_captions_frame_and_earlier_label_stays_in_text(tmp_path: Path) -> None:
+    parts = [
+        {"type": "text", "text": "camera 'first' (step 1):"},
+        {"type": "text", "text": "camera 'second' (step 2):"},
+        {"type": "text", "text": "[image omitted: streamed camera frame]"},
+    ]
+    _save_frame(tmp_path, "second", 2, np.zeros((2, 2, 3), dtype=np.uint8))
+
+    document = render_html(_frame_log(parts), title="later label", frames_dir=tmp_path)
+
+    assert '<div class="content">camera &#x27;first&#x27; (step 1):</div>' in document
+    assert "<figcaption>camera &#x27;second&#x27; (step 2)</figcaption>" in document
+    assert "camera &#x27;second&#x27; (step 2):" not in document
+    assert document.count('<figure class="frame-cell">') == 1
+
+
+def test_single_frame_renders_one_row_and_one_cell(tmp_path: Path) -> None:
+    _save_frame(tmp_path, "top_cam", 4, np.zeros((2, 2, 3), dtype=np.uint8))
+
+    document = render_html(_frame_log(_parts()), title="single", frames_dir=tmp_path)
+
+    assert document.count('<div class="frame-row">') == 1
+    assert document.count('<figure class="frame-cell">') == 1
+    assert document.count('<div class="content"></div>') == 0
+
+
+def test_budget_truncation_keeps_exact_frame_text_fallback(tmp_path: Path) -> None:
+    _save_frame(tmp_path, "top_cam", 4, np.zeros((2, 2, 3), dtype=np.uint8))
+
+    document = render_html(
+        _frame_log(_parts()),
+        title="truncated",
+        frames_dir=tmp_path,
+        frames_budget_bytes=1,
+    )
+
+    assert (
+        '<div class="content">camera &#x27;top_cam&#x27; (step 4):\n'
+        "[image omitted: streamed camera frame]</div>"
+    ) in document
+    assert '<figure class="frame-cell">' not in document
+    assert '<div class="frame-row">' not in document
+
+
+def test_camera_name_is_escaped_in_frame_caption_and_alt(tmp_path: Path) -> None:
+    name = "<b>"
+    _save_frame(tmp_path, name, 4, np.zeros((2, 2, 3), dtype=np.uint8))
+
+    document = render_html(_frame_log(_parts(name)), title="escaped", frames_dir=tmp_path)
+
+    assert "<figcaption>camera &#x27;&lt;b&gt;&#x27; (step 4)</figcaption>" in document
+    assert 'alt="camera &lt;b&gt; step 4"' in document
+    assert "<b>" not in document
+
+
+def test_frame_expand_script_and_wide_cell_rule_ship_without_frames() -> None:
+    document = render_html(_log(), title="no frames")
+
+    assert "event.target.closest('.frame-cell')" in document
+    assert ".frame-cell.wide { grid-column: 1 / -1; }" in document
 
 
 def test_transcript_index_is_used_as_epoch_for_frame_lookup(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #239.

`_render_frame_parts` already holds each frame's parsed label at embed time; this renders one observation's cameras as a `.frame-row` grid of captioned figures (caption above each image, click to expand a cell to full row width) instead of full-width stacked images with trailing text labels. Any camera count adapts via `auto-fit`; failed embeds keep today's fallback exactly.

Plan: `plans/0036-frame-grid.md` (critique loop in progress; implementation to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)