### PR TITLE
rerun: limit the llm/latest reading pane to the assistant message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ All notable changes to this project are documented here. The format is based on
   runs now prompt for exactly those trials — registered tasks and `eval-set`
   included (#194).
 
+### Changed
+
+- The `llm/latest` Rerun pane now shows only the step's assistant message(s);
+  the full conversation remains in the `llm` TextLog stream
+  ([plan 0037](plans/0037-rerun-latest-assistant-only.md), #243).
+
 ### Removed
 
 - **`Task.control_hz`** (breaking). `rollout()` never actually paced the

--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -80,9 +80,10 @@ Policies that support transcript streaming automatically add conversation rows
 at `trial/<scene>/e<epoch>/llm`. In the Rerun viewer, add a TextLog view and
 select that entity path. Tool results use the DEBUG level and system prompts use
 TRACE, so enable both levels in the view's log-level filter to see the whole
-conversation. The same updates are also available as markdown at
-`trial/<scene>/e<epoch>/llm/latest`; add a Text Document view for a wrapped
-reading pane that stays synchronized with the timeline cursor.
+conversation. The most recent assistant message is also available as markdown
+at `trial/<scene>/e<epoch>/llm/latest`; add a Text Document view for a wrapped
+reading pane that stays synchronized with the timeline cursor and always shows
+the policy's latest decision.
 
 Scrubbing the `step` timeline highlights the transcript rows emitted for that
 control step alongside its camera and state data. This live stream is a

--- a/plans/0037-rerun-latest-assistant-only.md
+++ b/plans/0037-rerun-latest-assistant-only.md
@@ -1,0 +1,130 @@
+# 0037 — RerunSink: limit the llm/latest reading pane to the assistant message
+
+Issue: #243.
+
+## Problem
+
+`RerunSink` emits each step's transcript delta twice: as `TextLog` rows at
+`{prefix}/llm` (one row per message, leveled INFO/DEBUG/TRACE by role) and as
+one markdown `TextDocument` at `{prefix}/llm/latest`. The document currently
+concatenates **every** rendered row, so a typical step reads
+
+```
+**[INFO]** user: Current observation ...
+---
+**[INFO]** assistant: tool_call move_by({"dx": 0.1})
+---
+**[DEBUG]** tool: result
+```
+
+The pane opens on observation boilerplate and the policy's actual decision is
+buried behind a separator. The `llm/latest` pane should answer "what did the
+policy just decide": one entry, the assistant message.
+
+## Design
+
+All changes in `src/inspect_robots/logging/rerun_sink.py`. The `{prefix}/llm`
+`TextLog` stream is untouched — it stays the complete leveled conversation.
+
+### 1. Carry the role through the payload
+
+`_render_message` returns `(role, level, text)` instead of `(level, text)`:
+
+- dict messages: the existing `str(message.get("role", "unknown"))`.
+- non-dict messages: role `""` (they render as bare INFO rows with no
+  `role:` prefix today; that stays).
+
+`_TranscriptPayload.entries` becomes `tuple[tuple[str, str, str], ...]`
+(role, level, text). Both are private, so this is not an API change; the
+public-API snapshot is unaffected.
+
+Every consumer of `entries` unpacks the new triple: the `TextLog` row loop in
+`_emit_transcript` becomes `for _role, level, text in payload.entries:` (rows
+themselves are emitted exactly as today), and the document filter below uses
+the role.
+
+Accepted trade-off: non-dict messages carry role `""`, so they can never
+appear in `llm/latest` (previously they did, as bare INFO rows). The live
+sink path does not normalize message shapes (`sink.py` contract), but the
+pane is defined as "the policy's decision", and a policy that streams plain
+strings still gets them in the `{prefix}/llm` TextLog stream. Documented in
+Non-goals.
+
+### 2. Filter the document (`_emit_transcript_document`)
+
+Select `[(level, text) for role, level, text in entries if role == "assistant"]`:
+
+- Non-empty selection: log the document exactly as today (same
+  `**[{level}]** ` prefix, same `\n\n---\n\n` separator, same hard-break
+  newline handling, same `media_type="text/markdown"`). A delta normally
+  holds one assistant message; if it holds several, all of them appear in
+  order — the filter is by role, not "last one wins".
+- Empty selection (tool-result-only delta, plain-string rows, system/user
+  only): **skip `rr.log` entirely.** Rerun's latest-at-time semantics then
+  keep the previous assistant document visible at the cursor instead of
+  blanking the pane. This also subsumes the existing
+  `if ... not payload.entries: return` guard, which stays as written.
+
+The `**[INFO]**` prefix is retained even though the filtered pane is always
+INFO: it keeps the format identical to today's entries and to the TextLog
+levels, and costs nothing.
+
+### 3. Docs
+
+- Module docstring (lines 44–46): "...paired with a markdown `TextDocument`
+  at `{prefix}/llm/latest` holding the step's assistant message(s) for a
+  wrapped, timeline-synced reading pane."
+- `docs/guide/logging-and-rerun.md` "Live transcript in the viewer": the
+  `llm/latest` sentence becomes "The most recent assistant message is also
+  available as markdown at `trial/<scene>/e<epoch>/llm/latest`; add a Text
+  Document view for a wrapped reading pane that stays synchronized with the
+  timeline cursor and always shows the policy's latest decision."
+
+## Non-goals
+
+No change to `{prefix}/llm` row emission, levels, or `_render_message` text
+formatting; no change to backpressure/eviction accounting (transcript payloads
+still count as one unit whether or not a document is emitted); no config knob
+for choosing which roles the pane shows. Non-dict (role-less) rows are
+deliberately excluded from the pane (see Design §1); they remain in the
+TextLog stream.
+
+## Tests (tests/test_rerun_sink.py)
+
+Updated expectations:
+
+- `test_policy_messages_emit_ordered_levels_on_the_step_timeline` (the
+  5-role `log_policy_messages` test): document body becomes
+  `"**[INFO]** assistant: answer"` only; the five TextLog rows are unchanged.
+- `test_transcript_emission_logs_rows_and_markdown_document`: document body
+  `"**[INFO]** assistant: answer"`; the DEBUG tool row still appears in the
+  TextLog stream.
+- `test_transcript_document_composes_multiline_entries_with_hard_breaks`:
+  rebuild around an assistant multiline message (content parts) so the
+  hard-break (`"  \n"`) behavior is still exercised on the surviving path.
+- `test_transcript_payload_emits_exactly_one_document_for_multiple_entries`:
+  payload entries gain roles; use two assistant entries plus one tool entry —
+  still exactly one document.
+- `test_policy_message_rendering_table`: expected tuples gain the role
+  element (`("assistant", "INFO", ...)`, `("", "INFO", "plain row")`, ...).
+- Payload literals elsewhere in the suite
+  (`("INFO", "first")` → `("", "INFO", "first")` or similar) updated
+  mechanically.
+
+New:
+
+- Tool-only delta: `_emit_transcript` on entries
+  `(("tool", "DEBUG", "tool: result"),)` logs the TextLog row and **no**
+  document (assert no `llm/latest` path in the fake-rerun log).
+- Mixed delta ordering: user + assistant + tool in one payload yields a
+  document containing only the assistant line (regression for the issue's
+  exact complaint).
+
+Coverage stays at the 100% gate; the skip branch is exercised by the
+tool-only test.
+
+## Rollout
+
+Changelog `### Changed` under `[Unreleased]`: the `llm/latest` Rerun pane now
+shows only the step's assistant message(s); the full conversation remains in
+the `llm` TextLog stream (plan 0037, #243).

--- a/src/inspect_robots/logging/rerun_sink.py
+++ b/src/inspect_robots/logging/rerun_sink.py
@@ -42,8 +42,8 @@ no ``flush`` method. A new sink in the same process can still hang in
 Each trial's entities are namespaced under ``trial/<scene_id>/e<epoch>`` so
 successive trials never overwrite one another on the shared step timeline.
 Transcripts are emitted as ``TextLog`` rows at ``{prefix}/llm`` paired with a
-markdown ``TextDocument`` at ``{prefix}/llm/latest`` for a wrapped,
-timeline-synced reading pane.
+markdown ``TextDocument`` at ``{prefix}/llm/latest`` holding the step's
+assistant message(s) for a wrapped, timeline-synced reading pane.
 
 Install with ``pip install "inspect-robots[rerun]"``.
 """
@@ -69,9 +69,9 @@ if TYPE_CHECKING:
     from inspect_robots.types import Action, Observation, StepResult
 
 
-def _render_message(message: Any) -> tuple[str, str]:
+def _render_message(message: Any) -> tuple[str, str, str]:
     if not isinstance(message, dict):
-        return "INFO", str(message)
+        return "", "INFO", str(message)
 
     role = str(message.get("role", "unknown"))
     level = {
@@ -103,7 +103,7 @@ def _render_message(message: Any) -> tuple[str, str]:
             name = function.get("name", "")
             arguments = function.get("arguments", "")
             lines.append(f"tool_call {name}({arguments})")
-    return level, f"{role}: " + "\n".join(lines)
+    return role, level, f"{role}: " + "\n".join(lines)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -122,11 +122,11 @@ class _StepPayload:
 
 @dataclasses.dataclass(frozen=True)
 class _TranscriptPayload:
-    """Rendered conversation rows snapshotted for one control step."""
+    """Rendered (role, level, text) rows snapshotted for one control step."""
 
     prefix: str
     t: int
-    entries: tuple[tuple[str, str], ...]
+    entries: tuple[tuple[str, str, str], ...]
 
 
 @dataclasses.dataclass
@@ -280,7 +280,7 @@ class RerunSink:
 
     def _emit_transcript(self, rr: Any, payload: _TranscriptPayload) -> None:
         self._set_step(rr, payload.t)
-        for level, text in payload.entries:
+        for _role, level, text in payload.entries:
             rr.log(f"{payload.prefix}/llm", rr.TextLog(text, level=level))
         self._emit_transcript_document(rr, payload)
 
@@ -288,8 +288,13 @@ class RerunSink:
         text_document = getattr(rr, "TextDocument", None)
         if text_document is None or not payload.entries:
             return
+        assistant_entries = [
+            (level, text) for role, level, text in payload.entries if role == "assistant"
+        ]
+        if not assistant_entries:
+            return
         body = "\n\n---\n\n".join(
-            f"**[{level}]** " + text.replace("\n", "  \n") for level, text in payload.entries
+            f"**[{level}]** " + text.replace("\n", "  \n") for level, text in assistant_entries
         )
         rr.log(
             f"{payload.prefix}/llm/latest",

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -402,11 +402,7 @@ def test_policy_messages_emit_ordered_levels_on_the_step_timeline(
         (
             "trial/scene/e2/llm/latest",
             _TextDocument(
-                "**[INFO]** assistant: answer\n\n---\n\n"
-                "**[INFO]** user: question\n\n---\n\n"
-                "**[DEBUG]** tool: result\n\n---\n\n"
-                "**[TRACE]** system: prompt\n\n---\n\n"
-                "**[TRACE]** critic: other",
+                "**[INFO]** assistant: answer",
                 media_type="text/markdown",
             ),
         ),
@@ -422,7 +418,10 @@ def test_transcript_emission_logs_rows_and_markdown_document(
     payload = _TranscriptPayload(
         "trial/scene/e0",
         3,
-        (("INFO", "assistant: answer"), ("DEBUG", "tool: result")),
+        (
+            ("assistant", "INFO", "assistant: answer"),
+            ("tool", "DEBUG", "tool: result"),
+        ),
     )
 
     RerunSink()._emit_transcript(rr, payload)
@@ -434,7 +433,7 @@ def test_transcript_emission_logs_rows_and_markdown_document(
         (
             "trial/scene/e0/llm/latest",
             _TextDocument(
-                "**[INFO]** assistant: answer\n\n---\n\n**[DEBUG]** tool: result",
+                "**[INFO]** assistant: answer",
                 media_type="text/markdown",
             ),
         ),
@@ -447,7 +446,7 @@ def test_transcript_document_composes_multiline_entries_with_hard_breaks(
     logged = _install_fake_rerun(monkeypatch)
     rr = sys.modules["rerun"]
     message = {
-        "role": "user",
+        "role": "assistant",
         "content": [
             {"type": "text", "text": "camera 'top':"},
             {"type": "image_url", "image_url": {"url": "elided"}},
@@ -457,7 +456,7 @@ def test_transcript_document_composes_multiline_entries_with_hard_breaks(
     payload = _TranscriptPayload(
         "trial/scene/e0",
         4,
-        (_render_message(message), ("DEBUG", "tool: result")),
+        (_render_message(message), ("tool", "DEBUG", "tool: result")),
     )
 
     RerunSink()._emit_transcript(rr, payload)
@@ -465,10 +464,7 @@ def test_transcript_document_composes_multiline_entries_with_hard_breaks(
     documents = [value for path, value in logged if path == "trial/scene/e0/llm/latest"]
     assert documents == [
         _TextDocument(
-            "**[INFO]** user: camera 'top':  \n"
-            "[image_url part]  \n"
-            "after\n\n---\n\n"
-            "**[DEBUG]** tool: result",
+            "**[INFO]** assistant: camera 'top':  \n[image_url part]  \nafter",
             media_type="text/markdown",
         )
     ]
@@ -482,12 +478,61 @@ def test_transcript_payload_emits_exactly_one_document_for_multiple_entries(
     payload = _TranscriptPayload(
         "trial/scene/e0",
         5,
-        (("INFO", "first"), ("DEBUG", "second"), ("TRACE", "third")),
+        (
+            ("assistant", "INFO", "assistant: first"),
+            ("tool", "DEBUG", "tool: second"),
+            ("assistant", "INFO", "assistant: third"),
+        ),
     )
 
     RerunSink()._emit_transcript(rr, payload)
 
     assert [path for path, _ in logged].count("trial/scene/e0/llm/latest") == 1
+
+
+def test_tool_only_transcript_delta_emits_row_without_document(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool-only delta preserves its row without replacing the reading pane."""
+    logged = _install_fake_rerun(monkeypatch)
+    rr = sys.modules["rerun"]
+    payload = _TranscriptPayload(
+        "trial/scene/e0",
+        6,
+        (("tool", "DEBUG", "tool: result"),),
+    )
+
+    RerunSink()._emit_transcript(rr, payload)
+
+    assert ("trial/scene/e0/llm", ("TextLog", "tool: result", "DEBUG")) in logged
+    assert all(path != "trial/scene/e0/llm/latest" for path, _ in logged)
+
+
+def test_mixed_transcript_delta_document_contains_only_assistant_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mixed delta limits the reading pane to assistant content."""
+    logged = _install_fake_rerun(monkeypatch)
+    rr = sys.modules["rerun"]
+    payload = _TranscriptPayload(
+        "trial/scene/e0",
+        6,
+        (
+            ("user", "INFO", "user: question"),
+            ("assistant", "INFO", "assistant: answer"),
+            ("tool", "DEBUG", "tool: result"),
+        ),
+    )
+
+    RerunSink()._emit_transcript(rr, payload)
+
+    documents = [value for path, value in logged if path == "trial/scene/e0/llm/latest"]
+    assert documents == [
+        _TextDocument(
+            "**[INFO]** assistant: answer",
+            media_type="text/markdown",
+        )
+    ]
 
 
 def test_empty_transcript_payload_emits_no_document(
@@ -509,7 +554,10 @@ def test_sdk_without_text_document_keeps_transcript_rows(
     payload = _TranscriptPayload(
         "trial/scene/e0",
         7,
-        (("INFO", "assistant: answer"), ("DEBUG", "tool: result")),
+        (
+            ("assistant", "INFO", "assistant: answer"),
+            ("tool", "DEBUG", "tool: result"),
+        ),
     )
 
     RerunSink()._emit_transcript(rr, payload)
@@ -524,7 +572,10 @@ def test_sdk_without_text_document_keeps_transcript_rows(
 @pytest.mark.parametrize(
     ("message", "expected"),
     [
-        ({"role": "assistant", "content": "hello"}, ("INFO", "assistant: hello")),
+        (
+            {"role": "assistant", "content": "hello"},
+            ("assistant", "INFO", "assistant: hello"),
+        ),
         (
             {
                 "role": "user",
@@ -535,7 +586,11 @@ def test_sdk_without_text_document_keeps_transcript_rows(
                     7,
                 ],
             },
-            ("INFO", "user: camera 'top':\n[image_url part]\nafter\n[unknown part]"),
+            (
+                "user",
+                "INFO",
+                "user: camera 'top':\n[image_url part]\nafter\n[unknown part]",
+            ),
         ),
         (
             {
@@ -549,34 +604,40 @@ def test_sdk_without_text_document_keeps_transcript_rows(
                     }
                 ],
             },
-            ("INFO", 'assistant: tool_call move_by({"dx": 0.1})'),
+            ("assistant", "INFO", 'assistant: tool_call move_by({"dx": 0.1})'),
         ),
-        ("plain row", ("INFO", "plain row")),
-        ({"content": "orphan"}, ("TRACE", "unknown: orphan")),
-        ({"role": "tool", "content": "result"}, ("DEBUG", "tool: result")),
-        ({"role": "system", "content": "prompt"}, ("TRACE", "system: prompt")),
-        ({"role": "assistant", "content": ""}, ("INFO", "assistant: ")),
+        ("plain row", ("", "INFO", "plain row")),
+        ({"content": "orphan"}, ("unknown", "TRACE", "unknown: orphan")),
+        ({"role": "tool", "content": "result"}, ("tool", "DEBUG", "tool: result")),
+        (
+            {"role": "system", "content": "prompt"},
+            ("system", "TRACE", "system: prompt"),
+        ),
+        (
+            {"role": "assistant", "content": ""},
+            ("assistant", "INFO", "assistant: "),
+        ),
         (
             {
                 "role": "assistant",
                 "content": [],
                 "tool_calls": [{"function": "malformed"}, "malformed"],
             },
-            ("INFO", "assistant: tool_call ()\ntool_call ()"),
+            ("assistant", "INFO", "assistant: tool_call ()\ntool_call ()"),
         ),
     ],
 )
-def test_policy_message_rendering_table(message: Any, expected: tuple[str, str]) -> None:
+def test_policy_message_rendering_table(message: Any, expected: tuple[str, str, str]) -> None:
     assert _render_message(message) == expected
 
 
 def test_mixed_queue_eviction_counts_transcripts_steps_and_images() -> None:
     sink = RerunSink(queue_size=2)
     sink._image_watermark = 99
-    sink._enqueue(_TranscriptPayload("trial/scene/e0", 0, (("INFO", "first"),)))
+    sink._enqueue(_TranscriptPayload("trial/scene/e0", 0, (("", "INFO", "first"),)))
     sink._enqueue(_step_payload(1))
 
-    sink._enqueue(_TranscriptPayload("trial/scene/e0", 2, (("INFO", "second"),)))
+    sink._enqueue(_TranscriptPayload("trial/scene/e0", 2, (("", "INFO", "second"),)))
     assert sink._dropped_transcripts == 1
     assert sink._dropped_steps == 0
     assert sink._dropped_frames == 0
@@ -595,8 +656,8 @@ def test_mixed_queue_eviction_counts_transcripts_steps_and_images() -> None:
 
 def test_transcript_only_drops_warn_and_reset_all_counters() -> None:
     sink = RerunSink(queue_size=1)
-    sink._enqueue(_TranscriptPayload("trial/scene/e0", 0, (("INFO", "first"),)))
-    sink._enqueue(_TranscriptPayload("trial/scene/e0", 1, (("INFO", "second"),)))
+    sink._enqueue(_TranscriptPayload("trial/scene/e0", 0, (("", "INFO", "first"),)))
+    sink._enqueue(_TranscriptPayload("trial/scene/e0", 1, (("", "INFO", "second"),)))
     with sink._cond:
         sink._queue.clear()
     _arm_completed_worker(sink)
@@ -636,7 +697,7 @@ def test_wedged_shutdown_accounts_for_mixed_backlog(
         worker = sink._worker
         assert worker is not None
         with sink._cond:
-            sink._queue.append(_TranscriptPayload("trial/scene/e0", 1, (("INFO", "queued"),)))
+            sink._queue.append(_TranscriptPayload("trial/scene/e0", 1, (("", "INFO", "queued"),)))
             sink._queue.append(_step_payload(2))
         with pytest.warns(RuntimeWarning) as caught:
             sink.on_eval_end(None)  # type: ignore[arg-type]

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -487,7 +487,13 @@ def test_transcript_payload_emits_exactly_one_document_for_multiple_entries(
 
     RerunSink()._emit_transcript(rr, payload)
 
-    assert [path for path, _ in logged].count("trial/scene/e0/llm/latest") == 1
+    documents = [value for path, value in logged if path == "trial/scene/e0/llm/latest"]
+    assert documents == [
+        _TextDocument(
+            "**[INFO]** assistant: first\n\n---\n\n**[INFO]** assistant: third",
+            media_type="text/markdown",
+        )
+    ]
 
 
 def test_tool_only_transcript_delta_emits_row_without_document(


### PR DESCRIPTION
Closes #243.

## What

The markdown `TextDocument` at `trial/<scene>/e<epoch>/llm/latest` now shows only the step's assistant message(s), e.g. `**[INFO]** assistant: tool_call move_by({"dx": 0.1})`, instead of concatenating the user observation prompt, the assistant reply, and tool results. When a step's transcript delta has no assistant message (tool-result-only deltas, plain-string rows), no document is emitted, so Rerun's latest-at-time semantics keep the previous decision visible at the cursor instead of blanking the pane.

The `{prefix}/llm` `TextLog` stream is untouched and still carries the full conversation at INFO/DEBUG/TRACE levels.

## How

`_render_message` returns `(role, level, text)` and `_TranscriptPayload.entries` carries the triple; `_emit_transcript_document` filters to `role == "assistant"` and returns without logging when the selection is empty. Non-dict messages carry role `""` and are deliberately excluded from the pane (accepted trade-off, documented in plan Non-goals). Design doc: `plans/0037-rerun-latest-assistant-only.md`.

Docs (`docs/guide/logging-and-rerun.md`) and the changelog are updated; tests cover the tool-only skip branch and the mixed-delta filter, keeping the 100% coverage gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)