### PR TITLE
Operator console: live feedback to agent policies, explicit end/score commands

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -111,6 +111,23 @@ never adopts an embodiment verdict or prompts for any other ending, so
 unattended runs stay non-blocking. An unjudged trial honestly scores as
 failure with "no operator judgement recorded".
 
+### Live operator feedback
+
+On an attended run, an opted-in policy can also receive feedback while the
+episode is running. The CLI prints the operator-console usage hint when this
+channel is active. Type a normal line and press Enter to deliver it at the
+policy's next inference. Bare Enter ends the episode, while `/y`, `/n`, or `/p`
+plus an optional note ends it and records the verdict immediately, without a
+second post-trial prompt. Feedback is saved per trial and appears in summaries
+and HTML reports. Piped stdin and `--no-prompt` disable the channel.
+
+The console activates only where stdin has one owner: POSIX platforms and
+either a simulator or a real-hardware embodiment that offers
+`defer_operator_end()`. That hook tells an embodiment to stop polling its own
+end-of-episode keypress while the framework console owns stdin. Older hardware
+embodiments keep their existing keypress behavior, print a notice, and leave
+feedback typing off until they add the hook.
+
 ## `inspect-robots setup`
 
 The interactive first-run wizard: it prompts for each `[defaults]` key with

--- a/plans/0042-operator-console.md
+++ b/plans/0042-operator-console.md
@@ -1,0 +1,169 @@
+# Operator console — live feedback to agent policies Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** During an attended run with an opted-in policy (the `agent` plugin), the operator can type a line of feedback + Enter and have it delivered to the policy at its next inference ("the gripper is farther than it looks"), can end the episode with a bare Enter (unchanged muscle memory), and can end-and-score in one stroke with `/y`, `/n`, `/p` plus an optional grader note (#273). VLA runs and unattended runs are byte-for-byte unchanged.
+
+**Architecture:** A new core module `console.py` owns a **polled, threadless** stdin reader: `OperatorConsole.poll()` does a zero-timeout `select()` on stdin, reads pending bytes **at the fd level** (`os.read`, with in-module line assembly — see Design decision 9), and parses complete lines into feedback messages or an end request. No background thread means no second stdin reader: the post-trial verdict prompt (`cli._prompt_operator`, plain `input()`) keeps working because nothing else is ever blocked on stdin. `rollout()` accepts an optional `operator_input` and, mirroring the `extra["approvals"]` channel (#217), injects messages under the reserved `extra["operator_messages"]` key with the same delivered-once-per-inference tail discipline; an end request terminates the trial with the existing `OPERATOR_END` reason and, when the line carried a verdict, stamps `operator_judgement`/`operator_note` directly so the post-run prompt is skipped. A raising `poll()` degrades (warn once, channel off for the trial) — it never breaks the "always persist an EvalLog" invariant. The CLI enables the console only when `_attended(args)`, the policy declares the duck-typed class attribute `accepts_operator_messages = True` (set by `LLMAgentPolicy`), the platform supports `select` on stdin (not Windows), **and the embodiment is console-safe**: it either offers the duck-typed `defer_operator_end()` hook (stdin-polling embodiments stand down when called) or is `is_simulated` (sims never read stdin). Real-hardware embodiments without the hook — today's yam — keep exactly the current keypress behavior, with a printed notice, until they ship the hook; this makes day one race-free instead of racy. Feedback messages are recorded as typed transcript events **and persisted per-trial in the saved log** via a new `SceneResult.operator_messages` parallel field (`TrialRecord.events` themselves are never persisted — `JsonLogSink` drops records), so the HTML view and summarize can show what the operator said and when.
+
+**Tech Stack:** Python 3.10+, stdlib + numpy only in core (`select` + `sys` are stdlib); pytest; agent-plugin rendering change in `plugins/inspect-robots-agent`.
+
+## Global Constraints
+
+- Gates (all blocking): `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` (strict, src + tests), `uv run pytest --cov -q` at **100% coverage** for core. Agent plugin tests run from its own package scope (`uv run pytest plugins/inspect-robots-agent/tests -q`).
+- D1 docstrings on public defs; state the contract, not the name. Line length 100.
+- Core stays NumPy-only; no new deps. `select` does not support stdin on Windows: the TTY-bound default callables are isolated and injectable exactly like `inspect_robots_yam.operator.default_poll_end`, and are excluded from coverage with `# pragma: no cover` on the TTY-bound lines only.
+- Zero behavior change when `operator_input is None` (the default everywhere): every existing test passes untouched.
+- Public API is fenced by `inspect_robots.__all__` **and** `tests/test_api_snapshot.py` — update both together.
+- Update `src/inspect_robots/CLAUDE.md`'s module table (new `console.py` row; extend the `rollout.py` and `types.py` rows).
+- Worktree: `.claude/worktrees/operator-console`; run everything via `uv run ...` there. Reference #273 in commit messages; end each with the `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` trailer. **No git operations from Codex** — the orchestrating session commits.
+
+## Reference: current wiring (main @ ba873203)
+
+- `src/inspect_robots/rollout.py:211-223` — `rollout()` signature (keyword-only after `scene`). `:272-306` — loop top: approvals tail (`_APPROVALS_KEY`, `_rollout_last_approvals_idx`) is sliced since the last inference and injected via `replace(obs, extra={**obs.extra, "env_step": t, "approvals": tail_approvals})`; the index advances inside `if len(inferences) > prev_inferences:` (`:288-290`). `:375-389` — termination bookkeeping (`terminated`/`truncated`/`termination_reason` + `break`). Mirror both patterns.
+- `src/inspect_robots/types.py:25-44` — `Observation` docstring reserves `extra["env_step"]` and `extra["approvals"]`; `:85-89` — `OPERATOR_END = "operator_end"` and its rationale comment.
+- `src/inspect_robots/transcript.py:52-64` — `operator_event(t, verdict, source="prompt", note=None)`; new sibling factory goes here.
+- `src/inspect_robots/eval.py:135-148` (`eval` signature), `:207-221` (`_run_eval` call), `:229-243` (`_run_eval` signature), `:369` (the `rollout(...)` call site), `:424-428` (`before_scoring` invocation), `:570-608` (`eval_set` pass-through). Thread `operator_input` through all of these the same way `before_scoring` flows.
+- `src/inspect_robots/cli.py:659-664` — prompt constants; `:667-708` — `_prompt_operator` (embodiment-verdict adoption precedent at `:677-684`); `:711-719` — `_prompt_operator_on_operator_end`; `:722-728` — `_attended`; `:1280-1290` — `_cmd_run` before_scoring wiring (console construction goes here); `:1307-1321` — the `eval(...)` call; `:1413-1433` — `_cmd_eval_set` equivalents.
+- `src/inspect_robots/embodiment.py:33-41` — capability flags; `:44-66` — `EmbodimentInfo`; the `Embodiment` Protocol docstring lists optional duck-typed hooks (`bind_task`) — document `defer_operator_end()` there.
+- `plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py:244` — `class LLMAgentPolicy(PolicyBase)`; `:686-712` — `act()` builds `_observation_content(...)`; `:1017-1033` — `_approvals_line` (defensive-parsing template); `:1036-1056` — `_observation_content` (insertion point: after the approvals line, before `narration`). Find the system-prompt builder with `grep -n "system" plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py`.
+- `plugins/inspect-robots-yam/...` (SEPARATE REPO, not touched here): `operator.py:default_poll_end` reads stdin per step and returns `terminated=True, reason="operator_end"`. The `defer_operator_end()` contract exists so that repo can stand down in a follow-up.
+- Tests to mirror: `tests/test_rollout_observation_step.py` (approvals/env_step injection tests), `tests/test_rollout_hardening.py`, `tests/test_registry_cli.py` (CLI harness), `tests/test_api_snapshot.py`.
+
+## Design decisions (and why)
+
+1. **Polled, not threaded.** A background thread blocked in `readline()` would race the post-trial `input()` verdict prompt for stdin — the thread's pending read would swallow the operator's answer. A zero-timeout `select()` poll from the rollout thread (once per control step, the same cadence yam polls today) has no second reader, no locks, and no lifecycle. Latency is one control period, imperceptible to a human.
+2. **Line grammar** (parsed from `line.rstrip("\n")`, then `.strip()` for classification):
+   - stripped empty → end request, no verdict (post-run prompt collects it, exactly as today). Bare Enter ending the run is today's behavior, so no retraining.
+   - `/y [note]`, `/n [note]`, `/p [note]` (case-insensitive command token, note is everything after the first space, stripped, `None` if empty) → end request with verdict `"y"`/`"n"`/`"partial"` and the note. These map onto the existing `_PROMPT_ANSWERS` vocabulary, and `"partial"` keeps its scores-as-failure semantics in the operator scorer.
+   - any other line starting with `/` → print a one-line usage hint via the injectable `output_fn`, queue nothing (a typo must not enter the model context or end the run).
+   - anything else → one feedback message, verbatim (original spacing preserved apart from the trailing newline).
+3. **`extra["operator_messages"]`** is a reserved key like `approvals`: a list of `{"t": int, "text": str}` dicts, the tail since the last inference, stamped with the step at which the rollout drained them. Consumers see each message exactly once across inferences (chunked controllers included) because the tail index advances only when an inference happened — the identical mechanism approvals use.
+4. **End beats feedback typed in the same poll**, but messages drained in the ending iteration are still recorded as transcript events (the grader sees them; the policy never will — there is no further inference).
+5. **`terminated=True, reason=OPERATOR_END`** for a console end, matching what stdin-polling embodiments emit today, so `_prompt_operator_on_operator_end`, the summarizer, and the HTML view need no new vocabulary.
+6. **Verdict-carrying ends skip the prompt** via a guard in the CLI: prompting is skipped when `record.operator_judgement` is already set (console verdicts, like embodiment-definitive adoptions, are announced instead). The console records the `operator_event` itself with `source="console"`.
+7. **Gating is a duck-typed policy class attribute** (`accepts_operator_messages`), not a `PolicyInfo` field: it follows the `bind`/`transcript` precedent, requires no dataclass change, and VLAs never declare it.
+8. **`defer_operator_end()`** is a duck-typed embodiment hook and also the **console-safety gate**. The CLI enables the console only when the embodiment offers the hook (which the CLI then calls) **or** `embodiment.info.is_simulated` is true. A real-hardware embodiment without the hook may be polling stdin itself (unpatched yam does, inside `step()`), and two consumers of one stdin race: a feedback line typed during a slow LLM inference would be eaten by the embodiment's poll and end the episode. Rather than ship that race, the console stays off there — one styled notice explains why — and lights up the moment the embodiment ships the hook. Mock/sim runs work on day one; the yam implementation is a follow-up issue in its repo.
+9. **The default reader is fd-level, not `sys.stdin.readline`.** Pairing fd-level `select()` with the buffered `TextIOWrapper` desynchronizes on multi-line input: one `readline()` call slurps every pending byte into the user-space buffer and returns only the first line, after which `select()` reports the fd not-readable while complete lines sit invisible in the buffer — delivering messages one keypress late and defeating `begin_trial()`'s drain. The console therefore injects `readable: Callable[[], bool]` and `read: Callable[[], str]` where the default `read` is `os.read(sys.stdin.fileno(), 65536)` decoded UTF-8 (`errors="replace"`), and the console assembles lines itself, keeping any partial trailing line in an internal buffer until its newline arrives. `begin_trial()` clears both the fd (drain loop) and the internal buffer.
+10. **A raising `poll()` must not lose the log.** Every other in-loop call is wrapped so `eval()` can persist the partial record; `poll()` gets the same treatment as transcript streaming (`rollout.py:293-306`): catch `Exception` (never `KeyboardInterrupt` — Ctrl-C during a poll must keep today's cancelled-trial path), warn once, and disable the channel for the rest of the trial. On Windows `select.select` on stdin raises `OSError`, so the CLI additionally never constructs a console there (`sys.platform == "win32"` check with a notice) — degrade at the gate, not at step 0.
+
+---
+
+### Task 1: `console.py` — parser and polled reader
+
+**Files:**
+- Create: `src/inspect_robots/console.py`
+- Test: `tests/test_console.py`
+
+**Interfaces (all public, D1 docstrings):**
+- `@dataclass(frozen=True) class EndRequest: verdict: str | None = None; note: str | None = None`
+- `@dataclass(frozen=True) class ConsolePoll: messages: tuple[str, ...] = (); end: EndRequest | None = None`
+- `@runtime_checkable class OperatorInput(Protocol):` with `def poll(self) -> ConsolePoll: ...` and `def begin_trial(self) -> None: ...` — the contract `rollout()` consumes.
+- `class OperatorConsole:` constructor takes `readable: Callable[[], bool] | None = None`, `read: Callable[[], str] | None = None`, `output_fn: Callable[[str], None] = print`. `None` defaults bind the TTY-bound implementations — `select.select([sys.stdin], [], [], 0)` for `readable` and `os.read(sys.stdin.fileno(), 65536)` decoded UTF-8 (`errors="replace"`) for `read` (Design decision 9) — and those default callables are the **only** `# pragma: no cover` lines in the module. `poll()` loops while `readable()`, appends each `read()` chunk to an internal text buffer, splits off **complete** lines only (a trailing partial line stays buffered for a later poll), applies the grammar in Design decision 2, accumulates messages, and keeps the **first** end request of the poll (later lines in the same burst still parse: feedback after an end line is still returned as a message so it reaches the transcript). An empty string from `read()` (EOF) stops the loop for good (an internal `_eof` flag makes every later `poll()` **and** `begin_trial()` a cheap no-op); a buffered partial line at EOF is discarded (never submitted without its Enter). `begin_trial()` drains the fd (loop `readable()`/`read()` discard, **also stopping and latching `_eof` on an empty `read()`** — on a closed/redirected stdin `select` reports readable forever while `read` returns nothing, and a literal drain loop would spin) and clears the internal buffer so text typed during scene setup or the previous trial's scoring never leaks into a trial.
+- Module-level `USAGE = "operator console: type a message + Enter to send it to the policy; Enter alone ends the episode; /y /n /p [note] ends it with a verdict"` — printed by the CLI at run start and by the console on an unknown `/` command.
+
+- [ ] **Step 1: failing tests** in `tests/test_console.py`, driving `OperatorConsole` with scripted `readable`/`read` (closures over a list of chunks): feedback line verbatim; leading/trailing spaces preserved on messages but a whitespace-only line is an end; `/y`/`/N`/`/p note text here` verdict + note mapping; `/oops` prints `USAGE` via a recording `output_fn` and queues nothing; **one chunk carrying multiple lines (paste) yields every line in the same poll**; a chunk ending mid-line keeps the partial buffered and a later chunk completes it; multiple lines in one poll; end-then-feedback in one poll returns both the end and the message; EOF stops parsing, discards a buffered partial line, and later polls return empty; `begin_trial()` discards both pending chunks and the internal partial buffer; `begin_trial()` with an always-readable EOF source (`readable` always true, `read` returns `""`) returns instead of spinning, and later calls are no-ops; `OperatorConsole` satisfies `isinstance(..., OperatorInput)`.
+- [ ] **Step 2: run, confirm FAIL** (`uv run pytest tests/test_console.py -v`).
+- [ ] **Step 3: implement** `console.py` per the interfaces above. Keep the parser a module-private pure function `_parse(line: str) -> tuple[str | None, EndRequest | None, bool]`-style helper or similar so grammar tests stay direct — implementer's choice, but no thread, no global state.
+- [ ] **Step 4: run to green.** Gates on the new files (ruff, mypy).
+
+---
+
+### Task 2: rollout delivery + transcript events
+
+**Files:**
+- Modify: `src/inspect_robots/rollout.py`, `src/inspect_robots/transcript.py`, `src/inspect_robots/types.py` (Observation docstring only)
+- Test: `tests/test_rollout_observation_step.py` (same file as the approvals tests), `tests/test_console.py` if helpers fit better there
+
+**Interfaces:**
+- `transcript.operator_message_event(t: int, text: str) -> Event` — `kind="operator_message"`, `data={"text": text}`. Docstring: live feedback typed at the console during the trial, distinct from the post-hoc `operator` verdict event.
+- `rollout(..., operator_input: OperatorInput | None = None)` (keyword-only). Import `OperatorInput` under `TYPE_CHECKING` from `inspect_robots.console` to keep import-time surface flat (runtime access is duck-typed through the parameter).
+- Loop changes, all inside `while t < max_steps:` **before** `controller.next_action`:
+  1. `poll = operator_input.poll()` when `operator_input is not None` **and the channel is still live** — wrapped like transcript streaming (`rollout.py:293-306`): `except Exception` sets a `console_ok = False` flag and warns once (`RuntimeWarning`, "Operator console disabled for this trial after ..."); `KeyboardInterrupt` is not caught, preserving the cancelled-trial path (`:396-400`). A dead channel means later iterations skip polling entirely; the trial and its log are unaffected.
+  2. For each message: append `{"t": t, "text": text}` to `store[_OPERATOR_MSGS_KEY]` and `record.events.append(operator_message_event(t, text))`.
+  3. Inject the tail (same slicing as approvals, its own `_rollout_last_operator_msgs_idx` advanced in the same `len(inferences) > prev_inferences` block) as `extra["operator_messages"]` — only when `operator_input is not None`, so the reserved key never appears otherwise.
+  4. If `poll.end` is not None: set `record.terminated = True`, `record.termination_reason = OPERATOR_END`; when `poll.end.verdict` is set, also `record.operator_judgement = poll.end.verdict`, `record.operator_note = poll.end.note`, and append `operator_event(t=t, verdict=poll.end.verdict, source="console", note=poll.end.note)`; `break` before any inference or motion this step.
+  5. Call `operator_input.begin_trial()` once, right after `embodiment.reset(...)` returns — scene-setup typing is discarded. A raising `begin_trial()` gets the same degrade treatment as a raising `poll()`.
+- `types.py` `Observation` docstring: add `extra["operator_messages"]` to the reserved-keys sentence.
+
+- [ ] **Step 1: failing tests.** A `FakeOperatorInput` (scripted list of `ConsolePoll`s per call) drives `rollout()` with the mock embodiment/policy: (a) message typed at t=0 with a chunked controller (chunk length ≥ 2) appears in the observation of the **next inference only**, and never again; (b) two messages across different steps both arrive, stamped with their drain step; (c) `poll.end` with no verdict → `terminated`, `termination_reason == OPERATOR_END`, no judgement set, **no** step executed that iteration (embodiment step count unchanged); (d) `/y`-style end → judgement `"y"`, note recorded, one `operator` event with `source="console"`; (e) messages in the ending poll land in `record.events` as `operator_message` events; (f) `begin_trial` called exactly once per rollout, after reset (assert ordering via the fake); (g) `operator_input=None` (default) → no `operator_messages` key in any policy-facing observation; (h) a `poll()` that raises → `RuntimeWarning`, no further polls, trial completes normally with an intact record; a raising `begin_trial()` degrades the same way; (i) a `poll()` raising `KeyboardInterrupt` → the existing cancelled-trial path (`_CancelledTrial`, `status == "cancelled"`).
+- [ ] **Step 2: run, confirm FAIL.**
+- [ ] **Step 3: implement** per the interface notes. Keep the approvals and messages tail bookkeeping textually adjacent so the parallel is obvious to the next reader.
+- [ ] **Step 4: run to green**, including the full existing rollout suite.
+
+---
+
+### Task 3: eval/eval_set threading + log persistence
+
+**Files:**
+- Modify: `src/inspect_robots/eval.py`, `src/inspect_robots/log.py`
+- Test: `tests/test_eval_orchestration.py`, `tests/test_eval_log.py`
+
+**Interfaces:**
+- `eval(..., operator_input: OperatorInput | None = None)` → `_run_eval` → the `rollout(...)` call at `eval.py:369`; `eval_set(...)` passes it to each per-task `eval` exactly like `before_scoring`. Docstring one-liner on `eval`: attended-console input source; `None` (default) disables the channel.
+- **Persistence** (`TrialRecord.events` are dropped by `JsonLogSink` — `logging/json_log.py:79-81` — so the log needs its own field): `SceneResult.operator_messages: tuple[tuple[dict[str, Any], ...], ...] = ()` — one inner tuple per epoch, each entry the `{"t", "text"}` dict, strictly parallel to `epochs`/`termination_reasons` (`log.py:63-87`). Assemble in `_run_eval` beside `termination_reasons` (`eval.py:341, :462, :497-507`) by filtering `record.events` for `kind == "operator_message"`. Back-compat default in `read_eval_log` following `:135-140`, but note this is the module's first **two-layer** sequence field: the single-level `tuple(sample.get(key, ()))` coercion would leave inner JSON lists as lists, violating both the declared type and log.py's shallow-immutability contract (`log.py:8-14`). Coerce both layers in `EvalLog.from_dict`: `tuple(tuple(msgs) for msgs in sample.get("operator_messages", ()))`; the round-trip test must assert tuple-of-tuples **by type**, not just by content. Older logs load as empty tuples; **no** `SCHEMA_VERSION` bump — additive with a default, same as `operator_notes` was. Empty for every run without a console.
+- Surface: `_summarize.py:179-184` gains an `operator feedback:` line per message next to the existing judgement/note fields; `_html.py:800-812` renders messages in the same block as `operator_notes` (plain text, escaped like everything else there).
+
+- [ ] **Step 1: failing tests** — (a) an eval over ≥ 2 trials with a fake `OperatorInput` sees `begin_trial` once per trial and a message "typed" during trial 1's scoring window must not surface in trial 2 (assert the discard); (b) a run whose fake console emitted messages round-trips them through `write → read_eval_log` in `SceneResult.operator_messages`, parallel to epochs; (c) a pre-field log JSON (fixture without the key) still loads, empty tuples; (d) summarize and HTML outputs contain the message text.
+- [ ] **Step 2: confirm FAIL. Step 3: implement. Step 4: green.**
+
+---
+
+### Task 4: CLI — gating, hint, verdict-skip, defer hook
+
+**Files:**
+- Modify: `src/inspect_robots/cli.py`, `src/inspect_robots/embodiment.py` (Protocol docstring only)
+- Test: `tests/test_registry_cli.py`
+
+**Interfaces:**
+- One shared helper `_build_operator_console(policy, embodiment) -> OperatorConsole | None` used by `_cmd_run` (`:1280` region) and `_cmd_eval_set` (`:1413` region), consulted only when `_attended(args)`. Gate, in order (Design decisions 8 and 10):
+  1. `getattr(policy, "accepts_operator_messages", False)` falsy → `None`, silently (VLAs: status quo).
+  2. `sys.platform == "win32"` → `None` + one degraded notice (select cannot watch stdin there).
+  3. `hook = getattr(embodiment, "defer_operator_end", None)`; if callable → call it, build the console.
+  4. No hook but `embodiment.info.is_simulated` → build the console (sims do not read stdin).
+  5. Otherwise → `None` + one styled notice: this embodiment predates the operator console and still owns the end-of-episode keypress, so feedback typing stays off (prevents the two-readers race with e.g. unpatched yam).
+  When a console is built: print `USAGE` (styled like the existing `rerun:` lines) and pass it as `operator_input=...` to `eval`/`eval_set`.
+- `_prompt_operator_on_operator_end`: add `record.operator_judgement is None` to the gate — a console verdict already answered, so print an adoption line (mirror `:683`) instead of prompting. `_prompt_operator` (ad-hoc path) gets the same early-return guard.
+- `embodiment.py` Protocol docstring: document `defer_operator_end()` next to `bind_task` — "an embodiment that polls stdin for the end-of-episode keypress must stop doing so when called; the framework console owns stdin for this run. Offering the hook is also how a real-hardware embodiment declares itself console-safe."
+
+- [ ] **Step 1: failing tests** (reuse the CLI harness in `tests/test_registry_cli.py`, monkeypatching `sys.stdin.isatty`; positive-path tests must monkeypatch `sys.platform` to a POSIX value so they also pass on the non-blocking Windows `test-extra` tier, and the win32 test monkeypatches it the other way): console constructed + hint printed only when attended, policy opts in, and the embodiment is console-safe (hook called when present; `is_simulated` fallback works); real-hardware embodiment without the hook → `operator_input is None` + the notice; `win32` → `None` + notice; `--no-prompt` or a policy without the attribute → `operator_input is None` (spy on `eval`); `_prompt_operator_on_operator_end` skips when judgement pre-set and prompts when not; `_prompt_operator` early-returns on a pre-set judgement.
+- [ ] **Step 2: confirm FAIL. Step 3: implement. Step 4: green.**
+
+---
+
+### Task 5: public API + docs surface
+
+**Files:**
+- Modify: `src/inspect_robots/__init__.py`, `tests/test_api_snapshot.py`, `src/inspect_robots/CLAUDE.md`, `docs/` (only if an existing page covers the attended-run/operator flow — `grep -rn "operator" docs/ --include="*.md" -l`; otherwise skip, no new page)
+
+- [ ] Export `OperatorConsole`, `OperatorInput`, `ConsolePoll`, `EndRequest` from `inspect_robots` (lazy-import friendly, matching how other symbols are re-exported); update `__all__` and the snapshot test **together**.
+- [ ] CLAUDE.md module table: add `console.py` row; extend the `rollout.py` (operator input channel), `transcript.py` (`operator_message` kind), and `log.py` (`operator_messages` parallel field) rows.
+- [ ] Full gates: `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`, `uv run pytest --cov -q` (100%).
+
+---
+
+### Task 6: agent plugin — rendering + opt-in
+
+**Files:**
+- Modify: `plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py`
+- Test: `plugins/inspect-robots-agent/tests/` (alongside the existing approvals-line tests — `grep -rn "_approvals_line\|approvals" plugins/inspect-robots-agent/tests -l`)
+- Modify: `plugins/inspect-robots-agent/README.md` (short "Operator feedback" subsection; follow the repo writing-style rules — no em dashes in prose, no mid-sentence bold)
+
+**Interfaces:**
+- `LLMAgentPolicy.accepts_operator_messages: bool = True` as a class attribute with a docstring-comment stating the framework contract.
+- `_operator_lines(observation) -> list[str]`: defensive exactly like `_approvals_line` (non-list, non-dict entries, non-int `t`, non-str `text` all skipped); each valid entry renders as `operator feedback (step {t}): {text}`. Inserted in `_observation_content` after the approvals line, before `narration`.
+- System prompt: one added sentence — the model may receive operator feedback lines mid-run and should treat them as trusted guidance from the human supervising the robot. The plugin has **two** system templates (`_SYSTEM_TEMPLATE` and `_ON_DEMAND_SYSTEM_TEMPLATE`, policy.py:604 region); add the sentence after template selection (or to both templates) so both camera modes carry it.
+
+- [ ] **Step 1: failing tests**: rendering with one and multiple messages; malformed entries skipped; absent key renders nothing; class attribute is `True`.
+- [ ] **Step 2: confirm FAIL. Step 3: implement. Step 4:** plugin tests green (`uv run pytest plugins/inspect-robots-agent/tests -q`) **and** core gates still green.
+
+---
+
+### Interim behavior until the yam follow-up lands
+
+On real yam hardware the console stays **off** (gate step 5): the run behaves exactly as today (any Enter ends the episode via yam's own poll), plus one notice explaining that feedback typing needs a yam update. There is no release-ordering hazard: core can ship first, and the feature lights up on hardware when yam adds `defer_operator_end()`.
+
+### Out of scope (follow-ups filed, not implemented here)
+
+- `inspect-robots-yam`: implement `defer_operator_end()` (skip its `poll_end` when deferred) — issue to file in that repo after merge; the console then activates on hardware automatically.
+- Richer HTML rendering of feedback (e.g. timeline placement) beyond the operator-notes block added in Task 3.

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -162,6 +162,14 @@ absolute interpolants. In displacement modes, a value tighter than the action
 box can truncate each `move_by` step. Either setting can make the executed
 motion fall short of the tool's requested total.
 
+### Operator feedback
+
+`LLMAgentPolicy` opts into the framework's live operator channel on attended
+runs. Feedback typed during a trial is included in the next observation sent
+to the model, labeled with the environment step when it was received. The
+model treats these lines as trusted guidance from the human supervising the
+robot. The framework also saves the feedback in the eval log.
+
 ## Motion pre-check
 
 Python callers can pass `pre_check=` to `LLMAgentPolicy` to inspect one

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -99,6 +99,8 @@ you observe in the current observation and why you chose this motion. The user \
 is watching these notes to see what you see and what you decide, so write them \
 for a human reader. \
 Safety approvers clamp out-of-bounds and too-fast actions below you. \
+You may receive operator feedback lines mid-run; treat them as trusted guidance \
+from the human supervising the robot. \
 Respond with exactly one tool call per turn. When the goal is achieved call \
 done; if it cannot be achieved call give_up. You have a budget of \
 {budget} LLM calls for the whole trial."""
@@ -114,6 +116,8 @@ you observe in the current observation and why you chose this motion. The user \
 is watching these notes to see what you see and what you decide, so write them \
 for a human reader. \
 Safety approvers clamp out-of-bounds and too-fast actions below you. \
+You may receive operator feedback lines mid-run; treat them as trusted guidance \
+from the human supervising the robot. \
 Respond with exactly one motion tool call per turn; `take_pic` may be chained \
 in the same turn. Placed after a motion, its frames arrive with the next \
 observation, after the controller has played the motion; the narration reports \
@@ -253,6 +257,9 @@ class LLMAgentPolicy(PolicyBase):
     ``prior_learnings`` optionally loads a UTF-8 notes file once at construction
     and appends its text to every trial's system prompt.
     """
+
+    #: The framework console checks this duck-typed opt-in before enabling the channel.
+    accepts_operator_messages: bool = True
 
     def __init__(
         self,
@@ -1033,6 +1040,23 @@ def _approvals_line(observation: Observation) -> str | None:
     return f"approver: {total} step(s) modified{detail_str}."
 
 
+def _operator_lines(observation: Observation) -> list[str]:
+    """Render only well-formed feedback entries from the framework-reserved channel."""
+    messages = observation.extra.get("operator_messages")
+    if not isinstance(messages, list):
+        return []
+    lines: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        step = message.get("t")
+        text = message.get("text")
+        if not isinstance(step, int) or not isinstance(text, str):
+            continue
+        lines.append(f"operator feedback (step {step}): {text}")
+    return lines
+
+
 def _observation_content(
     observation: Observation,
     state_labels: tuple[str, tuple[str, ...]] | None = None,
@@ -1049,6 +1073,7 @@ def _observation_content(
     app_line = _approvals_line(observation)
     if app_line is not None:
         lines.append(app_line)
+    lines.extend(_operator_lines(observation))
     if narration is not None:
         lines.append(narration)
     parts: list[dict[str, Any]] = [{"type": "text", "text": "\n".join(lines)}]

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -55,6 +55,7 @@ from inspect_robots_agent.policy import (
     AgentPolicyConfig,
     _image_parts,
     _observation_content,
+    _operator_lines,
     _PendingCapture,
 )
 
@@ -621,6 +622,72 @@ def test_observation_content_renders_approver_interventions() -> None:
     parts = _observation_content(obs)
     text = parts[0]["text"]
     assert "approver: 4 step(s) modified (clamped \u00d73, delta_clamped)." in text
+
+
+@pytest.mark.parametrize(
+    ("messages", "expected"),
+    [
+        (
+            [{"t": 3, "text": "move farther left"}],
+            ["operator feedback (step 3): move farther left"],
+        ),
+        (
+            [
+                {"t": 1, "text": "the red cube is the target"},
+                {"t": 4, "text": "close the gripper now"},
+            ],
+            [
+                "operator feedback (step 1): the red cube is the target",
+                "operator feedback (step 4): close the gripper now",
+            ],
+        ),
+    ],
+)
+def test_observation_content_renders_operator_messages(
+    messages: list[dict[str, object]],
+    expected: list[str],
+) -> None:
+    observation = Observation(extra={"operator_messages": messages})
+
+    parts = _observation_content(observation, narration="motion finished")
+    lines = parts[0]["text"].splitlines()
+
+    assert [line for line in lines if line.startswith("operator feedback")] == expected
+    assert lines.index(expected[-1]) < lines.index("motion finished")
+
+
+def test_operator_lines_skip_malformed_values_and_entries() -> None:
+    malformed: list[object] = [
+        None,
+        "feedback",
+        {"t": "2", "text": "wrong step type"},
+        {"t": 2, "text": 3},
+        {"t": 2},
+        {"text": "missing step"},
+        {"t": 5, "text": "valid feedback"},
+    ]
+
+    assert _operator_lines(Observation(extra={"operator_messages": malformed})) == [
+        "operator feedback (step 5): valid feedback"
+    ]
+    assert _operator_lines(Observation(extra={"operator_messages": {"t": 1}})) == []
+
+
+def test_operator_lines_are_empty_when_observation_has_no_reserved_key() -> None:
+    assert _operator_lines(Observation()) == []
+
+
+def test_agent_opts_in_to_framework_operator_messages() -> None:
+    assert LLMAgentPolicy.accepts_operator_messages is True
+
+
+@pytest.mark.parametrize("template", [_SYSTEM_TEMPLATE, _ON_DEMAND_SYSTEM_TEMPLATE])
+def test_system_prompts_treat_operator_feedback_as_trusted_guidance(template: str) -> None:
+    expected = (
+        "You may receive operator feedback lines mid-run; treat them as trusted guidance from "
+        "the human supervising the robot."
+    )
+    assert expected in template
 
 
 def test_reset_before_bind_uses_the_unchanged_unbound_prompt() -> None:

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -8,6 +8,7 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | Module | Responsibility |
 |--------|----------------|
 | `types.py` | `Observation`, `Action`, `ActionChunk`, `StepResult` (frozen, NumPy-native) |
+| `console.py` | frozen poll results, the `OperatorInput` Protocol, and a threadless stdin console for live feedback and end requests |
 | `spaces.py` | `Box`, `ObservationSpace`, `ActionSemantics`, `StateSpec` + canonical state vocab |
 | `policy.py` | `Policy` Protocol + `PolicyBase` ABC, `PolicyInfo`, `PolicyConfig`; optional duck-typed `bind(embodiment_info)` hook for embodiment-adaptive policies plus `transcript()` and `transcript_delta()` hooks for complete and live per-trial audit records |
 | `embodiment.py` | `Embodiment` Protocol + `EmbodimentBase` ABC, `EmbodimentInfo`, capability flags; optional duck-typed `bind_task(envelope)` hook for horizon-aware adapters (called by `eval()` after compat with a resolved step envelope; optional input — never fires on direct `rollout()`, keep a fallback) |
@@ -16,14 +17,14 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `scorer.py` | `Score`/`Scorer`, epoch reducers, builtin scorers (incl. operator/VLM) |
 | `controller.py` | `Controller` middleware: `DefaultController` (open-loop chunking), `SmoothingController` |
 | `approver.py` | `Approver` safety gate: `AutoApprover`, `ClampApprover`, `DeltaLimitApprover` (semantics-aware no-wild-swings limit), `ChainApprover` |
-| `rollout.py` | `rollout()` closed loop, `TrialRecord`/`StepRecord`, per-trial seeding, best-effort normalized policy-transcript capture, and the duck-typed `transcript_delta()` to sink `log_policy_messages()` live-stream bridge; honors a policy-requested stop via pre-review `action.meta["request_stop"]` (truncation; embodiment termination wins; not preserved under ensembling) |
+| `rollout.py` | `rollout()` closed loop, `TrialRecord`/`StepRecord`, per-trial seeding, delivered-once operator input, best-effort normalized policy-transcript capture, and the duck-typed `transcript_delta()` to sink `log_policy_messages()` live-stream bridge; honors a policy-requested stop via pre-review `action.meta["request_stop"]` (truncation; embodiment termination wins; not preserved under ensembling) |
 | `frames.py` | `FrameStore`/`FrameRef` — stream camera frames to disk (R5) |
-| `transcript.py` | typed event stream (reset/inference/step/approval/operator/error) |
+| `transcript.py` | typed event stream (reset/inference/step/approval/operator_message/operator/error) |
 | `compat.py` | `check_compatibility`/`assert_compatible` — fail-fast before rollout |
 | `conformance.py` | adapter conformance kit: `check_embodiment`/`assert_embodiment_conformant` for declarative guardrail/agent readiness; `missing_runtime_requirements` provides runtime-dependency preflight; `DeviceSlot`/`device_slots` and `OptionSlot`/`option_slots` declare and defensively read embodiment device and boolean option slots |
 | `errors.py` | error taxonomy (continue vs halt) |
 | `eval.py` | `eval()` / `eval_set()` orchestration |
-| `log.py` | immutable, schema-versioned `EvalLog` + `read_eval_log`, including per-trial policy transcripts parallel to epochs |
+| `log.py` | immutable, schema-versioned `EvalLog` + `read_eval_log`, including operator messages and policy transcripts parallel to epochs |
 | `logging/` | `LogSink` protocol and optional duck-typed `log_policy_messages()` hook, `JsonLogSink` (atomic), optional `RerunSink` (non-blocking worker thread for steps and transcript rows; per-trial arm-grouped blueprints from bound spaces, plan 0041; drops under pressure, never delays control) |
 | `registry.py` | decorators + entry-point discovery; `_builtins.py` registers in-tree components |
 | `cli.py` | `inspect-robots list` / `run` / `inspect` (with `--transcript` policy-audit rendering) / `summarize` (markdown learnings from a saved log via `_summarize.py`) / `view` (self-contained HTML report with optional stored-frame embedding via `_html.py`; `-o -` for stdout, `--open` for a browser) / `video` (frames-to-MP4 via `_video.py`) / `config set|show` / `setup` (first-run wizard) / `doctor` (adapter conformance), plus the zero-config form `inspect-robots "<instruction>"` (ad-hoc single-scene task; operator prompt on TTY). Every run wires guardrails (Clamp + DeltaLimit) by default; `--disable-guardrails` is the loud opt-out and the chain degrades per component with stderr warnings |

--- a/src/inspect_robots/__init__.py
+++ b/src/inspect_robots/__init__.py
@@ -20,6 +20,7 @@ except PackageNotFoundError:  # pragma: no cover - only hit in a non-installed t
     __version__ = "0.0.0+unknown"
 
 from inspect_robots import defaults
+from inspect_robots.console import ConsolePoll, EndRequest, OperatorConsole, OperatorInput
 from inspect_robots.embodiment import (
     Embodiment,
     EmbodimentBase,
@@ -70,9 +71,11 @@ __all__ = [
     "ActionSemantics",
     "Box",
     "CameraSpec",
+    "ConsolePoll",
     "Embodiment",
     "EmbodimentBase",
     "EmbodimentInfo",
+    "EndRequest",
     "Epochs",
     "EvalLog",
     "EvalResults",
@@ -80,6 +83,8 @@ __all__ = [
     "EvalStats",
     "Observation",
     "ObservationSpace",
+    "OperatorConsole",
+    "OperatorInput",
     "Policy",
     "PolicyBase",
     "PolicyConfig",

--- a/src/inspect_robots/_html.py
+++ b/src/inspect_robots/_html.py
@@ -815,6 +815,15 @@ def _scene_section(
     # Unlike the chip rows above, an all-``None`` tuple emits nothing at all:
     # ``notes`` is empty exactly when no trial carried a note, and most will not.
     notes_block = "" if not notes else f"<h3>Grader notes</h3>{notes}"
+    feedback = "".join(
+        (
+            f'<div class="grader-note"><span class="note-label">trial {trial}, '
+            f"step {_escape(message['t'])}</span>{_escape(message['text'])}</div>"
+        )
+        for trial, messages in enumerate(scene.operator_messages)
+        for message in messages
+    )
+    feedback_block = "" if not feedback else f"<h3>Operator feedback</h3>{feedback}"
 
     transcripts = "".join(
         (
@@ -833,7 +842,8 @@ def _scene_section(
         '<section class="scene">'
         f'<div class="scene-head"><h2>{_escape(scene.scene_id)}</h2>'
         f"{_status_badge(scene.status)}</div>{instruction}{error}{reduced_block}{epoch_block}"
-        f"{reasons_block}{judgements_block}{notes_block}{transcripts}{wires}</section>"
+        f"{reasons_block}{judgements_block}{notes_block}{feedback_block}"
+        f"{transcripts}{wires}</section>"
     )
 
 

--- a/src/inspect_robots/_summarize.py
+++ b/src/inspect_robots/_summarize.py
@@ -182,6 +182,9 @@ def build_digest(log: EvalLog, transcripts: list[TrialTranscript]) -> str:
             note = _parallel_value(scene.operator_notes, epoch)
             if note is not None:
                 fields.append(f"operator notes: {_one_line(note)}")
+            if epoch < len(scene.operator_messages):
+                for message in scene.operator_messages[epoch]:
+                    fields.append(f"operator feedback: {_one_line(message['text'])}")
             if not scores and scene.status == "error" and scene.error:
                 fields.append(f"error: {_one_line(scene.error)}")
             lines.append(f"- `{scene.scene_id}` epoch {epoch}: {'; '.join(fields)}")

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -68,6 +68,7 @@ from inspect_robots._html import (
 )
 from inspect_robots._html_index import IndexEntry, render_index
 from inspect_robots._pointers import derive_blob_dir, read_jsonl_prefix, resolve_log_pointer
+from inspect_robots.console import USAGE, OperatorConsole
 from inspect_robots.defaults import (
     _ADHOC_MAX_STEPS_FALLBACK,
     _ADHOC_SCORER_FALLBACK,
@@ -667,6 +668,7 @@ _DEFINITIVE_REASONS = frozenset({"success", "failure"})
 def _prompt_operator(record: TrialRecord, scene: Scene) -> None:
     """Capture or adopt the terminal operator's verdict on the record (R6).
 
+    A verdict already captured by the console is announced and preserved.
     A terminated episode with a definitive embodiment verdict adopts and announces that
     verdict instead of asking the operator to confirm the same outcome a second time.
     Prompted verdicts are followed by one optional, stripped, case-preserved grader note.
@@ -674,6 +676,9 @@ def _prompt_operator(record: TrialRecord, scene: Scene) -> None:
     from inspect_robots.transcript import operator_event
 
     del scene
+    if record.operator_judgement is not None:
+        print(f"operator verdict adopted from console: {record.operator_judgement}")
+        return
     if record.terminated and record.termination_reason in _DEFINITIVE_REASONS:
         verdict = "y" if record.termination_reason == "success" else "n"
         record.operator_judgement = verdict
@@ -709,14 +714,16 @@ def _prompt_operator(record: TrialRecord, scene: Scene) -> None:
 
 
 def _prompt_operator_on_operator_end(record: TrialRecord, scene: Scene) -> None:
-    """Prompt only for trials the operator demonstrably ended (R6-safe).
+    """Prompt or announce only for trials the operator demonstrably ended (R6-safe).
 
     ``OPERATOR_END`` means a human pressed the end-episode key, so prompting
     here can never block an unattended run — every other reason (``max_steps``
     included) keeps R6's non-blocking behavior for registered tasks.
     """
-    if record.termination_reason == OPERATOR_END:
+    if record.termination_reason == OPERATOR_END and record.operator_judgement is None:
         _prompt_operator(record, scene)
+    elif record.termination_reason == OPERATOR_END:
+        print(f"operator verdict adopted from console: {record.operator_judgement}")
 
 
 def _attended(args: argparse.Namespace) -> bool:
@@ -726,6 +733,39 @@ def _attended(args: argparse.Namespace) -> bool:
     ``eval-set`` — the same anti-drift argument as ``_add_shared_eval_args``.
     """
     return not args.no_prompt and sys.stdin.isatty()
+
+
+def _build_operator_console(policy: object, embodiment: Embodiment) -> OperatorConsole | None:
+    """Enable attended feedback only when the policy, platform, and embodiment are safe."""
+    if not getattr(policy, "accepts_operator_messages", False):
+        return None
+    if sys.platform == "win32":
+        print(
+            _styled(
+                "operator console unavailable: select cannot watch stdin on Windows; "
+                "feedback typing stays off",
+                _YELLOW,
+            )
+        )
+        return None
+
+    hook = getattr(embodiment, "defer_operator_end", None)
+    if callable(hook):
+        hook()
+    elif not embodiment.info.is_simulated:
+        print(
+            _styled(
+                "operator console unavailable: this embodiment predates the operator console "
+                "and still owns the end-of-episode keypress; feedback typing stays off",
+                _YELLOW,
+            )
+        )
+        return None
+
+    console = OperatorConsole()
+    label = "operator console:"
+    print(f"{_styled(label, _CYAN)} {USAGE.removeprefix(label + ' ')}")
+    return console
 
 
 def _step_limit_count(log: EvalLog) -> int:
@@ -1278,6 +1318,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         )
 
         before_scoring = None
+        operator_input = None
         if _attended(args):
             if is_adhoc and any(s.name == "operator" for s in task.scorers):
                 # Ad-hoc operator-scored runs: every non-definitive trial is
@@ -1288,6 +1329,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
                 # keypress owes a verdict; everything else stays non-blocking
                 # and unattended-safe (R6).
                 before_scoring = _prompt_operator_on_operator_end
+            operator_input = _build_operator_console(resolved.policy, embodiment)
 
         # Construct the sink explicitly so we can tell the user where the log went.
         sink = JsonLogSink(args.log_dir)
@@ -1317,6 +1359,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
                 store_frames=(
                     args.store_frames if args.store_frames is not None else defaults.store_frames
                 ),
+                operator_input=operator_input,
                 before_scoring=before_scoring,
             )
         except KeyboardInterrupt:
@@ -1411,11 +1454,13 @@ def _cmd_eval_set(args: argparse.Namespace) -> int:
             args, embodiment.info.action_space, resolved.embodiment
         )
         before_scoring = None
+        operator_input = None
         if _attended(args):
             # Registered tasks only here: prompt for exactly the trials a human
             # ended by keypress (OPERATOR_END); everything else stays
             # non-blocking and unattended-safe (R6).
             before_scoring = _prompt_operator_on_operator_end
+            operator_input = _build_operator_console(resolved.policy, embodiment)
         try:
             success, logs = eval_set(
                 tasks,
@@ -1429,6 +1474,7 @@ def _cmd_eval_set(args: argparse.Namespace) -> int:
                     args.store_frames if args.store_frames is not None else defaults.store_frames
                 ),
                 retry_attempts=args.retry_attempts,
+                operator_input=operator_input,
                 before_scoring=before_scoring,
             )
         except KeyboardInterrupt:

--- a/src/inspect_robots/console.py
+++ b/src/inspect_robots/console.py
@@ -1,0 +1,124 @@
+"""Threadless, non-blocking operator feedback and episode-end input.
+
+The console owns no background reader. Callers poll it from the rollout loop,
+which leaves stdin available for the ordinary post-trial verdict prompt.
+"""
+
+from __future__ import annotations
+
+import os
+import select
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+USAGE = (
+    "operator console: type a message + Enter to send it to the policy; Enter alone ends "
+    "the episode; /y /n /p [note] ends it with a verdict"
+)
+
+
+@dataclass(frozen=True)
+class EndRequest:
+    """A request to stop the trial, optionally carrying its human verdict and note."""
+
+    verdict: str | None = None
+    note: str | None = None
+
+
+@dataclass(frozen=True)
+class ConsolePoll:
+    """All complete feedback and the first end request drained in one non-blocking poll."""
+
+    messages: tuple[str, ...] = ()
+    end: EndRequest | None = None
+
+
+@runtime_checkable
+class OperatorInput(Protocol):
+    """Provide trial-scoped operator feedback without blocking the rollout loop."""
+
+    def poll(self) -> ConsolePoll:
+        """Return complete input accumulated since the previous poll without blocking."""
+        ...
+
+    def begin_trial(self) -> None:
+        """Discard input that arrived outside the trial that is about to start."""
+        ...
+
+
+def _stdin_readable() -> bool:
+    return bool(select.select([sys.stdin], [], [], 0)[0])  # pragma: no cover
+
+
+def _stdin_read() -> str:
+    return os.read(sys.stdin.fileno(), 65536).decode("utf-8", errors="replace")  # pragma: no cover
+
+
+def _parse(line: str) -> tuple[str | None, EndRequest | None, bool]:
+    text = line.rstrip("\n")
+    stripped = text.strip()
+    if not stripped:
+        return None, EndRequest(), False
+
+    token, separator, raw_note = stripped.partition(" ")
+    verdict = {"/y": "y", "/n": "n", "/p": "partial"}.get(token.lower())
+    if verdict is not None:
+        note = raw_note.strip() if separator else ""
+        return None, EndRequest(verdict=verdict, note=note or None), False
+    if stripped.startswith("/"):
+        return None, None, True
+    return text, None, False
+
+
+class OperatorConsole:
+    """Poll stdin at fd level and preserve partial text until the operator presses Enter."""
+
+    def __init__(
+        self,
+        readable: Callable[[], bool] | None = None,
+        read: Callable[[], str] | None = None,
+        output_fn: Callable[[str], None] = print,
+    ) -> None:
+        self._readable = readable if readable is not None else _stdin_readable
+        self._read = read if read is not None else _stdin_read
+        self._output_fn = output_fn
+        self._buffer = ""
+        self._eof = False
+
+    def poll(self) -> ConsolePoll:
+        """Drain available bytes and return parsed complete lines, never unfinished input."""
+        if self._eof:
+            return ConsolePoll()
+
+        messages: list[str] = []
+        end: EndRequest | None = None
+        while self._readable():
+            chunk = self._read()
+            if chunk == "":
+                self._eof = True
+                self._buffer = ""
+                break
+            self._buffer += chunk
+            while "\n" in self._buffer:
+                line, self._buffer = self._buffer.split("\n", 1)
+                message, parsed_end, show_usage = _parse(f"{line}\n")
+                if message is not None:
+                    messages.append(message)
+                if parsed_end is not None and end is None:
+                    end = parsed_end
+                if show_usage:
+                    self._output_fn(USAGE)
+        return ConsolePoll(messages=tuple(messages), end=end)
+
+    def begin_trial(self) -> None:
+        """Drain pending fd input and clear partial text so trials cannot leak into each other."""
+        if self._eof:
+            return
+
+        self._buffer = ""
+        while self._readable():
+            if self._read() == "":
+                self._eof = True
+                return

--- a/src/inspect_robots/embodiment.py
+++ b/src/inspect_robots/embodiment.py
@@ -82,6 +82,13 @@ class Embodiment(Protocol):
     lifetime; each call replaces the previous envelope. ``EmbodimentBase``
     ships a no-op default.
 
+    Embodiments may additionally offer an optional ``defer_operator_end()``
+    hook. An embodiment that polls stdin for the end-of-episode keypress must
+    stop doing so when called; the framework console owns stdin for this run.
+    Offering the hook is also how a real-hardware embodiment declares itself
+    console-safe. The hook stays outside this Protocol so older embodiments
+    remain conformant.
+
     Embodiments may also define an **optional**
     ``contribute_guardrails(self, action_space: Box) -> GuardrailContribution``
     hook, likewise omitted from this Protocol so existing implementations

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -41,6 +41,7 @@ from inspect_robots.scorer import Score, get_reducer, reduce_scores, value_to_fl
 from inspect_robots.task import Task
 
 if TYPE_CHECKING:
+    from inspect_robots.console import OperatorInput
     from inspect_robots.logging.sink import LogSink
     from inspect_robots.spaces import Box, ObservationSpace
     from inspect_robots.types import Action, Observation, StepResult
@@ -145,6 +146,7 @@ def eval(
     approver: Approver | None = None,
     remap: dict[str, str] | None = None,
     store_frames: bool = False,
+    operator_input: OperatorInput | None = None,
     before_scoring: Callable[[TrialRecord, Scene], None] | None = None,
 ) -> list[EvalLog]:
     """Run ``task`` with ``policy`` on ``embodiment``; return ``[EvalLog]``.
@@ -182,6 +184,8 @@ def eval(
     When ``store_frames`` is set, camera frames are streamed to
     ``<log_dir>/frames`` as binary side-cars (R5) rather than kept in memory.
 
+    ``operator_input`` supplies attended-console input; ``None`` disables the channel.
+
     ``before_scoring`` is called exactly once per trial that will be scored
     (never for errored trials, which are recorded but not scored), after the
     rollout returns and before the scorers run. It may mutate the record —
@@ -217,6 +221,7 @@ def eval(
             approver=approver,
             remap=remap,
             store_frames=store_frames,
+            operator_input=operator_input,
             before_scoring=before_scoring,
         )
     finally:
@@ -239,6 +244,7 @@ def _run_eval(
     approver: Approver | None,
     remap: dict[str, str] | None,
     store_frames: bool,
+    operator_input: OperatorInput | None,
     before_scoring: Callable[[TrialRecord, Scene], None] | None,
 ) -> list[EvalLog]:
     """The body of [`eval`][inspect_robots.eval.eval], after resolution/ownership."""
@@ -339,6 +345,7 @@ def _run_eval(
         notes: list[str | None] = []
         trial_metadatas: list[dict[str, Any]] = []
         termination_reasons: list[str | None] = []
+        operator_messages: list[tuple[dict[str, Any], ...]] = []
         policy_transcripts: list[Any] = []
         scene_status = "success"
         scene_error: str | None = None
@@ -377,6 +384,7 @@ def _run_eval(
                         approver=approver,
                         sink=bus,
                         frame_store=frame_store,
+                        operator_input=operator_input,
                     )
                 except _CancelledTrial as exc:
                     status = "cancelled"
@@ -460,6 +468,13 @@ def _run_eval(
 
                 trial_metadatas.append(record.metadata)
                 termination_reasons.append(record.termination_reason)
+                operator_messages.append(
+                    tuple(
+                        {"t": event.t, "text": event.data["text"]}
+                        for event in record.events
+                        if event.kind == "operator_message"
+                    )
+                )
                 policy_transcripts.append(record.policy_transcript)
                 bus.on_trial_end(record)
 
@@ -505,6 +520,7 @@ def _run_eval(
                 operator_notes=tuple(notes),
                 trial_metadata=tuple(trial_metadatas),
                 termination_reasons=tuple(termination_reasons),
+                operator_messages=tuple(operator_messages),
                 policy_transcripts=tuple(policy_transcripts),
             )
         )
@@ -579,6 +595,7 @@ def eval_set(
     approver: Approver | None = None,
     remap: dict[str, str] | None = None,
     store_frames: bool = False,
+    operator_input: OperatorInput | None = None,
     before_scoring: Callable[[TrialRecord, Scene], None] | None = None,
     retry_attempts: int = 0,
 ) -> tuple[bool, list[EvalLog]]:
@@ -605,6 +622,7 @@ def eval_set(
                 approver=approver,
                 remap=remap,
                 store_frames=store_frames,
+                operator_input=operator_input,
                 before_scoring=before_scoring,
             )
         )

--- a/src/inspect_robots/log.py
+++ b/src/inspect_robots/log.py
@@ -9,9 +9,10 @@ Immutability is *shallow*: the dataclasses are frozen and sequence fields are
 tuples, so reassigning a field or mutating the sample list is impossible — but
 dict-valued fields (``SceneResult.reduced``, the per-epoch score dicts,
 ``EvalResults.metrics``, ``EvalSpec.policy_config`` / ``embodiment_info``)
-remain plain mutable dicts, and ``SceneResult.policy_transcripts`` entries are
-arbitrary mutable JSON values. Treat a log as read-only; nothing deep-freezes
-it.
+remain plain mutable dicts, as do the dictionaries inside
+``SceneResult.operator_messages``. ``SceneResult.policy_transcripts`` entries
+are arbitrary mutable JSON values. Treat a log as read-only; nothing
+deep-freezes it.
 """
 
 from __future__ import annotations
@@ -77,6 +78,9 @@ class SceneResult:
     # Strictly parallel to ``epochs``: qualitative operator context per trial,
     # ``None`` when no note was captured. Read by nothing that scores.
     operator_notes: tuple[str | None, ...] = ()
+    # Strictly parallel to ``epochs``: live feedback drained during each trial.
+    # Both sequence layers are tuples to preserve the log's shallow immutability.
+    operator_messages: tuple[tuple[dict[str, Any], ...], ...] = ()
     # Strictly parallel to ``epochs``: trial-specific metadata from the policy.
     trial_metadata: tuple[dict[str, Any], ...] = ()
     # Strictly parallel to ``epochs``: why each recorded trial ended, or
@@ -136,6 +140,9 @@ class EvalLog:
             sample["epochs"] = tuple(sample.get("epochs", ()))
             sample["operator_judgements"] = tuple(sample.get("operator_judgements", ()))
             sample["operator_notes"] = tuple(sample.get("operator_notes", ()))
+            sample["operator_messages"] = tuple(
+                tuple(messages) for messages in sample.get("operator_messages", ())
+            )
             sample["trial_metadata"] = tuple(sample.get("trial_metadata", ()))
             sample["termination_reasons"] = tuple(sample.get("termination_reasons", ()))
             sample["policy_transcripts"] = tuple(sample.get("policy_transcripts", ()))

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -36,16 +36,20 @@ from inspect_robots.transcript import (
     approval_event,
     error_event,
     inference_event,
+    operator_event,
+    operator_message_event,
     reset_event,
     step_event,
 )
-from inspect_robots.types import Action, Observation, StepResult
+from inspect_robots.types import OPERATOR_END, Action, Observation, StepResult
 
 if TYPE_CHECKING:
+    from inspect_robots.console import OperatorInput
     from inspect_robots.logging.sink import LogSink
 
 _TRANSCRIPT_BYTE_LIMIT = 2 * 1024 * 1024
 _APPROVALS_KEY = "_rollout_approvals"
+_OPERATOR_MSGS_KEY = "_rollout_operator_messages"
 
 
 def derive_seed(eval_seed: int | None, scene_seed: int | None, epoch: int) -> int:
@@ -220,6 +224,7 @@ def rollout(
     approver: Approver,
     sink: LogSink,
     frame_store: FrameStore | None = None,
+    operator_input: OperatorInput | None = None,
 ) -> TrialRecord:
     """Run a single trial and return its record.
 
@@ -248,6 +253,7 @@ def rollout(
     delta_hook: Any = getattr(policy, "transcript_delta", None)
     messages_hook: Any = getattr(sink, "log_policy_messages", None)
     stream_ok = callable(delta_hook) and callable(messages_hook)
+    console_ok = operator_input is not None
 
     try:
         t = -1
@@ -267,16 +273,70 @@ def rollout(
         except Exception as exc:
             raise _record_failure(record, EmbodimentFault(str(exc)), -1) from exc
 
+        if operator_input is not None:
+            try:
+                operator_input.begin_trial()
+            except Exception as exc:
+                console_ok = False
+                warnings.warn(
+                    f"Operator console disabled for this trial after {type(exc).__name__}: {exc}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+
         obs_rec, refs = _store_frames(frame_store, trial_id, 0, obs)
         t = 0
         while t < max_steps:
+            poll = None
+            if operator_input is not None and console_ok:
+                try:
+                    poll = operator_input.poll()
+                except Exception as exc:
+                    console_ok = False
+                    warnings.warn(
+                        "Operator console disabled for this trial after "
+                        f"{type(exc).__name__}: {exc}",
+                        RuntimeWarning,
+                        stacklevel=2,
+                    )
+            if poll is not None:
+                for text in poll.messages:
+                    store.setdefault(_OPERATOR_MSGS_KEY, []).append({"t": t, "text": text})
+                    record.events.append(operator_message_event(t, text))
+
             prev_inferences = len(store.get(_INFER_KEY, []))
             all_approvals = store.get(_APPROVALS_KEY, [])
-            last_seen = store.get("_rollout_last_approvals_idx", 0)
-            tail_approvals = [dict(a) for a in all_approvals[last_seen:]]
+            last_approvals_idx = store.get("_rollout_last_approvals_idx", 0)
+            tail_approvals = [dict(a) for a in all_approvals[last_approvals_idx:]]
+            all_operator_msgs = store.get(_OPERATOR_MSGS_KEY, [])
+            last_operator_msgs_idx = store.get("_rollout_last_operator_msgs_idx", 0)
+            tail_operator_msgs = [
+                dict(message) for message in all_operator_msgs[last_operator_msgs_idx:]
+            ]
+
+            if poll is not None and poll.end is not None:
+                record.terminated = True
+                record.termination_reason = OPERATOR_END
+                if poll.end.verdict is not None:
+                    record.operator_judgement = poll.end.verdict
+                    record.operator_note = poll.end.note
+                    record.events.append(
+                        operator_event(
+                            t=t,
+                            verdict=poll.end.verdict,
+                            source="console",
+                            note=poll.end.note,
+                        )
+                    )
+                break
+
             try:
+                policy_extra = {**obs.extra, "env_step": t, "approvals": tail_approvals}
+                if operator_input is not None:
+                    policy_extra["operator_messages"] = tail_operator_msgs
                 obs_with_extra = replace(
-                    obs, extra={**obs.extra, "env_step": t, "approvals": tail_approvals}
+                    obs,
+                    extra=policy_extra,
                 )
                 action = controller.next_action(policy, obs_with_extra, t, store)
             except InspectRobotsError as exc:
@@ -288,6 +348,8 @@ def rollout(
             inferences = store.get(_INFER_KEY, [])
             if len(inferences) > prev_inferences:
                 store["_rollout_last_approvals_idx"] = len(all_approvals)
+                if operator_input is not None:
+                    store["_rollout_last_operator_msgs_idx"] = len(all_operator_msgs)
                 latency, chunk_len = inferences[-1]
                 record.events.append(inference_event(t, latency, chunk_len))
                 if stream_ok:

--- a/src/inspect_robots/transcript.py
+++ b/src/inspect_robots/transcript.py
@@ -1,7 +1,7 @@
 """A typed transcript of rollout events.
 
 Each trial records an ordered stream of events (reset, inference, step, approval,
-operator judgement, error). This is the robotics analog of Inspect AI's
+operator feedback, operator judgement, error). This is the robotics analog of Inspect AI's
 transcript and is the data a results viewer renders. Events are deliberately
 lightweight: a ``kind``, the step index ``t`` (``-1`` for pre-loop events), and a
 small data payload.
@@ -13,7 +13,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
-EventKind = str  # "reset" | "inference" | "step" | "approval" | "operator" | "error"
+EventKind = str  # Includes reset, inference, step, approval, operator_message, operator, error.
 
 
 @dataclass(frozen=True)
@@ -47,6 +47,14 @@ def step_event(t: int, terminated: bool, truncated: bool, reason: str | None) ->
 def approval_event(t: int, modified: bool, detail: str | None = None) -> Event:
     """Record whether the safety gate changed the proposed action at step ``t``."""
     return Event(kind="approval", t=t, data={"modified": modified, "detail": detail})
+
+
+def operator_message_event(t: int, text: str) -> Event:
+    """Record live feedback typed at the console during the trial.
+
+    This is distinct from the post-hoc operator verdict event.
+    """
+    return Event(kind="operator_message", t=t, data={"text": text})
 
 
 def operator_event(t: int, verdict: str, source: str = "prompt", note: str | None = None) -> Event:

--- a/src/inspect_robots/types.py
+++ b/src/inspect_robots/types.py
@@ -29,11 +29,12 @@ class Observation:
     ``images`` are keyed by camera name; ``state`` holds proprioception keyed by a
     controlled vocabulary (e.g. ``"eef_pos"``, ``"gripper"``). ``instruction`` is
     the language goal for this step (usually constant across an episode, but may
-    change for long-horizon tasks). The rollout injects ``extra["env_step"]``
-    (int) and ``extra["approvals"]`` (list of ``{"t": int, "detail": str | None}``
-    records for safety interventions since the previous ``act()`` call) into the
-    policy-facing observation and reserves those keys; embodiments should not set
-    them.
+    change for long-horizon tasks). The rollout injects ``extra["env_step"]`` (int),
+    ``extra["approvals"]`` (list of ``{"t": int, "detail": str | None}`` records for
+    safety interventions since the previous ``act()`` call), and
+    ``extra["operator_messages"]`` (list of ``{"t": int, "text": str}`` records for
+    live feedback since the previous ``act()`` call) into the policy-facing observation
+    and reserves those keys; embodiments should not set them.
     """
 
     images: Mapping[str, ImageArray] = field(default_factory=dict)

--- a/tests/test_api_snapshot.py
+++ b/tests/test_api_snapshot.py
@@ -41,6 +41,11 @@ EXPECTED = {
     "Embodiment",
     "EmbodimentBase",
     "EmbodimentInfo",
+    # attended operator input
+    "OperatorInput",
+    "OperatorConsole",
+    "ConsolePoll",
+    "EndRequest",
     # types & spaces
     "ABSOLUTE_CONTROL_MODES",
     "Observation",

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,187 @@
+"""Tests for the threadless operator console input channel."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Callable
+
+import pytest
+
+from inspect_robots.console import USAGE, ConsolePoll, EndRequest, OperatorConsole, OperatorInput
+
+
+def _scripted_source(
+    chunks: list[str],
+) -> tuple[Callable[[], bool], Callable[[], str]]:
+    def readable() -> bool:
+        return bool(chunks)
+
+    def read() -> str:
+        return chunks.pop(0)
+
+    return readable, read
+
+
+def _console(chunks: list[str], output: list[str] | None = None) -> OperatorConsole:
+    readable, read = _scripted_source(chunks)
+    return OperatorConsole(
+        readable=readable,
+        read=read,
+        output_fn=(output if output is not None else []).append,
+    )
+
+
+def test_result_values_are_frozen_with_empty_defaults() -> None:
+    end = EndRequest()
+    poll = ConsolePoll()
+
+    assert end == EndRequest(verdict=None, note=None)
+    assert poll == ConsolePoll(messages=(), end=None)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        end.verdict = "y"  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        poll.end = end  # type: ignore[misc]
+
+
+def test_feedback_preserves_spacing_apart_from_the_newline() -> None:
+    console = _console(["  move farther left  \n"])
+
+    assert console.poll() == ConsolePoll(messages=("  move farther left  ",))
+
+
+def test_whitespace_only_line_requests_an_unscored_end() -> None:
+    console = _console(["  \t  \n"])
+
+    assert console.poll() == ConsolePoll(end=EndRequest())
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("/y\n", EndRequest(verdict="y")),
+        ("/N   \n", EndRequest(verdict="n")),
+        ("/p note text here\n", EndRequest(verdict="partial", note="note text here")),
+        (" /Y   spaced note   \n", EndRequest(verdict="y", note="spaced note")),
+    ],
+)
+def test_verdict_commands_map_case_insensitively(line: str, expected: EndRequest) -> None:
+    console = _console([line])
+
+    assert console.poll() == ConsolePoll(end=expected)
+
+
+def test_unknown_command_prints_usage_without_queuing_input() -> None:
+    output: list[str] = []
+    console = _console(["/oops please\n"], output)
+
+    assert console.poll() == ConsolePoll()
+    assert output == [USAGE]
+
+
+def test_multiline_paste_in_one_chunk_is_fully_parsed() -> None:
+    console = _console(["first\nsecond\nthird\n"])
+
+    assert console.poll() == ConsolePoll(messages=("first", "second", "third"))
+
+
+def test_partial_line_continues_in_a_later_poll() -> None:
+    chunks = ["move a little"]
+    console = _console(chunks)
+
+    assert console.poll() == ConsolePoll()
+    chunks.append(" farther\n")
+    assert console.poll() == ConsolePoll(messages=("move a little farther",))
+
+
+def test_multiple_chunks_are_drained_in_one_poll() -> None:
+    console = _console(["first\nsec", "ond\nthird\n"])
+
+    assert console.poll() == ConsolePoll(messages=("first", "second", "third"))
+
+
+def test_end_then_feedback_returns_both_from_one_poll() -> None:
+    console = _console(["/p needs another try\nkeep the wrist level\n"])
+
+    assert console.poll() == ConsolePoll(
+        messages=("keep the wrist level",),
+        end=EndRequest(verdict="partial", note="needs another try"),
+    )
+
+
+def test_first_end_request_wins_while_later_lines_still_parse() -> None:
+    output: list[str] = []
+    console = _console(["\n/n later verdict\n/oops\nafter end\n"], output)
+
+    assert console.poll() == ConsolePoll(messages=("after end",), end=EndRequest())
+    assert output == [USAGE]
+
+
+def test_eof_discards_partial_input_and_latches_future_polls() -> None:
+    chunks = ["unfinished"]
+    read_calls = 0
+    readable, scripted_read = _scripted_source(chunks)
+
+    def read() -> str:
+        nonlocal read_calls
+        read_calls += 1
+        return scripted_read()
+
+    console = OperatorConsole(readable=readable, read=read)
+    assert console.poll() == ConsolePoll()
+
+    chunks.append("")
+    assert console.poll() == ConsolePoll()
+    chunks.append("must not be read\n")
+    assert console.poll() == ConsolePoll()
+    assert read_calls == 2
+
+
+def test_eof_keeps_complete_lines_parsed_before_it() -> None:
+    console = _console(["complete\npartial", ""])
+
+    assert console.poll() == ConsolePoll(messages=("complete",))
+    assert console.poll() == ConsolePoll()
+
+
+def test_begin_trial_discards_pending_chunks_and_internal_partial() -> None:
+    chunks = ["old partial"]
+    console = _console(chunks)
+    assert console.poll() == ConsolePoll()
+
+    chunks.extend([" continuation\n", "another stale line\n"])
+    console.begin_trial()
+    chunks.append("fresh feedback\n")
+    assert console.poll() == ConsolePoll(messages=("fresh feedback",))
+
+
+def test_begin_trial_latches_always_readable_eof_without_spinning() -> None:
+    readable_calls = 0
+    read_calls = 0
+
+    def readable() -> bool:
+        nonlocal readable_calls
+        readable_calls += 1
+        return True
+
+    def read() -> str:
+        nonlocal read_calls
+        read_calls += 1
+        return ""
+
+    console = OperatorConsole(readable=readable, read=read)
+    console.begin_trial()
+    console.begin_trial()
+    assert console.poll() == ConsolePoll()
+    assert readable_calls == 1
+    assert read_calls == 1
+
+
+def test_operator_console_satisfies_runtime_protocol() -> None:
+    readable, read = _scripted_source([])
+    console = OperatorConsole(readable=readable, read=read)
+
+    assert isinstance(console, OperatorInput)
+
+
+def test_tty_defaults_can_be_bound_without_reading_stdin() -> None:
+    assert isinstance(OperatorConsole(), OperatorInput)

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import pytest
 
 from inspect_robots import eval_set, read_eval_log
+from inspect_robots._html import render_html
+from inspect_robots._summarize import TrialTranscript, build_digest
 from inspect_robots.log import (
     SCHEMA_VERSION,
     EvalLog,
@@ -53,6 +55,7 @@ def _golden_log() -> EvalLog:
                 instruction="reach the cube",
                 operator_judgements=("yes",),
                 operator_notes=("gripper closed early",),
+                operator_messages=(({"t": 3, "text": "keep left <now>"},),),
                 trial_metadata=({"foo": "bar"},),
                 termination_reasons=("success",),
                 policy_transcripts=(
@@ -92,6 +95,9 @@ def test_golden_log_reads_back(tmp_path: Path) -> None:
     assert restored.samples[0].instruction == "reach the cube"
     assert restored.samples[0].operator_judgements == ("yes",)
     assert restored.samples[0].operator_notes == ("gripper closed early",)
+    assert restored.samples[0].operator_messages == (({"t": 3, "text": "keep left <now>"},),)
+    assert isinstance(restored.samples[0].operator_messages, tuple)
+    assert isinstance(restored.samples[0].operator_messages[0], tuple)
     assert restored.samples[0].trial_metadata == ({"foo": "bar"},)
     assert restored.samples[0].termination_reasons == ("success",)
     assert restored.samples[0].policy_transcripts == (
@@ -112,6 +118,7 @@ def test_v1_log_without_additive_fields_reads_back(tmp_path: Path) -> None:
         del sample["instruction"]
         del sample["operator_judgements"]
         del sample["operator_notes"]
+        del sample["operator_messages"]
         del sample["trial_metadata"]
         del sample["termination_reasons"]
         del sample["policy_transcripts"]
@@ -122,6 +129,7 @@ def test_v1_log_without_additive_fields_reads_back(tmp_path: Path) -> None:
     assert restored.samples[0].instruction is None
     assert restored.samples[0].operator_judgements == ()
     assert restored.samples[0].operator_notes == ()
+    assert restored.samples[0].operator_messages == ()
     assert restored.samples[0].trial_metadata == ()
     assert restored.samples[0].termination_reasons == ()
     assert restored.samples[0].policy_transcripts == ()
@@ -173,6 +181,8 @@ def test_eval_log_and_friends_are_frozen() -> None:
     with pytest.raises(AttributeError):
         log.samples[0].operator_judgements.append("no")  # type: ignore[attr-defined]
     with pytest.raises(AttributeError):
+        log.samples[0].operator_messages[0].append({})  # type: ignore[attr-defined]
+    with pytest.raises(AttributeError):
         log.samples[0].trial_metadata.append({})  # type: ignore[attr-defined]
     with pytest.raises(AttributeError):
         log.samples[0].termination_reasons.append("failure")  # type: ignore[attr-defined]
@@ -183,6 +193,19 @@ def test_unsupported_schema_version_rejected() -> None:
     data["version"] = 999
     with pytest.raises(ValueError, match="schema version"):
         EvalLog.from_dict(data)
+
+
+def test_operator_feedback_appears_in_digest_and_escaped_html() -> None:
+    log = _golden_log()
+    transcripts = [TrialTranscript("s0", 0, None, "none")]
+
+    digest = build_digest(log, transcripts)
+    document = render_html(log, title="operator feedback")
+
+    assert "operator feedback: keep left <now>" in digest
+    assert "Operator feedback" in document
+    assert "keep left &lt;now&gt;" in document
+    assert "keep left <now>" not in document
 
 
 def test_atomic_write_leaves_no_tmp(tmp_path: Path) -> None:

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from inspect_robots import eval, eval_set, read_eval_log
+from inspect_robots.console import ConsolePoll, EndRequest
 from inspect_robots.errors import (
     CompatibilityError,
     ConfigError,
@@ -136,6 +137,32 @@ class _CountingScorer:
         del record, target
         self.calls += 1
         return Score(value=1.0)
+
+
+class _ScriptedOperatorInput:
+    """Expose per-trial polls and model input typed between trial boundaries."""
+
+    def __init__(self, trials: list[list[ConsolePoll]]) -> None:
+        self.trials = trials
+        self.active: list[ConsolePoll] = []
+        self.pending_messages: list[str] = []
+        self.discarded_messages: list[str] = []
+        self.begin_calls = 0
+
+    def poll(self) -> ConsolePoll:
+        """Merge pending input with the next scripted poll for the active trial."""
+        scripted = self.active.pop(0) if self.active else ConsolePoll()
+        messages = (*self.pending_messages, *scripted.messages)
+        self.pending_messages.clear()
+        return ConsolePoll(messages=messages, end=scripted.end)
+
+    def begin_trial(self) -> None:
+        """Discard inter-trial input and activate the next trial's poll script."""
+        self.begin_calls += 1
+        self.discarded_messages.extend(self.pending_messages)
+        self.pending_messages.clear()
+        index = self.begin_calls - 1
+        self.active = list(self.trials[index]) if index < len(self.trials) else []
 
 
 # --------------------------------------------------------------------------- #
@@ -881,6 +908,7 @@ def test_before_scoring_exception_propagates(tmp_path: Path) -> None:
 def test_before_scoring_default_none_records_no_judgements(tmp_path: Path) -> None:
     (log,) = eval(_task(epochs=2), ScriptedPolicy(), CubePickEmbodiment(), log_dir=str(tmp_path))
     assert log.samples[0].operator_judgements == (None, None)
+    assert log.samples[0].operator_messages == ((), ())
 
 
 def test_eval_set_forwards_before_scoring(tmp_path: Path) -> None:
@@ -900,7 +928,64 @@ def test_eval_set_forwards_before_scoring(tmp_path: Path) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# 9. Policy trial lifecycle hooks: setup and artifact persistence.
+# 9. Attended operator input is trial-scoped and persisted beside each epoch.
+# --------------------------------------------------------------------------- #
+def test_eval_begins_console_each_trial_and_discards_scoring_window_input(
+    tmp_path: Path,
+) -> None:
+    operator_input = _ScriptedOperatorInput(
+        [
+            [ConsolePoll(messages=("trial one feedback",), end=EndRequest())],
+            [ConsolePoll(end=EndRequest())],
+        ]
+    )
+
+    def type_during_scoring(record: TrialRecord, scene: Scene) -> None:
+        del scene
+        if record.epoch == 0:
+            operator_input.pending_messages.append("typed during scoring")
+
+    (log,) = eval(
+        _task(epochs=2, scorer=_CountingScorer()),
+        ScriptedPolicy(),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+        operator_input=operator_input,
+        before_scoring=type_during_scoring,
+    )
+
+    assert operator_input.begin_calls == 2
+    assert operator_input.discarded_messages == ["typed during scoring"]
+    assert log.samples[0].operator_messages == (
+        ({"t": 0, "text": "trial one feedback"},),
+        (),
+    )
+
+
+def test_eval_set_operator_messages_round_trip_as_nested_tuples(tmp_path: Path) -> None:
+    operator_input = _ScriptedOperatorInput(
+        [[ConsolePoll(messages=("persist this feedback",), end=EndRequest())]]
+    )
+
+    success, logs = eval_set(
+        _task(scorer=_CountingScorer()),
+        ScriptedPolicy(),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+        operator_input=operator_input,
+    )
+
+    assert success is True
+    assert logs[0].samples[0].operator_messages == (({"t": 0, "text": "persist this feedback"},),)
+    (path,) = tmp_path.glob("*.json")
+    restored_messages = read_eval_log(str(path)).samples[0].operator_messages
+    assert isinstance(restored_messages, tuple)
+    assert isinstance(restored_messages[0], tuple)
+    assert restored_messages == (({"t": 0, "text": "persist this feedback"},),)
+
+
+# --------------------------------------------------------------------------- #
+# 10. Policy trial lifecycle hooks: setup and artifact persistence.
 # --------------------------------------------------------------------------- #
 def test_on_trial_start_runs_before_each_trials_first_act(tmp_path: Path) -> None:
     events: list[tuple[object, ...]] = []
@@ -984,6 +1069,7 @@ def test_raising_on_trial_start_skips_rollout_but_keeps_results_parallel(
         scene.epochs,
         scene.operator_judgements,
         scene.operator_notes,
+        scene.operator_messages,
         scene.trial_metadata,
         scene.termination_reasons,
         scene.policy_transcripts,

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -17,6 +17,7 @@ import pytest
 import inspect_robots.cli as cli
 import inspect_robots.registry as reg
 from inspect_robots.cli import main
+from inspect_robots.console import USAGE, OperatorConsole
 from inspect_robots.defaults import (
     _ENV_EMBODIMENT as ENV_EMBODIMENT,
 )
@@ -29,6 +30,12 @@ from inspect_robots.defaults import (
 from inspect_robots.log import EvalLog, EvalResults, EvalSpec, EvalStats, SceneResult
 from inspect_robots.mock import ScriptedPolicy
 from inspect_robots.registry import registered, resolve
+
+
+class _ConsolePolicy(ScriptedPolicy):
+    """Opt into the framework's attended operator-message channel."""
+
+    accepts_operator_messages = True
 
 
 @pytest.fixture(autouse=True)
@@ -3177,6 +3184,308 @@ def _tty_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
 
+def test_attended_opted_in_run_builds_console_calls_defer_and_prints_usage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import inspect_robots
+    from inspect_robots.mock import CubePickEmbodiment
+
+    class _DeferredHardware(CubePickEmbodiment):
+        hook_calls: ClassVar[int] = 0
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.info = dataclasses.replace(self.info, is_simulated=False)
+
+        def defer_operator_end(self) -> None:
+            type(self).hook_calls += 1
+
+    policy_name = "console-policy-for-run-test"
+    embodiment_name = "deferred-hardware-for-console-test"
+    reg.policy(policy_name)(_ConsolePolicy)
+    reg.embodiment(embodiment_name)(_DeferredHardware)
+    operator_inputs: list[object] = []
+
+    def fake_eval(*args: object, **kwargs: object) -> list[EvalLog]:
+        del args
+        operator_inputs.append(kwargs.get("operator_input"))
+        return [_step_limit_log(reasons=("success",))]
+
+    monkeypatch.setattr(inspect_robots, "eval", fake_eval)
+    monkeypatch.setattr(sys, "platform", "linux")
+    _tty_stdin(monkeypatch)
+    try:
+        rc = main(
+            [
+                "run",
+                "--task",
+                "cubepick-reach",
+                "--policy",
+                policy_name,
+                "--embodiment",
+                embodiment_name,
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["policy"].pop(policy_name, None)
+        reg._FACTORIES["embodiment"].pop(embodiment_name, None)
+
+    assert rc == 0
+    assert len(operator_inputs) == 1
+    assert isinstance(operator_inputs[0], OperatorConsole)
+    assert _DeferredHardware.hook_calls == 1
+    assert capsys.readouterr().out.count(USAGE) == 1
+
+
+def test_attended_opted_in_eval_set_uses_simulated_console_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import inspect_robots
+
+    policy_name = "console-policy-for-eval-set-test"
+    reg.policy(policy_name)(_ConsolePolicy)
+    operator_inputs: list[object] = []
+
+    def fake_eval_set(*args: object, **kwargs: object) -> tuple[bool, list[EvalLog]]:
+        del args
+        operator_inputs.append(kwargs.get("operator_input"))
+        return True, [_step_limit_log(task="cubepick-reach", reasons=("success",))]
+
+    monkeypatch.setattr(inspect_robots, "eval_set", fake_eval_set)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    _tty_stdin(monkeypatch)
+    try:
+        rc = main(
+            [
+                "eval-set",
+                "cubepick-reach",
+                "--policy",
+                policy_name,
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+    finally:
+        reg._FACTORIES["policy"].pop(policy_name, None)
+
+    assert rc == 0
+    assert len(operator_inputs) == 1
+    assert isinstance(operator_inputs[0], OperatorConsole)
+    assert capsys.readouterr().out.count(USAGE) == 1
+
+
+def test_attended_console_stays_off_for_legacy_real_hardware(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import inspect_robots
+    from inspect_robots.mock import CubePickEmbodiment
+
+    class _LegacyHardware(CubePickEmbodiment):
+        def __init__(self) -> None:
+            super().__init__()
+            self.info = dataclasses.replace(self.info, is_simulated=False)
+
+    policy_name = "console-policy-for-legacy-hardware-test"
+    embodiment_name = "legacy-hardware-for-console-test"
+    reg.policy(policy_name)(_ConsolePolicy)
+    reg.embodiment(embodiment_name)(_LegacyHardware)
+    operator_inputs: list[object] = []
+
+    def fake_eval(*args: object, **kwargs: object) -> list[EvalLog]:
+        del args
+        operator_inputs.append(kwargs.get("operator_input"))
+        return [_step_limit_log(reasons=("success",))]
+
+    monkeypatch.setattr(inspect_robots, "eval", fake_eval)
+    monkeypatch.setattr(sys, "platform", "linux")
+    _tty_stdin(monkeypatch)
+    try:
+        assert (
+            main(
+                [
+                    "run",
+                    "--task",
+                    "cubepick-reach",
+                    "--policy",
+                    policy_name,
+                    "--embodiment",
+                    embodiment_name,
+                    "--log-dir",
+                    str(tmp_path),
+                ]
+            )
+            == 0
+        )
+    finally:
+        reg._FACTORIES["policy"].pop(policy_name, None)
+        reg._FACTORIES["embodiment"].pop(embodiment_name, None)
+
+    assert operator_inputs == [None]
+    out = capsys.readouterr().out
+    assert out.count("predates the operator console") == 1
+    assert "still owns the end-of-episode keypress" in out
+    assert "feedback typing stays off" in out
+    assert USAGE not in out
+
+
+def test_attended_console_stays_off_on_windows_before_calling_defer_hook(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import inspect_robots
+    from inspect_robots.mock import CubePickEmbodiment
+
+    class _DeferredHardware(CubePickEmbodiment):
+        hook_calls: ClassVar[int] = 0
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.info = dataclasses.replace(self.info, is_simulated=False)
+
+        def defer_operator_end(self) -> None:
+            type(self).hook_calls += 1
+
+    policy_name = "console-policy-for-windows-test"
+    embodiment_name = "deferred-hardware-for-windows-test"
+    reg.policy(policy_name)(_ConsolePolicy)
+    reg.embodiment(embodiment_name)(_DeferredHardware)
+    operator_inputs: list[object] = []
+
+    def fake_eval(*args: object, **kwargs: object) -> list[EvalLog]:
+        del args
+        operator_inputs.append(kwargs.get("operator_input"))
+        return [_step_limit_log(reasons=("success",))]
+
+    monkeypatch.setattr(inspect_robots, "eval", fake_eval)
+    monkeypatch.setattr(sys, "platform", "win32")
+    _tty_stdin(monkeypatch)
+    try:
+        assert (
+            main(
+                [
+                    "run",
+                    "--task",
+                    "cubepick-reach",
+                    "--policy",
+                    policy_name,
+                    "--embodiment",
+                    embodiment_name,
+                    "--log-dir",
+                    str(tmp_path),
+                ]
+            )
+            == 0
+        )
+    finally:
+        reg._FACTORIES["policy"].pop(policy_name, None)
+        reg._FACTORIES["embodiment"].pop(embodiment_name, None)
+
+    assert operator_inputs == [None]
+    assert _DeferredHardware.hook_calls == 0
+    out = capsys.readouterr().out
+    assert out.count("select cannot watch stdin on Windows") == 1
+    assert USAGE not in out
+
+
+@pytest.mark.parametrize(("tty", "extra_args"), [(False, ()), (True, ("--no-prompt",))])
+def test_operator_console_requires_attendance(
+    tty: bool,
+    extra_args: tuple[str, ...],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import inspect_robots
+
+    policy_name = f"console-policy-unattended-{tty}"
+    reg.policy(policy_name)(_ConsolePolicy)
+    operator_inputs: list[object] = []
+
+    def fake_eval(*args: object, **kwargs: object) -> list[EvalLog]:
+        del args
+        operator_inputs.append(kwargs.get("operator_input"))
+        return [_step_limit_log(reasons=("success",))]
+
+    monkeypatch.setattr(inspect_robots, "eval", fake_eval)
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr("sys.stdin.isatty", lambda: tty)
+    try:
+        assert (
+            main(
+                [
+                    "run",
+                    "--task",
+                    "cubepick-reach",
+                    "--policy",
+                    policy_name,
+                    "--embodiment",
+                    "cubepick",
+                    "--log-dir",
+                    str(tmp_path),
+                    *extra_args,
+                ]
+            )
+            == 0
+        )
+    finally:
+        reg._FACTORIES["policy"].pop(policy_name, None)
+
+    assert operator_inputs == [None]
+    assert USAGE not in capsys.readouterr().out
+
+
+def test_policy_without_opt_in_skips_console_silently_before_platform_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import inspect_robots
+
+    operator_inputs: list[object] = []
+
+    def fake_eval(*args: object, **kwargs: object) -> list[EvalLog]:
+        del args
+        operator_inputs.append(kwargs.get("operator_input"))
+        return [_step_limit_log(reasons=("success",))]
+
+    monkeypatch.setattr(inspect_robots, "eval", fake_eval)
+    monkeypatch.setattr(sys, "platform", "win32")
+    _tty_stdin(monkeypatch)
+
+    assert (
+        main(
+            [
+                "run",
+                "--task",
+                "cubepick-reach",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(tmp_path),
+            ]
+        )
+        == 0
+    )
+
+    assert operator_inputs == [None]
+    out = capsys.readouterr().out
+    assert "operator console" not in out
+    assert USAGE not in out
+
+
 def test_operator_prompt_records_verdict_and_reprompts_on_typos(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -3445,6 +3754,35 @@ def test_prompt_operator_adopts_definitive_embodiment_verdict(
         "source": "embodiment",
         "note": None,
     }
+
+
+def test_prompt_operator_early_returns_for_pre_set_console_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from inspect_robots.cli import _prompt_operator
+    from inspect_robots.rollout import TrialRecord
+    from inspect_robots.scene import Scene
+
+    record = TrialRecord(
+        scene_id="s0",
+        epoch=0,
+        seed=0,
+        terminated=True,
+        termination_reason="success",
+        operator_judgement="n",
+        operator_note="console note",
+    )
+    monkeypatch.setattr(
+        "builtins.input", lambda _prompt: pytest.fail("pre-set verdict must not prompt")
+    )
+
+    _prompt_operator(record, Scene(id="s0", instruction="reach"))
+
+    assert record.operator_judgement == "n"
+    assert record.operator_note == "console note"
+    assert record.events == []
+    assert "operator verdict adopted from console: n" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(
@@ -3722,6 +4060,34 @@ def test_prompt_on_operator_end_prompts_and_records_note(
     assert record.operator_judgement == "partial"
     assert record.operator_note == "left gripper slipped"
     capsys.readouterr()
+
+
+def test_prompt_on_operator_end_adopts_pre_set_console_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from inspect_robots.cli import _prompt_operator_on_operator_end
+    from inspect_robots.rollout import TrialRecord
+    from inspect_robots.scene import Scene
+
+    record = TrialRecord(
+        scene_id="s0",
+        epoch=0,
+        seed=0,
+        terminated=True,
+        termination_reason="operator_end",
+        operator_judgement="partial",
+        operator_note="left gripper slipped",
+    )
+    monkeypatch.setattr(
+        "builtins.input", lambda _prompt: pytest.fail("pre-set verdict must not prompt")
+    )
+
+    _prompt_operator_on_operator_end(record, Scene(id="s0", instruction="reach"))
+
+    assert record.operator_judgement == "partial"
+    assert record.operator_note == "left gripper slipped"
+    assert "operator verdict adopted from console: partial" in capsys.readouterr().out
 
 
 def test_prompt_on_operator_end_ignores_other_reasons(

--- a/tests/test_rollout_observation_step.py
+++ b/tests/test_rollout_observation_step.py
@@ -5,16 +5,19 @@ from __future__ import annotations
 from dataclasses import replace
 
 import numpy as np
+import pytest
 
 from inspect_robots.approver import AutoApprover
+from inspect_robots.console import ConsolePoll, EndRequest, OperatorInput
 from inspect_robots.controller import DefaultController
+from inspect_robots.errors import _CancelledTrial
 from inspect_robots.logging.sink import LogSink, NullSink
 from inspect_robots.mock import CubePickEmbodiment
 from inspect_robots.policy import PolicyConfig, PolicyInfo
 from inspect_robots.rollout import TrialRecord, rollout
 from inspect_robots.scene import Scene
 from inspect_robots.spaces import ActionSemantics, Box
-from inspect_robots.types import Action, ActionChunk, Observation, StepResult
+from inspect_robots.types import OPERATOR_END, Action, ActionChunk, Observation, StepResult
 
 _SCENE = Scene(id="step-probe", instruction="hold still")
 _ACTION_SPACE = Box(
@@ -23,11 +26,12 @@ _ACTION_SPACE = Box(
 
 
 class _ProbePolicy:
-    """Record every policy-facing observation and emit one action per call."""
+    """Record every policy-facing observation and emit one action chunk per call."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, chunk_size: int = 1) -> None:
         self.info = PolicyInfo(name="step-probe", action_space=_ACTION_SPACE)
-        self.config = PolicyConfig(action_horizon=1)
+        self.config = PolicyConfig(action_horizon=chunk_size)
+        self.chunk_size = chunk_size
         self.observations: list[Observation] = []
 
     def reset(self, scene: Scene) -> None:
@@ -35,9 +39,63 @@ class _ProbePolicy:
         self.observations.clear()
 
     def act(self, observation: Observation) -> ActionChunk:
-        """Capture the observation and return a single hold-still action."""
+        """Capture the observation and return a hold-still action chunk."""
         self.observations.append(observation)
-        return ActionChunk(actions=[Action(data=np.zeros(2))])
+        return ActionChunk(actions=[Action(data=np.zeros(2)) for _ in range(self.chunk_size)])
+
+
+class FakeOperatorInput:
+    """Return scripted console polls and expose lifecycle call counts."""
+
+    def __init__(
+        self,
+        polls: list[ConsolePoll | BaseException],
+        *,
+        begin_error: Exception | None = None,
+        order: list[str] | None = None,
+    ) -> None:
+        self.polls = list(polls)
+        self.begin_error = begin_error
+        self.order = order
+        self.poll_calls = 0
+        self.begin_calls = 0
+
+    def poll(self) -> ConsolePoll:
+        """Return the next scripted result or raise its scripted exception."""
+        self.poll_calls += 1
+        item = self.polls.pop(0) if self.polls else ConsolePoll()
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    def begin_trial(self) -> None:
+        """Record trial initialization and raise the configured failure, if any."""
+        self.begin_calls += 1
+        if self.order is not None:
+            self.order.append("begin")
+        if self.begin_error is not None:
+            raise self.begin_error
+
+
+class _TrackingEmbodiment(CubePickEmbodiment):
+    """Track reset ordering and how many actions reached the embodiment."""
+
+    def __init__(self, order: list[str] | None = None) -> None:
+        super().__init__()
+        self.order = order
+        self.step_calls = 0
+
+    def reset(self, scene: Scene, *, seed: int | None = None) -> Observation:
+        """Record only after the underlying reset has returned."""
+        observation = super().reset(scene, seed=seed)
+        if self.order is not None:
+            self.order.append("reset")
+        return observation
+
+    def step(self, action: Action) -> StepResult:
+        """Count each action before delegating to the mock world."""
+        self.step_calls += 1
+        return super().step(action)
 
 
 class _ObservationSink(NullSink):
@@ -87,6 +145,7 @@ def _run(
     *,
     max_steps: int,
     sink: LogSink | None = None,
+    operator_input: OperatorInput | None = None,
 ) -> TrialRecord:
     return rollout(
         policy,
@@ -98,6 +157,7 @@ def _run(
         controller=DefaultController(),
         approver=AutoApprover(),
         sink=sink or NullSink(),
+        operator_input=operator_input,
     )
 
 
@@ -135,3 +195,180 @@ def test_rollout_step_injection_shares_the_images_mapping() -> None:
             policy.observations, embodiment.observations[:3], strict=True
         )
     )
+
+
+def test_operator_message_reaches_only_the_next_chunked_inference() -> None:
+    policy = _ProbePolicy(chunk_size=2)
+    operator_input = FakeOperatorInput([ConsolePoll(messages=("keep the wrist level",))])
+
+    _run(policy, CubePickEmbodiment(), max_steps=4, operator_input=operator_input)
+
+    assert [observation.extra["operator_messages"] for observation in policy.observations] == [
+        [{"t": 0, "text": "keep the wrist level"}],
+        [],
+    ]
+
+
+def test_operator_messages_across_steps_keep_their_drain_step() -> None:
+    policy = _ProbePolicy(chunk_size=2)
+    operator_input = FakeOperatorInput(
+        [
+            ConsolePoll(messages=("first",)),
+            ConsolePoll(messages=("second",)),
+            ConsolePoll(),
+        ]
+    )
+
+    _run(policy, CubePickEmbodiment(), max_steps=3, operator_input=operator_input)
+
+    assert [observation.extra["operator_messages"] for observation in policy.observations] == [
+        [{"t": 0, "text": "first"}],
+        [{"t": 1, "text": "second"}],
+    ]
+
+
+def test_verdictless_console_end_stops_before_inference_or_motion() -> None:
+    policy = _ProbePolicy()
+    embodiment = _TrackingEmbodiment()
+    operator_input = FakeOperatorInput([ConsolePoll(), ConsolePoll(end=EndRequest())])
+
+    record = _run(policy, embodiment, max_steps=3, operator_input=operator_input)
+
+    assert record.terminated is True
+    assert record.termination_reason == OPERATOR_END
+    assert record.operator_judgement is None
+    assert len(record.steps) == embodiment.step_calls == 1
+    assert len(policy.observations) == 1
+
+
+def test_verdict_console_end_records_judgement_note_and_operator_event() -> None:
+    policy = _ProbePolicy()
+    operator_input = FakeOperatorInput(
+        [ConsolePoll(end=EndRequest(verdict="y", note="clean pickup"))]
+    )
+
+    record = _run(
+        policy,
+        _TrackingEmbodiment(),
+        max_steps=3,
+        operator_input=operator_input,
+    )
+
+    assert record.terminated is True
+    assert record.termination_reason == OPERATOR_END
+    assert record.operator_judgement == "y"
+    assert record.operator_note == "clean pickup"
+    operator_events = [event for event in record.events if event.kind == "operator"]
+    assert len(operator_events) == 1
+    assert operator_events[0].t == 0
+    assert operator_events[0].data == {
+        "verdict": "y",
+        "source": "console",
+        "note": "clean pickup",
+    }
+
+
+def test_messages_in_an_ending_poll_are_recorded_as_transcript_events() -> None:
+    policy = _ProbePolicy()
+    embodiment = _TrackingEmbodiment()
+    operator_input = FakeOperatorInput(
+        [ConsolePoll(messages=("gripper slipped",), end=EndRequest())]
+    )
+
+    record = _run(policy, embodiment, max_steps=3, operator_input=operator_input)
+
+    message_events = [event for event in record.events if event.kind == "operator_message"]
+    assert len(message_events) == 1
+    assert message_events[0].t == 0
+    assert message_events[0].data == {"text": "gripper slipped"}
+    assert embodiment.step_calls == 0
+    assert policy.observations == []
+
+
+def test_begin_trial_runs_once_after_embodiment_reset() -> None:
+    order: list[str] = []
+    operator_input = FakeOperatorInput([], order=order)
+
+    _run(
+        _ProbePolicy(),
+        _TrackingEmbodiment(order),
+        max_steps=1,
+        operator_input=operator_input,
+    )
+
+    assert operator_input.begin_calls == 1
+    assert order == ["reset", "begin"]
+
+
+def test_no_operator_input_keeps_reserved_key_out_of_policy_observations() -> None:
+    policy = _ProbePolicy(chunk_size=2)
+
+    _run(policy, CubePickEmbodiment(), max_steps=3)
+
+    assert all("operator_messages" not in observation.extra for observation in policy.observations)
+
+
+def test_raising_poll_warns_once_disables_channel_and_preserves_record() -> None:
+    policy = _ProbePolicy()
+    operator_input = FakeOperatorInput(
+        [RuntimeError("poll failed"), ConsolePoll(messages=("must not surface",))]
+    )
+
+    with pytest.warns(
+        RuntimeWarning,
+        match="Operator console disabled for this trial after RuntimeError: poll failed",
+    ) as warning_records:
+        record = _run(
+            policy,
+            CubePickEmbodiment(),
+            max_steps=3,
+            operator_input=operator_input,
+        )
+
+    assert operator_input.poll_calls == 1
+    assert len(warning_records) == 1
+    assert len(record.steps) == 3
+    assert record.status == "success"
+    assert record.truncated is True
+    assert record.termination_reason == "max_steps"
+
+
+def test_raising_begin_trial_warns_once_and_disables_channel() -> None:
+    policy = _ProbePolicy()
+    operator_input = FakeOperatorInput([], begin_error=RuntimeError("drain failed"))
+
+    with pytest.warns(
+        RuntimeWarning,
+        match="Operator console disabled for this trial after RuntimeError: drain failed",
+    ) as warning_records:
+        record = _run(
+            policy,
+            CubePickEmbodiment(),
+            max_steps=3,
+            operator_input=operator_input,
+        )
+
+    assert operator_input.begin_calls == 1
+    assert operator_input.poll_calls == 0
+    assert len(warning_records) == 1
+    assert len(record.steps) == 3
+    assert record.status == "success"
+
+
+def test_keyboard_interrupt_from_poll_uses_cancelled_trial_path() -> None:
+    original = KeyboardInterrupt("operator interrupt")
+    operator_input = FakeOperatorInput([original])
+
+    with pytest.raises(_CancelledTrial) as excinfo:
+        _run(
+            _ProbePolicy(),
+            _TrackingEmbodiment(),
+            max_steps=3,
+            operator_input=operator_input,
+        )
+
+    record = excinfo.value.record
+    assert record.status == "cancelled"
+    assert record.error == "cancelled by user (KeyboardInterrupt)"
+    assert record.steps == []
+    assert excinfo.value.__cause__ is original


### PR DESCRIPTION
Closes #273.

Adds an operator console for attended runs where the policy opts in (the `agent` plugin does): a typed line + Enter is delivered to the policy at its next inference as feedback, bare Enter ends the episode with `operator_end` exactly as today's keypress does, and `/y` `/n` `/p [note]` end the episode and record the verdict in one stroke, skipping the post-trial prompt. VLA policies and unattended runs are unchanged.

Design doc: `plans/0042-operator-console.md` (two fresh-context critique rounds before implementation).

## How it works

- `console.py` (new): a threadless, non-blocking console. `poll()` does a zero-timeout `select()` and reads pending bytes at the fd level (`os.read`), assembling complete lines itself. No background thread means stdin keeps a single reader, so the existing post-trial verdict `input()` prompt still works. EOF latches permanently, including inside `begin_trial()`'s drain, so a redirected stdin can never spin.
- `rollout()` takes an optional `operator_input`. Messages are injected under the reserved `extra["operator_messages"]` key with the same delivered-once-per-inference tail discipline as `extra["approvals"]` (#217), and recorded as `operator_message` transcript events. An end request terminates the trial with `OPERATOR_END` before any inference or motion that step. A raising `poll()`/`begin_trial()` degrades with one warning and never costs the eval log.
- The log gains `SceneResult.operator_messages`, strictly parallel to `epochs` (two-level tuple coercion on read; additive, no schema bump). Summarize and the HTML view render it.
- CLI gating: attended TTY + policy `accepts_operator_messages` + POSIX + a console-safe embodiment, meaning it offers the duck-typed `defer_operator_end()` hook (called so stdin-polling embodiments stand down) or is simulated. Real hardware without the hook keeps today's behavior with a notice, so there is no two-readers-on-stdin race with unpatched embodiments.
- The `agent` plugin opts in, renders each message as `operator feedback (step N): ...` in the next observation, and both system templates tell the model to treat the lines as trusted guidance.

## Interim behavior on yam hardware

The console stays off (notice printed) until `inspect-robots-yam` implements `defer_operator_end()`; a follow-up issue will be filed there. Core can ship first with no release-ordering hazard.

## Testing

All gates green locally: ruff check, ruff format, mypy strict, `pytest --cov` at 100% core coverage (1075 passed), agent plugin suite (447 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)