### PR TITLE
Point docs links at docs.inspectrobots.org

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,4 +6,4 @@ authors:
 type: software
 license: MIT
 repository-code: "https://github.com/robocurve/inspect-robots"
-url: "https://inspectrobots.org/"
+url: "https://docs.inspectrobots.org/"

--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ If you know [Inspect AI](https://inspect.aisi.org.uk/), this is that for robotic
 
 ![Status: alpha](https://img.shields.io/badge/status-alpha-blue)
 [![CI](https://github.com/robocurve/inspect-robots/actions/workflows/ci.yml/badge.svg)](https://github.com/robocurve/inspect-robots/actions/workflows/ci.yml)
-[![Docs](https://github.com/robocurve/inspect-robots/actions/workflows/docs.yml/badge.svg)](https://inspectrobots.org/)
+[![Docs](https://github.com/robocurve/inspect-robots/actions/workflows/docs.yml/badge.svg)](https://docs.inspectrobots.org/)
 [![Python](https://img.shields.io/badge/python-3.10%E2%80%933.13-blue)](https://github.com/robocurve/inspect-robots)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Typed](https://img.shields.io/badge/typed-mypy%20strict-blue)](https://github.com/robocurve/inspect-robots)
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/robocurve/inspect-robots/actions/workflows/ci.yml)
 [![Docs coverage](https://img.shields.io/badge/public%20docstrings-100%25-brightgreen)](https://github.com/robocurve/inspect-robots/actions/workflows/ci.yml)
 
-[**Documentation**](https://inspectrobots.org/) ·
-[Quickstart](https://inspectrobots.org/guide/quickstart/) ·
-[Concepts](https://inspectrobots.org/guide/concepts/) ·
-[For LLMs](https://inspectrobots.org/llms.txt)
+[**Documentation**](https://docs.inspectrobots.org/) ·
+[Quickstart](https://docs.inspectrobots.org/guide/quickstart/) ·
+[Concepts](https://docs.inspectrobots.org/guide/concepts/) ·
+[For LLMs](https://docs.inspectrobots.org/llms.txt)
 
 </div>
 
@@ -68,7 +68,7 @@ The wizard picks your defaults, finds your cameras, and asks about behavior
 toggles declared by the embodiment plugin, such as yam's `auto_start`, then
 writes `~/.config/inspect-robots/config.ini`. On a different rig, install its
 plugin instead and type its component names at the prompts; to write the config
-file by hand, see [the CLI guide](https://inspectrobots.org/guide/cli/).
+file by hand, see [the CLI guide](https://docs.inspectrobots.org/guide/cli/).
 
 The `molmoact2` policy is only a client: nothing moves until the MolmoAct2
 server is listening, and the server does not start itself or survive a
@@ -313,7 +313,7 @@ Trossen discontinued the WidowX 250S in July 2025. That adapter supports
 existing 250S rigs; the successor WidowX AI uses a different stack.
 
 New robot integrations are welcome. If your rig is not listed,
-[Authoring an embodiment adapter](https://inspectrobots.org/guide/adapters/)
+[Authoring an embodiment adapter](https://docs.inspectrobots.org/guide/adapters/)
 walks through both halves of the pair, and opening an issue with the robot and
 its SDK is a good first step.
 
@@ -450,9 +450,9 @@ and backend adapters live in separate plugin packages.
 ## Documentation
 
 Full guides and an auto-generated API reference live at
-**[inspectrobots.org](https://inspectrobots.org/)**.
-LLM-friendly versions: [`llms.txt`](https://inspectrobots.org/llms.txt)
-and [`llms-full.txt`](https://inspectrobots.org/llms-full.txt).
+**[docs.inspectrobots.org](https://docs.inspectrobots.org/)**.
+LLM-friendly versions: [`llms.txt`](https://docs.inspectrobots.org/llms.txt)
+and [`llms-full.txt`](https://docs.inspectrobots.org/llms-full.txt).
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ inspect-robot = "inspect_robots.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/robocurve/inspect-robots"
-Documentation = "https://inspectrobots.org/"
+Documentation = "https://docs.inspectrobots.org/"
 Repository = "https://github.com/robocurve/inspect-robots"
 Issues = "https://github.com/robocurve/inspect-robots/issues"
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -20,7 +20,7 @@ const config: Config = {
       },
     },
   ],
-  url: 'https://inspectrobots.org',
+  url: 'https://docs.inspectrobots.org',
   baseUrl: '/',
   organizationName: 'robocurve',
   projectName: 'inspect-robots',

--- a/website/scripts/gen-llms-txt.mjs
+++ b/website/scripts/gen-llms-txt.mjs
@@ -32,7 +32,7 @@ function titleFromMarkdown(markdown, file) {
 }
 
 function siteUrl(file) {
-  return `https://inspectrobots.org/${file.replace(/\.md$/, '/')}`;
+  return `https://docs.inspectrobots.org/${file.replace(/\.md$/, '/')}`;
 }
 
 const guides = await Promise.all(

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,1 +1,1 @@
-inspectrobots.org
+docs.inspectrobots.org


### PR DESCRIPTION
The docs site moved from the `inspectrobots.org` apex to **docs.inspectrobots.org** (2026-08-01); the apex and all alias domains now 301 to this repo (managed in robocurve/cloudflare).

This updates every place the old docs URL was baked in:

- **README.md** — docs badge link, header links, guide links, Documentation section
- **website/docusaurus.config.ts** — `url`, so canonical URLs and the sitemap point at the new host
- **website/static/CNAME** — kept consistent (ignored by workflow-based Pages deploys, but stale otherwise)
- **website/scripts/gen-llms-txt.mjs** — generated `llms.txt`/`llms-full.txt` URLs
- **pyproject.toml** — PyPI `Documentation` project URL
- **CITATION.cff** — citation `url`

CHANGELOG mentions of the old domain are left as historical record. The GitHub Pages custom domain + DNS were already switched and verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)