### PR TITLE
chore(website): bump brace-expansion to 1.1.18 (Dependabot high, DoS)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7591,9 +7591,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",


### PR DESCRIPTION
Fixes the open high-severity Dependabot alert (#5): brace-expansion < 1.1.17 DoS via unbounded expansion, in website/package-lock.json.

Three-line surgical lockfile edit (version/resolved/integrity of the single brace-expansion entry, 1.1.16 to 1.1.18). Deliberately avoided `npm audit fix`, which regenerated the tree and pruned the optional `@docusaurus/faster` platform binaries (66 entries) — out of scope for a security bump.

Verified locally: `npm ci` against the patched lockfile, `npm audit` reports 0 vulnerabilities, and the full Docusaurus build (with generated API docs) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)