### PR TITLE
rerun: two-row blueprint: cameras left/top/right, transcript and reward behind tabs

### DIFF
--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -46,10 +46,13 @@ termination markers to a [Rerun](https://github.com/rerun-io/rerun) recording. I
 imports `rerun-sdk` lazily: if it isn't installed, the sink warns once and
 no-ops, so core never depends on it. Install with `pip install "inspect-robots[rerun]"`.
 
-The sink lays out labeled joint series per arm, with commanded `action/*` and
-measured `state/*` together for each side and cameras, the LLM transcript, and
-reward alongside. Embodiments without `dim_labels` get one combined joints
-plot. The layout is re-sent at each trial boundary so it follows the live trial,
+The sink lays out two rows: camera views in left/top/right name order across
+the top, then a tabbed text panel (latest LLM message up front, the full
+transcript and the reward series behind tabs) beside one plot per arm, with
+commanded `action/*` and measured `state/*` together for each side.
+Embodiments without `dim_labels` get one combined joints plot; runs without
+cameras send only the second row.
+The layout is re-sent at each trial boundary so it follows the live trial,
 which resets viewer tweaks then; a single-trial `run` sends it exactly once.
 The layout is built from the declared spaces, so entities logged outside them
 (an undeclared state key, or a camera whose runtime name differs from its

--- a/src/inspect_robots/logging/rerun_sink.py
+++ b/src/inspect_robots/logging/rerun_sink.py
@@ -128,6 +128,24 @@ def _joint_groups(labels: tuple[str, ...] | None, dim: int) -> list[tuple[str, l
     return list(groups.items())
 
 
+_CAMERA_RANK = {"left": 0, "top": 1, "right": 2}
+
+
+def _camera_order(names: tuple[str, ...]) -> list[str]:
+    """Order camera views left, top, right by name prefix.
+
+    The rank key is the name's first-underscore prefix, so ``left_cam`` and
+    a bare ``left`` both rank as ``left``. Operators read the workspace
+    spatially, which rarely matches the declared camera order (YAM declares
+    top first). Names without a ranked prefix sort after the ranked ones;
+    ties break alphabetically.
+    """
+    return sorted(
+        names,
+        key=lambda name: (_CAMERA_RANK.get(name.split("_", 1)[0], len(_CAMERA_RANK)), name),
+    )
+
+
 @dataclasses.dataclass(frozen=True)
 class _StepPayload:
     """One transition, snapshotted so no live buffers are shared across threads."""
@@ -313,6 +331,12 @@ class RerunSink:
     def _send_blueprint(self, rr: Any, prefix: str) -> None:
         """Send an explicit layout for one trial namespace, if the SDK can.
 
+        The layout is two rows: the camera views in left/top/right order
+        across the top, then the LLM text (latest document up front, the
+        full transcript log behind a tab) beside the per-group joint plots.
+        There is no reward view; agent-policy runs never log rewards, and a
+        permanently empty panel costs a plot slot.
+
         Rerun's entity queries support ``/**`` only as a suffix, so the views
         name each trial's entities with concrete paths and the layout is
         re-sent when a new trial namespace begins (the viewer follows the
@@ -348,32 +372,26 @@ class RerunSink:
                             contents=[f"+ {prefix}/state/{key}/**"],
                         )
                     )
-            plots.append(
-                rrb.TimeSeriesView(
-                    name="reward",
-                    origin="/",
-                    contents=[f"+ {prefix}/reward"],
-                )
-            )
             cameras = [
                 rrb.Spatial2DView(
                     name=camera,
                     origin="/",
                     contents=[f"+ {prefix}/camera/{camera}"],
                 )
-                for camera in self._camera_names
+                for camera in _camera_order(self._camera_names)
             ]
-            text = rrb.Vertical(
+            text = rrb.Tabs(
                 rrb.TextDocumentView(name="latest", contents=[f"+ {prefix}/llm/latest"]),
                 rrb.TextLogView(
                     name="llm",
                     contents=[f"+ {prefix}/llm", f"+ {prefix}/event/**"],
                 ),
             )
-            columns = [rrb.Vertical(*plots), text]
+            row = rrb.Horizontal(text, *plots)
             if cameras:
-                columns.insert(0, rrb.Grid(*cameras))
-            send(rrb.Blueprint(rrb.Horizontal(*columns)))
+                send(rrb.Blueprint(rrb.Vertical(rrb.Horizontal(*cameras), row)))
+            else:
+                send(rrb.Blueprint(row))
         except Exception as exc:
             if not self._blueprint_warned:
                 self._blueprint_warned = True

--- a/src/inspect_robots/logging/rerun_sink.py
+++ b/src/inspect_robots/logging/rerun_sink.py
@@ -134,15 +134,18 @@ _CAMERA_RANK = {"left": 0, "top": 1, "right": 2}
 def _camera_order(names: tuple[str, ...]) -> list[str]:
     """Order camera views left, top, right by name prefix.
 
-    The rank key is the name's first-underscore prefix, so ``left_cam`` and
-    a bare ``left`` both rank as ``left``. Operators read the workspace
-    spatially, which rarely matches the declared camera order (YAM declares
-    top first). Names without a ranked prefix sort after the ranked ones;
-    ties break alphabetically.
+    The rank key is the name's first-underscore prefix, lowercased, so
+    ``left_cam``, ``Left_cam``, and a bare ``left`` all rank as ``left``.
+    Operators read the workspace spatially, which rarely matches the
+    declared camera order (YAM declares top first). Names without a ranked
+    prefix sort after the ranked ones; ties break in codepoint order.
     """
     return sorted(
         names,
-        key=lambda name: (_CAMERA_RANK.get(name.split("_", 1)[0], len(_CAMERA_RANK)), name),
+        key=lambda name: (
+            _CAMERA_RANK.get(name.split("_", 1)[0].lower(), len(_CAMERA_RANK)),
+            name,
+        ),
     )
 
 
@@ -331,11 +334,13 @@ class RerunSink:
     def _send_blueprint(self, rr: Any, prefix: str) -> None:
         """Send an explicit layout for one trial namespace, if the SDK can.
 
-        The layout is two rows: the camera views in left/top/right order
-        across the top, then the LLM text (latest document up front, the
-        full transcript log behind a tab) beside the per-group joint plots.
-        There is no reward view; agent-policy runs never log rewards, and a
-        permanently empty panel costs a plot slot.
+        The layout is two rows (a run with no cameras sends only the second
+        row): the camera views in left/top/right order across the top, then
+        a tabbed text panel beside the per-group joint plots. The latest
+        LLM message is the default tab; the full transcript log and the
+        reward series sit behind tabs, so reward-logging runs keep it one
+        click away while agent-policy runs, which never log rewards, do not
+        spend a permanently empty plot slot on it.
 
         Rerun's entity queries support ``/**`` only as a suffix, so the views
         name each trial's entities with concrete paths and the layout is
@@ -385,6 +390,11 @@ class RerunSink:
                 rrb.TextLogView(
                     name="llm",
                     contents=[f"+ {prefix}/llm", f"+ {prefix}/event/**"],
+                ),
+                rrb.TimeSeriesView(
+                    name="reward",
+                    origin="/",
+                    contents=[f"+ {prefix}/reward"],
                 ),
             )
             row = rrb.Horizontal(text, *plots)

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -519,6 +519,7 @@ def test_camera_order_ranks_left_top_right() -> None:
         "wrist_cam",
         "zed",
     ]
+    assert rerun_sink_module._camera_order(("Top_cam", "left_cam")) == ["left_cam", "Top_cam"]
     assert rerun_sink_module._camera_order(()) == []
 
 
@@ -549,7 +550,7 @@ def test_blueprint_sent_per_trial_prefix_with_per_group_views(
     reachable_names = {
         view.kwargs.get("name") for view in reachable if view.kind == "TimeSeriesView"
     }
-    assert {"left", "right"} == reachable_names
+    assert {"left", "right", "reward"} == reachable_names
     assert any(view.kind == "Spatial2DView" for view in reachable)
     assert any(view.kind == "TextLogView" for view in reachable)
     assert any(view.kind == "TextDocumentView" for view in reachable)
@@ -566,10 +567,13 @@ def test_blueprint_sent_per_trial_prefix_with_per_group_views(
         "TimeSeriesView",
         "TimeSeriesView",
     ]
-    assert [_node(child).kind for child in _node(plot_row.args[0]).args] == [
+    tabs = _node(plot_row.args[0])
+    assert [_node(child).kind for child in tabs.args] == [
         "TextDocumentView",
         "TextLogView",
+        "TimeSeriesView",
     ]
+    assert _node(tabs.args[2]).kwargs.get("contents") == ["+ trial/s0/e0/reward"]
     time_series = _views(recorder, "TimeSeriesView")
     left = next(view for view in time_series if view.kwargs.get("name") == "left")
     right = next(view for view in time_series if view.kwargs.get("name") == "right")
@@ -602,9 +606,10 @@ def test_blueprint_sent_per_trial_prefix_with_per_group_views(
         view.kwargs.get("contents") == ["+ trial/s0/e0/llm/latest"]
         for view in _views(recorder, "TextDocumentView")
     )
-    # No reward view anywhere: agent-policy runs never log rewards, so a
-    # reward panel would sit permanently empty.
-    assert not any("reward" in str(view.kwargs.get("contents")) for view in time_series)
+    # The reward series lives behind the text tabs, not in a plot slot:
+    # agent-policy runs never log rewards, so a permanently visible reward
+    # panel would sit empty.
+    assert [_node(child).kwargs.get("name") for child in plot_row.args[1:]] == ["left", "right"]
 
     sink.on_trial_start("s1", 0)
     _blueprint_step(sink, 1)
@@ -665,6 +670,11 @@ def test_transcript_first_payload_sends_blueprint(monkeypatch: pytest.MonkeyPatc
     assert sink.flush(timeout=5.0)
 
     assert len(recorder.sent) == 1
+    # A camera-less run sends the plot row as the root, not a Vertical with
+    # an empty top row.
+    row = _node(_node(recorder.sent[0]).args[0])
+    assert row.kind == "Horizontal"
+    assert _node(row.args[0]).kind == "Tabs"
     sink.on_eval_end(None)  # type: ignore[arg-type]
 
 

--- a/tests/test_rerun_sink.py
+++ b/tests/test_rerun_sink.py
@@ -307,7 +307,7 @@ class _BlueprintRecorder:
             "TextDocumentView",
             "TextLogView",
             "Vertical",
-            "Grid",
+            "Tabs",
             "Horizontal",
             "Blueprint",
         ):
@@ -485,6 +485,12 @@ def _sent_tree(root: object) -> list[_BlueprintNode]:
     return nodes
 
 
+def _node(value: object) -> _BlueprintNode:
+    """Narrow a recorded child to a node so structure asserts can nest."""
+    assert isinstance(value, _BlueprintNode)
+    return value
+
+
 def test_joint_groups_split_on_label_prefix() -> None:
     labels = tuple(
         f"{side}_{part}" for side in ("left", "right") for part in ("j0", "j1", "gripper")
@@ -498,6 +504,22 @@ def test_joint_groups_split_on_label_prefix() -> None:
     assert rerun_sink_module._joint_groups(("ax", "by"), 2) == [("joints", [0, 1])]
     assert rerun_sink_module._joint_groups(("l_a", "up", "r_b"), 3) == [("joints", [0, 1, 2])]
     assert rerun_sink_module._joint_groups(("l_a", "r_b"), 3) == [("joints", [0, 1, 2])]
+
+
+def test_camera_order_ranks_left_top_right() -> None:
+    """Ranked prefixes lead in spatial order; unranked names trail alphabetically."""
+    assert rerun_sink_module._camera_order(("top_cam", "right_cam", "left_cam")) == [
+        "left_cam",
+        "top_cam",
+        "right_cam",
+    ]
+    assert rerun_sink_module._camera_order(("top", "right", "left")) == ["left", "top", "right"]
+    assert rerun_sink_module._camera_order(("zed", "wrist_cam", "top_cam")) == [
+        "top_cam",
+        "wrist_cam",
+        "zed",
+    ]
+    assert rerun_sink_module._camera_order(()) == []
 
 
 def test_blueprint_sent_per_trial_prefix_with_per_group_views(
@@ -527,10 +549,27 @@ def test_blueprint_sent_per_trial_prefix_with_per_group_views(
     reachable_names = {
         view.kwargs.get("name") for view in reachable if view.kind == "TimeSeriesView"
     }
-    assert {"left", "right", "reward"} <= reachable_names
+    assert {"left", "right"} == reachable_names
     assert any(view.kind == "Spatial2DView" for view in reachable)
     assert any(view.kind == "TextLogView" for view in reachable)
     assert any(view.kind == "TextDocumentView" for view in reachable)
+    # Two rows: cameras across the top, then the text tabs beside the plots.
+    # The tab order matters: the latest-message document is the default tab.
+    vertical = _node(_node(recorder.sent[0]).args[0])
+    assert vertical.kind == "Vertical"
+    camera_row, plot_row = (_node(child) for child in vertical.args)
+    assert camera_row.kind == "Horizontal"
+    assert [_node(child).kind for child in camera_row.args] == ["Spatial2DView"]
+    assert plot_row.kind == "Horizontal"
+    assert [_node(child).kind for child in plot_row.args] == [
+        "Tabs",
+        "TimeSeriesView",
+        "TimeSeriesView",
+    ]
+    assert [_node(child).kind for child in _node(plot_row.args[0]).args] == [
+        "TextDocumentView",
+        "TextLogView",
+    ]
     time_series = _views(recorder, "TimeSeriesView")
     left = next(view for view in time_series if view.kwargs.get("name") == "left")
     right = next(view for view in time_series if view.kwargs.get("name") == "right")
@@ -563,20 +602,54 @@ def test_blueprint_sent_per_trial_prefix_with_per_group_views(
         view.kwargs.get("contents") == ["+ trial/s0/e0/llm/latest"]
         for view in _views(recorder, "TextDocumentView")
     )
-    assert any(view.kwargs.get("contents") == ["+ trial/s0/e0/reward"] for view in time_series)
+    # No reward view anywhere: agent-policy runs never log rewards, so a
+    # reward panel would sit permanently empty.
+    assert not any("reward" in str(view.kwargs.get("contents")) for view in time_series)
 
     sink.on_trial_start("s1", 0)
     _blueprint_step(sink, 1)
     assert sink.flush(timeout=5.0)
     assert len(recorder.sent) == 2
     assert any(
-        view.kwargs.get("contents") == ["+ trial/s1/e0/reward"]
-        for view in _views(recorder, "TimeSeriesView")
+        view.kwargs.get("contents") == ["+ trial/s1/e0/llm/latest"]
+        for view in _views(recorder, "TextDocumentView")
     )
 
     _blueprint_step(sink, 2)
     assert sink.flush(timeout=5.0)
     assert len(recorder.sent) == 2
+    sink.on_eval_end(None)  # type: ignore[arg-type]
+
+
+def test_blueprint_camera_row_is_ordered_left_top_right(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Declared camera order (YAM lists top first) does not drive the row."""
+    recorder = _BlueprintRecorder()
+    _install_fake_rerun(monkeypatch, blueprint=recorder)
+    sink = RerunSink()
+    sink.bind_spaces(
+        _labeled_action_space(),
+        ObservationSpace(
+            cameras=tuple(
+                CameraSpec(name=name, height=4, width=4)
+                for name in ("top_cam", "wrist_cam", "right_cam", "left_cam")
+            )
+        ),
+    )
+    sink.on_eval_start(None)  # type: ignore[arg-type]
+    sink.on_trial_start("s0", 0)
+    _blueprint_step(sink)
+    assert sink.flush(timeout=5.0)
+
+    camera_row = _node(_node(_node(recorder.sent[0]).args[0]).args[0])
+    assert camera_row.kind == "Horizontal"
+    assert [_node(view).kwargs.get("name") for view in camera_row.args] == [
+        "left_cam",
+        "top_cam",
+        "right_cam",
+        "wrist_cam",
+    ]
     sink.on_eval_end(None)  # type: ignore[arg-type]
 
 


### PR DESCRIPTION
Closes #302.

## What changed

`RerunSink._send_blueprint` now builds a two-row layout instead of three columns:

- Row 1: one 2D view per declared camera, ordered left/top/right by the name's first-underscore prefix, lowercased (new module helper `_camera_order`, mirroring `_joint_groups`). YAM declares `top_cam` first, but operators read the workspace spatially. Unranked names trail the ranked ones in codepoint order; a run with no cameras sends only the second row.
- Row 2: a `Tabs` container followed by the per-group joint plots. The `llm/latest` document is the default tab; the `llm` transcript log and the reward series sit behind tabs. Length-mismatched state-key views are unchanged.
- The reward view no longer occupies a plot slot. Agent-policy runs never log rewards, so a permanently visible reward panel sat empty. Because an explicit blueprint suppresses the viewer's automatic layout, the reward series stays reachable as a tab (rather than being dropped) so scripted-policy runs keep it one click away.

The degradation contract is untouched: everything stays inside the existing guard in `_send_blueprint`, so an SDK without `Tabs` or any build failure falls back to the automatic layout with one warning. Core still never imports rerun-sdk at module scope. The camera row is a non-wrapping `Horizontal` by design; the declared-camera count on our rigs is three, and that is the count this layout was validated at.

## Validation

The default visible layout (identical sort key and container nesting; reward tab adds only a tab label) was iterated in a patched venv on the rig during live YAM runs and approved by the operator. The prefix ranking was specifically verified against the real camera names (`left_cam`, `top_cam`, `right_cam`); ranking bare names silently degrades to alphabetical order, which is the bug the first iteration hit.

## Tests

- New `_camera_order` unit test (ranked, bare, unranked, mixed-case, empty).
- New integration test asserting the camera row order for a YAM-style declaration plus an unranked `wrist_cam`.
- The per-group blueprint test asserts the full two-row nesting: Vertical of a camera Horizontal and a plot-row Horizontal whose children are exactly `Tabs`, `left`, `right`, with the tab order pinned as document, transcript log, reward.
- The camera-less root shape is pinned (plot row at the root, no empty top row).
- The fake blueprint module swaps `Grid` for `Tabs`, matching the constructors the sink actually uses; the real-SDK gated test covers `Tabs` (including the reward tab) against rerun-sdk.
- `docs/guide/logging-and-rerun.md` updated to describe the two-row layout.

## Review

Fresh-eye review round 1: no blockers; three minors (reward visibility for scripted runs, stale docs guide, unpinned camera-less root) and three nits (docstring precision, case sensitivity, Horizontal vs Grid at high camera counts) — all addressed in 0afcb35e except the Horizontal/Grid nit, which is intended behavior at our camera counts and documented above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)