### PR TITLE
feat(agent): Inkling on Tinker as a first-class provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ All notable changes to this project are documented here. The format is based on
   writes the selected file ([plan 0042](plans/0042-config-file-selection.md),
   #274).
 
+- **Agent plugin (0.21.0):** `thinkingmachines/*` models with
+  `$TINKER_API_KEY` now resolve directly to Tinker's Messages endpoint with
+  `wire=messages` inferred. `wire=anthropic` remains a permanent alias for
+  `wire=messages`; construction guards now diagnose explicit wire conflicts,
+  Messages endpoint routing mistakes, and possible silent tool drops on an
+  explicit Chat Completions endpoint (plan 0044, #278).
+
 - `FrameStore` now persists each post-action observation once and exposes it
   through `StepRecord.result_image_refs`. Stored records strip camera arrays
   from both pre-action and post-action observations, and the terminal visual
@@ -87,6 +94,12 @@ All notable changes to this project are documented here. The format is based on
   included (#194).
 
 ### Changed
+
+- **Agent plugin:** with both `$TINKER_API_KEY` and `$OPENROUTER_API_KEY` set,
+  an unset wire for `thinkingmachines/*` now prefers direct Tinker routing on
+  `wire=messages` over OpenRouter on `wire=chat`. An explicit conflicting wire
+  now requires dropping `-P wire=` or deliberately selecting a gateway with
+  `-P base_url=...` and `-P api_key_env=NAME` (plan 0042, #278).
 
 - The `llm/latest` Rerun pane now shows only the step's assistant message(s);
   the full conversation remains in the `llm` TextLog stream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@ All notable changes to this project are documented here. The format is based on
   an unset wire for `thinkingmachines/*` now prefers direct Tinker routing on
   `wire=messages` over OpenRouter on `wire=chat`. An explicit conflicting wire
   now requires dropping `-P wire=` or deliberately selecting a gateway with
-  `-P base_url=...` and `-P api_key_env=NAME` (plan 0042, #278).
+  `-P base_url=...` and `-P api_key_env=NAME` (plan 0044, #278).
 
 - The `llm/latest` Rerun pane now shows only the step's assistant message(s);
   the full conversation remains in the `llm` TextLog stream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ All notable changes to this project are documented here. The format is based on
 - **Agent plugin (0.21.0):** `thinkingmachines/*` models with
   `$TINKER_API_KEY` now resolve directly to Tinker's Messages endpoint with
   `wire=messages` inferred. `wire=anthropic` remains a permanent alias for
-  `wire=messages`; construction guards now diagnose explicit wire conflicts,
+  `wire=messages` (the recorded `policy_config` canonicalizes the alias to
+  `messages`); construction guards now diagnose explicit wire conflicts,
   Messages endpoint routing mistakes, and possible silent tool drops on an
   explicit Chat Completions endpoint (plan 0044, #278).
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ last line, so the operator only ever edits the end of the command:
 
 ```bash
 inspect-robots run --policy agent --rerun-connect \
-    -P model=anthropic/claude-opus-5 -P wire=anthropic -P speed=fast \
+    -P model=anthropic/claude-opus-5 -P wire=messages -P speed=fast \
     -P effort=high \
     --instruction "place the fork on the plate"
 ```

--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -163,7 +163,7 @@ The agent policy records **exactly what each LLM call sent and received** —
 by default, for every run. The saved transcript alone is not that object:
 outgoing requests carry the tool schemas, only the newest `image_horizon`
 frames (older ones become elision stubs), rendered depth composites, and, on
-the Anthropic wire, `cache_control` breakpoints — none of which survive into
+the Messages wire, `cache_control` breakpoints — none of which survive into
 `policy_transcripts`. Wire capture stores the real thing, per attempt,
 including retries and the failed calls a run died on.
 

--- a/plans/0042-tinker-inkling-provider.md
+++ b/plans/0042-tinker-inkling-provider.md
@@ -1,0 +1,380 @@
+# 0042 — Inkling on Tinker: `thinkingmachines/` provider and `wire=messages`
+
+Issue: #278. Revised after critiques R1 (8 findings: ENV_MODEL wire
+inference, the :451 fix ladder, capx blast radius, the hint's explicitness
+signal, and four smaller), R2 (7 findings: key-hint leak into
+default-`native_wires` errors, :451 branch conditions, conflict-guard text
+vs the OpenRouter-routed config, inference no-op pinning, guard ordering vs
+gemini-live, hint rationale, `speed` probe), R3 (7 findings:
+`resolve_provider` docstring inventory, falsified README prose inventory,
+and five polish items), and R4 (6 findings: ladder-test key
+preconditions, two more README lines, and four inventory nits); all
+resolved below.
+
+## Problem
+
+Tinker (Thinking Machines) now serves Inkling and Inkling-Small
+(`thinkingmachines/Inkling`, `thinkingmachines/Inkling-Small`: hybrid
+reasoners, vision, 64K context) via serverless inference. The agent plugin
+already drives them end to end — verified live on 2026-08-03, both models
+solved CubePick 1/1 through the Messages wire — but the working configuration
+is three flags of boilerplate, and the obvious wrong configuration fails in
+the worst possible way.
+
+### Verified facts (live probes, 2026-08-03)
+
+All probes used the plugin's exact request shapes (`_anthropic.py` bodies,
+`_png.png_data_url` frames).
+
+- **Anthropic-compatible endpoint**
+  (`https://tinker.thinkingmachines.dev/services/tinker-prod/anthropic/api/v1`,
+  auth via `x-api-key`): tool use (`tool_use` blocks, `stop_reason=tool_use`,
+  valid JSON args), base64 PNG image inputs (solid-green sanity check answered
+  "Green"), `thinking: {"type": "adaptive"}` accepted, thinking blocks
+  returned and their verbatim multi-turn replay accepted across a 14-turn
+  episode, system-block `cache_control` accepted (real cache reads served,
+  despite docs saying caching is unsupported), `max_tokens` accepted at the
+  plugin default 16000 and beyond (200000 probed).
+- **Effort**: `output_config.effort` accepts exactly `low`, `medium`, `high`,
+  `xhigh`, `max` — the same five values `_anthropic.py` sends. `none` and
+  `minimal` are a 422 whose body contains "effort", so the existing
+  `_rejection_guidance` branch already names the fix. Effort genuinely
+  modulates thinking volume (141 thinking chars at `low` vs 426 at `max` on
+  the same prompt).
+- **Model ids**: the endpoint expects the **full** id
+  (`thinkingmachines/Inkling`). Base-model names work on both compatible
+  APIs; `tinker://` checkpoint paths also work (out of scope here).
+- **`speed: "fast"` + the fast-mode beta header are silently ignored**
+  (probed 2026-08-03: HTTP 200, normal-speed response, no error) — so a
+  misdirected `-P speed=fast` neither fails nor helps on Tinker.
+- **OpenAI-compatible endpoint** (`.../oai/api/v1`): no image support, and
+  `tools` are **silently ignored** — HTTP 200 with the motion described in
+  prose, no `tool_calls`. On `wire=chat` the policy burns
+  `_MAX_CONSECUTIVE_FAILURES` (3) turns and dies at `policy.py:778` with the
+  unguided `LLM produced no tool call in 3 consecutive turns`.
+- **Usage quirk**: Tinker reports `input_tokens: 0`; input shows up as
+  `cache_creation_input_tokens`/`cache_read_input_tokens`. Cosmetic
+  (transcript `in=0`, EvalLog input-token stats read zero); document, don't
+  code around.
+
+### The two UX defects
+
+1. `wire=anthropic` names a vendor, but the value selects a protocol — the
+   Messages API — which now has multiple servers (Anthropic, Tinker,
+   gateways). The other wire names are endpoint-shaped (`chat` →
+   /chat/completions, `responses` → /responses); this one should be too.
+2. Supporting a provider should not require users to carry
+   `-P wire= -P base_url= -P api_key_env=` on every invocation. Every other
+   supported provider is one model prefix plus one env var.
+
+## Design
+
+Agent plugin only; no core changes. Four parts.
+
+### D1: `wire=messages`, with `anthropic` as a permanent alias
+
+- `_WIRE_FORMATS` becomes `{"chat", "responses", "messages", "gemini-live"}`.
+  A new `_WIRE_ALIASES = {"anthropic": "messages"}` is applied **before**
+  membership validation, so `-P wire=anthropic` keeps working forever and an
+  unknown value's `ConfigError` lists the canonical names.
+- Every wire comparison against `"anthropic"` in `policy.py` (lines 369
+  (negated guard), 432, 451, 513, 518 today) switches to `"messages"`. Error and fix strings that spell
+  `wire=anthropic` / `-P wire=anthropic` (all in `policy.py` and
+  `__init__.py`; `_anthropic.py` has none) say `wire=messages`.
+- `AgentPolicyConfig.wire` records the **canonical** value: a run launched
+  with `-P wire=anthropic` logs `wire: "messages"`. Old EvalLogs are
+  immutable and stay as written; nothing reads the stored wire back for
+  control flow. The `AgentPolicyConfig.wire` docstring names the alias.
+- Prose that teaches the old name is part of this rename, not incidental:
+  the package docstring (`__init__.py:6`, rendered into the generated API
+  docs) and the `AgentPolicyConfig.max_output_tokens` field comment
+  ("Effective per-response cap on ``wire=anthropic``", policy.py:216).
+  The `_EFFORT_LEVELS` comment block (policy.py:72-77) is touched for a
+  different reason: its "xhigh/max need a cap this client cannot stream"
+  claim becomes Anthropic-endpoint-specific once Tinker shares the wire
+  (Tinker returned 200 for xhigh/max at a 200000 cap, no streaming).
+
+### D2: provider-native wires and the `thinkingmachines/` entry
+
+`_llm.py` changes:
+
+- `_DirectProvider` gains two fields with defaults that leave the existing
+  eight entries (seven providers; `x-ai`/`xai` are one) untouched:
+  `wire: str = "chat"` and `keep_prefix: bool = False`. The table comment
+  "The prefix is stripped: these endpoints want the bare model id" is
+  updated for `keep_prefix`, and so is the `_ANTHROPIC_BASE` comment
+  ("The only endpoint that serves /v1/messages without an explicit
+  base_url", policy.py:60), which the Tinker entry falsifies.
+- `resolve_provider`'s **docstring** is public-API contract rendered into
+  the generated API docs and is falsified twice: step 2's provider
+  enumeration + "prefix stripped from the model id" (keep-prefix entries
+  keep it), and the new `native_wires` kwarg needs its contract stated
+  (which wires the caller can speak; entries with other native wires do
+  not claim and the ladder falls through). Two more public docstrings the
+  entry falsifies join the inventory: `Provider`'s ("A resolved
+  OpenAI-compatible endpoint", `_llm.py:75` — no longer necessarily
+  OpenAI-compatible, and it grows the `wire` field) and the `_llm.py`
+  module docstring (lines 1-7, which enumerates chat-only coverage).
+- The `speed`/`max_output_tokens` guard comment at policy.py:370-372
+  ("Both fail loudly rather than silently") is scoped to what it still
+  guarantees: with `messages` inferred for Tinker, `-P speed=fast` passes
+  construction and Tinker ignores it server-side (probed); the comment and
+  the README caveat must tell the same story.
+- New entry:
+
+  ```python
+  "thinkingmachines": _DirectProvider(
+      "https://tinker.thinkingmachines.dev/services/tinker-prod/anthropic/api/v1",
+      "TINKER_API_KEY",
+      wire="messages",
+      keep_prefix=True,
+  ),
+  ```
+
+- The claim condition in `resolve_provider` (prefix in table + bare model
+  non-empty + no OpenRouter `:variant` suffix + key env set) is extracted
+  into a single helper, `_direct_claim(model, env, native_wires) -> tuple[str, _DirectProvider] | None`,
+  used by both `resolve_provider` and the new wire inference below — one
+  predicate, no drift. On a successful claim, the resolved model id is the
+  full id when `keep_prefix` is set, else the bare id as today.
+- **`resolve_provider` stays back-compatible for its other consumers.**
+  `resolve_provider` and `Provider` are public plugin API, and
+  inspect-robots-capx calls them with clients that speak only
+  OpenAI-compatible wires; silently rerouting its `thinkingmachines/*`
+  resolution from OpenRouter to a Messages-only base URL would trade a
+  working config for an unguided hard failure. So `resolve_provider` (and
+  `_direct_claim`) gain a keyword `native_wires: frozenset[str] = frozenset({"chat"})`:
+  a table entry claims the model only when its wire is in the set,
+  otherwise the ladder falls through to OpenRouter exactly as today. The
+  agent policy passes `frozenset({"chat", "messages"})`; capx and any
+  out-of-tree caller keep the default and see zero routing change. No capx
+  edits, no capx release.
+- `_provider_key_hints()` takes the same `native_wires` and only names
+  entries claimable under it. Otherwise resolve_provider's no-key error
+  under the default set would tell a capx user with `thinkingmachines/*`
+  to `set $TINKER_API_KEY` — advice that cannot work there, since the
+  default set declines the claim and the same error would recur.
+- `Provider` gains `wire: str = "chat"`, recording the claimed entry's
+  native wire. The explicit-`base_url` and OpenRouter paths leave it at
+  `"chat"` (meaning: no provider opinion), so nothing downstream changes for
+  them.
+
+`policy.py` constructor changes (order per plan 0026: wire is resolved and
+validated before the wire-only params, key-env defaulting before resolution,
+endpoint checks after):
+
+- The `wire` parameter becomes `str | _Unset = _UNSET` (the module's existing
+  marker type; `agent_policy()` and the CLI pass strings through unchanged).
+  Resolution:
+  - explicit value → alias-normalize, validate against `_WIRE_FORMATS`;
+  - `_UNSET` → `_direct_claim(requested_model, environ, ...)`'s native wire
+    when the claim succeeds and no `base_url` was passed, else `"chat"`. An
+    explicit `base_url` bypasses the provider table today and keeps doing
+    so — no implied wire.
+- **Inference operates on the same model string resolution uses.** The
+  model can arrive via `$INSPECT_ROBOTS_MODEL`
+  (`requested_model = model or environ.get(ENV_MODEL)`, policy.py:436,
+  currently computed *after* wire validation). The `environ` and
+  `requested_model` computations are hoisted above wire resolution;
+  otherwise an env-supplied `thinkingmachines/Inkling` would infer
+  `wire="chat"` while `resolve_provider` claims Tinker's Messages base URL,
+  recreating exactly the silent chat-against-Messages failure this plan
+  exists to kill. Hoisting is safe: neither computation depends on
+  anything the moved-past checks establish.
+- `AgentPolicyConfig.wire`'s dataclass default stays `"chat"` (the effective
+  default for every model that doesn't claim a native-wire provider).
+- **Conflict guard** (construction-time, immediately after provider
+  resolution and **before** the endpoint checks at policy.py:451 and :499,
+  so it wins over the gemini-live "needs Google's direct Live API provider"
+  error for claiming models; the :499 guard stays reachable for
+  non-claiming ones): when the claim succeeds, the entry's wire is not
+  `"chat"`, and an explicit wire disagrees, raise a guided `ConfigError`:
+
+  ```
+  wire='chat' cannot drive thinkingmachines/* — the provider's direct
+  endpoint serves only the Messages API.
+  fix: drop -P wire= (thinkingmachines/* defaults to wire=messages), or
+  pass -P base_url=... (+ -P api_key_env=NAME) to route this wire through
+  a gateway such as OpenRouter deliberately
+  ```
+
+  The gateway half of the fix line appears only for `chat`/`responses`;
+  `gemini-live` gets just the drop-`-P wire=` half (no gateway serves the
+  Live protocol, and policy.py:414 requires a ws:// base_url there anyway).
+
+  The text names the endpoint mismatch, not Tinker's OAI limitations: with
+  both `TINKER_API_KEY` and `OPENROUTER_API_KEY` set, this exact config
+  routed through OpenRouter and *worked* until now, so the message must not
+  describe a failure the blocked config never had, and the fix line must
+  include the gateway escape (`-P base_url=https://openrouter.ai/api/v1
+  -P api_key_env=OPENROUTER_API_KEY`). The explicit-`base_url` escape hatch
+  is untouched: users who want Tinker's OAI endpoint on `wire=chat` can
+  still point at it and own the outcome (see D3).
+- The Messages-endpoint check at policy.py:451 ("only Anthropic's own
+  endpoint serves /v1/messages") learns about provider-native wires in both
+  directions:
+  - successful claim → skip the check (`provider.wire == "messages"`);
+  - failed claim on a native-messages prefix → the fix-string ladder
+    generalizes rather than gaining a bolt-on branch. The existing branches
+    were built to never name a fix the user already has right, and the new
+    prefix inherits that care:
+    - "Messages-capable prefixes" is a defined set, not vibes:
+      `{"anthropic"} ∪ {prefixes whose table entry has wire == "messages"}`.
+      It cannot be derived from `entry.wire` alone because the `anthropic`
+      entry's wire deliberately stays `"chat"` (its Messages service comes
+      from `wire=messages` selecting the endpoint, not from a claim);
+    - the empty-id branch (policy.py:464, today `removeprefix("anthropic/")`
+      only) strips any Messages-capable prefix, so bare `thinkingmachines/`
+      gets the full-command fix, not key advice for an unusable id;
+    - the foreign-prefix branch (policy.py:469-474) treats Messages-capable
+      prefixes as domestic — its comment "A foreign prefix can never
+      resolve to the Messages API" is false once a second such prefix
+      exists;
+    - the `:variant` branch keeps precedence: `thinkingmachines/Inkling:free`
+      with `TINKER_API_KEY` set gets "drop the OpenRouter variant suffix" —
+      post-resolution, the ladder never names a key the user already set
+      (the ladder only runs when `resolve_provider` succeeded, i.e. the
+      OpenRouter fallback fired; without any usable key the error is
+      `resolve_provider`'s own no-key raise, which legitimately names keys);
+    - only then, a usable un-suffixed `thinkingmachines/*` id with the key
+      env actually unset → `fix: set $TINKER_API_KEY` (spelled from the
+      entry's `key_env`, not hardcoded).
+
+  The `api_key_env` defaulting at line 432 (`wire=messages` + explicit
+  `base_url` → `ANTHROPIC_API_KEY`) is rename-only.
+
+Routing notes for the changelog (`### Changed`), stated as behavior changes,
+not precedent: with both `TINKER_API_KEY` and `OPENROUTER_API_KEY` set,
+`thinkingmachines/*` with `wire` unset previously fell through to OpenRouter
+on `wire=chat` and now resolves direct to Tinker on `wire=messages`; and an
+**explicit** `-P wire=chat` with that key pair, which previously worked via
+OpenRouter, is now the construction-time `ConfigError` above (the gateway
+escape re-enables it deliberately).
+
+### D3: guided hint on the silent-tool-drop failure
+
+The `policy.py:778` raise (`LLM produced no tool call in N consecutive
+turns`) appends, only when `wire == "chat"` **and** an explicit `base_url`
+was configured:
+
+```
+note: some OpenAI-compatible endpoints accept `tools` but silently ignore
+them (Tinker's OpenAI-compatible API is one). If the provider serves the
+Messages API, retry with -P wire=messages and its Messages base_url.
+```
+
+Not on first-party chat providers, and not on the `policy.py:931` raise,
+which is a different failure (tool calls present but invalid). The gating
+is about cost, not diagnosis: on the explicit-`base_url` path (gateways,
+local vLLM/Ollama) a silent tool drop is *possible* and the hedged "some
+endpoints" wording earns its place; on first-party endpoints it is not, so
+the note would be pure misdirection. A local-model streak that is really
+model behavior still reads the note and loses nothing.
+
+The "explicit `base_url`" bit is not derivable at the raise site today:
+`AgentPolicyConfig.base_url` stores the *resolved* `provider.base_url`
+(policy.py:549), which is always non-None. The constructor stashes the
+explicitness as a private attribute (`self._explicit_base_url = bool(base_url)`);
+the config schema is unchanged.
+
+### D4: documentation
+
+Public-facing text follows the repo writing-style rules (no em dashes in
+prose, no mid-sentence bold, headers use colons).
+
+- **Plugin README**: new "Inkling on Tinker" section — the two-flag
+  invocation, effort semantics (plugin default `low`; Inkling's own default
+  is high per Tinker's thinking-effort cookbook page, so pass `-P effort=`
+  deliberately; `none`/`minimal` rejected by the endpoint — the default
+  claim is doc-sourced, not probe-sourced, and is attributed as such), the
+  zero-input-tokens usage quirk, the beta
+  caveat, a note that `-P speed=fast` is Claude-on-Claude-API only and is
+  **silently ignored** by Tinker (probed: HTTP 200, normal speed — and with
+  messages inferred it no longer trips the construction-time wire check, so
+  nothing else will flag it), and a pointer that
+  `:peft:262144` extended-context ids are untested. Wires table row renamed
+  to `messages` with the `anthropic` alias noted; provider/key table gains
+  the `thinkingmachines/*` / `TINKER_API_KEY` row and the `anthropic/*`
+  row's "native with `-P wire=anthropic`" (README.md:40) takes the rename;
+  the "Fast mode on Claude" section's examples switch to `-P wire=messages`.
+  Existing prose the feature falsifies is part of the edit, not collateral:
+  the key-ladder step "the provider's own endpoint, prefix stripped from
+  the model id" (README.md:29) learns about keep-prefix entries; the
+  configuration-knobs paragraph "`speed` and `max_output_tokens` apply to
+  `-P wire=anthropic` only" (README.md:245) takes the rename; and the
+  fast-mode section's opening "`-P wire=anthropic` drives Claude through
+  the native Messages API" (README.md:341), its "Only Anthropic's own
+  endpoint serves /v1/messages, so anything that resolves elsewhere is
+  refused up front", and "The model id keeps the `anthropic/` prefix on
+  this wire" (README.md:351-353) are rewritten for the second
+  Messages-native provider.
+- **capx README** (repo copy only, no capx code change or release): one
+  qualifier line where it says routing "follow[s] the inspect-robots-agent
+  plugin" (capx README.md:58-59) — capx keeps chat-only routing, so
+  `thinkingmachines/*` resolves via OpenRouter there by design. Publishes
+  whenever capx next bumps.
+- **Root README**: the fast-mode example at line 142 switches to
+  `-P wire=messages`.
+- **docs/guide/logging-and-rerun.md:166**: "on the Anthropic wire" becomes
+  "on the Messages wire" (the one prose use of the old name under `docs/`;
+  released-version CHANGELOG history stays as written).
+- **CHANGELOG**: agent-plugin entries split by class — the new provider,
+  alias, and guards under `### Added`; the D2 routing note (direct-to-Tinker
+  precedence over OpenRouter when both keys are set) under `### Changed`.
+
+### Version
+
+`plugins/inspect-robots-agent/pyproject.toml` `0.20.0` → `0.21.0` (new
+provider, new accepted wire value; fully backward compatible). Publishes via
+the existing `publish-agent` job on the next core release.
+
+## Tests
+
+All in `plugins/inspect-robots-agent/tests/`, following the existing
+MockTransport / stub patterns; no live-API tests (beta service, secret key).
+
+- `test_llm.py`: `thinkingmachines/Inkling` + `TINKER_API_KEY` claims direct
+  (with `native_wires` including `"messages"`) with the full id preserved
+  and `Provider.wire == "messages"`; the **default** `native_wires` skips
+  the entry and routes to OpenRouter (the capx-compat contract); without the
+  key it falls through to OpenRouter as before; explicit `base_url` bypasses
+  the entry; `:peft:262144` suffix (a colon that is not an OpenRouter
+  variant) still claims direct. `test_guided_error_names_the_new_provider_keys`
+  (test_llm.py:183) updates for `$TINKER_API_KEY` in `_provider_key_hints()`
+  **under the agent's wire set**, plus the inverse: the default
+  `native_wires` hint string omits `$TINKER_API_KEY`.
+- `test_policy_e2e.py` / construction tests:
+  - `wire` unset + `thinkingmachines/*` + key → `AnthropicClient` selected,
+    Tinker base URL, config records `wire="messages"`.
+  - `wire` unset + model supplied only via `$INSPECT_ROBOTS_MODEL`
+    (`thinkingmachines/*`) + key → same outcome as the explicit-model case.
+  - `wire` unset + `anthropic/claude-*` + `ANTHROPIC_API_KEY` →
+    `ChatClient` on the compat endpoint, config records `wire="chat"` (pins
+    that no existing entry grows a native wire; the whole back-compat story
+    rests on this).
+  - `wire=messages` + `thinkingmachines/*` + `OPENROUTER_API_KEY` but no
+    `TINKER_API_KEY` → `ConfigError` whose fix says `set $TINKER_API_KEY`.
+  - `wire=messages` + `thinkingmachines/Inkling:free` with **both**
+    `TINKER_API_KEY` and `OPENROUTER_API_KEY` set (resolution must succeed
+    via OpenRouter for the `:451` ladder to run at all; every existing
+    ladder test sets both keys for this reason, test_anthropic.py:1060) →
+    the variant-suffix fix, not key advice; bare `thinkingmachines/` under
+    the same both-keys env → the full-command fix.
+  - `-P wire=anthropic` (any provider) → accepted, config records
+    `"messages"`, Messages client selected.
+  - explicit `wire=chat` / `responses` / `gemini-live` +
+    `thinkingmachines/*` + key → `ConfigError` with the guided text.
+  - unknown wire value → `ConfigError` listing the canonical set.
+  - 3-strikes raise: hint present with `wire=chat` + explicit `base_url`;
+    absent without `base_url`; absent on the invalid-tool-call raise.
+  - existing `wire="anthropic"` string literals in tests migrate to
+    `"messages"` except the ones that exist to prove the alias.
+- Wire-only param errors (`speed`, `max_output_tokens`) name
+  `wire=messages` in their fix strings.
+
+## Out of scope
+
+- Core changes of any kind; `inspect_robots.__all__` is untouched.
+- Tinker's OAI-compatible endpoint, `tinker://` checkpoint ids, the 256K
+  `:peft` variants (untested), audio input.
+- A live canary against Tinker (paid beta endpoint; would be flaky noise).

--- a/plans/0044-tinker-inkling-provider.md
+++ b/plans/0044-tinker-inkling-provider.md
@@ -1,4 +1,4 @@
-# 0042 — Inkling on Tinker: `thinkingmachines/` provider and `wire=messages`
+# 0044 — Inkling on Tinker: `thinkingmachines/` provider and `wire=messages`
 
 Issue: #278. Revised after critiques R1 (8 findings: ENV_MODEL wire
 inference, the :451 fix ladder, capx blast radius, the hint's explicitness

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -24,9 +24,9 @@ inspect-robots "pick up the cube" --policy agent \
 Model strings are OpenRouter-style `provider/model`, resolved from
 `-P model=...` or `$INSPECT_ROBOTS_MODEL`. API keys come from the environment:
 
-1. `-P base_url=...` (with `-P api_key_env=NAME`): any OpenAI-compatible endpoint
+1. `-P base_url=...` (with `-P api_key_env=NAME`): any supported compatible endpoint
 2. A known provider prefix with that provider's key set: the provider's own
-   endpoint, prefix stripped from the model id
+   endpoint, with the prefix stripped unless that endpoint requires the full id
 3. `OPENROUTER_API_KEY`: OpenRouter, any model string. Ids ending in a known
    OpenRouter variant suffix (`:free`, `:nitro`, `:floor`, `:extended`,
    `:online`, `:thinking`) always route here, since the variant means nothing
@@ -37,13 +37,14 @@ Providers resolved directly by prefix:
 
 | Prefix | Key | Endpoint |
 |---|---|---|
-| `anthropic/*` | `ANTHROPIC_API_KEY` | Anthropic (OpenAI-compat, or native with `-P wire=anthropic`) |
+| `anthropic/*` | `ANTHROPIC_API_KEY` | Anthropic (OpenAI-compat, or native with `-P wire=messages`) |
 | `openai/*` | `OPENAI_API_KEY` | OpenAI |
 | `google/*` | `GEMINI_API_KEY` | Google Gemini (OpenAI-compat) |
 | `x-ai/*` or `xai/*` | `XAI_API_KEY` | xAI |
 | `groq/*` | `GROQ_API_KEY` | Groq (rest of the id passed through, slashes and all) |
 | `mistralai/*` | `MISTRAL_API_KEY` | Mistral |
 | `deepseek/*` | `DEEPSEEK_API_KEY` | DeepSeek |
+| `thinkingmachines/*` | `TINKER_API_KEY` | Tinker Messages API (full model id passed through) |
 
 ### Gemini Robotics ER 2
 
@@ -72,7 +73,7 @@ endpoint support:
 |---|---|---|
 | `chat` (default) | `/chat/completions` | Anything OpenAI-compatible: OpenRouter, vLLM, Ollama, the Anthropic and Gemini compat endpoints |
 | `responses` | `/responses` | A direct OpenAI or compatible endpoint requires the Responses API |
-| `anthropic` | `/messages` | Driving Claude natively, which is what fast mode needs |
+| `messages` (`anthropic` alias) | `/messages` | Anthropic, Tinker, or a compatible Messages endpoint |
 | `gemini-live` | `BidiGenerateContent` (WSS) | Google's Live API: required for the `-streaming-` robotics model ids |
 
 ## How it works
@@ -250,8 +251,9 @@ Configuration knobs (all `-P key=value`): `model`, `base_url`, `api_key_env`,
 (default `always`; use `on_demand` for model-requested frames),
 `image_horizon`, `depth` (default `render`; use `off` to omit depth
 renders), and `prior_learnings`.
-`speed` and `max_output_tokens` apply to `-P wire=anthropic` only, and passing
-either on another wire is an error rather than a silent no-op.
+`speed` and `max_output_tokens` apply to `-P wire=messages` only, and passing
+either on another wire is an error. `speed=fast` is meaningful only for Claude
+on Anthropic's API; Tinker accepts and silently ignores it.
 
 | Image option | Default | Behavior |
 |---|---|---|
@@ -291,7 +293,7 @@ payloads deduplicated as `$blob:<sha256>` references into
 Requires a core with the `on_trial_start` policy hook; on older cores the
 policy prints one notice and captures nothing.
 At trial end, `record.metadata["llm_usage"]` records `llm_calls` and the summed
-integer token counters returned by the wire. The native Anthropic wire
+integer token counters returned by the wire. The Messages wire
 includes input, output, cache-creation, and cache-read tokens; other wires
 currently record `llm_calls` only. Trials with no LLM calls omit the key.
 
@@ -344,27 +346,54 @@ HTML viewer shows that placeholder text verbatim below the depth label because
 the frame store has no saved frame for rendered depth. This is a known
 cosmetic artifact; the metric label remains available in the report.
 
+## Inkling on Tinker
+
+Tinker serves Inkling and Inkling-Small directly through the Messages API.
+Set its key and select the model; the provider prefix infers the wire and keeps
+the full model id required by the endpoint:
+
+```bash
+export TINKER_API_KEY=tk-...
+
+inspect-robots "pick up the cube" --policy agent \
+    -P model=thinkingmachines/Inkling -P effort=low \
+    --embodiment cubepick
+```
+
+The plugin defaults to `effort=low` for latency-sensitive robot control.
+Tinker's thinking-effort cookbook documents Inkling's own default as high, so
+pass `-P effort=` deliberately when comparing results. The endpoint accepts
+`low`, `medium`, `high`, `xhigh`, and `max`; it rejects `none` and `minimal`.
+
+Tinker currently reports `input_tokens: 0` because input usage appears in its
+cache-creation and cache-read counters. EvalLog input-token statistics and the
+live `in=0` transcript line therefore undercount input even though requests are
+processed normally. Tinker is a beta service. `-P speed=fast` is a
+Claude-on-Anthropic-API option and Tinker silently ignores it, returning HTTP
+200 at normal speed. Extended-context model ids ending in `:peft:262144` have
+not been tested with this plugin.
+
 ## Fast mode on Claude
 
-`-P wire=anthropic` drives Claude through the native Messages API instead of
+`-P wire=messages` drives Claude through the native Messages API instead of
 the OpenAI-compat endpoint. That is the only way to reach fast mode, which
 serves the same model at up to 2.5x higher output tokens per second:
 
 ```bash
 inspect-robots "pick up the cube" --policy agent \
-    -P model=anthropic/claude-opus-5 -P wire=anthropic -P speed=fast \
+    -P model=anthropic/claude-opus-5 -P wire=messages -P speed=fast \
     --embodiment cubepick
 ```
 
-The model id keeps the `anthropic/` prefix on this wire, the same as every
-other model string here. Only Anthropic's own endpoint serves `/v1/messages`,
-so anything that resolves elsewhere is refused up front with the fix named: a
-bare `-P model=claude-opus-5`, another provider's prefix such as `openai/`, or
-an OpenRouter `:variant` suffix. Pass `-P base_url=...` to point at a gateway
-that serves the endpoint yourself.
+Direct-provider model-id handling follows the provider table: Anthropic takes
+the bare Claude id, while Tinker keeps `thinkingmachines/`. A Messages run is
+refused up front when its model resolves to an endpoint that does not serve
+`/v1/messages`, with a fix for a missing prefix, provider key, or an OpenRouter
+`:variant` suffix. Pass `-P base_url=...` to point at a compatible Messages
+gateway yourself.
 
 > [!NOTE]
-> With `-P base_url=...` and no `-P api_key_env=`, this wire sends
+> With `-P base_url=...` and no `-P api_key_env=`, the Messages wire sends
 > `$ANTHROPIC_API_KEY` to that host. The other wires default to
 > `$OPENROUTER_API_KEY` instead. Name the variable explicitly
 > (`-P api_key_env=MYGW_KEY`) when the gateway takes its own credential, and
@@ -383,8 +412,10 @@ Sonnet 4.5 and Haiku 4.5 do not support. Use `-P wire=chat` for those.
 The Messages API requires an output cap, so `-P max_output_tokens=` defaults to
 `16000` here. Thinking bills against that same cap, and a response truncated at
 the limit is an error naming the knob rather than a silently missing tool call.
-Keep `-P effort=` at `high` or below on this wire: `xhigh` and `max` want a cap
-of 64000 or more, which needs streaming this client does not implement yet.
+On Anthropic's endpoint, keep `-P effort=` at `high` or below: `xhigh` and
+`max` want a cap of 64000 or more, which needs streaming this client does not
+implement yet. Tinker accepts `xhigh` and `max` with the plugin's non-streaming
+request shape.
 The read timeout scales with the cap and tops out at 600 s per attempt, so a
 large cap plus retries can sit for several minutes before failing.
 

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.20.0"
+version = "0.21.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/__init__.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/__init__.py
@@ -1,11 +1,10 @@
-"""inspect-robots-agent — frontier LLMs as first-class Inspect Robots policies.
+"""inspect-robots-agent: frontier LLMs as first-class Inspect Robots policies.
 
-An LLM behind any OpenAI-compatible API (OpenRouter, OpenAI, local
-vLLM/Ollama, Anthropic's compat endpoint) drives whatever embodiment it is
+An LLM behind a supported API (OpenRouter, OpenAI, local vLLM/Ollama,
+Anthropic, Tinker, or compatible gateways) drives whatever embodiment it is
 paired with: each tool call becomes one smooth, approver-checked action
-chunk. ``-P wire=anthropic`` swaps the OpenAI-compat shim for Anthropic's
-native Messages API, which is what fast mode needs. Registered as the policy
-``agent``::
+chunk. ``-P wire=messages`` selects the Messages API; the permanent
+``anthropic`` alias remains accepted. Registered as the policy ``agent``::
 
     inspect-robots "pick up the cube" --policy agent \
         -P model=anthropic/claude-fable-5 --embodiment cubepick

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
@@ -1,9 +1,9 @@
-"""OpenAI-compatible chat client + provider resolution (plan 0008 §4a).
+"""Wire-neutral provider resolution and the Chat Completions client.
 
-No provider SDKs: one ``httpx`` client speaking the chat-completions wire
-format covers OpenRouter, OpenAI, local vLLM/Ollama, and Anthropic's
-OpenAI-compat endpoint — the same "speak the protocol, don't import the
-package" doctrine as the xpolicylab plugin.
+No provider SDKs: small ``httpx`` clients speak the selected protocol while
+this module resolves direct providers, OpenRouter, and explicit endpoints.
+Chat Completions still covers OpenRouter, OpenAI, local vLLM/Ollama, and
+provider compatibility endpoints (plan 0008 §4a).
 """
 
 from __future__ import annotations
@@ -27,14 +27,16 @@ _OPENROUTER_KEY = "OPENROUTER_API_KEY"
 
 @dataclass(frozen=True)
 class _DirectProvider:
-    """A provider with a stable OpenAI-compatible endpoint and conventional key name."""
+    """A provider with a stable endpoint, native wire, and conventional key name."""
 
     base_url: str
     key_env: str
+    wire: str = "chat"
+    keep_prefix: bool = False
 
 
 # OpenRouter-style prefixes that resolve to the provider's own endpoint when its
-# key is present. The prefix is stripped: these endpoints want the bare model id.
+# key is present. Prefixes are stripped unless an entry requests the full id.
 _DIRECT_PROVIDERS: dict[str, _DirectProvider] = {
     "anthropic": _DirectProvider("https://api.anthropic.com/v1", "ANTHROPIC_API_KEY"),
     "openai": _DirectProvider("https://api.openai.com/v1", "OPENAI_API_KEY"),
@@ -46,6 +48,12 @@ _DIRECT_PROVIDERS: dict[str, _DirectProvider] = {
     "groq": _DirectProvider("https://api.groq.com/openai/v1", "GROQ_API_KEY"),
     "mistralai": _DirectProvider("https://api.mistral.ai/v1", "MISTRAL_API_KEY"),
     "deepseek": _DirectProvider("https://api.deepseek.com/v1", "DEEPSEEK_API_KEY"),
+    "thinkingmachines": _DirectProvider(
+        "https://tinker.thinkingmachines.dev/services/tinker-prod/anthropic/api/v1",
+        "TINKER_API_KEY",
+        wire="messages",
+        keep_prefix=True,
+    ),
 }
 
 
@@ -62,21 +70,50 @@ def _has_openrouter_variant(model_id: str) -> bool:
     return bool(sep) and suffix in _OPENROUTER_VARIANTS
 
 
-def _provider_key_hints() -> str:
-    """One ``$KEY for prefix/*`` hint per distinct key, for the guided error."""
+def _provider_key_hints(native_wires: frozenset[str]) -> str:
+    """Name keys only for direct providers whose native wire the caller supports."""
     seen: dict[str, str] = {}
     for prefix, direct in _DIRECT_PROVIDERS.items():
+        if direct.wire not in native_wires:
+            continue
         seen.setdefault(direct.key_env, prefix)
     return ", ".join(f"${key} for {prefix}/*" for key, prefix in seen.items())
 
 
+def _direct_claim(
+    model: str | None,
+    env: Mapping[str, str],
+    *,
+    native_wires: frozenset[str] = frozenset({"chat"}),
+) -> tuple[str, _DirectProvider] | None:
+    """Return the claimable prefix and entry, or ``None`` when the ladder must continue."""
+    if not model:
+        return None
+    provider_prefix, _, bare_model = model.partition("/")
+    direct = _DIRECT_PROVIDERS.get(provider_prefix)
+    if (
+        direct is not None
+        and direct.wire in native_wires
+        and bare_model
+        and not _has_openrouter_variant(bare_model)
+        and env.get(direct.key_env)
+    ):
+        return provider_prefix, direct
+    return None
+
+
 @dataclass(frozen=True)
 class Provider:
-    """A resolved OpenAI-compatible endpoint: where, with which key, which model."""
+    """A resolved request target and any direct provider's native-wire opinion.
+
+    ``wire`` is ``"chat"`` for explicit endpoints and OpenRouter, and records
+    a direct table entry's native wire when that entry claims the model.
+    """
 
     base_url: str
     api_key: str
     model: str
+    wire: str = "chat"
 
 
 def resolve_provider(
@@ -84,23 +121,27 @@ def resolve_provider(
     base_url: str | None,
     api_key_env: str | None,
     env: Mapping[str, str],
+    *,
+    native_wires: frozenset[str] = frozenset({"chat"}),
 ) -> Provider:
     """The key/base-url ladder (plan 0008 §4a); first match wins.
 
-    1. Explicit ``base_url`` — any OpenAI-compatible endpoint; the key comes
+    1. Explicit ``base_url``: any caller-compatible endpoint; the key comes
        from ``api_key_env`` (default ``OPENROUTER_API_KEY``), and a missing
        key is allowed (local vLLM/Ollama endpoints are typically keyless).
     2. A known ``prefix/*`` model + that provider's key (``_DIRECT_PROVIDERS``:
-       anthropic, openai, google, x-ai/xai, groq, mistralai, deepseek) — the
-       provider's own endpoint, prefix stripped from the model id. Ids ending
-       in a known OpenRouter variant suffix (``_OPENROUTER_VARIANTS``, e.g.
-       ``:free``, ``:nitro``) are never claimed here — the variant only means
-       something to OpenRouter. Other colons (fine-tune ids) pass through.
-    3. ``OPENROUTER_API_KEY`` — OpenRouter, which takes the full
+       anthropic, openai, google, x-ai/xai, groq, mistralai, deepseek,
+       thinkingmachines): the provider's own endpoint, with the prefix
+       stripped unless the entry requires the full id. ``native_wires`` names
+       the protocols the caller can speak; entries on other wires do not claim
+       and the ladder continues. Ids ending in a known OpenRouter variant
+       suffix (``_OPENROUTER_VARIANTS``, e.g. ``:free``, ``:nitro``) are never
+       claimed here. Other colons (fine-tune and checkpoint ids) pass through.
+    3. ``OPENROUTER_API_KEY``: OpenRouter, which takes the full
        ``provider/model`` string.
 
     Anything else is a guided [`ConfigError`][inspect_robots.errors.ConfigError]
-    naming the fixes — never a traceback at the user.
+    naming the fixes, never a traceback at the user.
     """
     if not model:
         raise ConfigError(
@@ -111,21 +152,22 @@ def resolve_provider(
     if base_url:
         key_env = api_key_env or _OPENROUTER_KEY
         return Provider(base_url=base_url.rstrip("/"), api_key=env.get(key_env, ""), model=model)
-    provider_prefix, _, bare_model = model.partition("/")
-    direct = _DIRECT_PROVIDERS.get(provider_prefix)
-    if (
-        direct is not None
-        and bare_model  # a bare "anthropic" must not resolve to an empty model id
-        and not _has_openrouter_variant(bare_model)
-        and (key := env.get(direct.key_env))
-    ):
-        return Provider(base_url=direct.base_url, api_key=key, model=bare_model)
+    claim = _direct_claim(model, env, native_wires=native_wires)
+    if claim is not None:
+        _, direct = claim
+        _, _, bare_model = model.partition("/")
+        return Provider(
+            base_url=direct.base_url,
+            api_key=env[direct.key_env],
+            model=model if direct.keep_prefix else bare_model,
+            wire=direct.wire,
+        )
     if key := env.get(_OPENROUTER_KEY):
         return Provider(base_url=_OPENROUTER_BASE, api_key=key, model=model)
     raise ConfigError(
         f"no API key found for model {model!r}.\n"
         f"fix: set ${_OPENROUTER_KEY} (works for any model), or the provider's "
-        f"key ({_provider_key_hints()}), "
+        f"key ({_provider_key_hints(native_wires)}), "
         "or pass -P base_url=... (+ -P api_key_env=NAME) for a custom endpoint"
     )
 

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -46,6 +46,7 @@ from inspect_robots_agent._llm import (
     ChatClient,
     Provider,
     ToolCall,
+    _direct_claim,
     _has_openrouter_variant,
     resolve_provider,
 )
@@ -57,7 +58,7 @@ from ._capture import WireCapture
 
 _MAX_CONSECUTIVE_FAILURES = 3
 
-#: The only endpoint that serves /v1/messages without an explicit base_url.
+#: Anthropic's Messages endpoint, used to distinguish its compat endpoint.
 _ANTHROPIC_BASE = _DIRECT_PROVIDERS["anthropic"].base_url
 
 #: The HTTP endpoint resolution must land on before it can be upgraded to Live.
@@ -71,11 +72,17 @@ _GEMINI_LIVE_BASE = (
 
 # reasoning_effort values accepted across OpenAI-compatible endpoints
 # (Anthropic compat maps these to thinking effort; OpenRouter forwards them).
-# The native wire reuses the set as output_config.effort, where "none" and
-# "minimal" are rejected and xhigh/max need a cap this client cannot stream;
-# both surface as a guided 400 rather than a per-wire allowlist (plan 0026).
+# The Messages wire reuses the set as output_config.effort. Anthropic rejects
+# "none"/"minimal", and its endpoint requires streaming for the cap xhigh/max
+# need; Tinker accepts xhigh/max without streaming. Rejections get guided errors.
 _EFFORT_LEVELS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max"})
-_WIRE_FORMATS = frozenset({"chat", "responses", "anthropic", "gemini-live"})
+_WIRE_FORMATS = frozenset({"chat", "responses", "messages", "gemini-live"})
+_WIRE_ALIASES = {"anthropic": "messages"}
+_AGENT_NATIVE_WIRES = frozenset({"chat", "messages"})
+_MESSAGES_CAPABLE_PREFIXES = frozenset(
+    {"anthropic"}
+    | {prefix for prefix, direct in _DIRECT_PROVIDERS.items() if direct.wire == "messages"}
+)
 _SPEEDS = frozenset({"fast"})
 _IMAGE_MODES = frozenset({"always", "on_demand"})
 _DEPTH_MODES = frozenset({"render", "off"})
@@ -214,10 +221,11 @@ class AgentPolicyConfig(PolicyConfig):
     model: str | None = None
     base_url: str | None = None
     api_key_env: str | None = None
+    #: Canonical wire name; constructor input ``anthropic`` aliases ``messages``.
     wire: str = "chat"
     wire_capture: bool = True
     speed: str | None = None
-    #: Effective per-response cap on ``wire=anthropic``; ``None`` on the other
+    #: Effective per-response cap on ``wire=messages``; ``None`` on the other
     #: wires, where nothing constrained the output.
     max_output_tokens: int | None = None
     max_llm_calls: int = 100
@@ -266,7 +274,7 @@ class LLMAgentPolicy(PolicyBase):
         model: str | None = None,
         base_url: str | None = None,
         api_key_env: str | None = None,
-        wire: str = "chat",
+        wire: str | _Unset = _UNSET,
         wire_capture: bool = True,
         speed: str | None = None,
         max_output_tokens: int | None = None,
@@ -342,13 +350,25 @@ class LLMAgentPolicy(PolicyBase):
             raise ConfigError("max_speed_frac must be finite and > 0")
         if max_llm_calls < 1:
             raise ConfigError("max_llm_calls must be >= 1")
+        environ = dict(os.environ) if env is None else env
+        requested_model = model or environ.get(ENV_MODEL)
+        direct_claim = (
+            _direct_claim(requested_model, environ, native_wires=_AGENT_NATIVE_WIRES)
+            if not base_url
+            else None
+        )
         # Order matters from here down (plan 0026): wire is validated before
         # the params that are only legal on one wire, the api_key_env default
         # is applied before resolution, and the OpenRouter check after it.
         # Every construction check raises ConfigError so the CLI renders a
         # guided message instead of a traceback (#168).
-        if wire not in _WIRE_FORMATS:
-            raise ConfigError(f"wire must be one of {sorted(_WIRE_FORMATS)}, got {wire!r}")
+        wire_was_explicit = not isinstance(wire, _Unset)
+        if isinstance(wire, _Unset):
+            wire = direct_claim[1].wire if direct_claim is not None else "chat"
+        else:
+            wire = _WIRE_ALIASES.get(wire, wire)
+            if wire not in _WIRE_FORMATS:
+                raise ConfigError(f"wire must be one of {sorted(_WIRE_FORMATS)}, got {wire!r}")
         if effort is not _UNSET and effort is not None and effort not in _EFFORT_LEVELS:
             raise ConfigError(
                 f"effort must be one of {sorted(_EFFORT_LEVELS)}, or None to omit "
@@ -373,19 +393,19 @@ class LLMAgentPolicy(PolicyBase):
                 f"depth must be one of {sorted(_DEPTH_MODES)}, got {depth!r}.\n"
                 "fix: pass -P depth=render or -P depth=off"
             )
-        if wire != "anthropic":
-            # A dropped speed would bill at standard rates while the user
-            # believes fast mode is on; a dropped cap is a limit that never
-            # applied. Both fail loudly rather than silently.
+        if wire != "messages":
+            # Claude fast mode and the Messages output cap cannot apply on
+            # other wires, so reject those mismatches during construction.
+            # A Messages server may still ignore speed itself, as Tinker does.
             if speed is not None:
                 raise ConfigError(
-                    f"speed is only supported on wire='anthropic', got wire={wire!r}.\n"
-                    "fix: pass -P wire=anthropic, or drop -P speed="
+                    f"speed is only supported on wire='messages', got wire={wire!r}.\n"
+                    "fix: pass -P wire=messages, or drop -P speed="
                 )
             if max_output_tokens is not None:
                 raise ConfigError(
-                    "max_output_tokens is only supported on wire='anthropic', got "
-                    f"wire={wire!r}.\nfix: pass -P wire=anthropic, or drop "
+                    "max_output_tokens is only supported on wire='messages', got "
+                    f"wire={wire!r}.\nfix: pass -P wire=messages, or drop "
                     "-P max_output_tokens="
                 )
         if max_output_tokens is not None and (
@@ -425,7 +445,6 @@ class LLMAgentPolicy(PolicyBase):
                 "or pass a websocket endpoint"
             )
 
-        environ = dict(os.environ) if env is None else env
         # resolve_provider reads api_key_env only when base_url is set, where
         # it otherwise defaults to OPENROUTER_API_KEY and would send an
         # OpenRouter key as x-api-key to a third-party gateway.
@@ -436,17 +455,17 @@ class LLMAgentPolicy(PolicyBase):
         # consistency only, since resolve_provider ignores api_key_env when
         # base_url is falsy; it is load-bearing in the guard below.
         effective_key_env = api_key_env
-        if wire == "anthropic" and base_url and not api_key_env:
+        if wire == "messages" and base_url and not api_key_env:
             effective_key_env = "ANTHROPIC_API_KEY"
         if wire == "gemini-live" and base_url and not api_key_env:
             effective_key_env = "GEMINI_API_KEY"
-        requested_model = model or environ.get(ENV_MODEL)
         try:
             provider = resolve_provider(
                 model=requested_model,
                 base_url=base_url,
                 api_key_env=effective_key_env,
                 env=environ,
+                native_wires=_AGENT_NATIVE_WIRES,
             )
         except ConfigError as exc:
             if wire != "gemini-live" or base_url:
@@ -455,11 +474,32 @@ class LLMAgentPolicy(PolicyBase):
                 "wire='gemini-live' needs Google's direct Live API provider.\n"
                 "fix: use -P model=google/... and set $GEMINI_API_KEY"
             ) from exc
-        if wire == "anthropic" and not base_url and provider.base_url != _ANTHROPIC_BASE:
-            # Only Anthropic's own endpoint serves /v1/messages. Resolution can
-            # land elsewhere two ways: the OpenRouter fallback, or another
-            # direct provider whose key happens to be set (openai/* with
-            # $OPENAI_API_KEY). An explicit -P base_url= is the user's call.
+        if (
+            direct_claim is not None
+            and direct_claim[1].wire != "chat"
+            and wire_was_explicit
+            and wire != direct_claim[1].wire
+        ):
+            prefix, direct = direct_claim
+            fix = f"fix: drop -P wire= ({prefix}/* defaults to wire={direct.wire})"
+            if wire in {"chat", "responses"}:
+                fix += (
+                    ", or pass -P base_url=... (+ -P api_key_env=NAME) to route this wire "
+                    "through a gateway such as OpenRouter deliberately"
+                )
+            raise ConfigError(
+                f"wire={wire!r} cannot drive {prefix}/* — the provider's direct "
+                "endpoint serves only the Messages API.\n"
+                f"{fix}"
+            )
+        if (
+            wire == "messages"
+            and not base_url
+            and provider.wire != "messages"
+            and provider.base_url != _ANTHROPIC_BASE
+        ):
+            # Resolution can land elsewhere through OpenRouter or another
+            # direct provider. An explicit -P base_url= is the user's call.
             # Branch on the requested id, not provider.model: a direct
             # provider strips its own prefix, so the resolved id would read
             # as bare and draw a nonsense 'anthropic/gpt-5.6' suggestion.
@@ -468,16 +508,23 @@ class LLMAgentPolicy(PolicyBase):
             # through to OpenRouter even when $ANTHROPIC_API_KEY is set.
             asked = requested_model or ""
             stripped = asked.rpartition(":")[0] if _has_openrouter_variant(asked) else asked
-            if not stripped.removeprefix("anthropic/"):
+            prefix, separator, body = stripped.partition("/")
+            domestic = prefix in _MESSAGES_CAPABLE_PREFIXES
+            stripped_body = body if domestic and separator else stripped
+            if not stripped_body:
                 # ':free', 'anthropic/', 'anthropic/:free': nothing usable is
                 # left once the suffix comes off, so echoing the remainder
                 # would name an empty id. Give a whole command instead.
-                fix = "fix: pass a full model id (-P model=anthropic/claude-opus-5)"
-            elif "/" in stripped and not stripped.startswith("anthropic/"):
-                # A foreign prefix can never resolve to the Messages API, so
-                # this is terminal whatever the suffix says. Decided before
-                # the variant branch, which would otherwise spend a refusal
-                # removing a suffix that was never the real problem.
+                example = (
+                    "thinkingmachines/Inkling"
+                    if prefix == "thinkingmachines"
+                    else "anthropic/claude-opus-5"
+                )
+                fix = f"fix: pass a full model id (-P model={example})"
+            elif "/" in stripped and not domestic:
+                # A foreign prefix cannot resolve to a Messages endpoint.
+                # Decide this before the variant branch, which would otherwise
+                # remove a suffix that was never the real problem.
                 fix = "fix: use an anthropic/ model id"
             elif stripped != asked:
                 # A :variant id routes here whatever keys are set, so naming
@@ -493,13 +540,14 @@ class LLMAgentPolicy(PolicyBase):
             elif "/" not in asked:
                 fix = f"fix: prefix the model id (-P model=anthropic/{asked})"
             else:
-                # Anthropic-prefixed with a usable body: only the key is left.
-                # Unreachable with the key set, since such an id resolves to
-                # Anthropic's own endpoint and never reaches this guard.
-                fix = "fix: set $ANTHROPIC_API_KEY"
+                # A Messages-capable prefix with a usable body has only its
+                # direct-provider key left to fix.
+                entry = _DIRECT_PROVIDERS.get(prefix)
+                key_env = entry.key_env if entry is not None else "ANTHROPIC_API_KEY"
+                fix = f"fix: set ${key_env}"
             where = "OpenRouter" if provider.base_url == _OPENROUTER_BASE else provider.base_url
             raise ConfigError(
-                "wire='anthropic' needs a Messages API endpoint, but the model "
+                "wire='messages' needs a Messages API endpoint, but the model "
                 f"{asked!r} resolved to {where}, which does not serve one.\n"
                 f"{fix}, or pass -P base_url=... for a gateway that serves /v1/messages"
             )
@@ -517,12 +565,12 @@ class LLMAgentPolicy(PolicyBase):
 
         resolved_max_output_tokens = (
             (max_output_tokens if max_output_tokens is not None else _DEFAULT_MAX_OUTPUT_TOKENS)
-            if wire == "anthropic"
+            if wire == "messages"
             else None
         )
         self._capture = WireCapture() if wire_capture else None
         self._client: ChatClient | ResponsesClient | AnthropicClient | GeminiLiveClient
-        if wire == "anthropic":
+        if wire == "messages":
             assert resolved_max_output_tokens is not None
             self._client = AnthropicClient(
                 provider,
@@ -550,6 +598,8 @@ class LLMAgentPolicy(PolicyBase):
         self._image_horizon = resolved_image_horizon
         self._prior_learnings_text = prior_learnings_text
         self._pre_check = pre_check
+        self._explicit_base_url = bool(base_url)
+        self._wire = wire
         self.config = AgentPolicyConfig(
             temperature=temperature,
             model=provider.model,
@@ -782,7 +832,15 @@ class LLMAgentPolicy(PolicyBase):
             if not message.tool_calls:
                 failures += 1
                 if failures >= _MAX_CONSECUTIVE_FAILURES:
-                    raise RuntimeError(f"LLM produced no tool call in {failures} consecutive turns")
+                    error = f"LLM produced no tool call in {failures} consecutive turns"
+                    if self._wire == "chat" and self._explicit_base_url:
+                        error += (
+                            "\nnote: some OpenAI-compatible endpoints accept `tools` but "
+                            "silently ignore them (Tinker's OpenAI-compatible API is one). "
+                            "If the provider serves the Messages API, retry with "
+                            "-P wire=messages and its Messages base_url."
+                        )
+                    raise RuntimeError(error)
                 self._messages.append(
                     {
                         "role": "user",

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -58,7 +58,7 @@ from ._capture import WireCapture
 
 _MAX_CONSECUTIVE_FAILURES = 3
 
-#: Anthropic's Messages endpoint, used to distinguish its compat endpoint.
+#: Anthropic's base URL, allowlisted by the Messages-endpoint guard below.
 _ANTHROPIC_BASE = _DIRECT_PROVIDERS["anthropic"].base_url
 
 #: The HTTP endpoint resolution must land on before it can be upgraded to Live.
@@ -511,21 +511,21 @@ class LLMAgentPolicy(PolicyBase):
             prefix, separator, body = stripped.partition("/")
             domestic = prefix in _MESSAGES_CAPABLE_PREFIXES
             stripped_body = body if domestic and separator else stripped
+            example = (
+                "thinkingmachines/Inkling"
+                if prefix == "thinkingmachines"
+                else "anthropic/claude-opus-5"
+            )
             if not stripped_body:
                 # ':free', 'anthropic/', 'anthropic/:free': nothing usable is
                 # left once the suffix comes off, so echoing the remainder
                 # would name an empty id. Give a whole command instead.
-                example = (
-                    "thinkingmachines/Inkling"
-                    if prefix == "thinkingmachines"
-                    else "anthropic/claude-opus-5"
-                )
                 fix = f"fix: pass a full model id (-P model={example})"
             elif "/" in stripped and not domestic:
                 # A foreign prefix cannot resolve to a Messages endpoint.
                 # Decide this before the variant branch, which would otherwise
                 # remove a suffix that was never the real problem.
-                fix = "fix: use an anthropic/ model id"
+                fix = "fix: use an anthropic/ or thinkingmachines/ model id"
             elif stripped != asked:
                 # A :variant id routes here whatever keys are set, so naming
                 # the key would send the user to fix something already right.
@@ -533,18 +533,28 @@ class LLMAgentPolicy(PolicyBase):
                 # advice that earns a second refusal is worse than none.
                 fix = f"fix: drop the OpenRouter variant suffix (-P model={stripped})"
                 if "/" not in stripped:
+                    # A bare provider prefix must not be prefixed again:
+                    # 'anthropic/thinkingmachines' would name no model.
                     fix = (
-                        f"fix: use -P model=anthropic/{stripped} "
-                        "(the :variant suffix routes to OpenRouter)"
+                        f"fix: pass a full model id (-P model={example})"
+                        if stripped in _MESSAGES_CAPABLE_PREFIXES
+                        else (
+                            f"fix: use -P model=anthropic/{stripped} "
+                            "(the :variant suffix routes to OpenRouter)"
+                        )
                     )
             elif "/" not in asked:
-                fix = f"fix: prefix the model id (-P model=anthropic/{asked})"
+                fix = (
+                    f"fix: pass a full model id (-P model={example})"
+                    if asked in _MESSAGES_CAPABLE_PREFIXES
+                    else f"fix: prefix the model id (-P model=anthropic/{asked})"
+                )
             else:
                 # A Messages-capable prefix with a usable body has only its
-                # direct-provider key left to fix.
-                entry = _DIRECT_PROVIDERS.get(prefix)
-                key_env = entry.key_env if entry is not None else "ANTHROPIC_API_KEY"
-                fix = f"fix: set ${key_env}"
+                # direct-provider key left to fix. Reaching here implies
+                # `domestic` (a foreign prefix took the branch above), so the
+                # prefix is always a table entry.
+                fix = f"fix: set ${_DIRECT_PROVIDERS[prefix].key_env}"
             where = "OpenRouter" if provider.base_url == _OPENROUTER_BASE else provider.base_url
             raise ConfigError(
                 "wire='messages' needs a Messages API endpoint, but the model "

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -1003,6 +1003,34 @@ def test_bare_thinkingmachines_prefix_gets_a_full_command_fix() -> None:
     assert "fix: pass a full model id (-P model=thinkingmachines/Inkling)" in str(excinfo.value)
 
 
+def test_explicit_messages_wire_accepts_thinkingmachines() -> None:
+    """An agreeing explicit wire must not trip the conflict guard."""
+    policy = LLMAgentPolicy(
+        model="thinkingmachines/Inkling",
+        wire="messages",
+        env={"TINKER_API_KEY": "tk"},
+    )
+
+    assert isinstance(policy._client, AnthropicClient)
+    assert isinstance(policy.config, AgentPolicyConfig)
+    assert policy.config.wire == "messages"
+    assert policy.config.model == "thinkingmachines/Inkling"
+
+
+def test_bare_thinkingmachines_id_gets_a_full_command_fix() -> None:
+    """A provider prefix used as a bare model id must not be prefixed again."""
+    with pytest.raises(ConfigError) as excinfo:
+        LLMAgentPolicy(
+            model="thinkingmachines",
+            wire="messages",
+            env={"OPENROUTER_API_KEY": "sk-or"},
+        )
+
+    message = str(excinfo.value)
+    assert "fix: pass a full model id (-P model=thinkingmachines/Inkling)" in message
+    assert "anthropic/thinkingmachines" not in message
+
+
 def test_anthropic_wire_alias_is_accepted_and_recorded_canonically() -> None:
     policy = LLMAgentPolicy(
         model="anthropic/claude-opus-5",
@@ -1170,7 +1198,7 @@ def test_explicit_base_url_suppresses_the_openrouter_guard() -> None:
 
 
 def test_non_anthropic_prefix_is_not_told_to_set_the_anthropic_key() -> None:
-    with pytest.raises(ConfigError, match=r"fix: use an anthropic/ model id"):
+    with pytest.raises(ConfigError, match=r"fix: use an anthropic/ or thinkingmachines/ model id"):
         LLMAgentPolicy(
             model="meta-llama/llama-3",
             wire="messages",
@@ -1264,7 +1292,7 @@ def test_chat_wire_gateway_keeps_the_openrouter_default() -> None:
 def test_foreign_prefix_with_a_variant_is_terminal_in_one_step() -> None:
     # Dropping the suffix would leave 'openai/gpt-5.6', still refused. The
     # prefix is the real problem, so say so first.
-    with pytest.raises(ConfigError, match=r"fix: use an anthropic/ model id"):
+    with pytest.raises(ConfigError, match=r"fix: use an anthropic/ or thinkingmachines/ model id"):
         LLMAgentPolicy(
             model="openai/gpt-5.6:free",
             wire="messages",
@@ -1273,7 +1301,7 @@ def test_foreign_prefix_with_a_variant_is_terminal_in_one_step() -> None:
 
 
 def test_foreign_prefix_with_an_empty_body_does_not_name_an_empty_id() -> None:
-    with pytest.raises(ConfigError, match=r"fix: use an anthropic/ model id"):
+    with pytest.raises(ConfigError, match=r"fix: use an anthropic/ or thinkingmachines/ model id"):
         LLMAgentPolicy(
             model="openai/:free",
             wire="messages",
@@ -1337,7 +1365,7 @@ def test_another_direct_provider_is_refused_not_sent_to_its_endpoint() -> None:
 def test_direct_provider_guidance_uses_the_requested_id_not_the_stripped_one() -> None:
     # resolve_provider strips 'groq/', so branching on the resolved id would
     # read it as bare and suggest the nonsense 'anthropic/llama-3'.
-    with pytest.raises(ConfigError, match=r"fix: use an anthropic/ model id"):
+    with pytest.raises(ConfigError, match=r"fix: use an anthropic/ or thinkingmachines/ model id"):
         LLMAgentPolicy(model="groq/llama-3", wire="messages", env={"GROQ_API_KEY": "sk-groq"})
 
 

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -14,7 +14,7 @@ from inspect_robots.errors import ConfigError
 from inspect_robots.mock import CubePickEmbodiment
 from inspect_robots.scene import Scene
 from inspect_robots.types import Observation
-from inspect_robots_agent import LLMAgentPolicy
+from inspect_robots_agent import AgentPolicyConfig, LLMAgentPolicy
 from inspect_robots_agent._anthropic import (
     _DEFAULT_MAX_OUTPUT_TOKENS,
     AnthropicClient,
@@ -23,7 +23,7 @@ from inspect_robots_agent._anthropic import (
     _with_cache_breakpoint,
 )
 from inspect_robots_agent._capture import WireCapture
-from inspect_robots_agent._llm import Provider
+from inspect_robots_agent._llm import ChatClient, Provider
 from inspect_robots_agent._png import png_data_url
 
 # -- fixtures --------------------------------------------------------------------
@@ -927,10 +927,130 @@ def _policy(**kwargs: Any) -> LLMAgentPolicy:
     return LLMAgentPolicy(**kwargs)
 
 
-def test_policy_records_wire_speed_and_resolved_max_output_tokens() -> None:
-    policy = _policy(wire="anthropic", speed="fast")
+def test_thinkingmachines_infers_messages_wire_and_preserves_full_model_id() -> None:
+    policy = LLMAgentPolicy(
+        model="thinkingmachines/Inkling",
+        env={"TINKER_API_KEY": "tk"},
+    )
 
-    assert policy.config.wire == "anthropic"
+    assert isinstance(policy._client, AnthropicClient)
+    assert isinstance(policy.config, AgentPolicyConfig)
+    assert policy.config.wire == "messages"
+    assert policy.config.base_url == (
+        "https://tinker.thinkingmachines.dev/services/tinker-prod/anthropic/api/v1"
+    )
+    assert policy.config.model == "thinkingmachines/Inkling"
+
+
+def test_environment_model_infers_the_same_thinkingmachines_wire() -> None:
+    policy = LLMAgentPolicy(
+        env={
+            "INSPECT_ROBOTS_MODEL": "thinkingmachines/Inkling-Small",
+            "TINKER_API_KEY": "tk",
+        }
+    )
+
+    assert isinstance(policy._client, AnthropicClient)
+    assert isinstance(policy.config, AgentPolicyConfig)
+    assert policy.config.wire == "messages"
+    assert policy.config.model == "thinkingmachines/Inkling-Small"
+
+
+def test_existing_anthropic_direct_provider_stays_on_chat_by_default() -> None:
+    policy = LLMAgentPolicy(
+        model="anthropic/claude-opus-5",
+        env={"ANTHROPIC_API_KEY": "sk-ant"},
+    )
+
+    assert isinstance(policy._client, ChatClient)
+    assert isinstance(policy.config, AgentPolicyConfig)
+    assert policy.config.wire == "chat"
+    assert policy.config.base_url == "https://api.anthropic.com/v1"
+
+
+def test_thinkingmachines_messages_ladder_names_its_missing_key() -> None:
+    with pytest.raises(ConfigError) as excinfo:
+        LLMAgentPolicy(
+            model="thinkingmachines/Inkling",
+            wire="messages",
+            env={"OPENROUTER_API_KEY": "sk-or"},
+        )
+
+    assert "fix: set $TINKER_API_KEY" in str(excinfo.value)
+
+
+def test_thinkingmachines_variant_ladder_prefers_suffix_fix_over_key_advice() -> None:
+    with pytest.raises(ConfigError) as excinfo:
+        LLMAgentPolicy(
+            model="thinkingmachines/Inkling:free",
+            wire="messages",
+            env={"TINKER_API_KEY": "tk", "OPENROUTER_API_KEY": "sk-or"},
+        )
+
+    message = str(excinfo.value)
+    assert "fix: drop the OpenRouter variant suffix (-P model=thinkingmachines/Inkling)" in message
+    assert "set $TINKER_API_KEY" not in message
+
+
+def test_bare_thinkingmachines_prefix_gets_a_full_command_fix() -> None:
+    with pytest.raises(ConfigError) as excinfo:
+        LLMAgentPolicy(
+            model="thinkingmachines/",
+            wire="messages",
+            env={"TINKER_API_KEY": "tk", "OPENROUTER_API_KEY": "sk-or"},
+        )
+
+    assert "fix: pass a full model id (-P model=thinkingmachines/Inkling)" in str(excinfo.value)
+
+
+def test_anthropic_wire_alias_is_accepted_and_recorded_canonically() -> None:
+    policy = LLMAgentPolicy(
+        model="anthropic/claude-opus-5",
+        wire="anthropic",
+        env={"ANTHROPIC_API_KEY": "sk-ant"},
+    )
+
+    assert isinstance(policy._client, AnthropicClient)
+    assert isinstance(policy.config, AgentPolicyConfig)
+    assert policy.config.wire == "messages"
+
+
+@pytest.mark.parametrize("wire", ["chat", "responses", "gemini-live"])
+def test_thinkingmachines_explicit_wire_conflict_is_guided(wire: str) -> None:
+    with pytest.raises(ConfigError) as excinfo:
+        LLMAgentPolicy(
+            model="thinkingmachines/Inkling",
+            wire=wire,
+            env={"TINKER_API_KEY": "tk"},
+        )
+
+    message = str(excinfo.value)
+    expected = (
+        f"wire={wire!r} cannot drive thinkingmachines/* — the provider's direct "
+        "endpoint serves only the Messages API.\n"
+        "fix: drop -P wire= (thinkingmachines/* defaults to wire=messages)"
+    )
+    if wire in {"chat", "responses"}:
+        expected += (
+            ", or pass -P base_url=... (+ -P api_key_env=NAME) to route this wire "
+            "through a gateway such as OpenRouter deliberately"
+        )
+    assert message == expected
+
+
+def test_unknown_wire_lists_only_canonical_names() -> None:
+    with pytest.raises(ConfigError) as excinfo:
+        _policy(wire="unknown")
+
+    assert str(excinfo.value) == (
+        "wire must be one of ['chat', 'gemini-live', 'messages', 'responses'], got 'unknown'"
+    )
+
+
+def test_policy_records_wire_speed_and_resolved_max_output_tokens() -> None:
+    policy = _policy(wire="messages", speed="fast")
+
+    assert policy.config.wire == "messages"
     assert policy.config.speed == "fast"
     assert policy.config.max_output_tokens == _DEFAULT_MAX_OUTPUT_TOKENS
 
@@ -944,7 +1064,7 @@ def test_policy_passes_speed_and_cap_through_to_the_request() -> None:
     """
     seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
     policy = _policy(
-        wire="anthropic",
+        wire="messages",
         speed="fast",
         max_output_tokens=2000,
         transport=httpx.MockTransport(handler),
@@ -960,7 +1080,7 @@ def test_policy_passes_speed_and_cap_through_to_the_request() -> None:
 
 def test_policy_passes_the_default_cap_when_unset() -> None:
     seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
-    policy = _policy(wire="anthropic", transport=httpx.MockTransport(handler))
+    policy = _policy(wire="messages", transport=httpx.MockTransport(handler))
 
     policy._client.complete([_USER], [])
 
@@ -972,7 +1092,7 @@ def test_policy_passes_the_default_cap_when_unset() -> None:
 
 def test_policy_sends_the_prefix_stripped_model_id() -> None:
     seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
-    policy = _policy(wire="anthropic", transport=httpx.MockTransport(handler))
+    policy = _policy(wire="messages", transport=httpx.MockTransport(handler))
 
     policy._client.complete([_USER], [])
 
@@ -989,10 +1109,10 @@ def test_chat_wire_records_no_max_output_tokens() -> None:
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
-        ({"wire": "anthropic", "speed": "turbo"}, "speed must be one of"),
-        ({"wire": "anthropic", "max_output_tokens": 0}, "must be an int >= 1"),
-        ({"wire": "anthropic", "max_output_tokens": 1e5}, "must be an int >= 1"),
-        ({"wire": "anthropic", "max_output_tokens": True}, "must be an int >= 1"),
+        ({"wire": "messages", "speed": "turbo"}, "speed must be one of"),
+        ({"wire": "messages", "max_output_tokens": 0}, "must be an int >= 1"),
+        ({"wire": "messages", "max_output_tokens": 1e5}, "must be an int >= 1"),
+        ({"wire": "messages", "max_output_tokens": True}, "must be an int >= 1"),
         ({"wire": "antropic"}, "wire must be one of"),
     ],
 )
@@ -1008,8 +1128,9 @@ def test_invalid_configurations_raise(kwargs: dict[str, Any], match: str) -> Non
 def test_wire_gated_params_raise_config_error_so_the_cli_renders_them(
     kwargs: dict[str, Any],
 ) -> None:
-    with pytest.raises(ConfigError, match=r"only supported on wire='anthropic'"):
+    with pytest.raises(ConfigError, match=r"only supported on wire='messages'") as excinfo:
         _policy(**kwargs)
+    assert "fix: pass -P wire=messages" in str(excinfo.value)
 
 
 def test_misspelled_wire_reports_the_wire_not_the_speed() -> None:
@@ -1022,7 +1143,7 @@ def test_openrouter_fallback_is_refused_with_guidance() -> None:
     with pytest.raises(ConfigError, match=r"fix: set \$ANTHROPIC_API_KEY"):
         LLMAgentPolicy(
             model="anthropic/claude-opus-5",
-            wire="anthropic",
+            wire="messages",
             env={"OPENROUTER_API_KEY": "sk-or"},
         )
 
@@ -1032,7 +1153,7 @@ def test_bare_model_id_is_told_to_add_the_prefix_not_to_set_the_key() -> None:
     with pytest.raises(ConfigError, match=r"-P model=anthropic/claude-opus-5"):
         LLMAgentPolicy(
             model="claude-opus-5",
-            wire="anthropic",
+            wire="messages",
             env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
         )
 
@@ -1040,7 +1161,7 @@ def test_bare_model_id_is_told_to_add_the_prefix_not_to_set_the_key() -> None:
 def test_explicit_base_url_suppresses_the_openrouter_guard() -> None:
     policy = LLMAgentPolicy(
         model="claude-opus-5",
-        wire="anthropic",
+        wire="messages",
         base_url="http://gateway.test/v1",
         env={"OPENROUTER_API_KEY": "sk-or", "ANTHROPIC_API_KEY": "sk-ant"},
     )
@@ -1052,7 +1173,7 @@ def test_non_anthropic_prefix_is_not_told_to_set_the_anthropic_key() -> None:
     with pytest.raises(ConfigError, match=r"fix: use an anthropic/ model id"):
         LLMAgentPolicy(
             model="meta-llama/llama-3",
-            wire="anthropic",
+            wire="messages",
             env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
         )
 
@@ -1066,7 +1187,7 @@ def test_variant_suffix_is_told_to_drop_it_not_to_set_the_key() -> None:
     ):
         LLMAgentPolicy(
             model="anthropic/claude-opus-5:free",
-            wire="anthropic",
+            wire="messages",
             env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
         )
 
@@ -1083,7 +1204,7 @@ def test_bare_variant_id_is_fixed_in_one_step() -> None:
     ):
         LLMAgentPolicy(
             model="claude-opus-5:free",
-            wire="anthropic",
+            wire="messages",
             env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
         )
 
@@ -1094,7 +1215,7 @@ def test_variant_strip_keeps_fine_tune_colons() -> None:
     with pytest.raises(ConfigError, match=r"-P model=anthropic/ft:gpt-4o-mini\b"):
         LLMAgentPolicy(
             model="ft:gpt-4o-mini:free",
-            wire="anthropic",
+            wire="messages",
             env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
         )
 
@@ -1110,7 +1231,7 @@ def test_falsy_api_key_env_does_not_send_the_openrouter_key_to_a_gateway(
     seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
     policy = LLMAgentPolicy(
         model="claude-opus-5",
-        wire="anthropic",
+        wire="messages",
         base_url="https://gw.example/v1",
         api_key_env=api_key_env,  # type: ignore[arg-type]
         transport=httpx.MockTransport(handler),
@@ -1123,7 +1244,7 @@ def test_falsy_api_key_env_does_not_send_the_openrouter_key_to_a_gateway(
 
 
 def test_chat_wire_gateway_keeps_the_openrouter_default() -> None:
-    # The ANTHROPIC_API_KEY default is gated on wire='anthropic'. Dropping
+    # The ANTHROPIC_API_KEY default is gated on wire='messages'. Dropping
     # that clause would ship the Anthropic key to every chat-wire gateway,
     # where OpenRouter is the documented default.
     seen, handler = _capture({"choices": [{"message": {"content": "ok"}}]})
@@ -1146,7 +1267,7 @@ def test_foreign_prefix_with_a_variant_is_terminal_in_one_step() -> None:
     with pytest.raises(ConfigError, match=r"fix: use an anthropic/ model id"):
         LLMAgentPolicy(
             model="openai/gpt-5.6:free",
-            wire="anthropic",
+            wire="messages",
             env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
         )
 
@@ -1155,7 +1276,7 @@ def test_foreign_prefix_with_an_empty_body_does_not_name_an_empty_id() -> None:
     with pytest.raises(ConfigError, match=r"fix: use an anthropic/ model id"):
         LLMAgentPolicy(
             model="openai/:free",
-            wire="anthropic",
+            wire="messages",
             env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
         )
 
@@ -1170,7 +1291,7 @@ def test_ids_with_nothing_usable_left_get_a_whole_command(model: str) -> None:
     ):
         LLMAgentPolicy(
             model=model,
-            wire="anthropic",
+            wire="messages",
             env={"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
         )
 
@@ -1181,7 +1302,7 @@ def test_empty_base_url_still_hits_the_guard() -> None:
     with pytest.raises(ConfigError, match=r"resolved to OpenRouter"):
         LLMAgentPolicy(
             model="anthropic/claude-opus-5",
-            wire="anthropic",
+            wire="messages",
             base_url="",
             env={"OPENROUTER_API_KEY": "sk-or"},
         )
@@ -1190,7 +1311,7 @@ def test_empty_base_url_still_hits_the_guard() -> None:
 def test_model_from_the_environment_resolves_like_the_argument() -> None:
     with pytest.raises(ConfigError, match=r"fix: prefix the model id"):
         LLMAgentPolicy(
-            wire="anthropic",
+            wire="messages",
             env={
                 "INSPECT_ROBOTS_MODEL": "claude-opus-5",
                 "ANTHROPIC_API_KEY": "sk-ant",
@@ -1208,7 +1329,7 @@ def test_another_direct_provider_is_refused_not_sent_to_its_endpoint() -> None:
     ):
         LLMAgentPolicy(
             model="openai/gpt-5.6",
-            wire="anthropic",
+            wire="messages",
             env={"OPENAI_API_KEY": "sk-oai", "OPENROUTER_API_KEY": "sk-or"},
         )
 
@@ -1217,14 +1338,14 @@ def test_direct_provider_guidance_uses_the_requested_id_not_the_stripped_one() -
     # resolve_provider strips 'groq/', so branching on the resolved id would
     # read it as bare and suggest the nonsense 'anthropic/llama-3'.
     with pytest.raises(ConfigError, match=r"fix: use an anthropic/ model id"):
-        LLMAgentPolicy(model="groq/llama-3", wire="anthropic", env={"GROQ_API_KEY": "sk-groq"})
+        LLMAgentPolicy(model="groq/llama-3", wire="messages", env={"GROQ_API_KEY": "sk-groq"})
 
 
 def test_gateway_defaults_the_key_env_to_anthropic() -> None:
     seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
     policy = LLMAgentPolicy(
         model="claude-opus-5",
-        wire="anthropic",
+        wire="messages",
         base_url="http://gateway.test/v1",
         transport=httpx.MockTransport(handler),
         env={"OPENROUTER_API_KEY": "sk-or", "ANTHROPIC_API_KEY": "sk-ant"},
@@ -1259,7 +1380,7 @@ def test_act_drives_a_multi_turn_trial_and_replays_thinking() -> None:
 
     policy = LLMAgentPolicy(
         model="anthropic/claude-opus-5",
-        wire="anthropic",
+        wire="messages",
         transport=httpx.MockTransport(handler),
         env=dict(_ENV),
     )
@@ -1307,7 +1428,7 @@ def test_explicit_api_key_env_wins_over_the_default() -> None:
     seen, handler = _capture(_anthropic_response(_text("ok"), stop_reason="end_turn"))
     policy = LLMAgentPolicy(
         model="claude-opus-5",
-        wire="anthropic",
+        wire="messages",
         base_url="http://gateway.test/v1",
         api_key_env="OPENROUTER_API_KEY",
         transport=httpx.MockTransport(handler),
@@ -1343,7 +1464,7 @@ def test_act_marks_the_eviction_anchor_on_the_anthropic_wire() -> None:
         return httpx.Response(200, json=payload)
 
     embodiment = CubePickEmbodiment()
-    policy = _policy(wire="anthropic", transport=httpx.MockTransport(handler))
+    policy = _policy(wire="messages", transport=httpx.MockTransport(handler))
     policy.bind(embodiment.info)
     scene = Scene(id="s0", instruction="reach")
     policy.reset(scene)

--- a/plugins/inspect-robots-agent/tests/test_gemini_live.py
+++ b/plugins/inspect-robots-agent/tests/test_gemini_live.py
@@ -790,7 +790,7 @@ def test_per_wire_default_resolution_and_explicit_none() -> None:
     anthropic = LLMAgentPolicy(
         model="m",
         base_url="http://stub.test",
-        wire="anthropic",
+        wire="messages",
         wire_capture=False,
         env={},
     )

--- a/plugins/inspect-robots-agent/tests/test_llm.py
+++ b/plugins/inspect-robots-agent/tests/test_llm.py
@@ -55,6 +55,78 @@ def test_anthropic_model_with_anthropic_key() -> None:
     assert p.model == "claude-fable-5"  # provider prefix stripped for the compat endpoint
 
 
+def test_thinkingmachines_claims_direct_on_the_messages_wire() -> None:
+    p = resolve_provider(
+        model="thinkingmachines/Inkling",
+        base_url=None,
+        api_key_env=None,
+        env={"TINKER_API_KEY": "tk", "OPENROUTER_API_KEY": "or-key"},
+        native_wires=frozenset({"chat", "messages"}),
+    )
+
+    assert p.base_url == (
+        "https://tinker.thinkingmachines.dev/services/tinker-prod/anthropic/api/v1"
+    )
+    assert p.api_key == "tk"
+    assert p.model == "thinkingmachines/Inkling"
+    assert p.wire == "messages"
+
+
+def test_default_native_wires_routes_thinkingmachines_through_openrouter() -> None:
+    p = resolve_provider(
+        model="thinkingmachines/Inkling",
+        base_url=None,
+        api_key_env=None,
+        env={"TINKER_API_KEY": "tk", "OPENROUTER_API_KEY": "or-key"},
+    )
+
+    assert p.base_url == "https://openrouter.ai/api/v1"
+    assert p.model == "thinkingmachines/Inkling"
+    assert p.wire == "chat"
+
+
+def test_thinkingmachines_without_its_key_falls_back_to_openrouter() -> None:
+    p = resolve_provider(
+        model="thinkingmachines/Inkling",
+        base_url=None,
+        api_key_env=None,
+        env={"OPENROUTER_API_KEY": "or-key"},
+        native_wires=frozenset({"chat", "messages"}),
+    )
+
+    assert p.base_url == "https://openrouter.ai/api/v1"
+    assert p.model == "thinkingmachines/Inkling"
+
+
+def test_explicit_base_url_bypasses_thinkingmachines_entry() -> None:
+    p = resolve_provider(
+        model="thinkingmachines/Inkling",
+        base_url="http://gateway.test/v1",
+        api_key_env="OPENROUTER_API_KEY",
+        env={"TINKER_API_KEY": "tk", "OPENROUTER_API_KEY": "or-key"},
+        native_wires=frozenset({"chat", "messages"}),
+    )
+
+    assert p.base_url == "http://gateway.test/v1"
+    assert p.api_key == "or-key"
+    assert p.model == "thinkingmachines/Inkling"
+    assert p.wire == "chat"
+
+
+def test_thinkingmachines_peft_checkpoint_suffix_still_claims_direct() -> None:
+    p = resolve_provider(
+        model="thinkingmachines/Inkling:peft:262144",
+        base_url=None,
+        api_key_env=None,
+        env={"TINKER_API_KEY": "tk"},
+        native_wires=frozenset({"chat", "messages"}),
+    )
+
+    assert "tinker.thinkingmachines.dev" in p.base_url
+    assert p.model == "thinkingmachines/Inkling:peft:262144"
+    assert p.wire == "messages"
+
+
 def test_openai_model_with_openai_key() -> None:
     p = resolve_provider(
         model="openai/gpt-5.2", base_url=None, api_key_env=None, env={"OPENAI_API_KEY": "oai"}
@@ -182,10 +254,27 @@ def test_bare_prefix_without_openrouter_key_is_a_guided_error() -> None:
 
 def test_guided_error_names_the_new_provider_keys() -> None:
     with pytest.raises(ConfigError) as excinfo:
-        resolve_provider(model="google/gemini-3.5-flash", base_url=None, api_key_env=None, env={})
+        resolve_provider(
+            model="google/gemini-3.5-flash",
+            base_url=None,
+            api_key_env=None,
+            env={},
+            native_wires=frozenset({"chat", "messages"}),
+        )
     message = str(excinfo.value)
     assert "GEMINI_API_KEY" in message
     assert "google/*" in message
+    assert "TINKER_API_KEY" in message
+    assert "thinkingmachines/*" in message
+
+
+def test_default_native_wire_key_hints_omit_messages_only_providers() -> None:
+    with pytest.raises(ConfigError) as excinfo:
+        resolve_provider(model="thinkingmachines/Inkling", base_url=None, api_key_env=None, env={})
+
+    message = str(excinfo.value)
+    assert "TINKER_API_KEY" not in message
+    assert "thinkingmachines/*" not in message
 
 
 def test_missing_model_is_a_guided_error() -> None:

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,7 +6,7 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.20.0"
+    assert inspect_robots_agent.__version__ == "0.21.0"
     assert callable(inspect_robots_agent.agent_policy)
     assert inspect_robots_agent.__all__ == [
         "ENV_MODEL",

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -410,7 +410,7 @@ def test_goal_runs_to_done_and_config_lands_in_log(tmp_path: Path) -> None:
     assert "data:" not in serialized
 
 
-@pytest.mark.parametrize("wire", ["chat", "responses", "anthropic"])
+@pytest.mark.parametrize("wire", ["chat", "responses", "messages"])
 def test_wire_capture_matches_each_transport_body_after_blob_inlining(
     wire: str, tmp_path: Path
 ) -> None:
@@ -446,7 +446,7 @@ def test_wire_capture_matches_each_transport_body_after_blob_inlining(
         == {
             "chat": "/chat/completions",
             "responses": "/responses",
-            "anthropic": "/messages",
+            "messages": "/messages",
         }[wire]
     )
     blob_dir = capture_path.parent.parent / "blobs"
@@ -454,7 +454,7 @@ def test_wire_capture_matches_each_transport_body_after_blob_inlining(
     assert captured_request == script.requests[1]
     assert "camera frame(s) elided" in json.dumps(captured_request)
 
-    if wire == "anthropic":
+    if wire == "messages":
         elision_blocks = [
             block
             for message in captured_request["messages"]
@@ -1456,6 +1456,49 @@ def test_persistent_non_tool_output_becomes_policy_error(tmp_path: Path) -> None
     assert logs[0].status == "error"
     (record,) = sink.records
     assert record.error is not None and "no tool call" in record.error
+
+
+def test_no_tool_call_three_strikes_notes_explicit_chat_base_url() -> None:
+    policy = _policy(_Script([_text_response("no tools")]))
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="stop"))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        policy.act(Observation())
+
+    assert str(excinfo.value).endswith(
+        "note: some OpenAI-compatible endpoints accept `tools` but silently ignore "
+        "them (Tinker's OpenAI-compatible API is one). If the provider serves the "
+        "Messages API, retry with -P wire=messages and its Messages base_url."
+    )
+
+
+def test_no_tool_call_three_strikes_omits_note_without_explicit_base_url() -> None:
+    script = _Script([_text_response("no tools")])
+    policy = LLMAgentPolicy(
+        model="openai/gpt-test",
+        transport=httpx.MockTransport(script),
+        env={"OPENAI_API_KEY": "sk-oai"},
+    )
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="stop"))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        policy.act(Observation())
+
+    assert "silently ignore" not in str(excinfo.value)
+
+
+def test_invalid_tool_call_three_strikes_omits_silent_tool_drop_note() -> None:
+    policy = _policy(_Script([_tool_response("move_by", {"deltas": {"dz": 0.1}})]))
+    policy.bind(CubePickEmbodiment().info)
+    policy.reset(Scene(id="s0", instruction="stop"))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        policy.act(Observation())
+
+    assert "tool calls kept failing" in str(excinfo.value)
+    assert "silently ignore" not in str(excinfo.value)
 
 
 def test_recoverable_tool_error_is_fed_back_and_corrected(tmp_path: Path) -> None:
@@ -2542,7 +2585,7 @@ def test_anthropic_usage_is_summed_into_trial_metadata(
     sink = _RecordingSink()
     policy = LLMAgentPolicy(
         model="claude-opus-5",
-        wire="anthropic",
+        wire="messages",
         base_url="http://llm.test/v1",
         transcript_echo=True,
         transport=httpx.MockTransport(handler),

--- a/plugins/inspect-robots-agent/tests/test_responses.py
+++ b/plugins/inspect-robots-agent/tests/test_responses.py
@@ -653,7 +653,7 @@ def test_policy_rejects_invalid_wire_and_defaults_config_to_chat() -> None:
         LLMAgentPolicy(
             model="test/model",
             base_url="http://llm.test/v1",
-            wire="messages",
+            wire="response",
             env={},
         )
 

--- a/plugins/inspect-robots-capx/README.md
+++ b/plugins/inspect-robots-capx/README.md
@@ -58,6 +58,7 @@ inspect-robots "pick up the red cube" --policy capx \
 Model routing, API key selection, and the `chat` versus `responses` wire follow
 the [inspect-robots-agent](../inspect-robots-agent/) plugin. Model strings come
 from `-P model=...` or `$INSPECT_ROBOTS_MODEL`.
+CaP-X keeps chat-only direct routing, so `thinkingmachines/*` resolves through OpenRouter by design.
 
 ## Required embodiment profile:
 

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #278.

Implements plan 0042 (included in this PR): `wire=messages` as the canonical name for the Messages-API wire with `anthropic` as a permanent alias, a `thinkingmachines/` direct-provider entry (native wire + full-id passthrough) so `-P model=thinkingmachines/Inkling` + `$TINKER_API_KEY` needs no other flags, construction-time and runtime guardrails for the wire misconfigurations Tinker exposes, and documentation.

Verified live against Tinker's serverless inference (2026-08-03): both Inkling models solve CubePick end to end on the Messages wire; the OAI-compat endpoint silently drops `tools`, which motivates the guardrails. `resolve_provider` grows a `native_wires` kwarg defaulting to chat-only, so inspect-robots-capx and out-of-tree consumers see zero routing change.

inspect-robots-agent 0.20.0 -> 0.21.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)