### PR TITLE
agent: done()/give_up() ask for hindsight - what the model wishes it had known at episode start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- **Agent plugin (0.22.0):** `done` and `give_up` now ask for a required
+  `hindsight` argument: what the agent wishes it had known at the start of
+  the episode, as concrete transferable rig and task facts. The system
+  prompt announces the question up front; the answer persists as
+  `stop_hindsight` action meta and as `trial_metadata["hindsight"]` in the
+  JSON log, written to be usable as `prior_learnings` input on later runs.
+  Missing hindsight never fails execution (the budget-exhausted forced
+  `give_up` cannot answer)
+  ([plan 0047](plans/0047-stop-tool-hindsight.md), #305).
+
 - CLI `run` and `eval-set` now take per-user advisory claims for declared
   device slots before hardware construction, reject concurrent evals aimed at
   the same rig, and release claims during embodiment teardown

--- a/plans/0047-stop-tool-hindsight.md
+++ b/plans/0047-stop-tool-hindsight.md
@@ -191,9 +191,9 @@ pytest with the existing fake-client patterns in
 
 ## Task 4: version bump, docs, changelog
 
-- [ ] **Step 1:** Bump the plugin to 0.22.0 in all THREE places (pyproject
+- [x] **Step 1:** Bump the plugin to 0.22.0 in all THREE places (pyproject
   `version`, `uv lock` regeneration, `tests/test_package.py:9` pin).
-- [ ] **Step 2:** Docs sweep: `docs/` has NO agent-tools page (grep
+- [x] **Step 2:** Docs sweep: `docs/` has NO agent-tools page (grep
   verified); the documentation surface is
   `plugins/inspect-robots-agent/README.md` (give_up at lines 137, 144,
   234). Document the new argument, both persistence surfaces, and that
@@ -203,4 +203,4 @@ pytest with the existing fake-client patterns in
   entry under Unreleased as `**Agent plugin (0.22.0):**` bullets following
   the sibling convention, referencing #305 and plan 0047, with the same
   `prior_learnings` cross-reference.
-- [ ] **Step 3: gates green, commit.**
+- [x] **Step 3: gates green, commit.**

--- a/plans/0047-stop-tool-hindsight.md
+++ b/plans/0047-stop-tool-hindsight.md
@@ -30,9 +30,19 @@ pytest with the existing fake-client patterns in
 
 ## Global Constraints
 
-- Gates (all blocking), run from the worktree root: `uv run ruff check .`,
-  `uv run ruff format --check .`, `uv run mypy`, `uv run pytest --cov` at
-  **100% coverage**.
+- Gates (all blocking), run from the worktree root. The root mypy/pytest
+  configs do NOT cover the plugin (root `testpaths=["tests"]`, coverage
+  `source=["inspect_robots"]`), so the plugin gates must be the CI commands
+  (`.github/workflows/ci.yml:317-331`):
+  - `uv run ruff check .` and `uv run ruff format --check .` (repo-wide).
+  - `uv run mypy --config-file plugins/inspect-robots-agent/pyproject.toml
+    plugins/inspect-robots-agent/src/inspect_robots_agent`.
+  - `uv run pytest plugins/inspect-robots-agent/tests
+    --cov=inspect_robots_agent --cov-report=term-missing`.
+  Coverage bar: CI gates plugins at fail-under=0 and the plugin sits at
+  97.73% today (pre-existing `_gemini_live.py` gaps), so the rule is **no
+  regression on touched files**: `_tools.py` stays 100%, `policy.py` stays
+  at or above its current 99% with every new line and branch covered.
 - Every public module/class/function needs a docstring stating the contract
   (ruff D1).
 - Repo root is the `wt-ir-hindsight` worktree at
@@ -54,26 +64,39 @@ pytest with the existing fake-client patterns in
 - `plugins/.../src/inspect_robots_agent/_tools.py:191-216` — `done` schema
   (required `summary`) and `give_up` schema (required `reason`).
 - `_tools.py:265-266` — dispatch: both names route to `_stop`.
-- `_tools.py:307-318` — `_stop`: builds the hold action with meta
+- `_tools.py:307-317` — `_stop`: builds the hold action with meta
   `{request_stop: True, stop_reason: name, stop_detail: summary-or-reason}`,
   returns `note=f"{name}: {detail}"`.
-- `_tools.py` take_pic `note` validation (~321-325) — the existing pattern
+- `_tools.py:320-324` take_pic `note` validation — the existing pattern
   for an execution-level argument check; `hindsight` deliberately does NOT
-  get one (leniency contract above).
+  get one (leniency contract above). No wire client validates tool
+  parameters harness-side (`execute` only json.loads + dict-checks;
+  schemas pass through verbatim to every wire), so schema-required is
+  purely an instruction to the model.
+- Existing required-list assertions that break mechanically (permitted
+  edits): `tests/test_tools_motion.py:578-581` (`["summary"]`) and
+  `:601-604` (`["reason"]`).
 - `policy.py:100-134` — `_SYSTEM_TEMPLATE` and `_ON_DEMAND_SYSTEM_TEMPLATE`;
   both end with "When the goal is achieved call done; if it cannot be
   achieved call give_up. You have a budget of {budget} LLM calls...".
-- `policy.py:955` — the one site that detects the stop chunk:
-  `stopped = bool(chunk.actions[0].meta.get("request_stop"))`.
-- `policy.py:1011-1018` — `_forced_give_up`: synthesizes
+- `policy.py:955` — the tool-call loop's stop-chunk detection:
+  `stopped = bool(chunk.actions[0].meta.get("request_stop"))`. This is the
+  only stash site needed for LLM-produced stops (all four wires funnel
+  through this one loop), BUT the forced path BYPASSES it: `policy.py:810`
+  returns `self._forced_give_up(...)`'s chunk directly. That is safe by
+  construction (the synthetic call carries no hindsight, so `_stop` adds no
+  meta, and `reset()` cleared any previous trial's stash), and it is why
+  the two-trial reset test below is the load-bearing one.
+- `policy.py:1011-1019` — `_forced_give_up`: synthesizes
   `ToolCall(id="budget", name="give_up", arguments=json.dumps({"reason": why}))`
-  and requires `result.error` to be None, so `_stop` must not reject a
+  and raises if `result.chunk` is missing, so `_stop` must not reject a
   missing `hindsight`.
+- `policy.py:669-697` — `reset(scene)` is the per-trial state reset
+  (`_messages`, `_calls_used`, `_usage_totals`, `_pending`, ...); clear the
+  hindsight stash EARLY in this method body. (`on_trial_start` at :699-702
+  only begins wire capture and resets nothing — do not put it there.)
 - `policy.py:704-737` — `on_trial_end(record, ...)`: writes
-  `record.metadata["wire_capture"|"transcript"|"llm_usage"]`. The
-  per-trial reset lives wherever the policy resets `_messages`/counters for
-  a new trial (locate `on_trial_begin` or equivalent; wire the hindsight
-  stash reset there).
+  `record.metadata["wire_capture"|"transcript"|"llm_usage"]`.
 - `src/inspect_robots/rollout.py:106-107` — `TrialRecord.metadata`
   ("Extensible metadata for the trial (e.g. populated by policies)");
   `src/inspect_robots/eval.py:469,521` copies it into the sample's
@@ -98,11 +121,14 @@ pytest with the existing fake-client patterns in
   (c) a call WITHOUT `hindsight` (and one with `hindsight: "  "`) still
   succeeds, meta has NO `stop_hindsight` key, and `note` is unchanged.
 - [ ] **Step 2: implement.** Add the parameter to both schemas. Description
-  (same string for both, single source constant): "What do you know now
-  that you wish you had known at the start of this episode? Concrete,
-  transferable facts about this rig, task, or embodiment (geometry, grip
-  offsets, camera quirks, motion behavior), written as advice to a future
-  agent attempting the same task. Say 'none' if nothing qualifies." In
+  (same string for both, single source constant; categories calibrated
+  against a real rollout's answer, see issue #305 comment): "What do you
+  know now that you wish you had known at the start of this episode?
+  Concrete, transferable facts about this rig, task, or embodiment (camera
+  mounting and extrinsics, table and base geometry, gripper axis and
+  offsets, controller behavior, metric scale), written as advice to a
+  future agent attempting the same task. Say 'none' if nothing
+  qualifies." In
   `_stop`, read `arguments.get("hindsight")`; when it is a non-blank
   string, add `stop_hindsight` (stripped) to the meta. No validation
   error path.
@@ -111,22 +137,28 @@ pytest with the existing fake-client patterns in
 ## Task 2: policy stash and `trial_metadata` persistence
 
 - [ ] **Step 1: failing tests.** E2E, following the
-  `test_goal_runs_to_done_and_config_lands_in_log` pattern: a scripted run
-  whose `done` call carries `hindsight` produces a log where
-  `samples[0]["trial_metadata"][0]["hindsight"]` equals the string.
-  Second test: a forced give_up run (budget exhaustion, mirror
+  `test_goal_runs_to_done_and_config_lands_in_log` pattern and its
+  attribute-style access (`logs[0].samples[0].trial_metadata[0]`): a
+  scripted run whose `done` call carries `hindsight` produces a log where
+  `trial_metadata[0]["hindsight"]` equals the string. Second test: a
+  forced give_up run (budget exhaustion, mirror
   `test_transcript_echo_reports_forced_give_up`) produces trial_metadata
-  WITHOUT a `hindsight` key. Third test: two trials in one run where only
-  the first supplies hindsight; the second trial's metadata has no
-  `hindsight` key (per-trial reset, no bleed-through).
+  WITHOUT a `hindsight` key (pins end-to-end leniency: a validation error
+  in `_stop` would trip `_forced_give_up`'s no-chunk raise). Third test
+  (the load-bearing one for the reset): TWO trials in one run — trial 1
+  ends via `done` WITH hindsight, trial 2 ends via forced give_up — and
+  trial 2's metadata has no `hindsight` key. No two-trial helper exists:
+  hand-build `Task(scenes=[...], epochs=2, ...)` (`Task.epochs`,
+  `src/inspect_robots/task.py:69`); the `_Script` transport consumes
+  responses sequentially across trials.
 - [ ] **Step 2: implement.** At the `policy.py:955` stop-chunk site, stash
   `chunk.actions[0].meta.get("stop_hindsight")` on the policy when
-  `request_stop` is set. Reset the stash wherever per-trial state resets.
-  In `on_trial_end`, write `record.metadata["hindsight"]` when the stash
-  is a non-blank string. Note `on_trial_end` currently returns early when
-  there is no transcript (`policy.py:717-719`); the hindsight write must
-  happen BEFORE that early return, or a transcript-less trial silently
-  drops it.
+  `request_stop` is set. Clear the stash early in `reset()`
+  (`policy.py:669`). In `on_trial_end`, write
+  `record.metadata["hindsight"]` when the stash is a non-blank string.
+  `on_trial_end` returns early when there is no transcript
+  (`policy.py:717-719`); the hindsight write must happen BEFORE that early
+  return, or a transcript-less trial silently drops it.
 - [ ] **Step 3: gates green, commit.**
 
 ## Task 3: system prompt announcement
@@ -145,8 +177,14 @@ pytest with the existing fake-client patterns in
 
 - [ ] **Step 1:** Bump the plugin to 0.22.0 in all THREE places (pyproject
   `version`, `uv lock` regeneration, `tests/test_package.py:9` pin).
-- [ ] **Step 2:** Docs sweep: the plugin/agent docs page that lists the
-  tools (grep `docs/` for `give_up`) documents the new argument and both
-  persistence surfaces. Root `CHANGELOG.md` entry under Unreleased
-  referencing #305 and plan 0047, following the sibling-entry convention.
+- [ ] **Step 2:** Docs sweep: `docs/` has NO agent-tools page (grep
+  verified); the documentation surface is
+  `plugins/inspect-robots-agent/README.md` (give_up at lines 137, 144,
+  234). Document the new argument, both persistence surfaces, and that
+  harvested hindsight is suitable input for the existing `prior_learnings`
+  feed-forward mechanism (`policy.py:239-321`) — collection and
+  feed-forward should find each other in the docs. Root `CHANGELOG.md`
+  entry under Unreleased as `**Agent plugin (0.22.0):**` bullets following
+  the sibling convention, referencing #305 and plan 0047, with the same
+  `prior_learnings` cross-reference.
 - [ ] **Step 3: gates green, commit.**

--- a/plans/0047-stop-tool-hindsight.md
+++ b/plans/0047-stop-tool-hindsight.md
@@ -179,15 +179,15 @@ pytest with the existing fake-client patterns in
 
 ## Task 3: system prompt announcement
 
-- [ ] **Step 1: failing tests.** Parametrized over both templates (existing
+- [x] **Step 1: failing tests.** Parametrized over both templates (existing
   `:684` pattern): the rendered system prompt contains the announcement
   sentence.
-- [ ] **Step 2: implement.** Insert one sentence into BOTH templates,
+- [x] **Step 2: implement.** Insert one sentence into BOTH templates,
   immediately before the "You have a budget" sentence: "Note what you are
   learning about this rig and task as you go: done and give_up will ask
   what you wish you had known from the start." Update any prompt-snapshot
   assertions (permitted mechanical edits).
-- [ ] **Step 3: gates green, commit.**
+- [x] **Step 3: gates green, commit.**
 
 ## Task 4: version bump, docs, changelog
 

--- a/plans/0047-stop-tool-hindsight.md
+++ b/plans/0047-stop-tool-hindsight.md
@@ -33,16 +33,22 @@ pytest with the existing fake-client patterns in
 - Gates (all blocking), run from the worktree root. The root mypy/pytest
   configs do NOT cover the plugin (root `testpaths=["tests"]`, coverage
   `source=["inspect_robots"]`), so the plugin gates must be the CI commands
-  (`.github/workflows/ci.yml:317-331`):
-  - `uv run ruff check .` and `uv run ruff format --check .` (repo-wide).
+  (`.github/workflows/ci.yml:317-331`, quoted verbatim):
+  - `uv run --no-sync ruff check plugins/inspect-robots-agent` and
+    `uv run --no-sync ruff format --check plugins/inspect-robots-agent`
+    (repo-wide ruff is a strict superset and also acceptable).
   - `uv run mypy --config-file plugins/inspect-robots-agent/pyproject.toml
     plugins/inspect-robots-agent/src/inspect_robots_agent`.
   - `uv run pytest plugins/inspect-robots-agent/tests
-    --cov=inspect_robots_agent --cov-report=term-missing`.
-  Coverage bar: CI gates plugins at fail-under=0 and the plugin sits at
-  97.73% today (pre-existing `_gemini_live.py` gaps), so the rule is **no
-  regression on touched files**: `_tools.py` stays 100%, `policy.py` stays
-  at or above its current 99% with every new line and branch covered.
+    --cov=inspect_robots_agent --cov-report=term-missing
+    --cov-fail-under=0`. The `--cov-fail-under=0` is LOAD-BEARING: run
+    from the worktree root, pytest-cov otherwise inherits the root
+    `[tool.coverage.report] fail_under = 100` and fails a green suite at
+    the plugin's pre-existing 97.73%.
+  Coverage bar: the rule is **no regression on touched files**:
+  `_tools.py` stays 100%, `policy.py` stays at or above its current 99%
+  with every new line and branch covered (the 97.73% total is pre-existing
+  `_gemini_live.py` gaps, not the implementer's problem).
 - Every public module/class/function needs a docstring stating the contract
   (ruff D1).
 - Repo root is the `wt-ir-hindsight` worktree at
@@ -74,8 +80,11 @@ pytest with the existing fake-client patterns in
   schemas pass through verbatim to every wire), so schema-required is
   purely an instruction to the model.
 - Existing required-list assertions that break mechanically (permitted
-  edits): `tests/test_tools_motion.py:578-581` (`["summary"]`) and
-  `:601-604` (`["reason"]`).
+  edits): both in `test_schemas_match_control_mode_and_remove_duration`
+  (`tests/test_tools_motion.py:570`) — the full three-tool lists at
+  `:578-582` (`[["targets","note"],["summary"],["reason"]]`, absolute) and
+  `:601-605` (`[["deltas","note"],["summary"],["reason"]]`, displacement);
+  each needs BOTH stop-tool entries extended with `"hindsight"`.
 - `policy.py:100-134` — `_SYSTEM_TEMPLATE` and `_ON_DEMAND_SYSTEM_TEMPLATE`;
   both end with "When the goal is achieved call done; if it cannot be
   achieved call give_up. You have a budget of {budget} LLM calls...".
@@ -149,8 +158,15 @@ pytest with the existing fake-client patterns in
   ends via `done` WITH hindsight, trial 2 ends via forced give_up — and
   trial 2's metadata has no `hindsight` key. No two-trial helper exists:
   hand-build `Task(scenes=[...], epochs=2, ...)` (`Task.epochs`,
-  `src/inspect_robots/task.py:69`); the `_Script` transport consumes
-  responses sequentially across trials.
+  `src/inspect_robots/task.py:69`). `_Script` semantics trap
+  (`test_policy_e2e.py:160-170`): the transport pops sequentially but
+  REPEATS ITS FINAL RESPONSE FOREVER — a script ending in the
+  `done`+hindsight response makes trial 2 replay `done` and inverts the
+  scenario. The script must end with a MOVE response (e.g.
+  `[move, done+hindsight, move]`) and use a small `max_llm_calls` so
+  trial 2 loops the trailing move into budget exhaustion (budget is
+  checked before each call at `policy.py:810`; `_calls_used` resets per
+  trial at `policy.py:695`).
 - [ ] **Step 2: implement.** At the `policy.py:955` stop-chunk site, stash
   `chunk.actions[0].meta.get("stop_hindsight")` on the policy when
   `request_stop` is set. Clear the stash early in `reset()`

--- a/plans/0047-stop-tool-hindsight.md
+++ b/plans/0047-stop-tool-hindsight.md
@@ -33,7 +33,7 @@ pytest with the existing fake-client patterns in
 - Gates (all blocking), run from the worktree root. The root mypy/pytest
   configs do NOT cover the plugin (root `testpaths=["tests"]`, coverage
   `source=["inspect_robots"]`), so the plugin gates must be the CI commands
-  (`.github/workflows/ci.yml:317-331`, quoted verbatim):
+  (`.github/workflows/ci.yml:317-331`, equivalent modulo --no-sync/-q flags):
   - `uv run --no-sync ruff check plugins/inspect-robots-agent` and
     `uv run --no-sync ruff format --check plugins/inspect-robots-agent`
     (repo-wide ruff is a strict superset and also acceptable).
@@ -165,8 +165,8 @@ pytest with the existing fake-client patterns in
   scenario. The script must end with a MOVE response (e.g.
   `[move, done+hindsight, move]`) and use a small `max_llm_calls` so
   trial 2 loops the trailing move into budget exhaustion (budget is
-  checked before each call at `policy.py:810`; `_calls_used` resets per
-  trial at `policy.py:695`).
+  checked before each call at `policy.py:809`; `_calls_used` resets per
+  trial at `policy.py:694`).
 - [ ] **Step 2: implement.** At the `policy.py:955` stop-chunk site, stash
   `chunk.actions[0].meta.get("stop_hindsight")` on the policy when
   `request_stop` is set. Clear the stash early in `reset()`

--- a/plans/0047-stop-tool-hindsight.md
+++ b/plans/0047-stop-tool-hindsight.md
@@ -1,0 +1,152 @@
+# Stop-tool hindsight Implementation Plan
+
+> **For agentic workers:** Implement task-by-task in order; each task is
+> test-first and ends in its own commit. Steps use checkbox (`- [ ]`) syntax
+> for tracking.
+
+**Goal:** LLM agents relearn the same rig- and task-specific facts on every
+rollout. Collect them at the terminal tool call: `done` and `give_up` gain a
+required `hindsight` argument asking what the agent wishes it had known at
+episode start, the system prompt announces the question up front so the model
+tracks learnings during the rollout, and the answer persists in two
+harvestable places (stop-action meta, and `trial_metadata` in the JSON log).
+Feeding hindsight forward into future rollouts is explicitly out of scope.
+Closes #305.
+
+**Architecture:** the `hindsight` parameter is schema-required on both stop
+tools but execution-lenient: `_stop` records it into the stop action's meta
+as `stop_hindsight` only when present and non-blank, and never errors on its
+absence, because the budget-exhausted `_forced_give_up` path synthesizes the
+call with no LLM available to answer. The policy stashes the value when it
+detects the stop chunk (the existing `request_stop` site), resets it per
+trial, and `on_trial_end` writes `record.metadata["hindsight"]` next to the
+existing `llm_usage`/`transcript` keys, which lands it in the sample's
+`trial_metadata` in the JSON log. Both system-prompt templates gain one
+sentence so the model knows the question is coming.
+
+**Tech stack:** stdlib only, all inside `plugins/inspect-robots-agent`.
+pytest with the existing fake-client patterns in
+`plugins/inspect-robots-agent/tests/`.
+
+## Global Constraints
+
+- Gates (all blocking), run from the worktree root: `uv run ruff check .`,
+  `uv run ruff format --check .`, `uv run mypy`, `uv run pytest --cov` at
+  **100% coverage**.
+- Every public module/class/function needs a docstring stating the contract
+  (ruff D1).
+- Repo root is the `wt-ir-hindsight` worktree at
+  `~/robocurve/wt-ir-hindsight`; run everything via `uv run ...` there.
+- Existing tests pass untouched EXCEPT: tests that enumerate the stop tools'
+  required parameters or snapshot the system prompt text may be updated
+  mechanically to the new schema/text; list every such edit in the commit
+  message. Everything else is off limits.
+- The plugin version bump touches THREE files or CI fails (established
+  release rule): `plugins/inspect-robots-agent/pyproject.toml` `version`,
+  `uv.lock` (workspace member version is locked), and the hardcoded pin in
+  `plugins/inspect-robots-agent/tests/test_package.py:9`. Bump 0.21.0 →
+  0.22.0 (new tool argument = minor).
+- Docs follow the repo writing rules (no em dashes in prose).
+- Commit messages: imperative, scoped; reference #305.
+
+## Reference: current wiring (main @ 01fd2659)
+
+- `plugins/.../src/inspect_robots_agent/_tools.py:191-216` — `done` schema
+  (required `summary`) and `give_up` schema (required `reason`).
+- `_tools.py:265-266` — dispatch: both names route to `_stop`.
+- `_tools.py:307-318` — `_stop`: builds the hold action with meta
+  `{request_stop: True, stop_reason: name, stop_detail: summary-or-reason}`,
+  returns `note=f"{name}: {detail}"`.
+- `_tools.py` take_pic `note` validation (~321-325) — the existing pattern
+  for an execution-level argument check; `hindsight` deliberately does NOT
+  get one (leniency contract above).
+- `policy.py:100-134` — `_SYSTEM_TEMPLATE` and `_ON_DEMAND_SYSTEM_TEMPLATE`;
+  both end with "When the goal is achieved call done; if it cannot be
+  achieved call give_up. You have a budget of {budget} LLM calls...".
+- `policy.py:955` — the one site that detects the stop chunk:
+  `stopped = bool(chunk.actions[0].meta.get("request_stop"))`.
+- `policy.py:1011-1018` — `_forced_give_up`: synthesizes
+  `ToolCall(id="budget", name="give_up", arguments=json.dumps({"reason": why}))`
+  and requires `result.error` to be None, so `_stop` must not reject a
+  missing `hindsight`.
+- `policy.py:704-737` — `on_trial_end(record, ...)`: writes
+  `record.metadata["wire_capture"|"transcript"|"llm_usage"]`. The
+  per-trial reset lives wherever the policy resets `_messages`/counters for
+  a new trial (locate `on_trial_begin` or equivalent; wire the hindsight
+  stash reset there).
+- `src/inspect_robots/rollout.py:106-107` — `TrialRecord.metadata`
+  ("Extensible metadata for the trial (e.g. populated by policies)");
+  `src/inspect_robots/eval.py:469,521` copies it into the sample's
+  `trial_metadata`; no core changes are needed.
+- `plugins/inspect-robots-agent/tests/test_policy_e2e.py:52-54,684` —
+  imports both templates and parametrizes over them;
+  `test_goal_runs_to_done_and_config_lands_in_log` (:385) is the pattern
+  for asserting log contents end to end;
+  `test_transcript_echo_reports_forced_give_up` (:1228) covers the forced
+  path.
+- `tests/test_tools_motion.py:1144` — existing done/give_up toolset test.
+
+## Task 1: schema and `_stop` meta
+
+- [ ] **Step 1: failing tests.** In the toolset tests: (a) both stop tools'
+  schemas declare `hindsight` with `required == [<existing>, "hindsight"]`
+  and a description that asks what the agent wishes it had known at the
+  start; (b) `_stop` on a call carrying
+  `{"summary": "...", "hindsight": "the jar lid needs two approach angles"}`
+  puts `stop_hindsight` with that exact string into the action meta,
+  alongside the unchanged `request_stop`/`stop_reason`/`stop_detail`;
+  (c) a call WITHOUT `hindsight` (and one with `hindsight: "  "`) still
+  succeeds, meta has NO `stop_hindsight` key, and `note` is unchanged.
+- [ ] **Step 2: implement.** Add the parameter to both schemas. Description
+  (same string for both, single source constant): "What do you know now
+  that you wish you had known at the start of this episode? Concrete,
+  transferable facts about this rig, task, or embodiment (geometry, grip
+  offsets, camera quirks, motion behavior), written as advice to a future
+  agent attempting the same task. Say 'none' if nothing qualifies." In
+  `_stop`, read `arguments.get("hindsight")`; when it is a non-blank
+  string, add `stop_hindsight` (stripped) to the meta. No validation
+  error path.
+- [ ] **Step 3: gates green, commit.**
+
+## Task 2: policy stash and `trial_metadata` persistence
+
+- [ ] **Step 1: failing tests.** E2E, following the
+  `test_goal_runs_to_done_and_config_lands_in_log` pattern: a scripted run
+  whose `done` call carries `hindsight` produces a log where
+  `samples[0]["trial_metadata"][0]["hindsight"]` equals the string.
+  Second test: a forced give_up run (budget exhaustion, mirror
+  `test_transcript_echo_reports_forced_give_up`) produces trial_metadata
+  WITHOUT a `hindsight` key. Third test: two trials in one run where only
+  the first supplies hindsight; the second trial's metadata has no
+  `hindsight` key (per-trial reset, no bleed-through).
+- [ ] **Step 2: implement.** At the `policy.py:955` stop-chunk site, stash
+  `chunk.actions[0].meta.get("stop_hindsight")` on the policy when
+  `request_stop` is set. Reset the stash wherever per-trial state resets.
+  In `on_trial_end`, write `record.metadata["hindsight"]` when the stash
+  is a non-blank string. Note `on_trial_end` currently returns early when
+  there is no transcript (`policy.py:717-719`); the hindsight write must
+  happen BEFORE that early return, or a transcript-less trial silently
+  drops it.
+- [ ] **Step 3: gates green, commit.**
+
+## Task 3: system prompt announcement
+
+- [ ] **Step 1: failing tests.** Parametrized over both templates (existing
+  `:684` pattern): the rendered system prompt contains the announcement
+  sentence.
+- [ ] **Step 2: implement.** Insert one sentence into BOTH templates,
+  immediately before the "You have a budget" sentence: "Note what you are
+  learning about this rig and task as you go: done and give_up will ask
+  what you wish you had known from the start." Update any prompt-snapshot
+  assertions (permitted mechanical edits).
+- [ ] **Step 3: gates green, commit.**
+
+## Task 4: version bump, docs, changelog
+
+- [ ] **Step 1:** Bump the plugin to 0.22.0 in all THREE places (pyproject
+  `version`, `uv lock` regeneration, `tests/test_package.py:9` pin).
+- [ ] **Step 2:** Docs sweep: the plugin/agent docs page that lists the
+  tools (grep `docs/` for `give_up`) documents the new argument and both
+  persistence surfaces. Root `CHANGELOG.md` entry under Unreleased
+  referencing #305 and plan 0047, following the sibling-entry convention.
+- [ ] **Step 3: gates green, commit.**

--- a/plans/0047-stop-tool-hindsight.md
+++ b/plans/0047-stop-tool-hindsight.md
@@ -145,7 +145,7 @@ pytest with the existing fake-client patterns in
 
 ## Task 2: policy stash and `trial_metadata` persistence
 
-- [ ] **Step 1: failing tests.** E2E, following the
+- [x] **Step 1: failing tests.** E2E, following the
   `test_goal_runs_to_done_and_config_lands_in_log` pattern and its
   attribute-style access (`logs[0].samples[0].trial_metadata[0]`): a
   scripted run whose `done` call carries `hindsight` produces a log where
@@ -167,7 +167,7 @@ pytest with the existing fake-client patterns in
   trial 2 loops the trailing move into budget exhaustion (budget is
   checked before each call at `policy.py:809`; `_calls_used` resets per
   trial at `policy.py:694`).
-- [ ] **Step 2: implement.** At the `policy.py:955` stop-chunk site, stash
+- [x] **Step 2: implement.** At the `policy.py:955` stop-chunk site, stash
   `chunk.actions[0].meta.get("stop_hindsight")` on the policy when
   `request_stop` is set. Clear the stash early in `reset()`
   (`policy.py:669`). In `on_trial_end`, write
@@ -175,7 +175,7 @@ pytest with the existing fake-client patterns in
   `on_trial_end` returns early when there is no transcript
   (`policy.py:717-719`); the hindsight write must happen BEFORE that early
   return, or a transcript-less trial silently drops it.
-- [ ] **Step 3: gates green, commit.**
+- [x] **Step 3: gates green, commit.**
 
 ## Task 3: system prompt announcement
 

--- a/plans/0047-stop-tool-hindsight.md
+++ b/plans/0047-stop-tool-hindsight.md
@@ -120,7 +120,7 @@ pytest with the existing fake-client patterns in
 
 ## Task 1: schema and `_stop` meta
 
-- [ ] **Step 1: failing tests.** In the toolset tests: (a) both stop tools'
+- [x] **Step 1: failing tests.** In the toolset tests: (a) both stop tools'
   schemas declare `hindsight` with `required == [<existing>, "hindsight"]`
   and a description that asks what the agent wishes it had known at the
   start; (b) `_stop` on a call carrying
@@ -129,7 +129,7 @@ pytest with the existing fake-client patterns in
   alongside the unchanged `request_stop`/`stop_reason`/`stop_detail`;
   (c) a call WITHOUT `hindsight` (and one with `hindsight: "  "`) still
   succeeds, meta has NO `stop_hindsight` key, and `note` is unchanged.
-- [ ] **Step 2: implement.** Add the parameter to both schemas. Description
+- [x] **Step 2: implement.** Add the parameter to both schemas. Description
   (same string for both, single source constant; categories calibrated
   against a real rollout's answer, see issue #305 comment): "What do you
   know now that you wish you had known at the start of this episode?
@@ -141,7 +141,7 @@ pytest with the existing fake-client patterns in
   `_stop`, read `arguments.get("hindsight")`; when it is a non-blank
   string, add `stop_hindsight` (stripped) to the meta. No validation
   error path.
-- [ ] **Step 3: gates green, commit.**
+- [x] **Step 3: gates green, commit.**
 
 ## Task 2: policy stash and `trial_metadata` persistence
 

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -146,7 +146,8 @@ channel. Both tools ask for a required `hindsight` argument: what the agent
 knows now that it wishes it had known at the start of the episode, as
 concrete transferable rig and task facts. The system prompt announces the
 question up front so the model tracks learnings during the rollout. The
-answer persists twice: as `stop_hindsight` in the stop action's meta, and as
+answer persists twice deliberately (the transcript naturally carries the tool
+call as well): as `stop_hindsight` in the stop action's meta, and as
 `trial_metadata["hindsight"]` in the JSON log next to `llm_usage`. Missing
 hindsight never fails execution (the budget-exhausted forced `give_up`
 cannot answer). Harvested hindsight is written to be usable as

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -142,7 +142,15 @@ For displacement modes, `move_by` splits the requested total so every action
 fits the box side in that direction. The action box is the embodiment author's
 per-step speed statement, so `max_speed_frac` does not apply to displacement
 modes. `done` and `give_up` end the trial through the core's policy-stop
-channel.
+channel. Both tools ask for a required `hindsight` argument: what the agent
+knows now that it wishes it had known at the start of the episode, as
+concrete transferable rig and task facts. The system prompt announces the
+question up front so the model tracks learnings during the rollout. The
+answer persists twice: as `stop_hindsight` in the stop action's meta, and as
+`trial_metadata["hindsight"]` in the JSON log next to `llm_usage`. Missing
+hindsight never fails execution (the budget-exhausted forced `give_up`
+cannot answer). Harvested hindsight is written to be usable as
+`prior_learnings` input on later runs, which closes the relearning loop.
 
 When `control_hz` is `None`, the plugin uses a 10 Hz fallback to compute step
 counts and the per-call playout cap, but leaves the emitted chunk rate unset.
@@ -271,7 +279,9 @@ stored frames remain complete and unchanged.
 Set `-P prior_learnings=path/to/learnings.md` to append a nonempty UTF-8 notes
 file to the system prompt after any embodiment notes. The file is read once
 when the policy is constructed, and its resolved path and content hash are
-recorded in the eval configuration.
+recorded in the eval configuration. The `hindsight` answers that `done` and
+`give_up` collect into `trial_metadata` are the natural source material for
+this file: harvest them across runs, distill, and feed them back here.
 Set `-P transcript_echo=true` to print live `[agent]` conversation lines to
 stderr, including goals, observation summaries, assistant output, tool calls,
 and tool results.

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.21.0"
+version = "0.22.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -39,6 +39,13 @@ _MAX_DURATION_S = 10.0
 _BACKSTOP_STEP_FRAC = 0.05
 _DEFAULT_SPEED_FRAC = 0.1
 _RELATIVE_HEADROOM = 1e-6
+_HINDSIGHT_DESCRIPTION = (
+    "What do you know now that you wish you had known at the start of this episode? "
+    "Concrete, transferable facts about this rig, task, or embodiment (camera mounting "
+    "and extrinsics, table and base geometry, gripper axis and offsets, controller "
+    "behavior, metric scale), written as advice to a future agent attempting the same "
+    "task. Say 'none' if nothing qualifies."
+)
 
 #: A motion hook over the exact clipped absolute waypoints for one move call.
 #:
@@ -197,8 +204,14 @@ class Toolset:
                 ),
                 "parameters": {
                     "type": "object",
-                    "properties": {"summary": {"type": "string"}},
-                    "required": ["summary"],
+                    "properties": {
+                        "summary": {"type": "string"},
+                        "hindsight": {
+                            "type": "string",
+                            "description": _HINDSIGHT_DESCRIPTION,
+                        },
+                    },
+                    "required": ["summary", "hindsight"],
                 },
             },
         }
@@ -209,8 +222,14 @@ class Toolset:
                 "description": "Stop trying; the task cannot be completed. The trial ends.",
                 "parameters": {
                     "type": "object",
-                    "properties": {"reason": {"type": "string"}},
-                    "required": ["reason"],
+                    "properties": {
+                        "reason": {"type": "string"},
+                        "hindsight": {
+                            "type": "string",
+                            "description": _HINDSIGHT_DESCRIPTION,
+                        },
+                    },
+                    "required": ["reason", "hindsight"],
                 },
             },
         }
@@ -307,9 +326,13 @@ class Toolset:
     def _stop(self, name: str, arguments: dict[str, Any], observation: Observation) -> ToolResult:
         data = self._current_state(observation)
         detail = str(arguments.get("summary") or arguments.get("reason") or "")
+        meta = {"request_stop": True, "stop_reason": name, "stop_detail": detail}
+        hindsight = arguments.get("hindsight")
+        if isinstance(hindsight, str) and hindsight.strip():
+            meta["stop_hindsight"] = hindsight.strip()
         action = Action(
             data=data,
-            meta={"request_stop": True, "stop_reason": name, "stop_detail": detail},
+            meta=meta,
         )
         return ToolResult(
             chunk=ActionChunk(actions=[action], control_hz=self._hz),

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -328,7 +328,9 @@ class Toolset:
         detail = str(arguments.get("summary") or arguments.get("reason") or "")
         meta = {"request_stop": True, "stop_reason": name, "stop_detail": detail}
         hindsight = arguments.get("hindsight")
-        if isinstance(hindsight, str) and hindsight.strip():
+        # The schema's "say 'none'" escape hatch must not pollute harvested
+        # metadata with literal sentinels.
+        if isinstance(hindsight, str) and hindsight.strip() and hindsight.strip().lower() != "none":
             meta["stop_hindsight"] = hindsight.strip()
         action = Action(
             data=data,

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -708,7 +708,7 @@ class LLMAgentPolicy(PolicyBase):
             self._capture.begin_trial(log_dir, run_id, f"{scene_id}-e{epoch}")
 
     def on_trial_end(self, record: TrialRecord, log_dir: str, run_id: str) -> None:
-        """Persist wire capture and the transcript at the end of the trial."""
+        """Persist wire capture, hindsight, usage, and the transcript at trial end."""
         if isinstance(self._client, GeminiLiveClient):
             # Trial finalization must stay successful even if a half-dead Live
             # transport violates close()'s own best-effort contract.

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -636,6 +636,7 @@ class LLMAgentPolicy(PolicyBase):
         self._embodiment_name = "(unbound)"
         self._embodiment_docs: str | None = None
         self._state_labels: tuple[str, tuple[str, ...]] | None = None
+        self._hindsight: str | None = None
         self._messages: list[dict[str, Any]] = []
         self._delta_cursor = 0
         self._calls_used = 0
@@ -668,6 +669,7 @@ class LLMAgentPolicy(PolicyBase):
 
     def reset(self, scene: Scene) -> None:
         """Start a fresh per-trial conversation with the scene goal and call budget."""
+        self._hindsight = None
         template = _ON_DEMAND_SYSTEM_TEMPLATE if self._images == "on_demand" else _SYSTEM_TEMPLATE
         formatted = template.format(name=self._embodiment_name, budget=self._max_llm_calls)
         if self._pre_check is not None:
@@ -713,6 +715,10 @@ class LLMAgentPolicy(PolicyBase):
             if capture_path is not None:
                 record.metadata["wire_capture"] = capture_path
             self._capture.warn_if_never_began()
+
+        hindsight = self._hindsight.strip() if isinstance(self._hindsight, str) else ""
+        if hindsight:
+            record.metadata["hindsight"] = hindsight
 
         messages = self.transcript()
         if not messages:
@@ -953,6 +959,8 @@ class LLMAgentPolicy(PolicyBase):
                                 chunk = result.chunk
                                 target = result.target
                                 stopped = bool(chunk.actions[0].meta.get("request_stop"))
+                                if stopped:
+                                    self._hindsight = chunk.actions[0].meta.get("stop_hindsight")
                                 closed = True
                 elif is_capture and chunk is not None and not stopped and self._pending is None:
                     # The closed-state exception validates only the capture

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -109,7 +109,9 @@ Safety approvers clamp out-of-bounds and too-fast actions below you. \
 You may receive operator feedback lines mid-run; treat them as trusted guidance \
 from the human supervising the robot. \
 Respond with exactly one tool call per turn. When the goal is achieved call \
-done; if it cannot be achieved call give_up. You have a budget of \
+done; if it cannot be achieved call give_up. Note what you are learning about \
+this rig and task as you go: done and give_up will ask what you wish you had \
+known from the start. You have a budget of \
 {budget} LLM calls for the whole trial."""
 
 _ON_DEMAND_SYSTEM_TEMPLATE = """You are controlling a real robot embodiment named {name!r} \
@@ -130,7 +132,9 @@ in the same turn. Placed after a motion, its frames arrive with the next \
 observation, after the controller has played the motion; the narration reports \
 how much actually played. Placed alone, it looks before you decide what motion \
 to make. When the goal is achieved call done; if it cannot be achieved call \
-give_up. You have a budget of {budget} LLM calls for the whole trial."""
+give_up. Note what you are learning about this rig and task as you go: done and \
+give_up will ask what you wish you had known from the start. You have a budget \
+of {budget} LLM calls for the whole trial."""
 
 _PRE_CHECK_PROMPT_CLAUSE = (
     " A motion pre-check may reject a move with a stated reason. Adjust the target "

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,7 +6,7 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.21.0"
+    assert inspect_robots_agent.__version__ == "0.22.0"
     assert callable(inspect_robots_agent.agent_policy)
     assert inspect_robots_agent.__all__ == [
         "ENV_MODEL",

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -410,6 +410,64 @@ def test_goal_runs_to_done_and_config_lands_in_log(tmp_path: Path) -> None:
     assert "data:" not in serialized
 
 
+def test_done_hindsight_lands_in_trial_metadata(tmp_path: Path) -> None:
+    hindsight = "the overhead camera swaps the apparent left and right axes"
+    script = _Script([_tool_response("done", {"summary": "cube reached", "hindsight": hindsight})])
+
+    logs = ir_eval(
+        _task(),
+        _policy(script),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+    )
+
+    assert logs[0].samples[0].trial_metadata[0]["hindsight"] == hindsight
+
+
+def test_forced_give_up_omits_hindsight_from_trial_metadata(tmp_path: Path) -> None:
+    script = _Script([_tool_response("move_by", {"deltas": {"dx": 0.01}})])
+
+    logs = ir_eval(
+        _task(),
+        _policy(script, max_llm_calls=1),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+    )
+
+    metadata = logs[0].samples[0].trial_metadata[0]
+    assert "hindsight" not in metadata
+
+
+def test_hindsight_is_reset_before_a_later_forced_give_up(tmp_path: Path) -> None:
+    hindsight = "the gripper closes along the camera's vertical axis"
+    move = _tool_response("move_by", {"deltas": {"dx": 0.01}})
+    script = _Script(
+        [
+            move,
+            _tool_response("done", {"summary": "cube reached", "hindsight": hindsight}),
+            move,
+        ]
+    )
+    task = Task(
+        name="two-trial-hindsight-reset",
+        scenes=[Scene(id="s0", instruction="reach the cube", init_seed=0)],
+        scorer=success_at_end(),
+        max_steps=40,
+        epochs=2,
+    )
+
+    logs = ir_eval(
+        task,
+        _policy(script, max_llm_calls=2),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+    )
+
+    first, second = logs[0].samples[0].trial_metadata
+    assert first["hindsight"] == hindsight
+    assert "hindsight" not in second
+
+
 @pytest.mark.parametrize("wire", ["chat", "responses", "messages"])
 def test_wire_capture_matches_each_transport_body_after_blob_inlining(
     wire: str, tmp_path: Path

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -436,6 +436,24 @@ def test_forced_give_up_omits_hindsight_from_trial_metadata(tmp_path: Path) -> N
 
     metadata = logs[0].samples[0].trial_metadata[0]
     assert "hindsight" not in metadata
+    # Pin that the trial really ended via the forced give_up, not max_steps:
+    # a give_up termination with the whole budget consumed cannot be a real
+    # give_up because the script contains no stop response.
+    assert logs[0].samples[0].termination_reasons == ("give_up",)
+    assert metadata["llm_usage"]["llm_calls"] == 1
+
+
+def test_none_sentinel_hindsight_is_not_persisted(tmp_path: Path) -> None:
+    script = _Script([_tool_response("done", {"summary": "cube reached", "hindsight": "None"})])
+
+    logs = ir_eval(
+        _task(),
+        _policy(script),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+    )
+
+    assert "hindsight" not in logs[0].samples[0].trial_metadata[0]
 
 
 def test_hindsight_is_reset_before_a_later_forced_give_up(tmp_path: Path) -> None:
@@ -466,6 +484,10 @@ def test_hindsight_is_reset_before_a_later_forced_give_up(tmp_path: Path) -> Non
     first, second = logs[0].samples[0].trial_metadata
     assert first["hindsight"] == hindsight
     assert "hindsight" not in second
+    # Trial 2 must have ended via the forced give_up (budget consumed on
+    # replayed moves; the script's trailing response is not a stop).
+    assert logs[0].samples[0].termination_reasons == ("done", "give_up")
+    assert second["llm_usage"]["llm_calls"] == 2
 
 
 @pytest.mark.parametrize("wire", ["chat", "responses", "messages"])

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -748,6 +748,17 @@ def test_system_prompts_treat_operator_feedback_as_trusted_guidance(template: st
     assert expected in template
 
 
+@pytest.mark.parametrize("template", [_SYSTEM_TEMPLATE, _ON_DEMAND_SYSTEM_TEMPLATE])
+def test_system_prompts_announce_the_hindsight_question(template: str) -> None:
+    rendered = template.format(name="test-robot", budget=10)
+    announcement = (
+        "Note what you are learning about this rig and task as you go: done and give_up will ask "
+        "what you wish you had known from the start."
+    )
+
+    assert announcement in rendered
+
+
 def test_reset_before_bind_uses_the_unchanged_unbound_prompt() -> None:
     policy = _policy(_Script([_text_response("unused")]))
     policy.reset(Scene(id="s0", instruction="reach"))

--- a/plugins/inspect-robots-agent/tests/test_tools_motion.py
+++ b/plugins/inspect-robots-agent/tests/test_tools_motion.py
@@ -577,8 +577,8 @@ def test_schemas_match_control_mode_and_remove_duration() -> None:
     absolute_parameters = [schema["function"]["parameters"] for schema in absolute.schemas()]
     assert [parameters["required"] for parameters in absolute_parameters] == [
         ["targets", "note"],
-        ["summary"],
-        ["reason"],
+        ["summary", "hindsight"],
+        ["reason", "hindsight"],
     ]
     assert absolute_parameters[0]["properties"]["note"] == {
         "type": "string",
@@ -600,10 +600,29 @@ def test_schemas_match_control_mode_and_remove_duration() -> None:
     ]
     assert [parameters["required"] for parameters in displacement_parameters] == [
         ["deltas", "note"],
-        ["summary"],
-        ["reason"],
+        ["summary", "hindsight"],
+        ["reason", "hindsight"],
     ]
     assert displacement_parameters[0]["properties"]["note"]["type"] == "string"
+
+
+def test_stop_schemas_describe_required_hindsight() -> None:
+    toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+    expected_description = (
+        "What do you know now that you wish you had known at the start of this episode? "
+        "Concrete, transferable facts about this rig, task, or embodiment (camera mounting "
+        "and extrinsics, table and base geometry, gripper axis and offsets, controller "
+        "behavior, metric scale), written as advice to a future agent attempting the same "
+        "task. Say 'none' if nothing qualifies."
+    )
+
+    for schema, detail_key in zip(toolset.schemas()[1:], ("summary", "reason"), strict=True):
+        parameters = schema["function"]["parameters"]
+        assert parameters["required"] == [detail_key, "hindsight"]
+        assert parameters["properties"]["hindsight"] == {
+            "type": "string",
+            "description": expected_description,
+        }
 
 
 def test_take_pic_schema_is_exposed_only_on_demand() -> None:
@@ -1173,6 +1192,43 @@ def test_done_and_give_up_emit_control_mode_hold() -> None:
     assert result.chunk is not None
     assert np.array_equal(result.chunk.actions[0].data, np.zeros(2))
     assert result.chunk.actions[0].meta["stop_reason"] == "give_up"
+
+
+def test_done_carries_hindsight_in_stop_meta() -> None:
+    toolset = build_toolset(_absolute_space(), _absolute_obs_space(), control_hz=10.0)
+    hindsight = "the jar lid needs two approach angles"
+
+    result = toolset.execute(
+        _call("done", summary="jar opened", hindsight=hindsight),
+        _obs(),
+    )
+
+    assert result.error is None and result.chunk is not None
+    (action,) = result.chunk.actions
+    assert action.meta == {
+        "request_stop": True,
+        "stop_reason": "done",
+        "stop_detail": "jar opened",
+        "stop_hindsight": hindsight,
+    }
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [{"reason": "cannot see"}, {"reason": "cannot see", "hindsight": "  "}],
+)
+def test_give_up_accepts_absent_or_blank_hindsight(arguments: dict[str, object]) -> None:
+    toolset = build_toolset(_delta_space(), ObservationSpace(), control_hz=10.0)
+
+    result = toolset.execute(_call("give_up", **arguments), _obs({}))
+
+    assert result.error is None and result.chunk is not None
+    assert result.chunk.actions[0].meta == {
+        "request_stop": True,
+        "stop_reason": "give_up",
+        "stop_detail": "cannot see",
+    }
+    assert result.note == "give_up: cannot see"
 
 
 def test_tool_errors_are_messages_not_exceptions() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.21.0"
+version = "0.22.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #305.

Plan: plans/0047-stop-tool-hindsight.md (critique gate pending; implementation follows).

Agents relearn the same rig facts every rollout. The stop tools gain a schema-required (execution-lenient) `hindsight` argument, the system prompt announces the question up front, and the answer persists as `stop_hindsight` action meta plus `trial_metadata["hindsight"]` in the JSON log. Collection half only; feeding it forward is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)