### PR TITLE
cli: advisory flock claim on device slots so two evals cannot drive one rig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- CLI `run` and `eval-set` now take per-user advisory claims for declared
+  device slots before hardware construction, reject concurrent evals aimed at
+  the same rig, and release claims during embodiment teardown
+  ([plan 0045](plans/0045-hardware-claim-guard.md), #281).
+
 - `RerunSink` gains `spawn_port`, alongside the `rerun_port` config key and
   `--rerun-port`, giving each rig its own live viewer on multi-rig hosts
   ([plan 0044](plans/0044-rerun-viewer-port.md), #280).

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -79,10 +79,14 @@ DEVICE_SLOTS = (
 These declarations also feed a run-time advisory device claim. If two evals
 name the same device, the second fails at startup instead of double-driving the
 hardware. The claim is `flock`-based and vanishes with the process. Claims are
-per-user, so they do not guard against two different users driving one rig. On
-hosts without `XDG_RUNTIME_DIR`, the fallback lock directory lives under the
-world-writable temporary directory, so the guard is a safety net against your
-own concurrent evals, not a security boundary.
+per-user, so they do not guard against two different users driving one rig.
+Camera and serial paths count as the same device after resolving symlinks,
+while CAN interface names are compared verbatim, so `can0` in one config and a
+udev-pinned alias for the same adapter in another do not collide. On hosts
+without `XDG_RUNTIME_DIR`, the fallback lock directory lives under the
+world-writable temporary directory, and the guard refuses lock directories it
+does not own. The guard is a safety net against your own concurrent evals, not
+a security boundary.
 
 The recognized kinds are `v4l2` for stable camera paths, `can` for SocketCAN
 interface names, and `serial` for absolute `/dev/serial/by-id` paths. The setup

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -76,6 +76,14 @@ DEVICE_SLOTS = (
 )
 ```
 
+These declarations also feed a run-time advisory device claim. If two evals
+name the same device, the second fails at startup instead of double-driving the
+hardware. The claim is `flock`-based and vanishes with the process. Claims are
+per-user, so they do not guard against two different users driving one rig. On
+hosts without `XDG_RUNTIME_DIR`, the fallback lock directory lives under the
+world-writable temporary directory, so the guard is a safety net against your
+own concurrent evals, not a security boundary.
+
 The recognized kinds are `v4l2` for stable camera paths, `can` for SocketCAN
 interface names, and `serial` for absolute `/dev/serial/by-id` paths. The setup
 wizard probes and interviews slots in declaration order, then writes each

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -21,6 +21,10 @@ they came from are printed before the robot moves. Two flags exist only for
 instruction runs: `--max-steps N` (horizon, default 300) and `--scorer NAME`
 (default `operator`).
 
+If another eval holds a declared device, startup exits with
+`device 'can0' is already claimed by another inspect-robots process (PID 123):
+two evals must not drive one rig`.
+
 The sugar only fires when the first argument contains whitespace, so a
 mistyped subcommand (`inspect-robots isnpect`) errors out instead of starting
 a rollout; a single-word instruction needs the explicit

--- a/plans/0045-hardware-claim-guard.md
+++ b/plans/0045-hardware-claim-guard.md
@@ -1,0 +1,356 @@
+# Hardware claim guard Implementation Plan
+
+> **For agentic workers:** Implement task-by-task in order; each task is
+> test-first and ends in its own commit. Steps use checkbox (`- [ ]`) syntax
+> for tracking.
+
+**Goal:** Two eval processes must not silently drive the same hardware.
+Before constructing a hardware embodiment, the CLI takes an advisory `flock`
+on a lockfile per configured device-slot value (CAN channel names, camera and
+serial node paths) and fails loudly ("can0 is already claimed by PID N")
+when another live process holds one; claims release on teardown and vanish
+with the process (flock is kernel-scoped, so no stale-lock handling exists
+or is needed). Sim embodiments declare no device slots and are untouched.
+POSIX-only; where `fcntl` is unavailable the guard is a silent no-op.
+Closes #281.
+
+**Architecture:** A new private module `_claims.py` (stdlib-only, lazy
+`fcntl` import) exposes `claim_devices(slots, kvs, env) -> DeviceClaim`. It
+selects the kvs values whose keys match a `DeviceSlot.arg`, normalizes each
+(paths resolve through symlinks so a by-id and a by-path spelling of one
+camera collide; plain strings like `can0` are taken verbatim), and flocks
+`<runtime-dir>/inspect-robots/locks/<sha256[:16]>.lock` per value,
+`LOCK_EX | LOCK_NB`. On conflict it raises `SystemExit` with the device
+value and the holder's PID (read from the lockfile's advisory content); on
+success it writes its own PID+value into the file and keeps the fd open.
+The CLI acquires in `_resolve_components` between policy resolution and
+embodiment construction (fail before touching hardware), carries the claim
+in `_ResolvedComponents`, and releases it in the existing
+`finally: embodiment.close()` blocks of `run` and `eval-set`. The guard
+never blocks an eval for environmental reasons: unusable lock directory,
+missing `fcntl`, or an unregistered embodiment name all degrade to a
+warning or silent no-op.
+
+**Tech stack:** stdlib only (`fcntl` lazily imported, `hashlib`, `os`,
+`pathlib`). pytest; flock contention is testable in-process because flock
+conflicts across distinct file descriptors within one process.
+
+## Global Constraints
+
+- Gates (all blocking): `uv run ruff check .`, `uv run ruff format --check .`,
+  `uv run mypy` (strict, src and tests), `uv run pytest --cov` at **100%**
+  (branch coverage: BOTH sides of the lazy-import try and every degradation
+  branch need tests).
+- D1 docstrings on every public module/class/function.
+- Repo root is the `ir-wt-claim-guard` worktree at
+  `~/robocurve/ir-wt-claim-guard`; run everything via `uv run ...` there.
+- **Core stays NumPy-only**: no `filelock` dependency; `fcntl` is imported
+  inside the function, never at module top (the `_v4l2_color_capture`
+  precedent, `_setup.py:966-969`).
+- Every existing test passes byte-for-byte untouched. If one fails, treat it
+  as a bug in the new code.
+- POSIX-only tests that monkeypatch attributes ON the real `fcntl` module
+  carry the `_needs_fcntl` skipif (`tests/test_setup.py:621` precedent); the
+  no-fcntl arc is covered on Linux via
+  `monkeypatch.setitem(sys.modules, "fcntl", None)`
+  (`tests/test_setup.py:709-714` precedent).
+- `_claims` is private: no `inspect_robots.__all__` change, no
+  `test_api_snapshot.py` change.
+- Docs writing rules (no em dashes in prose).
+- Commit messages: imperative, scoped; reference #281.
+
+## Reference: current wiring (main @ 113aa906)
+
+- `src/inspect_robots/conformance.py`: `DEVICE_KINDS = ("v4l2", "can",
+  "serial")` :32; frozen `DeviceSlot(arg, kind, label, group=None)` :35-50;
+  `device_slots(factory)` :53-72 (reads `DEVICE_SLOTS` off the FACTORY,
+  never crashes, filters to known kinds).
+- Registry: `registered("embodiment") -> dict[str, Callable]`
+  (`registry.py:103-108`); the name→factory→slots idiom is
+  `_setup.py:1443-1450` (`slots = device_slots(factories[name]) if name in
+  factories else ()`).
+- `src/inspect_robots/cli.py`: `_ResolvedComponents` NamedTuple :1161-1169
+  (policy, policy_name, policy_source, embodiment, embodiment_name,
+  embodiment_source); `_resolve_components` :1194-1236 — embodiment args
+  dict built at :1225 (`embodiment_kvs = {**embodiment_defaults,
+  **_parse_kvs(args.embodiment_args)}`), embodiment constructed LAST at
+  :1227-1233 (docstring :1197-1199 says this ordering exists so callers can
+  open their try/finally right after). `_cmd_run` :1275: resolve :1322-1323,
+  `try:` :1324, `finally: embodiment.close()` :1390-1396. `_cmd_eval_set`
+  :1437: resolve :1466-1467, `finally:` :1518-1522. `_cmd_doctor` :2144
+  constructs too but is a short-lived diagnostic (out of scope, see below).
+- Programmatic `eval()` (`eval.py:136-231`): `owns_embodiment =
+  isinstance(embodiment, str)` :203, closes only what it resolved :227-231.
+  Out of scope here (see below).
+- fcntl precedent: `_setup.py:965-1000` (`try: import fcntl / except
+  ImportError: return None`); plan 0013 documented the same shape.
+- No lockfile/XDG_RUNTIME_DIR/pid conventions exist anywhere in `src/` yet;
+  env-injected path derivation precedent is `defaults.config_path(env)`
+  (`defaults.py:106-121`).
+- Coverage config: `pyproject.toml:125-141` (`branch = true`,
+  `fail_under = 100`, `pragma: no cover` honored).
+- Module map: `src/inspect_robots/CLAUDE.md` table :8-38 (underscore
+  modules listed; add a `_claims.py` row), "Key invariants" :40+ with the
+  "close what we open" invariant :55.
+- Docs: `docs/guide/adapters.md:35-83` "Declare device slots" (the natural
+  home for "slots are also claimed at run time"); CHANGELOG `### Added`
+  under `## [Unreleased]`.
+
+---
+
+### Task 1: `_claims.py` — normalization, lock dir, `DeviceClaim`, `claim_devices`
+
+**Files:**
+- Create: `src/inspect_robots/_claims.py`
+- Create: `tests/test_claims.py`
+
+**Interfaces (Task 2 consumes):**
+
+```python
+class DeviceClaim:
+    """Held advisory locks on a rig's devices; release() is idempotent."""
+    def release(self) -> None: ...
+
+def claim_devices(
+    slots: tuple[DeviceSlot, ...],
+    kvs: Mapping[str, Any],
+    env: Mapping[str, str],
+) -> DeviceClaim: ...
+```
+
+Behavior contract:
+
+- Claimed values: for each slot, `kvs.get(slot.arg)` when it is a non-empty
+  `str` (None/absent/non-string skipped). `v4l2`/`serial` values are
+  normalized `str(Path(value).resolve())` (a dangling or non-path value
+  resolves to itself harmlessly); `can` values are taken verbatim.
+  Duplicates after normalization are claimed once.
+- Lock directory: `<runtime>/inspect-robots/locks` where `<runtime>` is
+  `env["XDG_RUNTIME_DIR"]` when set and non-empty, else
+  `Path(tempfile.gettempdir()) / f"inspect-robots-{os.getuid()}"` (getuid
+  is only reached on POSIX because the fcntl import gates everything;
+  document this in the docstring). Created with `parents=True,
+  exist_ok=True`.
+- Lock file per value: `sha256(normalized.encode())[:16] + ".lock"`, opened
+  `O_CREAT | O_RDWR`, `flock(LOCK_EX | LOCK_NB)`. On success, truncate and
+  write `f"{os.getpid()} {normalized}\n"` (advisory diagnostics), keep the
+  fd. Lockfiles are deliberately never unlinked (unlink-while-locked races
+  a concurrent opener onto a dead inode; the runtime dir is per-user tmpfs).
+- On `BlockingIOError`/`OSError` from flock: release everything acquired so
+  far, read the holder line (best effort, empty on any error), raise
+  `SystemExit(f"device {value!r} is already claimed by another inspect-robots"
+  f" process{holder_suffix}: two evals must not drive one rig")` where
+  `holder_suffix` is `f" (PID {pid})"` when the line parsed.
+- Degradations (each a covered branch): `import fcntl` fails → return an
+  empty claim silently; lock dir uncreatable or a lock file unopenable
+  (OSError from mkdir/open) → one `warnings.warn(RuntimeWarning)` naming the
+  path, return an empty claim (never block an eval on environment trouble);
+  no slots or no matching kvs → empty claim.
+- `release()`: `flock(LOCK_UN)` + close each fd, tolerate OSError per fd,
+  idempotent (second call no-op).
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_claims.py`, driving everything through a tmp_path
+`XDG_RUNTIME_DIR` env dict and slots built with
+`DeviceSlot(arg="left_channel", kind="can", label="left arm CAN")` etc.:
+
+- `test_claim_then_conflict_reports_holder_pid`: claim `can0`; a second
+  `claim_devices` on the same env/slots/kvs raises SystemExit whose message
+  contains `can0` and `f"PID {os.getpid()}"`. (flock conflicts across two
+  fds in one process, so no subprocess is needed.)
+- `test_release_frees_the_device`: claim, release, claim again succeeds;
+  second release call is a no-op.
+- `test_conflict_releases_partial_acquisitions`: two slots, first value
+  free, second value pre-claimed → SystemExit, AND the first value is
+  claimable afterwards (the partial claim was rolled back).
+- `test_symlink_spellings_collide`: a v4l2 slot claimed via a tmp_path
+  symlink and a second claim via the target path conflict (normalization).
+- `test_can_names_taken_verbatim`: `can0` and `can1` coexist.
+- `test_none_and_missing_and_nonstring_values_skipped`: kvs with `None`,
+  absent key, and an `int` value yield an empty claim (no lock files
+  created).
+- `test_duplicate_values_claimed_once`: two slots naming one value → one
+  lock file, release works.
+- `test_without_fcntl_is_a_noop`: `monkeypatch.setitem(sys.modules,
+  "fcntl", None)` → empty claim, no lock dir created, and a concurrent
+  "claim" also succeeds.
+- `test_unusable_lock_dir_warns_and_noops`: point `XDG_RUNTIME_DIR` at a
+  path whose parent is a FILE → `pytest.warns(RuntimeWarning)`, empty
+  claim, eval not blocked.
+- `test_gettempdir_fallback_used_without_runtime_dir`: env without
+  `XDG_RUNTIME_DIR` → lock file appears under
+  `tempfile.gettempdir()/inspect-robots-<uid>/...` (monkeypatch
+  `tempfile.gettempdir` to tmp_path to stay hermetic).
+
+Mark any test that monkeypatches attributes ON the real fcntl module with
+`_needs_fcntl`-style skipif; plain flock-using tests need no mark on the
+blocking CI (Linux/macOS) but MUST be skipped on Windows — add a
+module-level `pytestmark = pytest.mark.skipif(sys.platform == "win32",
+reason="fcntl is POSIX-only")` EXCEPT for `test_without_fcntl_is_a_noop`,
+which must run everywhere; structure the file so that test sits outside the
+marked class or carries no mark (e.g. put the POSIX tests in a
+`@pytest.mark.skipif`-decorated class and leave the no-fcntl test at module
+level).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+`uv run pytest tests/test_claims.py -v` — ModuleNotFoundError.
+
+- [ ] **Step 3: Implement**
+
+Follow the contract above. Structure hint: a module-level
+`_lock_dir(env) -> Path | None`, `_normalize(slot_kind, value) -> str`, and
+`claim_devices` building a `DeviceClaim(fds: list[int])`. Keep the fcntl
+import at the top of `claim_devices` so the no-op arc is one early return.
+Use `os.open`/`os.write`/`os.close` (fd-based, matching flock) rather than
+file objects. Module docstring states the advisory nature and the flock
+lifetime guarantee (kernel releases on process death; stale locks cannot
+exist).
+
+- [ ] **Step 4: Run tests, then the full gate set**
+
+`uv run pytest tests/test_claims.py -v`, then
+`uv run ruff check . && uv run ruff format --check . && uv run mypy && uv run pytest --cov -q`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/inspect_robots/_claims.py tests/test_claims.py
+git commit -m "claims: advisory flock guard over device-slot values (#281)"
+```
+
+---
+
+### Task 2: acquire in `_resolve_components`, release in the CLI finallys
+
+**Files:**
+- Modify: `src/inspect_robots/cli.py`
+- Test: `tests/test_registry_cli.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Harness: register a fake embodiment whose factory carries `DEVICE_SLOTS =
+(DeviceSlot(arg="channel", kind="can", label="bus"),)` and accepts
+`channel` as a constructor kwarg (mirror the existing fake-registry idiom
+in `tests/test_registry_cli.py` — find the `_register`/fixture pattern the
+run-path tests use). Point `XDG_RUNTIME_DIR` at tmp_path via monkeypatch
+(the CLI passes `os.environ`).
+
+- `test_run_claims_and_releases_device`: pre-claim `channel=can9` with
+  `claim_devices` directly, run `main(["run", ...])` with `-E channel=can9`
+  → SystemExit message contains `can9` and "already claimed"; then release
+  the pre-claim, run again → eval executes (exit 0) AND after main returns
+  the value is claimable again (release happened in the finally).
+- `test_run_without_device_slots_untouched`: the standard sim/mock
+  embodiment path constructs no claim (no lock dir appears under tmp_path).
+- `test_claim_released_when_embodiment_construction_fails`: fake factory
+  raises TypeError on construction → `main` exits via the existing
+  `_resolve_or_exit` SystemExit, and the device is claimable afterwards
+  (the claim rolled back on construction failure).
+- `test_eval_set_claims_once_for_the_set`: eval-set over two tasks with the
+  slotted embodiment claims before and releases after (claimable again
+  post-run; use the pre-claim trick to assert the conflict message also
+  fires for eval-set).
+- Windows: these tests use real flock — give the file/section the same
+  skipif treatment as Task 1 (module already imports `_claims`; a plain
+  platform skipif on these specific tests is fine).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+`uv run pytest tests/test_registry_cli.py -k claim -v` — the pre-claimed
+run currently succeeds (no guard), so the conflict assertions fail.
+
+- [ ] **Step 3: Implement**
+
+- `_ResolvedComponents` gains `claim: DeviceClaim` (import `_claims` at the
+  top of cli.py; it is stdlib-only and cheap).
+- In `_resolve_components`, after the policy resolves and `embodiment_kvs`
+  is built (:1225), and BEFORE the embodiment constructs (:1227-1233):
+
+```python
+    factories = registered("embodiment")
+    slots = (
+        device_slots(factories[embodiment_name]) if embodiment_name in factories else ()
+    )
+    claim = claim_devices(slots, embodiment_kvs, os.environ)
+    try:
+        embodiment = _resolve_or_exit("embodiment", embodiment_name, ..., **embodiment_kvs)
+    except BaseException:
+        claim.release()
+        raise
+```
+
+  (`BaseException` because `_resolve_or_exit` raises SystemExit; a comment
+  says so. `registered` and `device_slots` are already imported or need
+  imports — check the top of cli.py.)
+- `_cmd_run` finally (:1390-1396) becomes `finally: embodiment.close();
+  resolved.claim.release()` — close first, release second, and the release
+  must run even if `close()` raises (nested try/finally). Same in
+  `_cmd_eval_set` (:1518-1522).
+- Do NOT touch `_cmd_doctor` or `eval.py` (out of scope below).
+
+- [ ] **Step 4: Run tests, then the full gate set**
+
+`uv run pytest tests/test_registry_cli.py -v && uv run pytest tests/test_claims.py -v`,
+then all four gates. Every pre-existing run/eval-set test must pass
+untouched (sim embodiments declare no slots, so the guard is invisible to
+them).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/inspect_robots/cli.py tests/test_registry_cli.py
+git commit -m "cli: claim device slots before constructing hardware embodiments (#281)"
+```
+
+---
+
+### Task 3: docs
+
+**Files:**
+- Modify: `docs/guide/adapters.md` ("Declare device slots" section, :35-83)
+- Modify: `docs/guide/cli.md` (a short note near the run reference)
+- Modify: `CHANGELOG.md` (`### Added`, newest on top)
+- Modify: `src/inspect_robots/CLAUDE.md` (new `_claims.py` row; extend the
+  "Key invariants" list with the claim-release-mirrors-close point)
+
+- [ ] **Step 1: Guide edits**
+
+adapters.md: one paragraph after the slot declaration example: declared
+slots also feed a run-time advisory claim; when two evals name the same
+device the second fails at startup instead of double-driving the hardware;
+the claim is flock-based, per-user, and vanishes with the process. cli.md:
+one sentence in the run section with the conflict error's shape. No em
+dashes in prose.
+
+- [ ] **Step 2: CHANGELOG + module map + gates + commit**
+
+CHANGELOG `### Added` bullet ([plan 0045](plans/0045-hardware-claim-guard.md),
+#281). Module map row for `_claims.py` at matching density; invariants list
+gains "the CLI releases device claims in the same finally that closes the
+embodiment". `uv run pytest -q` green, then:
+
+```bash
+git add docs/guide/adapters.md docs/guide/cli.md CHANGELOG.md src/inspect_robots/CLAUDE.md
+git commit -m "docs: advisory device claims for multi-rig hosts (#281)"
+```
+
+---
+
+## Out of scope
+
+- Guarding the programmatic `eval()` path: callers passing a built
+  embodiment own its lifecycle; a claim inside `eval()` would only cover
+  the registry-name path and would acquire/release per task under
+  `eval_set`. The CLI is where concurrent-rig collisions actually happen.
+- `_cmd_doctor`: short-lived diagnostic; claiming there would make "why is
+  my eval failing" spot checks impossible during a run. Revisit if it bites.
+- Cross-host claims (locks are per-host by nature; two hosts cannot share a
+  CAN bus anyway).
+- An opt-out flag: flock cannot go stale (kernel-released), so the only
+  reason to bypass is deliberately driving one rig from two processes,
+  which is exactly what the guard exists to stop.
+- Claiming RealSense depth serials (`*_depth_serial` args are not
+  device-slot declared today; the capture child claims per-serial at the
+  librealsense layer already).

--- a/plans/0045-hardware-claim-guard.md
+++ b/plans/0045-hardware-claim-guard.md
@@ -14,7 +14,7 @@ or is needed). Sim embodiments declare no device slots and are untouched.
 POSIX-only; where `fcntl` is unavailable the guard is a silent no-op.
 Closes #281.
 
-**Architecture:** A new private module `_claims.py` (stdlib-only, lazy
+**Architecture:** A new private module `_claims.py` (no new deps, lazy
 `fcntl` import) exposes `claim_devices(slots, kvs, env) -> DeviceClaim`. It
 selects the kvs values whose keys match a `DeviceSlot.arg`, normalizes each
 (paths resolve through symlinks so a by-id and a by-path spelling of one
@@ -31,9 +31,12 @@ never blocks an eval for environmental reasons: unusable lock directory,
 missing `fcntl`, or an unregistered embodiment name all degrade to a
 warning or silent no-op.
 
-**Tech stack:** stdlib only (`fcntl` lazily imported, `hashlib`, `os`,
-`pathlib`). pytest; flock contention is testable in-process because flock
-conflicts across distinct file descriptors within one process.
+**Tech stack:** no new dependencies (`fcntl` lazily imported, `hashlib`,
+`os`, `pathlib`; the `DeviceSlot` import from `conformance` pulls numpy,
+which is already a hard core dep). pytest; flock contention is testable
+in-process because flock conflicts across distinct file descriptors within
+one process (while a re-flock on the SAME open file description does not,
+which is why values are deduplicated before locking).
 
 ## Global Constraints
 
@@ -71,11 +74,16 @@ conflicts across distinct file descriptors within one process.
   factories else ()`).
 - `src/inspect_robots/cli.py`: `_ResolvedComponents` NamedTuple :1161-1169
   (policy, policy_name, policy_source, embodiment, embodiment_name,
-  embodiment_source); `_resolve_components` :1194-1236 — embodiment args
+  embodiment_source; ONE construction site at :1234, every consumer uses
+  attribute access); `_resolve_components` :1194-1236 — embodiment args
   dict built at :1225 (`embodiment_kvs = {**embodiment_defaults,
-  **_parse_kvs(args.embodiment_args)}`), embodiment constructed LAST at
-  :1227-1233 (docstring :1197-1199 says this ordering exists so callers can
-  open their try/finally right after). `_cmd_run` :1275: resolve :1322-1323,
+  **_parse_kvs(args.embodiment_args)}`), then the POLICY resolves at :1227,
+  then the embodiment constructs at :1228-1233 through TWO call sites (the
+  `--sim` branch passes `"sim_embodiment.args"` positionally, the real
+  branch does not; docstring :1197-1199 says the embodiment-last ordering
+  exists so callers can open their try/finally right after). The claim is
+  acquired AFTER the policy resolves and before either embodiment call
+  site, and the rollback try/except must wrap BOTH sites. `_cmd_run` :1275: resolve :1322-1323,
   `try:` :1324, `finally: embodiment.close()` :1390-1396. `_cmd_eval_set`
   :1437: resolve :1466-1467, `finally:` :1518-1522. `_cmd_doctor` :2144
   constructs too but is a short-lived diagnostic (out of scope, see below).
@@ -130,12 +138,15 @@ Behavior contract:
   `Path(tempfile.gettempdir()) / f"inspect-robots-{os.getuid()}"` (getuid
   is only reached on POSIX because the fcntl import gates everything;
   document this in the docstring). Created with `parents=True,
-  exist_ok=True`.
-- Lock file per value: `sha256(normalized.encode())[:16] + ".lock"`, opened
-  `O_CREAT | O_RDWR`, `flock(LOCK_EX | LOCK_NB)`. On success, truncate and
-  write `f"{os.getpid()} {normalized}\n"` (advisory diagnostics), keep the
-  fd. Lockfiles are deliberately never unlinked (unlink-while-locked races
-  a concurrent opener onto a dead inode; the runtime dir is per-user tmpfs).
+  exist_ok=True, mode=0o700` — and created LAZILY, only once at least one
+  value will actually be claimed, so slotless runs never touch the
+  filesystem.
+- Lock file per value: `sha256(normalized.encode()).hexdigest()[:16] +
+  ".lock"`, opened `os.open(path, O_CREAT | O_RDWR, 0o600)`,
+  `flock(LOCK_EX | LOCK_NB)`. On success, truncate and write
+  `f"{os.getpid()} {normalized}\n"` (advisory diagnostics), keep the fd.
+  Lockfiles are deliberately never unlinked (unlink-while-locked races a
+  concurrent opener onto a dead inode; the runtime dir is per-user tmpfs).
 - On `BlockingIOError`/`OSError` from flock: release everything acquired so
   far, read the holder line (best effort, empty on any error), raise
   `SystemExit(f"device {value!r} is already claimed by another inspect-robots"
@@ -143,9 +154,11 @@ Behavior contract:
   `holder_suffix` is `f" (PID {pid})"` when the line parsed.
 - Degradations (each a covered branch): `import fcntl` fails → return an
   empty claim silently; lock dir uncreatable or a lock file unopenable
-  (OSError from mkdir/open) → one `warnings.warn(RuntimeWarning)` naming the
-  path, return an empty claim (never block an eval on environment trouble);
-  no slots or no matching kvs → empty claim.
+  (OSError from mkdir/open) → RELEASE everything acquired so far (share the
+  conflict path's rollback helper), one `warnings.warn(RuntimeWarning)`
+  naming the path, return an empty claim (never block an eval on
+  environment trouble, and never leave handle-less fds flocked); no slots
+  or no matching kvs → empty claim.
 - `release()`: `flock(LOCK_UN)` + close each fd, tolerate OSError per fd,
   idempotent (second call no-op).
 
@@ -182,16 +195,24 @@ Behavior contract:
   `XDG_RUNTIME_DIR` → lock file appears under
   `tempfile.gettempdir()/inspect-robots-<uid>/...` (monkeypatch
   `tempfile.gettempdir` to tmp_path to stay hermetic).
+- `test_unopenable_lock_file_warns_and_noops`: lock DIR exists but the lock
+  file path is unopenable (pre-create the hashed filename as a DIRECTORY so
+  `os.open` raises) → RuntimeWarning, empty claim; the per-value open
+  OSError arc is distinct from the mkdir arc above.
+- `test_conflict_with_unparseable_holder_omits_pid`: pre-claim a value,
+  then truncate/garbage the lockfile content behind the claim's back;
+  a second claim still raises SystemExit containing the value but no
+  `PID` suffix (the best-effort holder parse arc).
+- `test_release_survives_externally_closed_fd`: claim, `os.close` one of
+  the claim's fds behind its back, `release()` does not raise and the
+  remaining fds release (the per-fd OSError tolerance arc).
 
-Mark any test that monkeypatches attributes ON the real fcntl module with
-`_needs_fcntl`-style skipif; plain flock-using tests need no mark on the
-blocking CI (Linux/macOS) but MUST be skipped on Windows — add a
-module-level `pytestmark = pytest.mark.skipif(sys.platform == "win32",
-reason="fcntl is POSIX-only")` EXCEPT for `test_without_fcntl_is_a_noop`,
-which must run everywhere; structure the file so that test sits outside the
-marked class or carries no mark (e.g. put the POSIX tests in a
-`@pytest.mark.skipif`-decorated class and leave the no-fcntl test at module
-level).
+Skip structure (this is the instruction, not a suggestion): put every
+flock-using test in a `@pytest.mark.skipif(sys.platform == "win32",
+reason="fcntl is POSIX-only")`-decorated class (`TestClaimsPosix`), and
+keep `test_without_fcntl_is_a_noop` as a module-level function with NO
+skip mark so it runs on every platform including the Windows advisory
+lane. Do NOT use a module-level `pytestmark` (it cannot exempt a test).
 
 - [ ] **Step 2: Run tests to verify they fail**
 
@@ -204,9 +225,15 @@ Follow the contract above. Structure hint: a module-level
 `claim_devices` building a `DeviceClaim(fds: list[int])`. Keep the fcntl
 import at the top of `claim_devices` so the no-op arc is one early return.
 Use `os.open`/`os.write`/`os.close` (fd-based, matching flock) rather than
-file objects. Module docstring states the advisory nature and the flock
-lifetime guarantee (kernel releases on process death; stale locks cannot
-exist).
+file objects. The holder read on conflict keeps `os.read` and the `int()`
+parse inside ONE `except (OSError, ValueError, IndexError)` block: a
+separate read-only except arm is untriggerable from a fresh O_RDWR fd and
+would break the branch gate. Module docstring states the advisory nature
+and the flock lifetime guarantee (kernel releases on process death; stale
+locks cannot exist). Test caution: in
+`test_release_survives_externally_closed_fd`, close the fd immediately
+before `release()` with no intervening file-opening operations, or a
+recycled fd number makes release() unlock an unrelated file.
 
 - [ ] **Step 4: Run tests, then the full gate set**
 
@@ -264,26 +291,35 @@ run currently succeeds (no guard), so the conflict assertions fail.
 - [ ] **Step 3: Implement**
 
 - `_ResolvedComponents` gains `claim: DeviceClaim` (import `_claims` at the
-  top of cli.py; it is stdlib-only and cheap).
-- In `_resolve_components`, after the policy resolves and `embodiment_kvs`
-  is built (:1225), and BEFORE the embodiment constructs (:1227-1233):
+  top of cli.py; it adds no new dependencies and is cheap).
+- In `_resolve_components`: the policy resolves FIRST (:1227, unchanged and
+  outside the claim's lifetime — a policy failure must not leak a claim);
+  then acquire the claim; then construct the embodiment with the rollback
+  wrapping BOTH embodiment call sites (the `--sim` branch at :1229-1231 and
+  the real branch at :1233):
 
 ```python
+    policy = _resolve_or_exit("policy", ...)          # unchanged, before the claim
     factories = registered("embodiment")
     slots = (
         device_slots(factories[embodiment_name]) if embodiment_name in factories else ()
     )
     claim = claim_devices(slots, embodiment_kvs, os.environ)
     try:
-        embodiment = _resolve_or_exit("embodiment", embodiment_name, ..., **embodiment_kvs)
+        if ...sim branch...:
+            embodiment = _resolve_or_exit("embodiment", embodiment_name,
+                                          "sim_embodiment.args", **embodiment_kvs)
+        else:
+            embodiment = _resolve_or_exit("embodiment", embodiment_name, **embodiment_kvs)
     except BaseException:
+        # _resolve_or_exit raises SystemExit, which is not an Exception.
         claim.release()
         raise
 ```
 
-  (`BaseException` because `_resolve_or_exit` raises SystemExit; a comment
-  says so. `registered` and `device_slots` are already imported or need
-  imports — check the top of cli.py.)
+  (Match the actual existing branch shapes at :1228-1233 rather than this
+  sketch's ellipses. `registered` and `device_slots` need imports — check
+  the top of cli.py.)
 - `_cmd_run` finally (:1390-1396) becomes `finally: embodiment.close();
   resolved.claim.release()` — close first, release second, and the release
   must run even if `close()` raises (nested try/finally). Same in
@@ -320,9 +356,13 @@ git commit -m "cli: claim device slots before constructing hardware embodiments 
 adapters.md: one paragraph after the slot declaration example: declared
 slots also feed a run-time advisory claim; when two evals name the same
 device the second fails at startup instead of double-driving the hardware;
-the claim is flock-based, per-user, and vanishes with the process. cli.md:
-one sentence in the run section with the conflict error's shape. No em
-dashes in prose.
+the claim is flock-based and vanishes with the process. State the scope
+honestly: claims are per-user (two different users driving one rig are not
+guarded), and on hosts without `XDG_RUNTIME_DIR` the fallback directory
+lives under the world-writable temp dir, so the guard is a safety net
+against your own concurrent evals, not a security boundary. cli.md: one
+sentence in the run section with the conflict error's shape. No em dashes
+in prose.
 
 - [ ] **Step 2: CHANGELOG + module map + gates + commit**
 

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -33,6 +33,7 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `_pngenc.py` | strict-uint8, NumPy plus stdlib PNG and data-URL encoding for stored camera frames |
 | `_video.py` | `inspect-robots video`: reunite a log with its `FrameStore` side-cars and pipe them to the ffmpeg binary, one MP4 per (trial, camera) stream (plan 0016: stderr temp file not pipe, per-stream failure isolation, strict uint8) |
 | `defaults.py` | public reader for user default policy/embodiment (+ `--sim` counterpart): component env vars > selected config file; `INSPECT_ROBOTS_CONFIG` overrides its XDG/HOME-derived location (INI, py3.10 has no tomllib; deliberately no project-local file); `_set_default` backs `config set` |
+| `_claims.py` | per-user advisory `flock` claims for normalized embodiment device-slot values, with lazy no-op behavior without `fcntl`, process-lifetime locks, and idempotent release |
 | `_dotenv.py` | dependency-free `.env` parsing and working-directory auto-loading with real environment variables taking precedence |
 | `_setup.py` | the `inspect-robots setup` wizard (plans 0009, 0011, 0032, 0040, and 0043): IO-injected prompts for `[defaults]`, plugin-declared V4L2/CAN/serial device slots with serial-pinned or port-pinned CAN udev rules, boolean option interviews, color-probed camera inventory grouped by sysfs USB device, trust-ladder naming, device-level unplug identify, headless-rerun warning; renders config.ini itself (comments survive) and carries unmanaged sections/keys through raw |
 | `mock/` | dependency-free `CubePick` world + scripted/random/noop policies |
@@ -54,4 +55,6 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
   default `fail_on_error=False`.
 - `eval()` closes embodiments it resolved from registry names ("close what we
   open"); caller-constructed objects are caller-owned.
+- The CLI releases device claims in the same `finally` that closes the
+  embodiment.
 - `mock/` and core must never import `rerun`/`torch` at module top.

--- a/src/inspect_robots/_claims.py
+++ b/src/inspect_robots/_claims.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import stat
 import tempfile
 import warnings
 from collections.abc import Mapping
@@ -36,6 +37,7 @@ class DeviceClaim:
                 fcntl.flock(fd, fcntl.LOCK_UN)
                 os.close(fd)
             except OSError:
+                # Unlock or close may race an external close; release is best-effort and idempotent.
                 pass
 
 
@@ -48,9 +50,17 @@ def _lock_dir(env: Mapping[str, str]) -> Path | None:
     lock_dir = runtime_dir / "inspect-robots" / "locks"
     try:
         lock_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        lock_dir_stat = os.lstat(lock_dir)
     except OSError as exc:
         warnings.warn(
             f"cannot create device claim lock directory {lock_dir}: {exc}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return None
+    if not stat.S_ISDIR(lock_dir_stat.st_mode) or lock_dir_stat.st_uid != os.getuid():
+        warnings.warn(
+            f"cannot use device claim lock directory {lock_dir}: not a directory we own",
             RuntimeWarning,
             stacklevel=2,
         )
@@ -100,7 +110,7 @@ def claim_devices(
         digest = hashlib.sha256(value.encode()).hexdigest()[:16]
         lock_path = lock_dir / f"{digest}.lock"
         try:
-            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
         except OSError as exc:
             claim.release()
             warnings.warn(
@@ -126,7 +136,16 @@ def claim_devices(
                 f" process{holder_suffix}: two evals must not drive one rig"
             ) from None
 
-        os.ftruncate(fd, 0)
-        os.write(fd, f"{os.getpid()} {value}\n".encode())
+        try:
+            os.ftruncate(fd, 0)
+            os.write(fd, f"{os.getpid()} {value}\n".encode())
+        except OSError as exc:
+            claim.release()
+            warnings.warn(
+                f"cannot write device claim lock file {lock_path}: {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return claim
 
     return claim

--- a/src/inspect_robots/_claims.py
+++ b/src/inspect_robots/_claims.py
@@ -1,0 +1,132 @@
+"""Advisory device claims held for the lifetime of open file descriptors.
+
+Claims use POSIX ``flock`` locks. The kernel releases them when a process
+dies, so stale locks cannot exist and lockfiles never need to be removed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+import warnings
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from inspect_robots.conformance import DeviceSlot
+
+
+class DeviceClaim:
+    """Held advisory locks on a rig's devices; release() is idempotent."""
+
+    def __init__(self, fds: list[int]) -> None:
+        self._fds = fds
+
+    def release(self) -> None:
+        """Release every held device lock, tolerating already-closed handles."""
+        if not self._fds:
+            return
+
+        import fcntl
+
+        fds, self._fds = self._fds, []
+        for fd in fds:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _lock_dir(env: Mapping[str, str]) -> Path | None:
+    runtime_value = env.get("XDG_RUNTIME_DIR")
+    if runtime_value:
+        runtime_dir = Path(runtime_value)
+    else:
+        runtime_dir = Path(tempfile.gettempdir()) / f"inspect-robots-{os.getuid()}"
+    lock_dir = runtime_dir / "inspect-robots" / "locks"
+    try:
+        lock_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    except OSError as exc:
+        warnings.warn(
+            f"cannot create device claim lock directory {lock_dir}: {exc}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return None
+    return lock_dir
+
+
+def _normalize(slot_kind: str, value: str) -> str:
+    if slot_kind in ("v4l2", "serial"):
+        return str(Path(value).resolve())
+    return value
+
+
+def claim_devices(
+    slots: tuple[DeviceSlot, ...],
+    kvs: Mapping[str, Any],
+    env: Mapping[str, str],
+) -> DeviceClaim:
+    """Claim configured device-slot values without blocking on environment trouble.
+
+    On platforms without ``fcntl`` this returns before filesystem setup. Thus
+    the ``os.getuid`` fallback in lock-directory selection is reached only on
+    POSIX, where ``fcntl`` is available.
+    """
+    try:
+        import fcntl
+    except ImportError:
+        return DeviceClaim([])
+
+    values: list[str] = []
+    for slot in slots:
+        value = kvs.get(slot.arg)
+        if isinstance(value, str) and value:
+            normalized = _normalize(slot.kind, value)
+            if normalized not in values:
+                values.append(normalized)
+
+    if not values:
+        return DeviceClaim([])
+
+    lock_dir = _lock_dir(env)
+    if lock_dir is None:
+        return DeviceClaim([])
+
+    claim = DeviceClaim([])
+    for value in values:
+        digest = hashlib.sha256(value.encode()).hexdigest()[:16]
+        lock_path = lock_dir / f"{digest}.lock"
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        except OSError as exc:
+            claim.release()
+            warnings.warn(
+                f"cannot open device claim lock file {lock_path}: {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return claim
+
+        claim._fds.append(fd)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            try:
+                pid = int(os.read(fd, 4096).split()[0])
+            except (OSError, ValueError, IndexError):
+                holder_suffix = ""
+            else:
+                holder_suffix = f" (PID {pid})"
+            claim.release()
+            raise SystemExit(
+                f"device {value!r} is already claimed by another inspect-robots"
+                f" process{holder_suffix}: two evals must not drive one rig"
+            ) from None
+
+        os.ftruncate(fd, 0)
+        os.write(fd, f"{os.getpid()} {value}\n".encode())
+
+    return claim

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -58,6 +58,7 @@ from types import FrameType
 from typing import TYPE_CHECKING, Any, NamedTuple, NoReturn, cast
 
 from inspect_robots import __version__
+from inspect_robots._claims import DeviceClaim, claim_devices
 from inspect_robots._dotenv import init_dotenv
 from inspect_robots._html import (
     _chat_content,
@@ -68,6 +69,7 @@ from inspect_robots._html import (
 )
 from inspect_robots._html_index import IndexEntry, render_index
 from inspect_robots._pointers import derive_blob_dir, read_jsonl_prefix, resolve_log_pointer
+from inspect_robots.conformance import device_slots
 from inspect_robots.console import USAGE, OperatorConsole
 from inspect_robots.defaults import (
     _ADHOC_MAX_STEPS_FALLBACK,
@@ -81,6 +83,7 @@ from inspect_robots.defaults import (
     _set_default,
     load_defaults,
 )
+from inspect_robots.registry import registered
 from inspect_robots.types import OPERATOR_END
 
 if TYPE_CHECKING:
@@ -1183,6 +1186,7 @@ class _ResolvedComponents(NamedTuple):
     embodiment: Any
     embodiment_name: str
     embodiment_source: str
+    claim: DeviceClaim
 
 
 def _check_shared_run_conflicts(args: argparse.Namespace) -> None:
@@ -1241,14 +1245,21 @@ def _resolve_components(args: argparse.Namespace, defaults: Defaults) -> _Resolv
     embodiment_kvs = {**embodiment_defaults, **_parse_kvs(args.embodiment_args)}
 
     policy = _resolve_or_exit("policy", policy_name, **policy_kvs)
-    if args.sim:
-        embodiment = _resolve_or_exit(
-            "embodiment", embodiment_name, "sim_embodiment.args", **embodiment_kvs
-        )
-    else:
-        embodiment = _resolve_or_exit("embodiment", embodiment_name, **embodiment_kvs)
+    factories = registered("embodiment")
+    slots = device_slots(factories[embodiment_name]) if embodiment_name in factories else ()
+    claim = claim_devices(slots, embodiment_kvs, os.environ)
+    try:
+        if args.sim:
+            embodiment = _resolve_or_exit(
+                "embodiment", embodiment_name, "sim_embodiment.args", **embodiment_kvs
+            )
+        else:
+            embodiment = _resolve_or_exit("embodiment", embodiment_name, **embodiment_kvs)
+    except BaseException:
+        claim.release()
+        raise
     return _ResolvedComponents(
-        policy, policy_name, policy_source, embodiment, embodiment_name, embodiment_source
+        policy, policy_name, policy_source, embodiment, embodiment_name, embodiment_source, claim
     )
 
 
@@ -1427,7 +1438,10 @@ def _cmd_run(args: argparse.Namespace) -> int:
         # torque in close(); skipping this leaves a robot energized. The span
         # starts right after resolution: --epochs/scorer validation between
         # here and eval() can raise, and that must not leak the embodiment.
-        embodiment.close()
+        try:
+            embodiment.close()
+        finally:
+            resolved.claim.release()
     log = logs[0]
     _print_run_summary(log, str(sink.path), is_adhoc)
     return 0 if log.status == "success" else 1
@@ -1553,7 +1567,10 @@ def _cmd_eval_set(args: argparse.Namespace) -> int:
         # Same "close what we open" contract as _cmd_run: the CLI resolved the
         # embodiment itself, so it — not eval_set() — is responsible for
         # releasing it, exactly once, after every task has run.
-        embodiment.close()
+        try:
+            embodiment.close()
+        finally:
+            resolved.claim.release()
     _print_eval_set_summary(success, logs, args.log_dir)
     return 0 if success else 1
 

--- a/tests/test_claims.py
+++ b/tests/test_claims.py
@@ -126,6 +126,38 @@ class TestClaimsPosix:
 
         assert claim._fds == []
 
+    def test_symlink_lock_dir_warns_and_noops(self, tmp_path: Path) -> None:
+        real_lock_dir = tmp_path / "real-locks"
+        real_lock_dir.mkdir()
+        lock_dir = _lock_dir(tmp_path)
+        lock_dir.parent.mkdir()
+        lock_dir.symlink_to(real_lock_dir, target_is_directory=True)
+
+        with pytest.warns(RuntimeWarning, match=str(lock_dir)):
+            claim = claim_devices(
+                (_slot("left_channel"),),
+                {"left_channel": "can0"},
+                {"XDG_RUNTIME_DIR": str(tmp_path)},
+            )
+
+        assert claim._fds == []
+        assert list(real_lock_dir.iterdir()) == []
+
+    def test_foreign_owned_lock_dir_warns_and_noops(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        actual_uid = os.getuid()
+        monkeypatch.setattr(os, "getuid", lambda: actual_uid + 1)
+
+        with pytest.warns(RuntimeWarning, match=str(_lock_dir(tmp_path))):
+            claim = claim_devices(
+                (_slot("left_channel"),),
+                {"left_channel": "can0"},
+                {"XDG_RUNTIME_DIR": str(tmp_path)},
+            )
+
+        assert claim._fds == []
+
     def test_gettempdir_fallback_used_without_runtime_dir(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -150,6 +182,42 @@ class TestClaimsPosix:
             )
 
         assert claim._fds == []
+
+    def test_symlink_lock_file_warns_and_noops(self, tmp_path: Path) -> None:
+        target = tmp_path / "victim"
+        target.write_text("keep me", encoding="utf-8")
+        lock_path = _lock_path(tmp_path, "can0")
+        lock_path.parent.mkdir(parents=True)
+        lock_path.symlink_to(target)
+
+        with pytest.warns(RuntimeWarning, match=str(lock_path)):
+            claim = claim_devices(
+                (_slot("left_channel"),),
+                {"left_channel": "can0"},
+                {"XDG_RUNTIME_DIR": str(tmp_path)},
+            )
+
+        assert claim._fds == []
+        assert target.read_text(encoding="utf-8") == "keep me"
+
+    def test_write_failure_warns_releases_and_noops(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        slots = (_slot("left_channel"),)
+        kvs = {"left_channel": "can0"}
+        env = {"XDG_RUNTIME_DIR": str(tmp_path)}
+
+        def fail_ftruncate(_fd: int, _length: int) -> None:
+            raise OSError("truncate failed")
+
+        with monkeypatch.context() as patch:
+            patch.setattr(os, "ftruncate", fail_ftruncate)
+            with pytest.warns(RuntimeWarning, match=str(_lock_path(tmp_path, "can0"))):
+                claim = claim_devices(slots, kvs, env)
+
+        assert claim._fds == []
+        replacement = claim_devices(slots, kvs, env)
+        replacement.release()
 
     def test_conflict_with_unparseable_holder_omits_pid(self, tmp_path: Path) -> None:
         slots = (_slot("left_channel"),)

--- a/tests/test_claims.py
+++ b/tests/test_claims.py
@@ -1,0 +1,193 @@
+import hashlib
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from inspect_robots._claims import claim_devices
+from inspect_robots.conformance import DeviceSlot
+
+
+def _slot(arg: str, kind: str = "can") -> DeviceSlot:
+    return DeviceSlot(arg=arg, kind=kind, label=f"{arg} device")
+
+
+def _lock_dir(runtime_dir: Path) -> Path:
+    return runtime_dir / "inspect-robots" / "locks"
+
+
+def _lock_path(runtime_dir: Path, value: str) -> Path:
+    digest = hashlib.sha256(value.encode()).hexdigest()[:16]
+    return _lock_dir(runtime_dir) / f"{digest}.lock"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fcntl is POSIX-only")
+class TestClaimsPosix:
+    def test_claim_then_conflict_reports_holder_pid(self, tmp_path: Path) -> None:
+        slots = (_slot("left_channel"),)
+        kvs = {"left_channel": "can0"}
+        env = {"XDG_RUNTIME_DIR": str(tmp_path)}
+        claim = claim_devices(slots, kvs, env)
+
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                claim_devices(slots, kvs, env)
+            assert "can0" in str(exc_info.value)
+            assert f"PID {os.getpid()}" in str(exc_info.value)
+        finally:
+            claim.release()
+
+    def test_release_frees_the_device(self, tmp_path: Path) -> None:
+        slots = (_slot("left_channel"),)
+        kvs = {"left_channel": "can0"}
+        env = {"XDG_RUNTIME_DIR": str(tmp_path)}
+        first = claim_devices(slots, kvs, env)
+
+        first.release()
+        first.release()
+        second = claim_devices(slots, kvs, env)
+        second.release()
+
+    def test_conflict_releases_partial_acquisitions(self, tmp_path: Path) -> None:
+        first_slot = _slot("left_channel")
+        second_slot = _slot("right_channel")
+        env = {"XDG_RUNTIME_DIR": str(tmp_path)}
+        existing = claim_devices((second_slot,), {"right_channel": "can1"}, env)
+
+        try:
+            with pytest.raises(SystemExit):
+                claim_devices(
+                    (first_slot, second_slot),
+                    {"left_channel": "can0", "right_channel": "can1"},
+                    env,
+                )
+            recovered = claim_devices((first_slot,), {"left_channel": "can0"}, env)
+            recovered.release()
+        finally:
+            existing.release()
+
+    def test_symlink_spellings_collide(self, tmp_path: Path) -> None:
+        target = tmp_path / "video0"
+        target.touch()
+        link = tmp_path / "camera"
+        link.symlink_to(target)
+        slot = _slot("camera", "v4l2")
+        env = {"XDG_RUNTIME_DIR": str(tmp_path / "runtime")}
+        claim = claim_devices((slot,), {"camera": str(link)}, env)
+
+        try:
+            with pytest.raises(SystemExit):
+                claim_devices((slot,), {"camera": str(target)}, env)
+        finally:
+            claim.release()
+
+    def test_can_names_taken_verbatim(self, tmp_path: Path) -> None:
+        slot = _slot("left_channel")
+        env = {"XDG_RUNTIME_DIR": str(tmp_path)}
+        first = claim_devices((slot,), {"left_channel": "can0"}, env)
+        second = claim_devices((slot,), {"left_channel": "can1"}, env)
+
+        second.release()
+        first.release()
+
+    def test_none_and_missing_and_nonstring_values_skipped(self, tmp_path: Path) -> None:
+        slots = (_slot("none"), _slot("missing"), _slot("number"))
+        env = {"XDG_RUNTIME_DIR": str(tmp_path)}
+
+        claim = claim_devices(slots, {"none": None, "number": 3}, env)
+
+        assert claim._fds == []
+        assert not _lock_dir(tmp_path).exists()
+
+    def test_duplicate_values_claimed_once(self, tmp_path: Path) -> None:
+        slots = (_slot("left_channel"), _slot("right_channel"))
+        kvs = {"left_channel": "can0", "right_channel": "can0"}
+        env = {"XDG_RUNTIME_DIR": str(tmp_path)}
+        claim = claim_devices(slots, kvs, env)
+
+        assert len(list(_lock_dir(tmp_path).iterdir())) == 1
+        claim.release()
+        replacement = claim_devices((_slot("left_channel"),), {"left_channel": "can0"}, env)
+        replacement.release()
+
+    def test_unusable_lock_dir_warns_and_noops(self, tmp_path: Path) -> None:
+        file_parent = tmp_path / "not-a-directory"
+        file_parent.write_text("blocked", encoding="utf-8")
+        runtime_dir = file_parent / "runtime"
+
+        with pytest.warns(RuntimeWarning, match=str(runtime_dir)):
+            claim = claim_devices(
+                (_slot("left_channel"),),
+                {"left_channel": "can0"},
+                {"XDG_RUNTIME_DIR": str(runtime_dir)},
+            )
+
+        assert claim._fds == []
+
+    def test_gettempdir_fallback_used_without_runtime_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+        claim = claim_devices((_slot("left_channel"),), {"left_channel": "can0"}, {})
+        expected_runtime = tmp_path / f"inspect-robots-{os.getuid()}"
+
+        try:
+            assert len(list(_lock_dir(expected_runtime).iterdir())) == 1
+        finally:
+            claim.release()
+
+    def test_unopenable_lock_file_warns_and_noops(self, tmp_path: Path) -> None:
+        lock_path = _lock_path(tmp_path, "can0")
+        lock_path.mkdir(parents=True)
+
+        with pytest.warns(RuntimeWarning, match=str(lock_path)):
+            claim = claim_devices(
+                (_slot("left_channel"),),
+                {"left_channel": "can0"},
+                {"XDG_RUNTIME_DIR": str(tmp_path)},
+            )
+
+        assert claim._fds == []
+
+    def test_conflict_with_unparseable_holder_omits_pid(self, tmp_path: Path) -> None:
+        slots = (_slot("left_channel"),)
+        kvs = {"left_channel": "can0"}
+        env = {"XDG_RUNTIME_DIR": str(tmp_path)}
+        claim = claim_devices(slots, kvs, env)
+        _lock_path(tmp_path, "can0").write_text("not-a-pid holder\n", encoding="utf-8")
+
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                claim_devices(slots, kvs, env)
+            assert "can0" in str(exc_info.value)
+            assert "PID" not in str(exc_info.value)
+        finally:
+            claim.release()
+
+    def test_release_survives_externally_closed_fd(self, tmp_path: Path) -> None:
+        slots = (_slot("left_channel"), _slot("right_channel"))
+        kvs = {"left_channel": "can0", "right_channel": "can1"}
+        env = {"XDG_RUNTIME_DIR": str(tmp_path)}
+        claim = claim_devices(slots, kvs, env)
+
+        os.close(claim._fds[0])
+        claim.release()
+
+        replacement = claim_devices((_slot("right_channel"),), {"right_channel": "can1"}, env)
+        replacement.release()
+
+
+def test_without_fcntl_is_a_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "fcntl", None)
+    slots = (_slot("left_channel"),)
+    kvs = {"left_channel": "can0"}
+    env = {"XDG_RUNTIME_DIR": str(tmp_path)}
+
+    first = claim_devices(slots, kvs, env)
+    second = claim_devices(slots, kvs, env)
+
+    assert first._fds == []
+    assert second._fds == []
+    assert not _lock_dir(tmp_path).exists()

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -16,7 +16,9 @@ import pytest
 
 import inspect_robots.cli as cli
 import inspect_robots.registry as reg
+from inspect_robots._claims import claim_devices
 from inspect_robots.cli import main
+from inspect_robots.conformance import DeviceSlot
 from inspect_robots.console import USAGE, OperatorConsole
 from inspect_robots.defaults import (
     _ENV_EMBODIMENT as ENV_EMBODIMENT,
@@ -459,6 +461,157 @@ def _register_task(name: str, *, num_scenes: int = 1, max_steps: int = 20) -> No
             scorer=success_at_end(),
             max_steps=max_steps,
         )
+
+
+_DEVICE_CLAIM_SLOTS = (DeviceSlot(arg="channel", kind="can", label="bus"),)
+_DEVICE_CLAIM_EMBODIMENT = "device-claim-test-embodiment"
+
+
+def _register_device_claim_embodiment(monkeypatch: pytest.MonkeyPatch) -> str:
+    from inspect_robots.mock import CubePickEmbodiment
+
+    class _DeviceClaimEmbodiment(CubePickEmbodiment):
+        DEVICE_SLOTS = _DEVICE_CLAIM_SLOTS
+
+        def __init__(self, channel: str) -> None:
+            super().__init__()
+            self.channel = channel
+
+    monkeypatch.setitem(
+        reg._FACTORIES["embodiment"], _DEVICE_CLAIM_EMBODIMENT, _DeviceClaimEmbodiment
+    )
+    return _DEVICE_CLAIM_EMBODIMENT
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fcntl is POSIX-only")
+def test_run_claims_and_releases_device(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    name = _register_device_claim_embodiment(monkeypatch)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    args = [
+        "run",
+        "--task",
+        "cubepick-reach",
+        "--policy",
+        "scripted",
+        "--embodiment",
+        name,
+        "-E",
+        "channel=can9",
+        "--log-dir",
+        str(tmp_path / "logs"),
+    ]
+    existing = claim_devices(_DEVICE_CLAIM_SLOTS, {"channel": "can9"}, os.environ)
+
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            main(args)
+        assert "can9" in str(exc_info.value)
+        assert "already claimed" in str(exc_info.value)
+    finally:
+        existing.release()
+
+    assert main(args) == 0
+    after = claim_devices(_DEVICE_CLAIM_SLOTS, {"channel": "can9"}, os.environ)
+    after.release()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fcntl is POSIX-only")
+def test_run_without_device_slots_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+
+    assert (
+        main(
+            [
+                "run",
+                "--task",
+                "cubepick-reach",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                "cubepick",
+                "--log-dir",
+                str(tmp_path / "logs"),
+            ]
+        )
+        == 0
+    )
+    assert not (tmp_path / "inspect-robots" / "locks").exists()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fcntl is POSIX-only")
+def test_claim_released_when_embodiment_construction_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _BrokenDeviceClaimEmbodiment:
+        DEVICE_SLOTS = _DEVICE_CLAIM_SLOTS
+
+        def __init__(self, channel: str) -> None:
+            raise TypeError(f"construction exploded for {channel}")
+
+    monkeypatch.setitem(
+        reg._FACTORIES["embodiment"], _DEVICE_CLAIM_EMBODIMENT, _BrokenDeviceClaimEmbodiment
+    )
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+
+    with pytest.raises(SystemExit, match="construction exploded"):
+        main(
+            [
+                "run",
+                "--task",
+                "cubepick-reach",
+                "--policy",
+                "scripted",
+                "--embodiment",
+                _DEVICE_CLAIM_EMBODIMENT,
+                "-E",
+                "channel=can9",
+                "--log-dir",
+                str(tmp_path / "logs"),
+            ]
+        )
+
+    after = claim_devices(_DEVICE_CLAIM_SLOTS, {"channel": "can9"}, os.environ)
+    after.release()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fcntl is POSIX-only")
+def test_eval_set_claims_once_for_the_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    name = _register_device_claim_embodiment(monkeypatch)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    _register_task("claim/a")
+    _register_task("claim/b")
+    args = [
+        "eval-set",
+        "claim/a",
+        "claim/b",
+        "--policy",
+        "scripted",
+        "--embodiment",
+        name,
+        "-E",
+        "channel=can9",
+        "--log-dir",
+        str(tmp_path / "logs"),
+    ]
+
+    try:
+        existing = claim_devices(_DEVICE_CLAIM_SLOTS, {"channel": "can9"}, os.environ)
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                main(args)
+            assert "can9" in str(exc_info.value)
+            assert "already claimed" in str(exc_info.value)
+        finally:
+            existing.release()
+
+        assert main(args) == 0
+        after = claim_devices(_DEVICE_CLAIM_SLOTS, {"channel": "can9"}, os.environ)
+        after.release()
+    finally:
+        reg._FACTORIES["task"].pop("claim/a", None)
+        reg._FACTORIES["task"].pop("claim/b", None)
 
 
 def test_cli_eval_set_runs_multiple_exact_tasks(


### PR DESCRIPTION
Closes #281

New private `_claims.py`: before constructing a hardware embodiment, the CLI flocks a per-user lockfile for each configured device-slot value (CAN channels verbatim, camera/serial paths symlink-normalized) and fails loudly with the holder's PID on conflict; claims release in the same `finally` that closes the embodiment and vanish with the process (flock is kernel-scoped, so stale locks cannot exist). Sim embodiments declare no slots and are untouched; missing `fcntl` or an unusable lock dir degrade to a no-op, never blocking an eval.

Plan: `plans/0045-hardware-claim-guard.md` (implementation to follow task-by-task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)