### PR TITLE
core: operator footer — fixed status line and owned input line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ All notable changes to this project are documented here. The format is based on
   and stand down their own terminal I/O for that run
   ([plan 0048](plans/0048-operator-session.md), #308).
 
+- Attended runs with a real POSIX TTY now render operator feedback in a fixed
+  two-row footer, with an in-place status line above a session-owned input line.
+  Sent feedback moves into scrollback, while off-TTY and Windows rendering stays
+  unchanged ([plan 0048](plans/0048-operator-session.md),
+  [plan 0051](plans/0051-operator-footer.md), #308).
+
 - CLI `run` and `eval-set` now take per-user advisory claims for declared
   device slots before hardware construction, reject concurrent evals aimed at
   the same rig, and release claims during embodiment teardown

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -155,6 +155,23 @@ plus an optional note ends it and records the verdict immediately, without a
 second post-trial prompt. Feedback is saved per trial and appears in summaries
 and HTML reports. Piped stdin and `--no-prompt` disable the channel.
 
+On an attended run with the console enabled and a real POSIX TTY, the session
+renders a two-row footer. The timer and controls repaint in place above a stable
+`> ` line that the session owns, so ticker updates never tear the operator's
+typing:
+
+```text
+  [sent] you might wanna move the right arm out of the way
+  t = 61s / 120s | Enter ends the episode
+  > is there anything I can hand you█
+```
+
+After Enter, feedback moves into scrollback as `[sent] ...`. End-only rows use
+`[noted] ...`. Keystroke echo is pumped at the rollout poll cadence, so on a
+self-paced robot it can lag up to one control step. Third-party prints can
+smudge one frame; the next repaint heals it. Off-TTY, Windows, and piped-stdin
+rendering is unchanged.
+
 Install `inspect-robots-voice` and pass `--voice` to add local microphone
 transcription to an attended run. Repeat `-V key=value` for voice settings such
 as the model, microphone device, language, and compute type. Voice input is

--- a/plans/0049-operator-footer.md
+++ b/plans/0049-operator-footer.md
@@ -100,7 +100,13 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    attrs so the atexit fallback can never replay a stale saved state over a later
    trial's raw window. `KeyboardInterrupt` is converted by `rollout()` to its
    cancelled-trial path and re-raised **through** the same `finally`
-   (rollout.py:458-463), so Ctrl-C restores too.
+   (rollout.py:458-463), so Ctrl-C restores too. Guard scope: `end_trial()` runs
+   whenever `operator_input is not None` and the hook exists — it does NOT check
+   `console_ok`. Only the catch-warn part mirrors poll's discipline, not its guard: a
+   footer-mode `poll()` that raises (the pump is the likeliest raiser) flips
+   `console_ok` False, and skipping restore on that flag would leave the verdict
+   prompt running in cbreak with echo off — the exact scenario the teardown exists
+   for.
 2. **Footer mode gates on: console channel enabled AND `sys.stdin.isatty()` AND
    termios importable AND raw-mode entry succeeded.** Any failure (non-tty, Windows,
    exotic terminal, `termios.error`) falls back to plain mode silently at
@@ -170,11 +176,18 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    completes lines only on `"\n" in buffer`, so a line handed over without its
    newline would sit unparsed until the next Enter; `""` returns only on real EOF,
    preserving the console's EOF contract); in plain mode the same closures delegate
-   straight to the fd defaults. The fd defaults are `console.py`'s existing module-private
-   `_stdin_readable`/`_stdin_read` (imported — same package), injectable on the
-   session as `fd_readable`/`fd_read` seams, so the session adds **no new
-   pragma-no-cover fd lines** (amending decision 8: uncovered lines are the termios
-   syscalls plus nothing new). This keeps `OperatorConsole` byte-for-byte untouched:
+   to the fd seams. Seam types: `fd_readable: () -> bool` defaults to `console.py`'s
+   existing pragma'd module-private `_stdin_readable` (imported — same package);
+   `fd_read: () -> bytes` is **bytes-typed** so the editor can buffer raw bytes
+   across split UTF-8 sequences (decision 4) — its default is a new one-line
+   module-private helper `_stdin_read_bytes()` returning
+   `os.read(sys.stdin.fileno(), 65536)` (pragma'd body; the one new fd pragma line,
+   see decision 8). Console.py's str-typed `_stdin_read` cannot be the default: it
+   decodes per chunk, destroying split sequences before the editor sees them. The
+   plain-mode dispatching `read` closure decodes each chunk itself with
+   `decode("utf-8", errors="replace")` — the same str per chunk that the console's
+   own default produces today, and pure covered logic over the injected `fd_read`.
+   This keeps `OperatorConsole` byte-for-byte untouched:
    the fd-desync rationale of plan 0042 decision 9 targets the buffered
    TextIOWrapper, which this pump is not. Footer-mode `session.begin_trial()`:
    drain the fd raw with **no echo** (stale pre-trial bytes must not paint into a
@@ -188,10 +201,11 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
 8. **Raw-mode syscalls are the only NEW uncovered lines.** `_enter_cbreak()` /
    `_restore()` module-private helpers own `termios.tcgetattr`/`tcsetattr`
    (`# pragma: no cover` bodies, lazy `import termios`), injectable as
-   `raw_mode_fn`-style seams on the session for tests. The session's fd access
-   reuses `console.py`'s already-pragma'd module-private `_stdin_readable` /
-   `_stdin_read` as the defaults behind its `fd_readable`/`fd_read` seams
-   (decision 7) — no new fd pragma lines in session.py. The editor, renderer,
+   `raw_mode_fn`-style seams on the session for tests. The session's fd access:
+   `fd_readable` reuses `console.py`'s already-pragma'd module-private
+   `_stdin_readable`; `fd_read` defaults to the new bytes-typed
+   `_stdin_read_bytes()` (decision 7), whose one-line body is the only new fd
+   pragma line — decoding lives in covered closure code. The editor, renderer,
    dispatching closures, `end_trial` paths, and mode fallback are all pure logic
    over injected callables — fully covered.
 
@@ -228,7 +242,7 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
 ### Task 2: raw-mode window — `begin_trial()`/`end_trial()` + rollout hook
 
 **Files:** `src/inspect_robots/session.py`, `src/inspect_robots/rollout.py`,
-`tests/test_session.py`, `tests/test_rollout_hardening.py`
+`tests/test_session.py`, `tests/test_rollout_observation_step.py`
 
 - [ ] **Step 1: failing tests.** Session: footer entered only when enabled+tty+raw-ok
   AND the console is session-built (caller-injected `console=...` → documented no-op);
@@ -240,7 +254,10 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
   KeyboardInterrupt cancelled-trial path; skipped without error when the hook is
   absent (plain `OperatorConsole`); a raising `end_trial` warns and never masks the
   trial's own outcome (mirror the `poll()` degrade tests in
-  `tests/test_rollout_observation_step.py`).
+  `tests/test_rollout_observation_step.py`); `end_trial` still called after a
+  raising `poll()` flipped `console_ok` False mid-trial (decision 1 guard scope);
+  `end_trial()` on a session that never entered footer mode writes zero bytes and
+  does not touch `_status_open` (plain-mode byte-identity backstop).
 - [ ] **Step 2-4: fail → implement → green.**
 
 ### Task 3: CLI opt-in + `[sent]` confirmations

--- a/plans/0049-operator-footer.md
+++ b/plans/0049-operator-footer.md
@@ -56,14 +56,15 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
 
 ## Reference: current wiring (main @ 6c022ead)
 
-- `src/inspect_robots/session.py` — the whole module (162 lines): `_flush_stdin_fd`,
+- `src/inspect_robots/session.py` — the whole module (172 lines): `_flush_stdin_fd`,
   `OperatorSession.__init__` seams (`console`, `input_fn`, `write`, `flush_fn`),
   `_write`/`_input` late-binding, `poll`/`begin_trial` delegation, `status`/`write_line`
   state machine (`_status_open`, `_status_line`), `gate`, verdict prompts.
 - `src/inspect_robots/console.py` — `OperatorConsole(readable, read, output_fn)`;
-  `poll()` assembles lines from chunks (`:90-113`); `begin_trial()` drains (`:115-124`).
-  The console's default `read` is fd-level `os.read` (`:55-56`); the session currently
-  builds its default console with only `output_fn=self.write_line`.
+  `poll()` assembles lines from chunks (`:94-117`); `begin_trial()` drains (`:119-129`).
+  `_stdin_readable` is at `:55-56`; the console's default `read` is the str-typed
+  fd-level `_stdin_read` (`:59-60`); the session currently builds its default
+  console with only `output_fn=self.write_line`.
 - `src/inspect_robots/rollout.py:276-285` — `operator_input.begin_trial()` inside a
   try/except that disables the channel on failure; `:291-301` — the per-iteration poll
   with the same degrade discipline; `:458-463` — KeyboardInterrupt conversion
@@ -133,12 +134,24 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    the line, `\n`/`\r` completes it (echoing `\r` as line completion matches
    raw-mode Enter), everything else non-printable is ignored. Ignoring `\x1b` alone
    is not enough: in cbreak an arrow key arrives as `\x1b [ A` whose tail bytes are
-   printable and would append as literal `[A` junk — so on `\x1b[` discard bytes
-   until the CSI final byte (`0x40`–`0x7E`), and on a bare `\x1b` discard the next
-   byte. Multi-byte UTF-8 arrives whole from `os.read` chunks in
-   practice, but the editor must tolerate split sequences: buffer bytes, decode with
-   `errors="replace"` only at display time, and hand the console the raw completed
-   line so message content is preserved exactly as today. Paste works because chunk
+   printable and would append as literal `[A` junk — so on `\x1b` followed by `[`
+   or `O` (CSI **and SS3**: xterm-family terminals send F1–F4 as `\x1bOP`…`\x1bOS`,
+   and arrows arrive as `\x1bOA`…`\x1bOD` whenever application-cursor mode is left
+   set) discard bytes until the final byte (`0x40`–`0x7E`); on any other bare
+   `\x1b` discard the next byte. The discard state is editor state persisting
+   across `fd_read` chunks AND across polls: the pump can land a read between
+   `\x1b[` and its final byte (select goes quiet mid-sequence), the tail arriving a
+   whole control period later — a chunk-local scan would append the stray final
+   byte, the same desync split UTF-8 gets below. Multi-byte UTF-8 arrives whole
+   from `os.read` chunks in
+   practice, but the editor must tolerate split sequences: buffer bytes, decode
+   with `errors="replace"` at display time for the echo, and decode each completed
+   line **once** with `errors="replace"` at queue handoff — the console's `read`
+   seam is str-typed (`read: Callable[[], str]`, console.py:86), so bytes cannot
+   pass through it, and a strict decode there would turn malformed paste bytes into
+   a raising `poll()` that kills the channel; decoding only complete lines
+   preserves content exactly where today's per-64KiB-chunk decode could not. Paste
+   works because chunk
    processing is loop-per-byte over arbitrarily large reads. No history, no arrow
    keys, no cursor movement (YAGNI; the plan-0048 arc can add them later if operators
    ask).
@@ -235,9 +248,11 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
 - [ ] **Step 1: failing tests.** Editor + pump (decision 7): scripted `fd_readable`/
   `fd_read` sequences drive `poll()` — append/backspace/Ctrl-U/Enter incl. split
   UTF-8 and 64KiB paste; backspace after a multi-byte character removes the whole
-  character (buffer and echo both clean); arrow-key/Delete escape sequences
-  (`\x1b[A`, `\x1b[3~`, bare `\x1b` + byte) are swallowed whole — no junk in the
-  buffer or the echo; bytes without a newline echo but deliver nothing; the
+  character (buffer and echo both clean); arrow-key/Delete/F-key escape sequences
+  (`\x1b[A`, `\x1b[3~`, SS3 `\x1bOP`, bare `\x1b` + byte) are swallowed whole — no
+  junk in the buffer or the echo — including an escape sequence split across two
+  `fd_read` chunks and across two `poll()` calls (discard state persists); bytes
+  without a newline echo but deliver nothing; the
   completed line reaches the console parser verbatim on the same `poll()`; the
   dispatching `readable`/`read` closures satisfy the console's EOF contract (`""`
   only on real EOF); footer `begin_trial()` discards stale fd bytes with no echo and

--- a/plans/0049-operator-footer.md
+++ b/plans/0049-operator-footer.md
@@ -74,8 +74,9 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
   footer activates only on rows where the console turns on; the helper tells the
   session (see decision 3).
 - Tests: `tests/test_session.py` (exact-byte rendering tests to extend),
-  `tests/test_rollout_hardening.py` (channel-degrade discipline to mirror for
-  `end_trial`), `tests/test_registry_cli.py` (matrix rows unchanged).
+  `tests/test_rollout_observation_step.py` (the poll/begin_trial channel-degrade
+  tests to mirror for `end_trial`; the new rollout `end_trial` tests can live
+  beside them), `tests/test_registry_cli.py` (matrix rows unchanged).
 
 ## Design decisions (and why)
 
@@ -146,11 +147,13 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    plugin-driven close leaves a clean terminal; `end_trial()` does the same teardown
    idempotently as the backstop (decision 1); plain mode keeps its existing
    close-with-newline semantics.
-6. **`[sent]` confirmations come from `poll()`, not from the editor.** The editor
+6. **Confirmations come from `poll()`, not from the editor.** The editor
    cannot know whether a completed line is feedback, an end request, a verdict, or a
    usage typo — the console's parser decides. Footer-mode `poll()` delegates, then
    for each message in the returned `ConsolePoll.messages` writes
-   `write_line(f"[sent] {text}")`. End requests and verdict lines print nothing (the
+   `write_line(f"[{label}] {text}")` where `label` is the CLI-chosen decision-3(b)
+   value (`sent` on feedback rows, `noted` on end-only rows — do not hardcode
+   `sent`). End requests and verdict lines print nothing (the
    episode visibly ends); usage hints already arrive via the console's `output_fn`,
    which is `write_line`. The confirmation therefore appears at the next rollout
    poll, at most one control period after Enter — imperceptible.
@@ -163,9 +166,11 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    editor (echoing per decision 5), and append each completed raw line to a queue;
    then call `console.poll()`, whose session-provided seams are dispatching
    closures — `readable` returns "queue non-empty or real EOF seen", `read` pops
-   queued lines joined with `"\n"` (`""` only on real EOF, preserving the console's
-   EOF contract); in plain mode the same closures delegate straight to the fd
-   defaults. The fd defaults are `console.py`'s existing module-private
+   the queued lines concatenated **each with its terminating `"\n"`** (the console
+   completes lines only on `"\n" in buffer`, so a line handed over without its
+   newline would sit unparsed until the next Enter; `""` returns only on real EOF,
+   preserving the console's EOF contract); in plain mode the same closures delegate
+   straight to the fd defaults. The fd defaults are `console.py`'s existing module-private
    `_stdin_readable`/`_stdin_read` (imported — same package), injectable on the
    session as `fd_readable`/`fd_read` seams, so the session adds **no new
    pragma-no-cover fd lines** (amending decision 8: uncovered lines are the termios

--- a/plans/0049-operator-footer.md
+++ b/plans/0049-operator-footer.md
@@ -1,0 +1,204 @@
+# Operator footer: fixed status line and an owned input line Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** PR 3 of the plan-0048 arc (#308). On attended runs with the console enabled and
+a real TTY, `OperatorSession` renders a fixed two-line footer: a status line that rewrites
+in place and never moves, and a `> ` input line the session itself echoes into. Typing is
+never torn by ticker repaints, sent feedback is confirmed in scrollback, and the timer
+stays put:
+
+```
+  [sent] you might wanna move the right arm out of the way
+  t = 61s / 120s | Enter ends the episode
+  > is there anything I can hand you█
+```
+
+Off-TTY, on Windows, when the console channel is off, or when termios is unavailable,
+rendering stays exactly as today (plain in-place status line, tty-driver echo).
+
+**Architecture:** Footer mode lives entirely inside `session.py` plus one small,
+optional rollout hook. The session takes terminal ownership per trial: a new duck-typed
+`end_trial()` on operator input (called best-effort by `rollout()` in the same `finally`
+that already exists for trial teardown) pairs with `begin_trial()` so the session can
+enter cbreak-with-echo-off on trial start and always restore termios on trial end,
+Ctrl-C included (`ISIG` stays on; an `atexit` fallback catches process death). While in
+footer mode the session wraps the composed console's `read` seam with a line editor:
+raw chunks are edited (printable append, backspace, Ctrl-U) and echoed into the input
+line by the session, and the console receives only completed lines, so its parser and
+`begin_trial()` drain discipline are untouched. `status(line)` repaints the status line
+above the input line; `write_line(text)` inserts scrollback above both and repaints;
+`poll()` delegates then prints one `[sent] <text>` confirmation per returned feedback
+message. Everything is injectable; the only `# pragma: no cover` lines are the genuine
+termios/tty syscalls, isolated in module-private raw-mode helpers.
+
+**Tech Stack:** Python 3.10+, stdlib only (`termios` is POSIX-stdlib; imported lazily
+inside the helpers so core imports stay clean on Windows); pytest; no new deps.
+
+## Global Constraints
+
+- Gates (all blocking): `uv run ruff check .`, `uv run ruff format --check .`,
+  `uv run mypy` (strict, src + tests), `uv run pytest --cov -q` at **100% coverage**.
+- D1 docstrings state contracts. Line length 100. Core stays numpy+stdlib.
+- Zero behavior change off the footer path: plain mode must be byte-identical to
+  today's `session.py` rendering, and unattended/no-console runs never touch termios.
+- Public API: no new exports expected (`OperatorSession` is already public; `end_trial`
+  is a duck-typed method on it). If anything public is added, update
+  `inspect_robots.__all__` and `tests/test_api_snapshot.py` together.
+- Update `src/inspect_robots/CLAUDE.md` rows (`session.py`, `rollout.py`), CHANGELOG
+  under Unreleased, and the docs operator pages (`docs/guide/cli.md` live-feedback
+  section gains a short footer description). Writing-style rules for prose.
+- Worktree: `.claude/worktrees/operator-footer`. Reference #308 in commits; end with
+  the `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` trailer. **No git
+  operations from Codex.**
+- Before merge: re-check `git ls-tree origin/main plans/` for a 0049 collision and
+  renumber if a concurrent session took it.
+
+## Reference: current wiring (main @ 6c022ead)
+
+- `src/inspect_robots/session.py` — the whole module (162 lines): `_flush_stdin_fd`,
+  `OperatorSession.__init__` seams (`console`, `input_fn`, `write`, `flush_fn`),
+  `_write`/`_input` late-binding, `poll`/`begin_trial` delegation, `status`/`write_line`
+  state machine (`_status_open`, `_status_line`), `gate`, verdict prompts.
+- `src/inspect_robots/console.py` — `OperatorConsole(readable, read, output_fn)`;
+  `poll()` assembles lines from chunks (`:90-113`); `begin_trial()` drains (`:115-124`).
+  The console's default `read` is fd-level `os.read` (`:55-56`); the session currently
+  builds its default console with only `output_fn=self.write_line`.
+- `src/inspect_robots/rollout.py:276-283` — `operator_input.begin_trial()` inside a
+  try/except that disables the channel on failure; `:288-306` — the per-iteration poll
+  with the same degrade discipline; the trial's `finally` teardown block (find with
+  `grep -n "finally" src/inspect_robots/rollout.py`) is where `end_trial()` goes.
+- `src/inspect_robots/cli.py` — `_build_operator_session` (decision-9 ladder): the
+  footer activates only on rows where the console turns on; the helper tells the
+  session (see decision 3).
+- Tests: `tests/test_session.py` (exact-byte rendering tests to extend),
+  `tests/test_rollout_hardening.py` (channel-degrade discipline to mirror for
+  `end_trial`), `tests/test_registry_cli.py` (matrix rows unchanged).
+
+## Design decisions (and why)
+
+1. **Per-trial raw-mode window via `begin_trial()`/`end_trial()`.** Terminal mode must
+   be canonical between trials: the verdict prompts (`input()`), the yam gates, and
+   any embodiment homing output run there. `begin_trial()` already exists on the
+   `OperatorInput` protocol; `end_trial()` joins as a **duck-typed optional** method
+   (same pattern as every other optional hook) so third-party `OperatorInput`
+   implementations stay conformant. `rollout()` calls it best-effort in the trial's
+   `finally`: wrapped in the same catch-warn-disable discipline as `poll()`, and it
+   must run even when the trial raised (`EmbodimentFault` mid-trial must not leave the
+   user's terminal in raw mode). Restore is idempotent and additionally registered
+   with `atexit` once per session as a crash net; `KeyboardInterrupt` unwinds through
+   the `finally` like any exception.
+2. **Footer mode gates on: console channel enabled AND `sys.stdin.isatty()` AND
+   termios importable AND raw-mode entry succeeded.** Any failure (non-tty, Windows,
+   exotic terminal, `termios.error`) falls back to plain mode silently at
+   `begin_trial()` time — plain mode is today's behavior, which is always safe. The
+   mode is re-decided each trial (a TTY cannot appear mid-run, but a failed entry
+   must not poison later trials).
+3. **The CLI opts the session into footer mode explicitly** (`session.enable_footer()`
+   or a constructor flag set inside `_build_operator_session` exactly where the
+   console turns on — implementer's choice, but it must be the CLI's decision, not
+   ambient sniffing inside `poll()`): direct API users of `OperatorSession` (yam
+   routes `status()` through it on connected runs) get footer behavior only when the
+   run actually has the interjection console, which only the CLI knows.
+4. **Line editing is deliberately minimal:** printable characters append, backspace
+   (`\x7f`/`\x08`) deletes one, Ctrl-U kills the line, `\n`/`\r` completes it
+   (echoing `\r` as line completion matches raw-mode Enter), everything else
+   non-printable is ignored. Multi-byte UTF-8 arrives whole from `os.read` chunks in
+   practice, but the editor must tolerate split sequences: buffer bytes, decode with
+   `errors="replace"` only at display time, and hand the console the raw completed
+   line so message content is preserved exactly as today. Paste works because chunk
+   processing is loop-per-byte over arbitrarily large reads. No history, no arrow
+   keys, no cursor movement (YAGNI; the plan-0048 arc can add them later if operators
+   ask).
+5. **Rendering model: the cursor lives at the end of the input line.** All updates
+   are relative two-line repaints using `\r` and ANSI `\x1b[A` (cursor up) /
+   `\x1b[K` (clear to end): status update = save input, move up, clear, write status,
+   move down, rewrite input; scrollback insert = move up, clear, write text + newline,
+   write status + newline, rewrite input. Repaints always clear before writing, which
+   also self-heals after any stray third-party print (one smudged frame, then clean).
+   The input display clips to `terminal width - 4` showing the tail (injectable
+   `width_fn` defaulting to `shutil.get_terminal_size().columns`). In footer mode
+   `status(None)` tears down both lines (clear input line, clear status line) so the
+   trial ends with a clean terminal for the verdict prompt; plain mode keeps its
+   existing close-with-newline semantics.
+6. **`[sent]` confirmations come from `poll()`, not from the editor.** The editor
+   cannot know whether a completed line is feedback, an end request, a verdict, or a
+   usage typo — the console's parser decides. Footer-mode `poll()` delegates, then
+   for each message in the returned `ConsolePoll.messages` writes
+   `write_line(f"[sent] {text}")`. End requests and verdict lines print nothing (the
+   episode visibly ends); usage hints already arrive via the console's `output_fn`,
+   which is `write_line`. The confirmation therefore appears at the next rollout
+   poll, at most one control period after Enter — imperceptible.
+7. **The console keeps line assembly; the editor feeds it completed lines.** The
+   session wraps the `readable`/`read` seams it passes to its default
+   `OperatorConsole`: footer-mode `read` drains the real fd (`os.read`), runs bytes
+   through the editor (echoing per decision 5), and returns only the completed lines
+   (`"line\n"` joined) — an empty string return means EOF exactly as today, and "no
+   completed lines yet" returns `""`? No: `""` signals EOF to the console. The
+   wrapper must instead report `readable() == False` until a completed line exists —
+   i.e. the session buffers keystrokes itself and its wrapped `readable` returns
+   True only when completed lines are queued (or real EOF was seen). This keeps
+   `OperatorConsole` byte-for-byte untouched: its fd-desync rationale (plan 0042
+   decision 9) doesn't apply because the wrapper is not the buffered TextIOWrapper —
+   it drains the fd fully on every rollout poll. `begin_trial()` clears the editor
+   buffer, queued lines, and the composed console's buffer (existing behavior).
+8. **Raw-mode syscalls are the only uncovered lines.** `_enter_cbreak()` /
+   `_restore()` module-private helpers own `termios.tcgetattr`/`tcsetattr`
+   (`# pragma: no cover` bodies, lazy `import termios`), injectable as
+   `raw_mode_fn`-style seams on the session for tests. The editor, renderer, wrapped
+   seams, `end_trial` paths, and mode fallback are all pure logic over injected
+   callables — fully covered.
+
+## Behavior notes (document in CHANGELOG/docs, not code comments)
+
+- Operators see their typing on a stable `> ` line; the timer above never tears.
+- Feedback confirms as `[sent] …` scrollback; Enter still ends; `/y /n /p` still
+  verdict; typos still print the usage hint — all above the footer.
+- Off-TTY/Windows/piped stdin: unchanged.
+- Third-party prints (driver chatter) can smudge one frame; the next repaint heals it.
+
+---
+
+### Task 1: line editor + footer renderer (pure logic)
+
+**Files:** `src/inspect_robots/session.py`, `tests/test_session.py`
+
+- [ ] **Step 1: failing tests.** Editor: append/backspace/Ctrl-U/Enter over scripted
+  chunk sequences incl. split UTF-8 and 64KiB paste; queued-lines `readable` protocol
+  (False until a line completes; True after; EOF passthrough). Renderer: exact byte
+  sequences for status update, write_line insert, input echo, teardown on
+  `status(None)`, tail-clipping at injected width. Plain-mode tests untouched.
+- [ ] **Step 2-4: fail → implement → green.**
+
+### Task 2: raw-mode window — `begin_trial()`/`end_trial()` + rollout hook
+
+**Files:** `src/inspect_robots/session.py`, `src/inspect_robots/rollout.py`,
+`tests/test_session.py`, `tests/test_rollout_hardening.py`
+
+- [ ] **Step 1: failing tests.** Session: footer entered only when enabled+tty+raw-ok
+  (each gate falsified via injected seams); failed entry → plain mode this trial and
+  the next trial retries; `end_trial()` restores exactly once (idempotent);
+  restore-on-exception. Rollout: `end_trial` called in `finally` on success, on
+  trial-ending exceptions, and skipped without error when the hook is absent
+  (plain `OperatorConsole`); a raising `end_trial` warns and never masks the trial's
+  own outcome (mirror the `poll()` degrade tests).
+- [ ] **Step 2-4: fail → implement → green.**
+
+### Task 3: CLI opt-in + `[sent]` confirmations
+
+**Files:** `src/inspect_robots/cli.py`, `src/inspect_robots/session.py`,
+`tests/test_registry_cli.py`, `tests/test_session.py`
+
+- [ ] **Step 1: failing tests.** Footer enabled on exactly the decision-9 rows where
+  the console turns on (both new-hook and legacy ladders), never otherwise; footer
+  `poll()` emits one `[sent]` per feedback message, nothing for ends/verdicts; matrix
+  outputs otherwise unchanged.
+- [ ] **Step 2-4: fail → implement → green.**
+
+### Task 4: docs, module map, changelog, gates
+
+**Files:** `src/inspect_robots/CLAUDE.md`, `CHANGELOG.md`, `docs/guide/cli.md`
+
+- [ ] Rows, entry (Added: footer; the arc's user-visible payoff — reference plans
+  0048/0049 and #308), docs paragraph with the footer example block.
+- [ ] **Full gates** at 100%.

--- a/plans/0049-operator-footer.md
+++ b/plans/0049-operator-footer.md
@@ -147,7 +147,7 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    practice, but the editor must tolerate split sequences: buffer bytes, decode
    with `errors="replace"` at display time for the echo, and decode each completed
    line **once** with `errors="replace"` at queue handoff — the console's `read`
-   seam is str-typed (`read: Callable[[], str]`, console.py:86), so bytes cannot
+   seam is str-typed (`read: Callable[[], str]`, console.py:85), so bytes cannot
    pass through it, and a strict decode there would turn malformed paste bytes into
    a raising `poll()` that kills the channel; decoding only complete lines
    preserves content exactly where today's per-64KiB-chunk decode could not. Paste
@@ -155,22 +155,35 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    processing is loop-per-byte over arbitrarily large reads. No history, no arrow
    keys, no cursor movement (YAGNI; the plan-0048 arc can add them later if operators
    ask).
-5. **Rendering model: the cursor lives at the end of the input line.** All updates
-   are relative two-line repaints using `\r` and ANSI `\x1b[A` (cursor up) /
-   `\x1b[K` (clear to end): status update = save input, move up, clear, write status,
-   move down, rewrite input; scrollback insert = move up, clear, write text + newline,
-   write status + newline, rewrite input. Repaints always clear before writing, which
-   also self-heals after any stray third-party print (one smudged frame, then clean).
-   BOTH rows clip to the terminal width (injectable `width_fn` defaulting to
-   `shutil.get_terminal_size().columns`, re-read at each repaint so resizes re-clip):
-   the input row clips to `width - 4` showing the tail; the status row clips to
-   `width - 1`. An unclipped row that wraps to two physical lines desyncs every
-   relative `\r`/`ESC[A` movement afterward — clipping is correctness, not
-   cosmetics. A `write_line` insert must `\r ESC[K`-clear the input row FIRST, then
-   write the scrollback text, status row, and input row in order. In footer mode
-   `status(None)` tears down both lines (clear input line, clear status line) so a
-   plugin-driven close leaves a clean terminal; `end_trial()` does the same teardown
-   idempotently as the backstop (decision 1); plain mode keeps its existing
+5. **Rendering model: the input row is the footer-window constant; the status row is
+   optional.** The input row is drawn (empty `> `) at footer `begin_trial()` and
+   exists for the whole footer window; the status row exists only while
+   `_status_open` — and on most attended runs it NEVER opens (no core code calls
+   `session.status()`; only plugins like the yam ticker do), so the one-row state
+   is the default, not an edge case. The cursor lives at the end of the input line.
+   All updates are relative repaints using `\r` and ANSI `\x1b[A` (cursor up) /
+   `\x1b[K` (clear to end), and every sequence branches on `_status_open`:
+   - **Two-row state** (status open): status update = save input, move up, clear,
+     write status, move down, rewrite input; scrollback insert = `\r ESC[K`-clear
+     the input row FIRST, move up, clear, write text + newline, write status +
+     newline, rewrite input; `status(None)` = clear input row, move up, clear
+     status row, write input row there (the footer collapses upward one line into
+     the one-row state; typing continues on the retained input row).
+   - **One-row state** (status never opened, or closed): scrollback insert = clear
+     input row, write text + newline, redraw input row — NO cursor-up, there is no
+     status row above and moving up would `ESC[K` real scrollback; the first
+     `status(line)` = clear input row, write status + newline, redraw input row
+     (creates the status row above, entering the two-row state).
+   Repaints always clear before writing, which also self-heals after any stray
+   third-party print (one smudged frame, then clean). BOTH rows clip to the
+   terminal width (injectable `width_fn` defaulting to
+   `shutil.get_terminal_size().columns`, re-read at each repaint so resizes
+   re-clip): the input row clips to `width - 4` showing the tail; the status row
+   clips to `width - 1`. An unclipped row that wraps to two physical lines desyncs
+   every relative `\r`/`ESC[A` movement afterward — clipping is correctness, not
+   cosmetics. `end_trial()` tears down whatever exists (clear input row; clear
+   status row too if open) idempotently as the backstop (decision 1), leaving a
+   clean terminal for the verdict prompt; plain mode keeps its existing
    close-with-newline semantics.
 6. **Confirmations come from `poll()`, not from the editor.** The editor
    cannot know whether a completed line is feedback, an end request, a verdict, or a
@@ -256,11 +269,16 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
   completed line reaches the console parser verbatim on the same `poll()`; the
   dispatching `readable`/`read` closures satisfy the console's EOF contract (`""`
   only on real EOF); footer `begin_trial()` discards stale fd bytes with no echo and
-  clears editor + queue. Renderer: exact byte sequences for status update,
-  write_line insert (input row cleared first), input echo, teardown on
-  `status(None)` AND on `end_trial()`, tail-clipping of the input row at
-  `width - 4`, clipping of the status row at `width - 1`, re-clip after a
-  `width_fn` change. Plain-mode tests untouched.
+  clears editor + queue. Renderer, exact byte sequences in BOTH states of the
+  decision-5 machine: input row drawn at footer `begin_trial()`; one-row
+  `write_line` (no cursor-up — prior scrollback untouched); first `status(line)`
+  creates the status row from the one-row state; two-row status update; two-row
+  `write_line` insert (input row cleared first); input echo in both states,
+  including typing after `status(None)`; `status(None)` collapses two-row to
+  one-row (input row retained); `end_trial()` teardown from the one-row state,
+  the two-row state, and (idempotently) after a prior teardown; tail-clipping of
+  the input row at `width - 4`, clipping of the status row at `width - 1`,
+  re-clip after a `width_fn` change. Plain-mode tests untouched.
 - [ ] **Step 2-4: fail → implement → green.**
 
 ### Task 2: raw-mode window — `begin_trial()`/`end_trial()` + rollout hook

--- a/plans/0049-operator-footer.md
+++ b/plans/0049-operator-footer.md
@@ -157,7 +157,15 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    ask).
 5. **Rendering model: the input row is the footer-window constant; the status row is
    optional.** The input row is drawn (empty `> `) at footer `begin_trial()` and
-   exists for the whole footer window; the status row exists only while
+   exists for the whole footer window. Before drawing it, footer `begin_trial()`
+   closes any plain-open status line using the existing plain semantics (write
+   `"\n"`, reset `_status_open` — session.py:79-83): a prior plain trial's ticker
+   line survives the zero-byte plain `end_trial()` (and a plugin can call
+   `status()` during `embodiment.reset()`, which runs before `begin_trial()`), and
+   drawing the footer onto it would append `> ` to the stale line AND start the
+   renderer in the two-row branch with no footer status row above — desyncing
+   every relative repaint into scrollback. This closing write is on the footer
+   path only, so plain byte-identity is untouched. The status row exists only while
    `_status_open` — and on most attended runs it NEVER opens (no core code calls
    `session.status()`; only plugins like the yam ticker do), so the one-row state
    is the default, not an edge case. The cursor lives at the end of the input line.
@@ -270,7 +278,10 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
   dispatching `readable`/`read` closures satisfy the console's EOF contract (`""`
   only on real EOF); footer `begin_trial()` discards stale fd bytes with no echo and
   clears editor + queue. Renderer, exact byte sequences in BOTH states of the
-  decision-5 machine: input row drawn at footer `begin_trial()`; one-row
+  decision-5 machine: input row drawn at footer `begin_trial()`; footer
+  `begin_trial()` on a session with a plain-open status line emits the closing
+  `"\n"` then a clean `> ` row, and the next `status(line)` takes the one-row
+  branch (no `ESC[A` into scrollback); one-row
   `write_line` (no cursor-up — prior scrollback untouched); first `status(line)`
   creates the status row from the one-row state; two-row status update; two-row
   `write_line` insert (input row cleared first); input echo in both states,

--- a/plans/0049-operator-footer.md
+++ b/plans/0049-operator-footer.md
@@ -64,10 +64,12 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
   `poll()` assembles lines from chunks (`:90-113`); `begin_trial()` drains (`:115-124`).
   The console's default `read` is fd-level `os.read` (`:55-56`); the session currently
   builds its default console with only `output_fn=self.write_line`.
-- `src/inspect_robots/rollout.py:276-283` — `operator_input.begin_trial()` inside a
-  try/except that disables the channel on failure; `:288-306` — the per-iteration poll
-  with the same degrade discipline; the trial's `finally` teardown block (find with
-  `grep -n "finally" src/inspect_robots/rollout.py`) is where `end_trial()` goes.
+- `src/inspect_robots/rollout.py:276-285` — `operator_input.begin_trial()` inside a
+  try/except that disables the channel on failure; `:291-301` — the per-iteration poll
+  with the same degrade discipline; `:458-463` — KeyboardInterrupt conversion
+  re-raised through the per-trial `finally` at `:463`, which is where `end_trial()`
+  goes. The degrade tests to mirror live in `tests/test_rollout_observation_step.py`
+  (NOT test_rollout_hardening.py, which has no console tests).
 - `src/inspect_robots/cli.py` — `_build_operator_session` (decision-9 ladder): the
   footer activates only on rows where the console turns on; the helper tells the
   session (see decision 3).
@@ -85,9 +87,19 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    implementations stay conformant. `rollout()` calls it best-effort in the trial's
    `finally`: wrapped in the same catch-warn-disable discipline as `poll()`, and it
    must run even when the trial raised (`EmbodimentFault` mid-trial must not leave the
-   user's terminal in raw mode). Restore is idempotent and additionally registered
-   with `atexit` once per session as a crash net; `KeyboardInterrupt` unwinds through
-   the `finally` like any exception.
+   user's terminal in raw mode). `end_trial()` owns the FULL footer teardown, not just
+   termios: idempotently close the footer (clear the input row and the status row,
+   reset `_status_open`) and then restore termios — no core code calls
+   `session.status(None)` (only plugins do), so on `EmbodimentFault`, Ctrl-C, or a
+   plugin that never closes its status line, `end_trial` is the only thing standing
+   between the verdict prompt and a stale `> ` row. The restore callable is an
+   injectable, idempotent method (tests call it directly — a closure registered only
+   with `atexit` would run at interpreter exit and fail the 100% gate), registered
+   with `atexit` once per session as a crash net; restore clears the saved termios
+   attrs so the atexit fallback can never replay a stale saved state over a later
+   trial's raw window. `KeyboardInterrupt` is converted by `rollout()` to its
+   cancelled-trial path and re-raised **through** the same `finally`
+   (rollout.py:458-463), so Ctrl-C restores too.
 2. **Footer mode gates on: console channel enabled AND `sys.stdin.isatty()` AND
    termios importable AND raw-mode entry succeeded.** Any failure (non-tty, Windows,
    exotic terminal, `termios.error`) falls back to plain mode silently at
@@ -100,6 +112,13 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    ambient sniffing inside `poll()`): direct API users of `OperatorSession` (yam
    routes `status()` through it on connected runs) get footer behavior only when the
    run actually has the interjection console, which only the CLI knows.
+   Two contract points: (a) on a session constructed with a caller-injected
+   `console=...`, `enable_footer()` is a documented no-op — the footer requires the
+   session-built console whose seams are the decision-7 dispatching closures;
+   checked at `begin_trial()` alongside the tty/termios gates. (b) the confirmation
+   label is CLI-chosen at enable time: `[sent]` on feedback rows (messages reach the
+   policy), `[noted]` on end-only rows (`USAGE_END_ONLY` says lines are saved to the
+   log; "sent" would imply delivery to the policy that is not happening).
 4. **Line editing is deliberately minimal:** printable characters append, backspace
    (`\x7f`/`\x08`) deletes one, Ctrl-U kills the line, `\n`/`\r` completes it
    (echoing `\r` as line completion matches raw-mode Enter), everything else
@@ -116,11 +135,17 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    move down, rewrite input; scrollback insert = move up, clear, write text + newline,
    write status + newline, rewrite input. Repaints always clear before writing, which
    also self-heals after any stray third-party print (one smudged frame, then clean).
-   The input display clips to `terminal width - 4` showing the tail (injectable
-   `width_fn` defaulting to `shutil.get_terminal_size().columns`). In footer mode
-   `status(None)` tears down both lines (clear input line, clear status line) so the
-   trial ends with a clean terminal for the verdict prompt; plain mode keeps its
-   existing close-with-newline semantics.
+   BOTH rows clip to the terminal width (injectable `width_fn` defaulting to
+   `shutil.get_terminal_size().columns`, re-read at each repaint so resizes re-clip):
+   the input row clips to `width - 4` showing the tail; the status row clips to
+   `width - 1`. An unclipped row that wraps to two physical lines desyncs every
+   relative `\r`/`ESC[A` movement afterward — clipping is correctness, not
+   cosmetics. A `write_line` insert must `\r ESC[K`-clear the input row FIRST, then
+   write the scrollback text, status row, and input row in order. In footer mode
+   `status(None)` tears down both lines (clear input line, clear status line) so a
+   plugin-driven close leaves a clean terminal; `end_trial()` does the same teardown
+   idempotently as the backstop (decision 1); plain mode keeps its existing
+   close-with-newline semantics.
 6. **`[sent]` confirmations come from `poll()`, not from the editor.** The editor
    cannot know whether a completed line is feedback, an end request, a verdict, or a
    usage typo — the console's parser decides. Footer-mode `poll()` delegates, then
@@ -129,31 +154,50 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    episode visibly ends); usage hints already arrive via the console's `output_fn`,
    which is `write_line`. The confirmation therefore appears at the next rollout
    poll, at most one control period after Enter — imperceptible.
-7. **The console keeps line assembly; the editor feeds it completed lines.** The
-   session wraps the `readable`/`read` seams it passes to its default
-   `OperatorConsole`: footer-mode `read` drains the real fd (`os.read`), runs bytes
-   through the editor (echoing per decision 5), and returns only the completed lines
-   (`"line\n"` joined) — an empty string return means EOF exactly as today, and "no
-   completed lines yet" returns `""`? No: `""` signals EOF to the console. The
-   wrapper must instead report `readable() == False` until a completed line exists —
-   i.e. the session buffers keystrokes itself and its wrapped `readable` returns
-   True only when completed lines are queued (or real EOF was seen). This keeps
-   `OperatorConsole` byte-for-byte untouched: its fd-desync rationale (plan 0042
-   decision 9) doesn't apply because the wrapper is not the buffered TextIOWrapper —
-   it drains the fd fully on every rollout poll. `begin_trial()` clears the editor
-   buffer, queued lines, and the composed console's buffer (existing behavior).
-8. **Raw-mode syscalls are the only uncovered lines.** `_enter_cbreak()` /
+7. **The console keeps line assembly; footer-mode `poll()` pumps the editor first.**
+   The pump cannot live in a passive `readable` wrapper: `OperatorConsole.poll()`
+   only calls `read()` while `readable()` is true, so a queue-checking `readable`
+   plus an fd-draining `read` would never drain the fd at all — no echo, no
+   completed line, deadlock. Instead, footer-mode `session.poll()` runs an explicit
+   pump **before** delegating: while the fd is readable, `os.read` chunks, feed the
+   editor (echoing per decision 5), and append each completed raw line to a queue;
+   then call `console.poll()`, whose session-provided seams are dispatching
+   closures — `readable` returns "queue non-empty or real EOF seen", `read` pops
+   queued lines joined with `"\n"` (`""` only on real EOF, preserving the console's
+   EOF contract); in plain mode the same closures delegate straight to the fd
+   defaults. The fd defaults are `console.py`'s existing module-private
+   `_stdin_readable`/`_stdin_read` (imported — same package), injectable on the
+   session as `fd_readable`/`fd_read` seams, so the session adds **no new
+   pragma-no-cover fd lines** (amending decision 8: uncovered lines are the termios
+   syscalls plus nothing new). This keeps `OperatorConsole` byte-for-byte untouched:
+   the fd-desync rationale of plan 0042 decision 9 targets the buffered
+   TextIOWrapper, which this pump is not. Footer-mode `session.begin_trial()`:
+   drain the fd raw with **no echo** (stale pre-trial bytes must not paint into a
+   not-yet-drawn footer), clear the editor buffer and the queue, then call
+   `console.begin_trial()` (its own drain loop sees an empty queue and is a no-op,
+   and it clears its internal buffer as today).
+   Echo cadence note (document in docs, it is a property, not a bug): the pump runs
+   at the rollout poll cadence, once per control step, so on a self-paced robot
+   executing a chunk, keystroke echo can lag up to one `embodiment.step()`. Threads
+   are excluded by the 0048 arc; state it.
+8. **Raw-mode syscalls are the only NEW uncovered lines.** `_enter_cbreak()` /
    `_restore()` module-private helpers own `termios.tcgetattr`/`tcsetattr`
    (`# pragma: no cover` bodies, lazy `import termios`), injectable as
-   `raw_mode_fn`-style seams on the session for tests. The editor, renderer, wrapped
-   seams, `end_trial` paths, and mode fallback are all pure logic over injected
-   callables — fully covered.
+   `raw_mode_fn`-style seams on the session for tests. The session's fd access
+   reuses `console.py`'s already-pragma'd module-private `_stdin_readable` /
+   `_stdin_read` as the defaults behind its `fd_readable`/`fd_read` seams
+   (decision 7) — no new fd pragma lines in session.py. The editor, renderer,
+   dispatching closures, `end_trial` paths, and mode fallback are all pure logic
+   over injected callables — fully covered.
 
 ## Behavior notes (document in CHANGELOG/docs, not code comments)
 
 - Operators see their typing on a stable `> ` line; the timer above never tears.
-- Feedback confirms as `[sent] …` scrollback; Enter still ends; `/y /n /p` still
-  verdict; typos still print the usage hint — all above the footer.
+- Feedback confirms as `[sent] …` scrollback (`[noted] …` in end-only mode); Enter
+  still ends; `/y /n /p` still verdict; typos still print the usage hint — all above
+  the footer.
+- Keystroke echo is pumped at the rollout poll cadence: on a self-paced robot it can
+  lag up to one control step. Property of the threadless design, documented.
 - Off-TTY/Windows/piped stdin: unchanged.
 - Third-party prints (driver chatter) can smudge one frame; the next repaint heals it.
 
@@ -163,11 +207,17 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
 
 **Files:** `src/inspect_robots/session.py`, `tests/test_session.py`
 
-- [ ] **Step 1: failing tests.** Editor: append/backspace/Ctrl-U/Enter over scripted
-  chunk sequences incl. split UTF-8 and 64KiB paste; queued-lines `readable` protocol
-  (False until a line completes; True after; EOF passthrough). Renderer: exact byte
-  sequences for status update, write_line insert, input echo, teardown on
-  `status(None)`, tail-clipping at injected width. Plain-mode tests untouched.
+- [ ] **Step 1: failing tests.** Editor + pump (decision 7): scripted `fd_readable`/
+  `fd_read` sequences drive `poll()` — append/backspace/Ctrl-U/Enter incl. split
+  UTF-8 and 64KiB paste; bytes without a newline echo but deliver nothing; the
+  completed line reaches the console parser verbatim on the same `poll()`; the
+  dispatching `readable`/`read` closures satisfy the console's EOF contract (`""`
+  only on real EOF); footer `begin_trial()` discards stale fd bytes with no echo and
+  clears editor + queue. Renderer: exact byte sequences for status update,
+  write_line insert (input row cleared first), input echo, teardown on
+  `status(None)` AND on `end_trial()`, tail-clipping of the input row at
+  `width - 4`, clipping of the status row at `width - 1`, re-clip after a
+  `width_fn` change. Plain-mode tests untouched.
 - [ ] **Step 2-4: fail → implement → green.**
 
 ### Task 2: raw-mode window — `begin_trial()`/`end_trial()` + rollout hook
@@ -176,12 +226,16 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
 `tests/test_session.py`, `tests/test_rollout_hardening.py`
 
 - [ ] **Step 1: failing tests.** Session: footer entered only when enabled+tty+raw-ok
-  (each gate falsified via injected seams); failed entry → plain mode this trial and
-  the next trial retries; `end_trial()` restores exactly once (idempotent);
-  restore-on-exception. Rollout: `end_trial` called in `finally` on success, on
-  trial-ending exceptions, and skipped without error when the hook is absent
-  (plain `OperatorConsole`); a raising `end_trial` warns and never masks the trial's
-  own outcome (mirror the `poll()` degrade tests).
+  AND the console is session-built (caller-injected `console=...` → documented no-op);
+  each gate falsified via injected seams; failed entry → plain mode this trial and
+  the next trial retries; `end_trial()` closes the footer rows and restores exactly
+  once (idempotent; saved termios attrs cleared on restore so atexit cannot replay
+  stale state); restore-on-exception. Rollout: `end_trial` called in the per-trial
+  `finally` (rollout.py:463) on success, on trial-ending exceptions, and on the
+  KeyboardInterrupt cancelled-trial path; skipped without error when the hook is
+  absent (plain `OperatorConsole`); a raising `end_trial` warns and never masks the
+  trial's own outcome (mirror the `poll()` degrade tests in
+  `tests/test_rollout_observation_step.py`).
 - [ ] **Step 2-4: fail → implement → green.**
 
 ### Task 3: CLI opt-in + `[sent]` confirmations
@@ -189,10 +243,12 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
 **Files:** `src/inspect_robots/cli.py`, `src/inspect_robots/session.py`,
 `tests/test_registry_cli.py`, `tests/test_session.py`
 
-- [ ] **Step 1: failing tests.** Footer enabled on exactly the decision-9 rows where
-  the console turns on (both new-hook and legacy ladders), never otherwise; footer
-  `poll()` emits one `[sent]` per feedback message, nothing for ends/verdicts; matrix
-  outputs otherwise unchanged.
+- [ ] **Step 1: failing tests.** Footer enabled on exactly the plan-0048 decision-9
+  rows where the console turns on (both new-hook and legacy ladders), never
+  otherwise; the CLI passes the confirmation label per row — `[sent]` on feedback
+  rows, `[noted]` on end-only rows (decision 3, contract point b); footer `poll()` emits one labeled
+  confirmation per feedback message, nothing for ends/verdicts; matrix outputs
+  otherwise unchanged.
 - [ ] **Step 2-4: fail → implement → green.**
 
 ### Task 4: docs, module map, changelog, gates

--- a/plans/0049-operator-footer.md
+++ b/plans/0049-operator-footer.md
@@ -127,9 +127,15 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    policy), `[noted]` on end-only rows (`USAGE_END_ONLY` says lines are saved to the
    log; "sent" would imply delivery to the policy that is not happening).
 4. **Line editing is deliberately minimal:** printable characters append, backspace
-   (`\x7f`/`\x08`) deletes one, Ctrl-U kills the line, `\n`/`\r` completes it
-   (echoing `\r` as line completion matches raw-mode Enter), everything else
-   non-printable is ignored. Multi-byte UTF-8 arrives whole from `os.read` chunks in
+   (`\x7f`/`\x08`) deletes one **character** — strip trailing UTF-8 continuation
+   bytes (`0x80`–`0xBF`) plus one lead byte, never a lone byte, or backspace after
+   "é" leaves a dangling lead byte that mangles the delivered message — Ctrl-U kills
+   the line, `\n`/`\r` completes it (echoing `\r` as line completion matches
+   raw-mode Enter), everything else non-printable is ignored. Ignoring `\x1b` alone
+   is not enough: in cbreak an arrow key arrives as `\x1b [ A` whose tail bytes are
+   printable and would append as literal `[A` junk — so on `\x1b[` discard bytes
+   until the CSI final byte (`0x40`–`0x7E`), and on a bare `\x1b` discard the next
+   byte. Multi-byte UTF-8 arrives whole from `os.read` chunks in
    practice, but the editor must tolerate split sequences: buffer bytes, decode with
    `errors="replace"` only at display time, and hand the console the raw completed
    line so message content is preserved exactly as today. Paste works because chunk
@@ -228,7 +234,10 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
 
 - [ ] **Step 1: failing tests.** Editor + pump (decision 7): scripted `fd_readable`/
   `fd_read` sequences drive `poll()` — append/backspace/Ctrl-U/Enter incl. split
-  UTF-8 and 64KiB paste; bytes without a newline echo but deliver nothing; the
+  UTF-8 and 64KiB paste; backspace after a multi-byte character removes the whole
+  character (buffer and echo both clean); arrow-key/Delete escape sequences
+  (`\x1b[A`, `\x1b[3~`, bare `\x1b` + byte) are swallowed whole — no junk in the
+  buffer or the echo; bytes without a newline echo but deliver nothing; the
   completed line reaches the console parser verbatim on the same `poll()`; the
   dispatching `readable`/`read` closures satisfy the console's EOF contract (`""`
   only on real EOF); footer `begin_trial()` discards stale fd bytes with no echo and

--- a/plans/0051-operator-footer.md
+++ b/plans/0051-operator-footer.md
@@ -51,29 +51,44 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
 - Worktree: `.claude/worktrees/operator-footer`. Reference #308 in commits; end with
   the `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` trailer. **No git
   operations from Codex.**
-- Before merge: re-check `git ls-tree origin/main plans/` for a 0049 collision and
+- Before merge: re-check `git ls-tree origin/main plans/` for a 0051 collision and
   renumber if a concurrent session took it.
 
-## Reference: current wiring (main @ 6c022ead)
+## Reference: current wiring (main @ 4e5cc772, post-voice #316)
 
-- `src/inspect_robots/session.py` — the whole module (172 lines): `_flush_stdin_fd`,
+- `src/inspect_robots/session.py` — the whole module (209 lines): `_flush_stdin_fd`,
   `OperatorSession.__init__` seams (`console`, `input_fn`, `write`, `flush_fn`),
-  `_write`/`_input` late-binding, `poll`/`begin_trial` delegation, `status`/`write_line`
-  state machine (`_status_open`, `_status_line`), `gate`, verdict prompts.
-- `src/inspect_robots/console.py` — `OperatorConsole(readable, read, output_fn)`;
-  `poll()` assembles lines from chunks (`:94-117`); `begin_trial()` drains (`:119-129`).
-  `_stdin_readable` is at `:55-56`; the console's default `read` is the str-typed
-  fd-level `_stdin_read` (`:59-60`); the session currently builds its default
-  console with only `output_fn=self.write_line`.
-- `src/inspect_robots/rollout.py:276-285` — `operator_input.begin_trial()` inside a
-  try/except that disables the channel on failure; `:291-301` — the per-iteration poll
-  with the same degrade discipline; `:458-463` — KeyboardInterrupt conversion
-  re-raised through the per-trial `finally` at `:463`, which is where `end_trial()`
-  goes. The degrade tests to mirror live in `tests/test_rollout_observation_step.py`
-  (NOT test_rollout_hardening.py, which has no console tests).
-- `src/inspect_robots/cli.py` — `_build_operator_session` (decision-9 ladder): the
-  footer activates only on rows where the console turns on; the helper tells the
-  session (see decision 3).
+  `_write`/`_input` late-binding, `status`/`write_line` state machine
+  (`_status_open`, `_status_line`; the `status(None)` close branch is `:116-119`),
+  `gate`, verdict prompts. Since voice (#316), `poll()` (`:70-91`) is NOT a pure
+  delegate: it polls the console first, then merges every healthy attached input
+  (`attach_input(source, label=...)`, `:106-112`), echoing each attached message as
+  `f"{label}: {text}"` via `write_line` and returning
+  `ConsolePoll(messages, end, sources)` with `sources` parallel to `messages`
+  (`"console"` vs the attach label; empty tuple = all-console). `begin_trial()`
+  (`:93-104`) fans out to the console and every attached input with
+  detach-on-raise.
+- `src/inspect_robots/console.py` — `OperatorConsole(readable, read, output_fn)`
+  (`read: Callable[[], str] | None`, `:90`); `poll()` assembles lines from chunks
+  (`:99-122`; reads only `while self._readable()`, `:106`; EOF latch `:108-111`);
+  `begin_trial()` drains (`:124-134`). `_stdin_readable` is at `:60-61`; the
+  console's default `read` is the str-typed fd-level `_stdin_read` (`:64-65`);
+  `ConsolePoll.sources` defaults to `()` (`:38-44`). The session builds its
+  default console with only `output_fn=self.write_line`.
+- `src/inspect_robots/rollout.py:277-285` — `operator_input.begin_trial()` inside a
+  try/except that disables the channel on failure (`console_ok`, init `:256`);
+  `:291-301` — the per-iteration poll with the same degrade discipline; `:302-308`
+  — the per-message loop now records `poll.sources[i]` provenance; `:461-465` —
+  KeyboardInterrupt conversion re-raised through the per-trial `finally` at
+  `:466`, which is where `end_trial()` goes. The degrade tests to mirror live in
+  `tests/test_rollout_observation_step.py` (NOT test_rollout_hardening.py, which
+  has no console tests).
+- `src/inspect_robots/cli.py` — `_build_operator_session` (`:729-781`, decision-9
+  ladder; `USAGE_END_ONLY` chosen at `:747`): the footer activates only on rows
+  where the console turns on; the helper tells the session (see decision 3).
+  Voice wiring (`_build_voice_input`/`_start_voice_input`/`_close_voice_input`,
+  `:782-817`) attaches a `label="voice"` input around the session — the footer
+  must compose with it (decisions 6/7).
 - Tests: `tests/test_session.py` (exact-byte rendering tests to extend),
   `tests/test_rollout_observation_step.py` (the poll/begin_trial channel-degrade
   tests to mirror for `end_trial`; the new rollout `end_trial` tests can live
@@ -101,7 +116,7 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    attrs so the atexit fallback can never replay a stale saved state over a later
    trial's raw window. `KeyboardInterrupt` is converted by `rollout()` to its
    cancelled-trial path and re-raised **through** the same `finally`
-   (rollout.py:458-463), so Ctrl-C restores too. Guard scope: `end_trial()` runs
+   (rollout.py:461-466), so Ctrl-C restores too. Guard scope: `end_trial()` runs
    whenever `operator_input is not None` and the hook exists — it does NOT check
    `console_ok`. Only the catch-warn part mirrors poll's discipline, not its guard: a
    footer-mode `poll()` that raises (the pump is the likeliest raiser) flips
@@ -147,7 +162,7 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    practice, but the editor must tolerate split sequences: buffer bytes, decode
    with `errors="replace"` at display time for the echo, and decode each completed
    line **once** with `errors="replace"` at queue handoff — the console's `read`
-   seam is str-typed (`read: Callable[[], str]`, console.py:85), so bytes cannot
+   seam is str-typed (`read: Callable[[], str]`, console.py:90), so bytes cannot
    pass through it, and a strict decode there would turn malformed paste bytes into
    a raising `poll()` that kills the channel; decoding only complete lines
    preserves content exactly where today's per-64KiB-chunk decode could not. Paste
@@ -159,7 +174,7 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    optional.** The input row is drawn (empty `> `) at footer `begin_trial()` and
    exists for the whole footer window. Before drawing it, footer `begin_trial()`
    closes any plain-open status line using the existing plain semantics (write
-   `"\n"`, reset `_status_open` — session.py:79-83): a prior plain trial's ticker
+   `"\n"`, reset `_status_open` — session.py:116-119): a prior plain trial's ticker
    line survives the zero-byte plain `end_trial()` (and a plugin can call
    `status()` during `embodiment.reset()`, which runs before `begin_trial()`), and
    drawing the footer onto it would append `> ` to the stale line AND start the
@@ -193,13 +208,19 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    status row too if open) idempotently as the backstop (decision 1), leaving a
    clean terminal for the verdict prompt; plain mode keeps its existing
    close-with-newline semantics.
-6. **Confirmations come from `poll()`, not from the editor.** The editor
-   cannot know whether a completed line is feedback, an end request, a verdict, or a
-   usage typo — the console's parser decides. Footer-mode `poll()` delegates, then
-   for each message in the returned `ConsolePoll.messages` writes
+6. **Confirmations come from `poll()`, not from the editor — and only for
+   console-sourced messages.** The editor cannot know whether a completed line is
+   feedback, an end request, a verdict, or a usage typo — the console's parser
+   decides. Footer-mode `poll()` delegates, then for each message in the returned
+   `ConsolePoll` **whose source is the console** writes
    `write_line(f"[{label}] {text}")` where `label` is the CLI-chosen decision-3(b)
    value (`sent` on feedback rows, `noted` on end-only rows — do not hardcode
-   `sent`). End requests and verdict lines print nothing (the
+   `sent`). Source filtering follows the `ConsolePoll.sources` contract: empty
+   `sources` means every message is console-sourced; otherwise confirm exactly the
+   indices where `sources[i] == "console"`. Voice-sourced messages (#316) are
+   already echoed by the merge loop as `voice: <text>` — a blanket iteration over
+   `messages` would print a second, `[sent]`-stamped line for input the footer
+   never delivered-confirmed. End requests and verdict lines print nothing (the
    episode visibly ends); usage hints already arrive via the console's `output_fn`,
    which is `write_line`. The confirmation therefore appears at the next rollout
    poll, at most one control period after Enter — imperceptible.
@@ -208,7 +229,10 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    only calls `read()` while `readable()` is true, so a queue-checking `readable`
    plus an fd-draining `read` would never drain the fd at all — no echo, no
    completed line, deadlock. Instead, footer-mode `session.poll()` runs an explicit
-   pump **before** delegating: while the fd is readable, `os.read` chunks, feed the
+   pump **before** the console-delegate portion of the merged poll
+   (session.py:70-91) — pump → `console.poll()` → attached-input merge, with the
+   merge loop (voice echo, detach-on-raise, `sources` stamping) untouched after
+   it: while the fd is readable, `os.read` chunks, feed the
    editor (echoing per decision 5), and append each completed raw line to a queue;
    then call `console.poll()`, whose session-provided seams are dispatching
    closures — `readable` returns "queue non-empty or real EOF seen", `read` pops
@@ -231,9 +255,11 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
    the fd-desync rationale of plan 0042 decision 9 targets the buffered
    TextIOWrapper, which this pump is not. Footer-mode `session.begin_trial()`:
    drain the fd raw with **no echo** (stale pre-trial bytes must not paint into a
-   not-yet-drawn footer), clear the editor buffer and the queue, then call
-   `console.begin_trial()` (its own drain loop sees an empty queue and is a no-op,
-   and it clears its internal buffer as today).
+   not-yet-drawn footer), clear the editor buffer and the queue, then run the
+   existing `begin_trial()` fan-out (session.py:93-104) — `console.begin_trial()`'s
+   own drain loop sees an empty queue and is a no-op, it clears its internal
+   buffer as today, and the attached-input fan-out with detach-on-raise runs
+   unchanged after.
    Echo cadence note (document in docs, it is a property, not a bug): the pump runs
    at the rollout poll cadence, once per control step, so on a self-paced robot
    executing a chunk, keystroke echo can lag up to one `embodiment.step()`. Threads
@@ -303,9 +329,9 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
   the next trial retries; `end_trial()` closes the footer rows and restores exactly
   once (idempotent; saved termios attrs cleared on restore so atexit cannot replay
   stale state); restore-on-exception. Rollout: `end_trial` called in the per-trial
-  `finally` (rollout.py:463) on success, on trial-ending exceptions, and on the
+  `finally` (rollout.py:466) on success, on trial-ending exceptions, and on the
   KeyboardInterrupt cancelled-trial path; skipped without error when the hook is
-  absent (plain `OperatorConsole`); a raising `end_trial` warns and never masks the
+  absent (a bare `OperatorInput`); a raising `end_trial` warns and never masks the
   trial's own outcome (mirror the `poll()` degrade tests in
   `tests/test_rollout_observation_step.py`); `end_trial` still called after a
   raising `poll()` flipped `console_ok` False mid-trial (decision 1 guard scope);
@@ -322,8 +348,11 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
   rows where the console turns on (both new-hook and legacy ladders), never
   otherwise; the CLI passes the confirmation label per row — `[sent]` on feedback
   rows, `[noted]` on end-only rows (decision 3, contract point b); footer `poll()` emits one labeled
-  confirmation per feedback message, nothing for ends/verdicts; matrix outputs
-  otherwise unchanged.
+  confirmation per CONSOLE-sourced feedback message, nothing for ends/verdicts;
+  a poll carrying a voice-sourced message (attached input, #316) emits no
+  confirmation beyond the merge loop's existing `voice: <text>` echo — both with
+  non-empty `sources` and in the empty-`sources` all-console case (decision 6);
+  matrix outputs otherwise unchanged.
 - [ ] **Step 2-4: fail → implement → green.**
 
 ### Task 4: docs, module map, changelog, gates
@@ -331,5 +360,5 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
 **Files:** `src/inspect_robots/CLAUDE.md`, `CHANGELOG.md`, `docs/guide/cli.md`
 
 - [ ] Rows, entry (Added: footer; the arc's user-visible payoff — reference plans
-  0048/0049 and #308), docs paragraph with the footer example block.
+  0048/0051 and #308), docs paragraph with the footer example block.
 - [ ] **Full gates** at 100%.

--- a/plans/0051-operator-footer.md
+++ b/plans/0051-operator-footer.md
@@ -2,6 +2,10 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **Critique status:** 10 fresh-context rounds; R10 returned no substantive issues
+> against main @ 4e5cc772 (2026-08-06). R4-R9 findings and fixes are in this
+> branch's `plan:` commit history.
+
 **Goal:** PR 3 of the plan-0048 arc (#308). On attended runs with the console enabled and
 a real TTY, `OperatorSession` renders a fixed two-line footer: a status line that rewrites
 in place and never moves, and a `> ` input line the session itself echoes into. Typing is
@@ -83,11 +87,11 @@ inside the helpers so core imports stay clean on Windows); pytest; no new deps.
   `:466`, which is where `end_trial()` goes. The degrade tests to mirror live in
   `tests/test_rollout_observation_step.py` (NOT test_rollout_hardening.py, which
   has no console tests).
-- `src/inspect_robots/cli.py` — `_build_operator_session` (`:729-781`, decision-9
+- `src/inspect_robots/cli.py` — `_build_operator_session` (`:729-779`, decision-9
   ladder; `USAGE_END_ONLY` chosen at `:747`): the footer activates only on rows
   where the console turns on; the helper tells the session (see decision 3).
   Voice wiring (`_build_voice_input`/`_start_voice_input`/`_close_voice_input`,
-  `:782-817`) attaches a `label="voice"` input around the session — the footer
+  `:782-823`) attaches a `label="voice"` input around the session — the footer
   must compose with it (decisions 6/7).
 - Tests: `tests/test_session.py` (exact-byte rendering tests to extend),
   `tests/test_rollout_observation_step.py` (the poll/begin_trial channel-degrade

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -9,7 +9,7 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 |--------|----------------|
 | `types.py` | `Observation`, `Action`, `ActionChunk`, `StepResult` (frozen, NumPy-native); operator-message extras carry `t`, `text`, and `source` provenance |
 | `console.py` | frozen poll results with optional per-message source labels, the `OperatorInput` Protocol, and the threadless fd-level stdin polling primitive |
-| `session.py` | attended-run owner that polls the console first, merges and stamps attached feedback-only input sources, permanently detaches a failing source, and owns verdict prompts, readiness gates, status rendering, and scrollback output |
+| `session.py` | attended-run owner that polls the console first, merges and stamps attached feedback-only input sources, permanently detaches a failing source, and owns verdict prompts, readiness gates, scrollback output, and the attended-TTY two-row footer with its owned input line, in-place status, and per-trial cbreak window |
 | `spaces.py` | `Box`, `ObservationSpace`, `ActionSemantics`, `StateSpec` + canonical state vocab |
 | `policy.py` | `Policy` Protocol + `PolicyBase` ABC, `PolicyInfo`, `PolicyConfig`; optional duck-typed `bind(embodiment_info)` hook for embodiment-adaptive policies plus `transcript()` and `transcript_delta()` hooks for complete and live per-trial audit records |
 | `embodiment.py` | `Embodiment` Protocol + `EmbodimentBase` ABC, `EmbodimentInfo`, capability flags; optional duck-typed `bind_task(envelope)` hook for horizon-aware adapters (called by `eval()` after compat with a resolved step envelope; optional input — never fires on direct `rollout()`, keep a fallback) |
@@ -19,7 +19,7 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `grader.py` | `Grader` Protocol — judgement *capture*, the other half of R6 (plan 0049): runs once per scored trial via the `before_scoring` seam, mutates the record, scorers stay pure readers; builtin `operator` grader wraps `OperatorSession.prompt_verdict` with a lazy default session and a `connect_session(session)` hook |
 | `controller.py` | `Controller` middleware: `DefaultController` (open-loop chunking), `SmoothingController` |
 | `approver.py` | `Approver` safety gate: `AutoApprover`, `ClampApprover`, `DeltaLimitApprover` (semantics-aware no-wild-swings limit), `ChainApprover` |
-| `rollout.py` | `rollout()` closed loop, `TrialRecord`/`StepRecord`, per-trial seeding, delivered-once sourced operator input, best-effort normalized policy-transcript capture, and the duck-typed `transcript_delta()` to sink `log_policy_messages()` live-stream bridge; honors a policy-requested stop via pre-review `action.meta["request_stop"]` (truncation; embodiment termination wins; not preserved under ensembling) |
+| `rollout.py` | `rollout()` closed loop, `TrialRecord`/`StepRecord`, per-trial seeding, delivered-once sourced operator input, best-effort normalized policy-transcript capture, the duck-typed `transcript_delta()` to sink `log_policy_messages()` live-stream bridge, and a duck-typed best-effort `end_trial()` hook in the per-trial `finally`; honors a policy-requested stop via pre-review `action.meta["request_stop"]` (truncation; embodiment termination wins; not preserved under ensembling) |
 | `frames.py` | `FrameStore`/`FrameRef` — stream camera frames to disk (R5) |
 | `transcript.py` | typed event stream (reset/inference/step/approval/sourced operator_message/operator/error) |
 | `compat.py` | `check_compatibility`/`assert_compatible` — fail-fast before rollout |

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -754,6 +754,7 @@ def _build_operator_session(
             return session, None
         connect_hook(session)
         usage = USAGE if accepts_messages else USAGE_END_ONLY
+        session.enable_footer(label="sent" if accepts_messages else "noted")
         label = "operator console:"
         session.write_line(f"{_styled(label, _CYAN)} {usage.removeprefix(label + ' ')}")
         return session, session
@@ -784,6 +785,7 @@ def _build_operator_session(
         return session, None
 
     label = "operator console:"
+    session.enable_footer(label="sent")
     session.write_line(f"{_styled(label, _CYAN)} {USAGE.removeprefix(label + ' ')}")
     return session, session
 

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -464,6 +464,17 @@ def rollout(
         record.events.append(error_event(t, "KeyboardInterrupt", "cancelled by user"))
         raise _CancelledTrial(record.error, record) from exc
     finally:
+        if operator_input is not None:
+            try:
+                end_trial = getattr(operator_input, "end_trial", None)
+                if callable(end_trial):
+                    end_trial()
+            except Exception as exc:
+                warnings.warn(
+                    f"Operator console disabled for this trial after {type(exc).__name__}: {exc}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
         # Preserve measured latencies even when the trial ends in an error.
         record.inference_latencies = [
             lat for lat, _ in store.get(_INFER_KEY, []) if lat is not None

--- a/src/inspect_robots/session.py
+++ b/src/inspect_robots/session.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import os
 import select
+import shutil
 import sys
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from inspect_robots.console import ConsolePoll, OperatorConsole, OperatorInput
+from inspect_robots.console import ConsolePoll, OperatorConsole, OperatorInput, _stdin_readable
 from inspect_robots.errors import EmbodimentFault
 
 if TYPE_CHECKING:
@@ -33,6 +34,80 @@ def _flush_stdin_fd() -> None:
             break  # pragma: no cover
 
 
+def _stdin_read_bytes() -> bytes:
+    """Read up to 64KiB of raw stdin without decoding (the footer pump's default fd seam)."""
+    return os.read(sys.stdin.fileno(), 65536)  # pragma: no cover
+
+
+def _default_width() -> int:
+    """Return the current terminal width in columns, re-read fresh on every call."""
+    return shutil.get_terminal_size().columns
+
+
+def _clip_tail(text: str, limit: int) -> str:
+    """Return ``text`` unchanged if it fits ``limit`` characters, else just its trailing tail."""
+    return text if len(text) <= limit else text[-limit:]
+
+
+class _LineEditor:
+    """Assemble raw stdin bytes into one editable line: append, backspace, Ctrl-U, Enter.
+
+    Escape sequences (CSI ``ESC [ ... final``, SS3 ``ESC O final``, and a bare ``ESC``
+    plus one byte) are discarded whole so arrow keys, Delete, and function keys never
+    leak into the buffer or its echo (decision 4). The discard state persists across
+    ``feed()`` calls so a sequence split across reads, or across polls, is still
+    swallowed cleanly.
+    """
+
+    def __init__(self) -> None:
+        self._buffer = bytearray()
+        self._escape_pending = False
+        self._csi_discard = False
+
+    def reset(self) -> None:
+        """Clear the in-progress line and any mid-flight escape-discard state."""
+        self._buffer.clear()
+        self._escape_pending = False
+        self._csi_discard = False
+
+    def text(self) -> str:
+        """Decode the unfinished line for display, replacing any not-yet-complete UTF-8 tail."""
+        return self._buffer.decode("utf-8", errors="replace")
+
+    def feed(self, chunk: bytes) -> list[str]:
+        """Apply one raw read; return each line ``chunk`` completed, decoded once, in order."""
+        completed: list[str] = []
+        for b in chunk:
+            if self._csi_discard:
+                if 0x40 <= b <= 0x7E:
+                    self._csi_discard = False
+                continue
+            if self._escape_pending:
+                self._escape_pending = False
+                if b in (0x5B, 0x4F):  # '[' (CSI) or 'O' (SS3)
+                    self._csi_discard = True
+                continue
+            if b == 0x1B:  # ESC
+                self._escape_pending = True
+            elif b in (0x7F, 0x08):  # backspace / DEL
+                self._delete_char()
+            elif b == 0x15:  # Ctrl-U
+                self._buffer.clear()
+            elif b in (0x0A, 0x0D):  # \n or \r completes the line
+                completed.append(self._buffer.decode("utf-8", errors="replace"))
+                self._buffer.clear()
+            elif b >= 0x20 and b != 0x7F:
+                self._buffer.append(b)
+            # else: other non-printable control bytes are ignored
+        return completed
+
+    def _delete_char(self) -> None:
+        while self._buffer and 0x80 <= self._buffer[-1] <= 0xBF:
+            self._buffer.pop()
+        if self._buffer:
+            self._buffer.pop()
+
+
 class OperatorSession:
     """Coordinate all attended-run terminal input and output through injectable seams."""
 
@@ -43,14 +118,34 @@ class OperatorSession:
         input_fn: Callable[[str], str] | None = None,
         write: Callable[[str], None] | None = None,
         flush_fn: Callable[[], None] | None = None,
+        fd_readable: Callable[[], bool] | None = None,
+        fd_read: Callable[[], bytes] | None = None,
+        width_fn: Callable[[], int] | None = None,
     ) -> None:
         self._input_fn = input_fn
         self._write_fn = write
         self._flush_fn = flush_fn if flush_fn is not None else _flush_stdin_fd
         self._status_open = False
         self._status_line: str | None = None
+        self._owns_console = console is None
+        self._footer_requested = False
+        self._footer_active = False
+        self._fd_readable: Callable[[], bool] = (
+            fd_readable if fd_readable is not None else _stdin_readable
+        )
+        self._fd_read: Callable[[], bytes] = fd_read if fd_read is not None else _stdin_read_bytes
+        self._width_fn: Callable[[], int] = width_fn if width_fn is not None else _default_width
+        self._editor = _LineEditor()
+        self._line_queue: list[str] = []
+        self._pump_eof = False
         self._console = (
-            console if console is not None else OperatorConsole(output_fn=self.write_line)
+            console
+            if console is not None
+            else OperatorConsole(
+                readable=self._dispatch_readable,
+                read=self._dispatch_read,
+                output_fn=self.write_line,
+            )
         )
         self._attached_inputs: list[tuple[OperatorInput, str]] = []
 
@@ -66,8 +161,122 @@ class OperatorSession:
             return self._input_fn(prompt)
         return input(prompt)
 
+    def _dispatch_readable(self) -> bool:
+        """Console-facing ``readable`` seam: footer queue/EOF state, else the raw fd seam."""
+        if self._footer_active:
+            return bool(self._line_queue) or self._pump_eof
+        return self._fd_readable()
+
+    def _dispatch_read(self) -> str:
+        """Console-facing ``read`` seam: queued footer lines, or one decoded fd chunk."""
+        if self._footer_active:
+            if self._line_queue:
+                chunk = "".join(f"{line}\n" for line in self._line_queue)
+                self._line_queue = []
+                return chunk
+            return ""
+        raw = self._fd_read()
+        return "" if raw == b"" else raw.decode("utf-8", errors="replace")
+
+    def _pump_input(self) -> None:
+        """Drain readable stdin into the line editor, echoing the input row after each chunk."""
+        while self._fd_readable():
+            chunk = self._fd_read()
+            if chunk == b"":
+                self._pump_eof = True
+                break
+            self._line_queue.extend(self._editor.feed(chunk))
+            self._draw_input_row()
+
+    def _clipped_input_text(self) -> str:
+        return _clip_tail(self._editor.text(), self._width_fn() - 4)
+
+    def _clipped_status_text(self) -> str:
+        assert self._status_line is not None
+        return _clip_tail(self._status_line, self._width_fn() - 1)
+
+    def _draw_input_row(self) -> None:
+        self._write(f"\r\x1b[K> {self._clipped_input_text()}")
+
+    def _enter_footer(self) -> None:
+        """Enter the footer window for a new trial (decisions 5 and 7).
+
+        Drains stale fd bytes with no echo, resets the editor and queue, closes a
+        stale plain-open status line, then draws the (now empty) input row.
+        """
+        self._footer_active = True
+        while self._fd_readable():
+            if self._fd_read() == b"":
+                self._pump_eof = True
+                break
+        self._editor.reset()
+        self._line_queue = []
+        prefix = ""
+        if self._status_open:
+            prefix = "\n"
+            self._status_open = False
+        self._write(f"{prefix}\r\x1b[K> {self._clipped_input_text()}")
+
+    def _footer_status(self, line: str | None) -> None:
+        if line is None:
+            if self._status_open:
+                self._write(f"\r\x1b[K\x1b[A\r\x1b[K> {self._clipped_input_text()}")
+                self._status_open = False
+            return
+
+        self._status_line = line
+        if self._status_open:
+            self._write(
+                f"\x1b[A\r\x1b[K{self._clipped_status_text()}"
+                f"\x1b[B\r\x1b[K> {self._clipped_input_text()}"
+            )
+        else:
+            self._write(
+                f"\r\x1b[K{self._clipped_status_text()}\n\r\x1b[K> {self._clipped_input_text()}"
+            )
+            self._status_open = True
+
+    def _footer_write_line(self, text: str) -> None:
+        if self._status_open:
+            self._write(
+                f"\r\x1b[K\x1b[A\r\x1b[K{text}\n"
+                f"{self._clipped_status_text()}\n"
+                f"\r\x1b[K> {self._clipped_input_text()}"
+            )
+        else:
+            self._write(f"\r\x1b[K{text}\n\r\x1b[K> {self._clipped_input_text()}")
+
+    def enable_footer(self) -> None:
+        """Opt into the two-row footer renderer (decision 3).
+
+        A documented no-op when this session was built with a caller-injected
+        ``console=...``: the footer requires the session-built console whose seams
+        are the decision-7 dispatching closures wired in ``__init__``.
+        """
+        if self._owns_console:
+            self._footer_requested = True
+
+    def end_trial(self) -> None:
+        """Idempotently tear down the footer's rows; a no-op unless footer mode was entered.
+
+        Duck-typed hook (decision 1): ``rollout()`` calls this best-effort in the
+        per-trial ``finally``. Task 2 layers termios restore around this same call;
+        here it is pure rendering teardown, clearing whatever rows exist and leaving
+        a clean terminal for the verdict prompt.
+        """
+        if not self._footer_active:
+            return
+        if self._status_open:
+            self._write("\r\x1b[K\x1b[A\r\x1b[K")
+            self._status_open = False
+        else:
+            self._write("\r\x1b[K")
+        self._footer_active = False
+
     def poll(self) -> ConsolePoll:
         """Poll the console first, then merge every healthy attached input in order."""
+        if self._footer_active:
+            self._pump_input()
         console_poll = self._console.poll()
         if not self._attached_inputs:
             return console_poll
@@ -91,6 +300,8 @@ class OperatorSession:
 
     def begin_trial(self) -> None:
         """Ask every healthy input to discard feedback predating the next trial."""
+        if self._footer_requested:
+            self._enter_footer()
         self._console.begin_trial()
         healthy_inputs: list[tuple[OperatorInput, str]] = []
         for source, label in self._attached_inputs:
@@ -111,7 +322,14 @@ class OperatorSession:
         self._attached_inputs.append((source, label))
 
     def status(self, line: str | None) -> None:
-        """Render one in-place status line, or idempotently close an open line."""
+        """Render one in-place status line, or idempotently close an open line.
+
+        In footer mode this drives the two-row/one-row renderer from decision 5
+        instead of the plain single-line ticker.
+        """
+        if self._footer_active:
+            self._footer_status(line)
+            return
         if line is None:
             if self._status_open:
                 self._write("\n")
@@ -123,7 +341,10 @@ class OperatorSession:
         self._status_open = True
 
     def write_line(self, text: str) -> None:
-        """Write scrollback text without losing an open status line."""
+        """Write scrollback text without losing an open status line (or the footer's input row)."""
+        if self._footer_active:
+            self._footer_write_line(text)
+            return
         if self._status_open:
             self._write("\n")
         self._write(f"{text}\n")

--- a/src/inspect_robots/session.py
+++ b/src/inspect_robots/session.py
@@ -263,6 +263,8 @@ class OperatorSession:
 
     def _try_enter_footer(self) -> None:
         """Re-evaluate the per-trial gate ladder and silently retain plain mode on failure."""
+        if self._footer_active:
+            return
         if not self._footer_requested or not self._owns_console:
             return
         try:
@@ -330,7 +332,9 @@ class OperatorSession:
 
         A documented no-op when this session was built with a caller-injected
         ``console=...``: the footer requires the session-built console whose seams
-        are the decision-7 dispatching closures wired in ``__init__``.
+        are the decision-7 dispatching closures wired in ``__init__``. The first
+        enabling call also registers this session's idempotent terminal-restore
+        with ``atexit`` as a crash net.
         """
         if self._owns_console:
             self._footer_requested = True

--- a/src/inspect_robots/session.py
+++ b/src/inspect_robots/session.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import atexit
 import os
 import select
 import shutil
 import sys
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from inspect_robots.console import ConsolePoll, OperatorConsole, OperatorInput, _stdin_readable
 from inspect_robots.errors import EmbodimentFault
@@ -23,6 +24,7 @@ _PROMPT = "did the robot succeed? [y/n/partial/skip] (partial scores as failure)
 _NOTES_PROMPT = "grader notes (Enter for none): "
 _PROMPT_ANSWERS = frozenset({"y", "yes", "n", "no", "partial", "skip"})
 _DEFINITIVE_REASONS = frozenset({"success", "failure"})
+_NO_TERMIOS_STATE = object()
 
 
 def _flush_stdin_fd() -> None:
@@ -37,6 +39,29 @@ def _flush_stdin_fd() -> None:
 def _stdin_read_bytes() -> bytes:
     """Read up to 64KiB of raw stdin without decoding (the footer pump's default fd seam)."""
     return os.read(sys.stdin.fileno(), 65536)  # pragma: no cover
+
+
+def _enter_cbreak() -> object:
+    """Enter stdin cbreak mode without echo and return the exact attributes to restore."""
+    import termios  # pragma: no cover
+
+    fd = sys.stdin.fileno()  # pragma: no cover
+    saved = termios.tcgetattr(fd)  # pragma: no cover
+    current = saved.copy()  # pragma: no cover
+    current[6] = saved[6].copy()  # pragma: no cover
+    current[3] &= ~(termios.ECHO | termios.ICANON)  # pragma: no cover
+    current[6][termios.VMIN] = 1  # pragma: no cover
+    current[6][termios.VTIME] = 0  # pragma: no cover
+    termios.tcsetattr(fd, termios.TCSANOW, current)  # pragma: no cover
+    return (fd, saved)  # pragma: no cover
+
+
+def _restore(state: object) -> None:
+    """Restore one exact termios snapshot returned by ``_enter_cbreak``."""
+    import termios  # pragma: no cover
+
+    fd, attrs = cast(tuple[int, list[Any]], state)  # pragma: no cover
+    termios.tcsetattr(fd, termios.TCSANOW, attrs)  # pragma: no cover
 
 
 def _default_width() -> int:
@@ -121,6 +146,10 @@ class OperatorSession:
         fd_readable: Callable[[], bool] | None = None,
         fd_read: Callable[[], bytes] | None = None,
         width_fn: Callable[[], int] | None = None,
+        isatty_fn: Callable[[], bool] | None = None,
+        raw_mode_fn: Callable[[], object] | None = None,
+        restore_fn: Callable[[object], None] | None = None,
+        atexit_register: Callable[[Callable[[], None]], object] | None = None,
     ) -> None:
         self._input_fn = input_fn
         self._write_fn = write
@@ -130,6 +159,20 @@ class OperatorSession:
         self._owns_console = console is None
         self._footer_requested = False
         self._footer_active = False
+        self._isatty_fn: Callable[[], bool] = (
+            isatty_fn if isatty_fn is not None else sys.stdin.isatty
+        )
+        self._raw_mode_fn: Callable[[], object] = (
+            raw_mode_fn if raw_mode_fn is not None else _enter_cbreak
+        )
+        self._restore_fn: Callable[[object], None] = (
+            restore_fn if restore_fn is not None else _restore
+        )
+        self._atexit_register: Callable[[Callable[[], None]], object] = (
+            atexit_register if atexit_register is not None else atexit.register
+        )
+        self._atexit_registered = False
+        self._saved_termios_state: object = _NO_TERMIOS_STATE
         self._fd_readable: Callable[[], bool] = (
             fd_readable if fd_readable is not None else _stdin_readable
         )
@@ -217,6 +260,41 @@ class OperatorSession:
             self._status_open = False
         self._write(f"{prefix}\r\x1b[K> {self._clipped_input_text()}")
 
+    def _try_enter_footer(self) -> None:
+        """Re-evaluate the per-trial gate ladder and silently retain plain mode on failure."""
+        if not self._footer_requested or not self._owns_console:
+            return
+        try:
+            if not self._isatty_fn():
+                return
+            saved_state = self._raw_mode_fn()
+        except Exception:
+            return
+
+        self._saved_termios_state = saved_state
+        try:
+            self._enter_footer()
+        except BaseException:
+            self._reset_footer_state()
+            self._restore_terminal()
+            raise
+
+    def _reset_footer_state(self) -> None:
+        """Discard all renderer and editor state after a footer window closes or aborts."""
+        self._footer_active = False
+        self._status_open = False
+        self._editor.reset()
+        self._line_queue = []
+        self._pump_eof = False
+
+    def _restore_terminal(self) -> None:
+        """Idempotently restore and forget the active termios snapshot."""
+        if self._saved_termios_state is _NO_TERMIOS_STATE:
+            return
+        saved_state = self._saved_termios_state
+        self._saved_termios_state = _NO_TERMIOS_STATE
+        self._restore_fn(saved_state)
+
     def _footer_status(self, line: str | None) -> None:
         if line is None:
             if self._status_open:
@@ -255,23 +333,27 @@ class OperatorSession:
         """
         if self._owns_console:
             self._footer_requested = True
+            if not self._atexit_registered:
+                self._atexit_register(self._restore_terminal)
+                self._atexit_registered = True
 
     def end_trial(self) -> None:
-        """Idempotently tear down the footer's rows; a no-op unless footer mode was entered.
+        """Idempotently clear footer rows and restore the trial's exact terminal attributes.
 
         Duck-typed hook (decision 1): ``rollout()`` calls this best-effort in the
-        per-trial ``finally``. Task 2 layers termios restore around this same call;
-        here it is pure rendering teardown, clearing whatever rows exist and leaving
-        a clean terminal for the verdict prompt.
+        per-trial ``finally``. A session that did not enter footer mode writes no
+        bytes and leaves plain-renderer state untouched.
         """
         if not self._footer_active:
             return
-        if self._status_open:
-            self._write("\r\x1b[K\x1b[A\r\x1b[K")
-            self._status_open = False
-        else:
-            self._write("\r\x1b[K")
-        self._footer_active = False
+        try:
+            if self._status_open:
+                self._write("\r\x1b[K\x1b[A\r\x1b[K")
+            else:
+                self._write("\r\x1b[K")
+        finally:
+            self._reset_footer_state()
+            self._restore_terminal()
 
     def poll(self) -> ConsolePoll:
         """Poll the console first, then merge every healthy attached input in order."""
@@ -299,9 +381,8 @@ class OperatorSession:
         return ConsolePoll(messages=tuple(messages), end=console_poll.end, sources=tuple(sources))
 
     def begin_trial(self) -> None:
-        """Ask every healthy input to discard feedback predating the next trial."""
-        if self._footer_requested:
-            self._enter_footer()
+        """Re-decide footer eligibility, then discard feedback predating the next trial."""
+        self._try_enter_footer()
         self._console.begin_trial()
         healthy_inputs: list[tuple[OperatorInput, str]] = []
         for source, label in self._attached_inputs:

--- a/src/inspect_robots/session.py
+++ b/src/inspect_robots/session.py
@@ -159,6 +159,7 @@ class OperatorSession:
         self._owns_console = console is None
         self._footer_requested = False
         self._footer_active = False
+        self._footer_label: str | None = None
         self._isatty_fn: Callable[[], bool] = (
             isatty_fn if isatty_fn is not None else sys.stdin.isatty
         )
@@ -324,8 +325,8 @@ class OperatorSession:
         else:
             self._write(f"\r\x1b[K{text}\n\r\x1b[K> {self._clipped_input_text()}")
 
-    def enable_footer(self) -> None:
-        """Opt into the two-row footer renderer (decision 3).
+    def enable_footer(self, *, label: str) -> None:
+        """Opt into the two-row footer renderer with its feedback confirmation label.
 
         A documented no-op when this session was built with a caller-injected
         ``console=...``: the footer requires the session-built console whose seams
@@ -333,6 +334,7 @@ class OperatorSession:
         """
         if self._owns_console:
             self._footer_requested = True
+            self._footer_label = label
             if not self._atexit_registered:
                 self._atexit_register(self._restore_terminal)
                 self._atexit_registered = True
@@ -361,6 +363,7 @@ class OperatorSession:
             self._pump_input()
         console_poll = self._console.poll()
         if not self._attached_inputs:
+            self._confirm_console_messages(console_poll)
             return console_poll
 
         messages = list(console_poll.messages)
@@ -378,7 +381,17 @@ class OperatorSession:
                 messages.append(text)
                 sources.append(label)
         self._attached_inputs = healthy_inputs
-        return ConsolePoll(messages=tuple(messages), end=console_poll.end, sources=tuple(sources))
+        poll = ConsolePoll(messages=tuple(messages), end=console_poll.end, sources=tuple(sources))
+        self._confirm_console_messages(poll)
+        return poll
+
+    def _confirm_console_messages(self, poll: ConsolePoll) -> None:
+        if not self._footer_active:
+            return
+        assert self._footer_label is not None
+        for index, message in enumerate(poll.messages):
+            if not poll.sources or poll.sources[index] == "console":
+                self.write_line(f"[{self._footer_label}] {message}")
 
     def begin_trial(self) -> None:
         """Re-decide footer eligibility, then discard feedback predating the next trial."""

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -3717,10 +3717,11 @@ def test_end_only_voice_mode_prints_log_only_notice(
         "expected_output",
         "expected_connect_calls",
         "expected_defer_calls",
+        "expected_footer_label",
     ),
     [
-        ("new", True, "linux", True, f"{USAGE}\n", 1, 0),
-        ("new", False, "linux", True, f"{USAGE_END_ONLY}\n", 1, 0),
+        ("new", True, "linux", True, f"{USAGE}\n", 1, 0, "sent"),
+        ("new", False, "linux", True, f"{USAGE_END_ONLY}\n", 1, 0, "noted"),
         (
             "new",
             True,
@@ -3730,6 +3731,7 @@ def test_end_only_voice_mode_prints_log_only_notice(
             "feedback typing stays off\n",
             0,
             0,
+            None,
         ),
         (
             "new",
@@ -3740,11 +3742,12 @@ def test_end_only_voice_mode_prints_log_only_notice(
             "feedback typing stays off\n",
             0,
             0,
+            None,
         ),
-        ("defer", True, "linux", True, f"{USAGE}\n", 0, 1),
-        ("defer", False, "win32", False, "", 0, 0),
-        ("simulated", True, "linux", True, f"{USAGE}\n", 0, 0),
-        ("simulated", False, "linux", False, "", 0, 0),
+        ("defer", True, "linux", True, f"{USAGE}\n", 0, 1, "sent"),
+        ("defer", False, "win32", False, "", 0, 0, None),
+        ("simulated", True, "linux", True, f"{USAGE}\n", 0, 0, "sent"),
+        ("simulated", False, "linux", False, "", 0, 0, None),
         (
             "bare",
             True,
@@ -3754,8 +3757,9 @@ def test_end_only_voice_mode_prints_log_only_notice(
             "and still owns the end-of-episode keypress; feedback typing stays off\n",
             0,
             0,
+            None,
         ),
-        ("bare", False, "win32", False, "", 0, 0),
+        ("bare", False, "win32", False, "", 0, 0, None),
     ],
 )
 def test_build_operator_session_enablement_matrix(
@@ -3766,6 +3770,7 @@ def test_build_operator_session_enablement_matrix(
     expected_output: str,
     expected_connect_calls: int,
     expected_defer_calls: int,
+    expected_footer_label: str | None,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -3806,6 +3811,14 @@ def test_build_operator_session_enablement_matrix(
     else:
         embodiment = BareEmbodiment()
     monkeypatch.setattr(sys, "platform", platform)
+    footer_labels: list[str] = []
+    original_enable_footer = OperatorSession.enable_footer
+
+    def record_enable_footer(self: OperatorSession, *, label: str) -> None:
+        footer_labels.append(label)
+        original_enable_footer(self, label=label)
+
+    monkeypatch.setattr(OperatorSession, "enable_footer", record_enable_footer)
 
     session, operator_input = cli._build_operator_session(policy, embodiment)
 
@@ -3815,6 +3828,7 @@ def test_build_operator_session_enablement_matrix(
     assert getattr(embodiment, "defer_calls", 0) == expected_defer_calls
     if expected_connect_calls:
         assert getattr(embodiment, "connected_session", None) is session
+    assert footer_labels == ([] if expected_footer_label is None else [expected_footer_label])
     assert capsys.readouterr().out == expected_output
 
 

--- a/tests/test_rollout_observation_step.py
+++ b/tests/test_rollout_observation_step.py
@@ -10,7 +10,7 @@ import pytest
 from inspect_robots.approver import AutoApprover
 from inspect_robots.console import ConsolePoll, EndRequest, OperatorInput
 from inspect_robots.controller import DefaultController
-from inspect_robots.errors import _CancelledTrial
+from inspect_robots.errors import EmbodimentFault, _CancelledTrial
 from inspect_robots.logging.sink import LogSink, NullSink
 from inspect_robots.mock import CubePickEmbodiment
 from inspect_robots.policy import PolicyConfig, PolicyInfo
@@ -77,6 +77,26 @@ class FakeOperatorInput:
             raise self.begin_error
 
 
+class _EndingOperatorInput(FakeOperatorInput):
+    """Add a duck-typed trial-finalization hook to the scripted operator input."""
+
+    def __init__(
+        self,
+        polls: list[ConsolePoll | BaseException],
+        *,
+        end_error: Exception | None = None,
+    ) -> None:
+        super().__init__(polls)
+        self.end_error = end_error
+        self.end_calls = 0
+
+    def end_trial(self) -> None:
+        """Record trial finalization and raise the configured failure, if any."""
+        self.end_calls += 1
+        if self.end_error is not None:
+            raise self.end_error
+
+
 class _TrackingEmbodiment(CubePickEmbodiment):
     """Track reset ordering and how many actions reached the embodiment."""
 
@@ -96,6 +116,15 @@ class _TrackingEmbodiment(CubePickEmbodiment):
         """Count each action before delegating to the mock world."""
         self.step_calls += 1
         return super().step(action)
+
+
+class _FailingStepEmbodiment(CubePickEmbodiment):
+    """Raise a trial-ending embodiment failure from the first action."""
+
+    def step(self, action: Action) -> StepResult:
+        """Fail every attempted action so rollout exercises its exception path."""
+        del action
+        raise RuntimeError("motion failed")
 
 
 class _ObservationSink(NullSink):
@@ -326,6 +355,87 @@ def test_begin_trial_runs_once_after_embodiment_reset() -> None:
     assert order == ["reset", "begin"]
 
 
+def test_end_trial_runs_on_success_path() -> None:
+    operator_input = _EndingOperatorInput([])
+
+    record = _run(
+        _ProbePolicy(),
+        CubePickEmbodiment(),
+        max_steps=1,
+        operator_input=operator_input,
+    )
+
+    assert record.status == "success"
+    assert operator_input.end_calls == 1
+
+
+def test_end_trial_runs_on_trial_ending_exception_path() -> None:
+    operator_input = _EndingOperatorInput([])
+
+    with pytest.raises(EmbodimentFault, match="motion failed"):
+        _run(
+            _ProbePolicy(),
+            _FailingStepEmbodiment(),
+            max_steps=1,
+            operator_input=operator_input,
+        )
+
+    assert operator_input.end_calls == 1
+
+
+def test_operator_input_without_end_trial_hook_is_skipped_without_error() -> None:
+    operator_input = FakeOperatorInput([])
+
+    record = _run(
+        _ProbePolicy(),
+        CubePickEmbodiment(),
+        max_steps=1,
+        operator_input=operator_input,
+    )
+
+    assert record.status == "success"
+
+
+def test_raising_end_trial_warns_without_masking_successful_outcome() -> None:
+    operator_input = _EndingOperatorInput([], end_error=RuntimeError("restore failed"))
+
+    with pytest.warns(
+        RuntimeWarning,
+        match="Operator console disabled for this trial after RuntimeError: restore failed",
+    ) as warning_records:
+        record = _run(
+            _ProbePolicy(),
+            CubePickEmbodiment(),
+            max_steps=1,
+            operator_input=operator_input,
+        )
+
+    assert len(warning_records) == 1
+    assert record.status == "success"
+    assert operator_input.end_calls == 1
+
+
+def test_raising_end_trial_warns_without_masking_trial_exception() -> None:
+    operator_input = _EndingOperatorInput([], end_error=RuntimeError("restore failed"))
+
+    with (
+        pytest.warns(
+            RuntimeWarning,
+            match="Operator console disabled for this trial after RuntimeError: restore failed",
+        ) as warning_records,
+        pytest.raises(EmbodimentFault, match="motion failed"),
+    ):
+        _run(
+            _ProbePolicy(),
+            _FailingStepEmbodiment(),
+            max_steps=1,
+            operator_input=operator_input,
+        )
+
+    assert len(warning_records) == 1
+    assert operator_input.end_calls == 1
+
+
 def test_no_operator_input_keeps_reserved_key_out_of_policy_observations() -> None:
     policy = _ProbePolicy(chunk_size=2)
 
@@ -357,6 +467,26 @@ def test_raising_poll_warns_once_disables_channel_and_preserves_record() -> None
     assert record.status == "success"
     assert record.truncated is True
     assert record.termination_reason == "max_steps"
+
+
+def test_end_trial_still_runs_after_raising_poll_disables_channel() -> None:
+    operator_input = _EndingOperatorInput([RuntimeError("poll failed")])
+
+    with pytest.warns(
+        RuntimeWarning,
+        match="Operator console disabled for this trial after RuntimeError: poll failed",
+    ) as warning_records:
+        record = _run(
+            _ProbePolicy(),
+            CubePickEmbodiment(),
+            max_steps=2,
+            operator_input=operator_input,
+        )
+
+    assert len(warning_records) == 1
+    assert record.status == "success"
+    assert operator_input.poll_calls == 1
+    assert operator_input.end_calls == 1
 
 
 def test_raising_begin_trial_warns_once_and_disables_channel() -> None:
@@ -398,3 +528,20 @@ def test_keyboard_interrupt_from_poll_uses_cancelled_trial_path() -> None:
     assert record.error == "cancelled by user (KeyboardInterrupt)"
     assert record.steps == []
     assert excinfo.value.__cause__ is original
+
+
+def test_end_trial_runs_on_keyboard_interrupt_cancelled_trial_path() -> None:
+    original = KeyboardInterrupt("operator interrupt")
+    operator_input = _EndingOperatorInput([original])
+
+    with pytest.raises(_CancelledTrial) as excinfo:
+        _run(
+            _ProbePolicy(),
+            _TrackingEmbodiment(),
+            max_steps=3,
+            operator_input=operator_input,
+        )
+
+    assert excinfo.value.__cause__ is original
+    assert excinfo.value.record.status == "cancelled"
+    assert operator_input.end_calls == 1

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import builtins
 import io
+import os
+import shutil
 import sys
 from collections.abc import Callable
 
@@ -589,3 +591,519 @@ def test_prompt_verdict_notes_early_end_reason_before_asking() -> None:
     assert "note: this trial ended early ('give_up')\n" in output
     assert prompts == [_PROMPT, _NOTES_PROMPT]
     assert record.operator_judgement == "y"
+
+
+# --- Footer mode: line editor + pump + two-state renderer (plan 0051, task 1) -------------
+
+
+class _ScriptedFd:
+    """Feed pre-scripted raw byte chunks to the footer pump's fd seams.
+
+    ``chunks`` is public and mutable so a test can queue more bytes between two
+    ``poll()`` calls (exercising state that must persist across polls).
+    """
+
+    def __init__(self, chunks: list[bytes] | None = None) -> None:
+        self.chunks: list[bytes] = list(chunks) if chunks is not None else []
+
+    def readable(self) -> bool:
+        return bool(self.chunks)
+
+    def read(self) -> bytes:
+        return self.chunks.pop(0)
+
+
+def _footer_session(
+    output: list[str], fd: _ScriptedFd | None = None, width: int = 200
+) -> tuple[OperatorSession, _ScriptedFd]:
+    """Build a footer-enabled session, run ``begin_trial()``, then drop its input-row draw."""
+    fd = fd if fd is not None else _ScriptedFd()
+    session = OperatorSession(
+        write=output.append,
+        fd_readable=fd.readable,
+        fd_read=fd.read,
+        width_fn=lambda: width,
+    )
+    session.enable_footer()
+    session.begin_trial()
+    output.clear()
+    return session, fd
+
+
+def test_enable_footer_is_noop_on_caller_injected_console() -> None:
+    output: list[str] = []
+    session = OperatorSession(console=_RecordingConsole(), write=output.append)
+
+    session.enable_footer()
+    session.begin_trial()
+
+    assert output == []
+
+
+def test_default_console_dispatch_closures_delegate_to_fd_seams_when_footer_inactive() -> None:
+    output: list[str] = []
+    chunks = [b"/oops\n"]
+    session = OperatorSession(
+        write=output.append,
+        fd_readable=lambda: bool(chunks),
+        fd_read=lambda: chunks.pop(0),
+    )
+
+    assert session.poll() == ConsolePoll()
+    assert output == [f"{USAGE}\n"]
+
+
+def test_footer_begin_trial_draws_empty_input_row() -> None:
+    output: list[str] = []
+    fd = _ScriptedFd()
+    session = OperatorSession(
+        write=output.append, fd_readable=fd.readable, fd_read=fd.read, width_fn=lambda: 200
+    )
+    session.enable_footer()
+
+    session.begin_trial()
+
+    assert output == ["\r\x1b[K> "]
+
+
+def test_footer_begin_trial_closes_plain_open_status_then_one_row_branch() -> None:
+    output: list[str] = []
+    fd = _ScriptedFd()
+    session = OperatorSession(
+        write=output.append, fd_readable=fd.readable, fd_read=fd.read, width_fn=lambda: 200
+    )
+    session.status("t = 3s")
+    output.clear()
+    session.enable_footer()
+
+    session.begin_trial()
+
+    assert output == ["\n\r\x1b[K> "]
+    output.clear()
+
+    session.status("t = 4s")
+
+    assert output == ["\r\x1b[Kt = 4s\n\r\x1b[K> "]
+    assert "\x1b[A" not in output[0]
+
+
+def test_footer_begin_trial_drain_stops_on_real_eof() -> None:
+    output: list[str] = []
+    fd = _ScriptedFd([b""])
+    session = OperatorSession(
+        write=output.append, fd_readable=fd.readable, fd_read=fd.read, width_fn=lambda: 200
+    )
+    session.enable_footer()
+
+    session.begin_trial()
+
+    assert output == ["\r\x1b[K> "]
+    poll = session.poll()
+    assert poll == ConsolePoll()
+
+
+def test_footer_status_none_on_already_closed_status_is_noop() -> None:
+    output: list[str] = []
+    session, _fd = _footer_session(output)
+
+    session.status(None)
+
+    assert output == []
+
+
+def test_footer_default_width_fn_reads_terminal_size(monkeypatch: pytest.MonkeyPatch) -> None:
+    output: list[str] = []
+    fd = _ScriptedFd()
+    monkeypatch.setattr(shutil, "get_terminal_size", lambda: os.terminal_size((10, 24)))
+    session = OperatorSession(write=output.append, fd_readable=fd.readable, fd_read=fd.read)
+    session.enable_footer()
+    session.begin_trial()
+    output.clear()
+    fd.chunks = [b"abcdefgh"]
+
+    session.poll()
+
+    assert output == ["\r\x1b[K> cdefgh"]
+
+
+def test_footer_begin_trial_discards_stale_bytes_with_no_echo_and_clears_state() -> None:
+    output: list[str] = []
+    fd = _ScriptedFd([b"stale", b"\n"])
+    session = OperatorSession(
+        write=output.append, fd_readable=fd.readable, fd_read=fd.read, width_fn=lambda: 200
+    )
+    session.enable_footer()
+
+    session.begin_trial()
+
+    assert output == ["\r\x1b[K> "]
+    assert fd.chunks == []
+    assert session.poll().messages == ()
+
+
+def test_footer_one_row_write_line_has_no_cursor_up() -> None:
+    output: list[str] = []
+    session, _fd = _footer_session(output)
+
+    session.write_line("hello")
+
+    assert output == ["\r\x1b[Khello\n\r\x1b[K> "]
+    assert "\x1b[A" not in output[0]
+
+
+def test_footer_first_status_creates_status_row_from_one_row_state() -> None:
+    output: list[str] = []
+    session, _fd = _footer_session(output)
+
+    session.status("t = 3s")
+
+    assert output == ["\r\x1b[Kt = 3s\n\r\x1b[K> "]
+
+
+def test_footer_two_row_status_update() -> None:
+    output: list[str] = []
+    session, _fd = _footer_session(output)
+    session.status("t = 3s")
+    output.clear()
+
+    session.status("t = 4s")
+
+    assert output == ["\x1b[A\r\x1b[Kt = 4s\x1b[B\r\x1b[K> "]
+
+
+def test_footer_two_row_write_line_clears_input_row_first() -> None:
+    output: list[str] = []
+    session, _fd = _footer_session(output)
+    session.status("t = 4s")
+    output.clear()
+
+    session.write_line("operator message")
+
+    assert output == ["\r\x1b[K\x1b[A\r\x1b[Koperator message\nt = 4s\n\r\x1b[K> "]
+
+
+def test_footer_status_none_collapses_two_row_to_one_row_retaining_input() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    session.status("t = 4s")
+    output.clear()
+    fd.chunks = [b"h", b"i"]
+    session.poll()
+    output.clear()
+
+    session.status(None)
+
+    assert output == ["\r\x1b[K\x1b[A\r\x1b[K> hi"]
+
+    # The one-row branch is active again: no cursor-up in a follow-up status(line).
+    output.clear()
+    session.status("t = 5s")
+    assert output == ["\r\x1b[Kt = 5s\n\r\x1b[K> hi"]
+
+
+def test_footer_input_echo_one_row_state() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"h"]
+
+    session.poll()
+
+    assert output == ["\r\x1b[K> h"]
+
+
+def test_footer_input_echo_two_row_state() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    session.status("t = 4s")
+    output.clear()
+    fd.chunks = [b"h"]
+
+    session.poll()
+
+    assert output == ["\r\x1b[K> h"]
+
+
+def test_footer_end_trial_teardown_one_row_state() -> None:
+    output: list[str] = []
+    session, _fd = _footer_session(output)
+
+    session.end_trial()
+
+    assert output == ["\r\x1b[K"]
+
+
+def test_footer_end_trial_teardown_two_row_state() -> None:
+    output: list[str] = []
+    session, _fd = _footer_session(output)
+    session.status("t = 4s")
+    output.clear()
+
+    session.end_trial()
+
+    assert output == ["\r\x1b[K\x1b[A\r\x1b[K"]
+
+
+def test_footer_end_trial_teardown_is_idempotent() -> None:
+    output: list[str] = []
+    session, _fd = _footer_session(output)
+
+    session.end_trial()
+    output.clear()
+    session.end_trial()
+
+    assert output == []
+
+
+def test_footer_end_trial_noop_when_footer_never_entered_leaves_plain_status_untouched() -> None:
+    output: list[str] = []
+    session = OperatorSession(write=output.append)
+    session.status("t = 3s")
+    output.clear()
+
+    session.end_trial()
+
+    assert output == []
+    # The plain-open status line survives: end_trial() must not touch it when footer
+    # mode was never entered (the plain-mode byte-identity backstop).
+    session.status(None)
+    assert output == ["\n"]
+
+
+def test_footer_input_row_tail_clips_at_width_minus_4() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output, width=10)
+    fd.chunks = [b"abcdefgh"]
+
+    session.poll()
+
+    assert output == ["\r\x1b[K> cdefgh"]
+
+
+def test_footer_status_row_clips_at_width_minus_1() -> None:
+    output: list[str] = []
+    session, _fd = _footer_session(output, width=6)
+
+    session.status("0123456789")
+
+    assert output == ["\r\x1b[K56789\n\r\x1b[K> "]
+
+
+def test_footer_reclips_after_width_fn_change() -> None:
+    output: list[str] = []
+    width = {"cols": 200}
+    fd = _ScriptedFd()
+    session = OperatorSession(
+        write=output.append,
+        fd_readable=fd.readable,
+        fd_read=fd.read,
+        width_fn=lambda: width["cols"],
+    )
+    session.enable_footer()
+    session.begin_trial()
+    output.clear()
+    fd.chunks = [b"abcdef"]
+    session.poll()
+    assert output == ["\r\x1b[K> abcdef"]
+    output.clear()
+
+    width["cols"] = 8
+    fd.chunks = [b"g"]
+    session.poll()
+
+    assert output == ["\r\x1b[K> defg"]
+
+
+def test_footer_pump_backspace_deletes_one_byte() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"a", b"b"]
+    session.poll()
+    output.clear()
+
+    fd.chunks = [b"\x7f"]
+    session.poll()
+
+    assert output == ["\r\x1b[K> a"]
+
+
+def test_footer_pump_backspace_on_empty_buffer_is_noop() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"\x7f"]
+
+    session.poll()
+
+    assert output == ["\r\x1b[K> "]
+
+
+def test_footer_pump_backspace_after_multibyte_char_removes_whole_character() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"caf", "é".encode()]
+    session.poll()
+    output.clear()
+
+    fd.chunks = [b"\x7f"]
+    session.poll()
+
+    assert output == ["\r\x1b[K> caf"]
+
+    fd.chunks = [b"\n"]
+    poll = session.poll()
+    assert poll.messages == ("caf",)
+
+
+def test_footer_pump_ctrl_u_kills_line() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"abc"]
+    session.poll()
+    output.clear()
+
+    fd.chunks = [b"\x15"]
+    session.poll()
+
+    assert output == ["\r\x1b[K> "]
+
+
+def test_footer_pump_ignores_other_control_bytes() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"a", b"\x01", b"\n"]
+
+    poll = session.poll()
+
+    assert poll.messages == ("a",)
+
+
+@pytest.mark.parametrize("terminator", [b"\n", b"\r"])
+def test_footer_pump_enter_completes_line_reaching_console_same_poll(terminator: bytes) -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"hello", terminator]
+
+    poll = session.poll()
+
+    assert poll.messages == ("hello",)
+    assert output[-1] == "\r\x1b[K> "
+
+
+def test_footer_pump_bytes_without_newline_echo_but_deliver_nothing() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"h", b"i"]
+
+    poll = session.poll()
+
+    assert poll == ConsolePoll()
+    assert output == ["\r\x1b[K> h", "\r\x1b[K> hi"]
+
+
+def test_footer_pump_split_utf8_across_chunks_decodes_cleanly_at_completion() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    lead, cont = "é".encode()[0:1], "é".encode()[1:2]
+    fd.chunks = [lead, cont, b"\n"]
+
+    poll = session.poll()
+
+    assert poll.messages == ("é",)
+
+
+def test_footer_pump_handles_64kib_paste_chunk() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output, width=50)
+    pasted = b"a" * 65536
+    fd.chunks = [pasted]
+
+    session.poll()
+
+    assert output == ["\r\x1b[K> " + "a" * 46]
+    output.clear()
+
+    fd.chunks = [b"\n"]
+    poll = session.poll()
+
+    assert poll.messages == (pasted.decode(),)
+
+
+def test_footer_pump_swallows_arrow_key_csi_sequence() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"a", b"\x1b[A", b"b"]
+
+    poll = session.poll()
+
+    assert output == ["\r\x1b[K> a", "\r\x1b[K> a", "\r\x1b[K> ab"]
+    fd.chunks = [b"\n"]
+    poll = session.poll()
+    assert poll.messages == ("ab",)
+
+
+def test_footer_pump_swallows_csi_sequence_with_intermediate_byte() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"\x1b[3~"]
+
+    session.poll()
+
+    assert output == ["\r\x1b[K> "]
+
+
+def test_footer_pump_swallows_ss3_sequence() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"\x1bOP"]
+
+    session.poll()
+
+    assert output == ["\r\x1b[K> "]
+
+
+def test_footer_pump_swallows_bare_esc_plus_byte() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"\x1bq", b"z"]
+
+    session.poll()
+
+    assert output == ["\r\x1b[K> ", "\r\x1b[K> z"]
+
+
+def test_footer_pump_escape_sequence_split_across_two_fd_read_chunks() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"\x1b", b"[", b"A", b"z"]
+
+    session.poll()
+
+    assert output == ["\r\x1b[K> ", "\r\x1b[K> ", "\r\x1b[K> ", "\r\x1b[K> z"]
+
+
+def test_footer_pump_escape_sequence_split_across_two_poll_calls() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"\x1b"]
+    session.poll()
+    output.clear()
+
+    fd.chunks = [b"[A"]
+    poll = session.poll()
+
+    assert output == ["\r\x1b[K> "]
+    assert poll == ConsolePoll()
+
+    output.clear()
+    fd.chunks = [b"z", b"\n"]
+    poll = session.poll()
+    assert poll.messages == ("z",)
+
+
+def test_footer_dispatch_eof_contract_returns_empty_string_only_on_real_eof() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b""]
+
+    poll = session.poll()
+
+    assert poll == ConsolePoll()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -614,7 +614,10 @@ class _ScriptedFd:
 
 
 def _footer_session(
-    output: list[str], fd: _ScriptedFd | None = None, width: int = 200
+    output: list[str],
+    fd: _ScriptedFd | None = None,
+    width: int = 200,
+    label: str = "sent",
 ) -> tuple[OperatorSession, _ScriptedFd]:
     """Build a footer-enabled session, run ``begin_trial()``, then drop its input-row draw."""
     fd = fd if fd is not None else _ScriptedFd()
@@ -627,7 +630,7 @@ def _footer_session(
         raw_mode_fn=object,
         restore_fn=lambda _state: None,
     )
-    session.enable_footer()
+    session.enable_footer(label=label)
     session.begin_trial()
     output.clear()
     return session, fd
@@ -650,7 +653,7 @@ def test_enable_footer_is_noop_on_caller_injected_console() -> None:
         restore_fn=lambda _state: None,
     )
 
-    session.enable_footer()
+    session.enable_footer(label="sent")
     session.begin_trial()
 
     assert output == []
@@ -682,7 +685,7 @@ def test_footer_begin_trial_draws_empty_input_row() -> None:
         raw_mode_fn=object,
         restore_fn=lambda _state: None,
     )
-    session.enable_footer()
+    session.enable_footer(label="sent")
 
     session.begin_trial()
 
@@ -703,7 +706,7 @@ def test_footer_begin_trial_closes_plain_open_status_then_one_row_branch() -> No
     )
     session.status("t = 3s")
     output.clear()
-    session.enable_footer()
+    session.enable_footer(label="sent")
 
     session.begin_trial()
 
@@ -728,7 +731,7 @@ def test_footer_begin_trial_drain_stops_on_real_eof() -> None:
         raw_mode_fn=object,
         restore_fn=lambda _state: None,
     )
-    session.enable_footer()
+    session.enable_footer(label="sent")
 
     session.begin_trial()
 
@@ -758,7 +761,7 @@ def test_footer_default_width_fn_reads_terminal_size(monkeypatch: pytest.MonkeyP
         raw_mode_fn=object,
         restore_fn=lambda _state: None,
     )
-    session.enable_footer()
+    session.enable_footer(label="sent")
     session.begin_trial()
     output.clear()
     fd.chunks = [b"abcdefgh"]
@@ -780,7 +783,7 @@ def test_footer_begin_trial_discards_stale_bytes_with_no_echo_and_clears_state()
         raw_mode_fn=object,
         restore_fn=lambda _state: None,
     )
-    session.enable_footer()
+    session.enable_footer(label="sent")
 
     session.begin_trial()
 
@@ -950,7 +953,7 @@ def test_footer_non_tty_gate_falls_back_to_plain_mode_without_raw_entry() -> Non
         raw_mode_fn=enter_raw_mode,
         restore_fn=lambda _state: None,
     )
-    session.enable_footer()
+    session.enable_footer(label="sent")
 
     session.begin_trial()
     session.end_trial()
@@ -972,7 +975,7 @@ def test_footer_missing_termios_gate_falls_back_to_plain_mode_silently() -> None
         raw_mode_fn=missing_termios,
         restore_fn=lambda _state: None,
     )
-    session.enable_footer()
+    session.enable_footer(label="sent")
 
     session.begin_trial()
     session.end_trial()
@@ -1000,7 +1003,7 @@ def test_footer_failed_raw_entry_falls_back_then_retries_next_trial() -> None:
         raw_mode_fn=enter_raw_mode,
         restore_fn=restored.append,
     )
-    session.enable_footer()
+    session.enable_footer(label="sent")
 
     session.begin_trial()
     session.end_trial()
@@ -1029,8 +1032,8 @@ def test_footer_restore_runs_once_and_atexit_cannot_replay_cleared_state() -> No
         atexit_register=lambda callback: callbacks.append(callback),
     )
 
-    session.enable_footer()
-    session.enable_footer()
+    session.enable_footer(label="sent")
+    session.enable_footer(label="sent")
     session.begin_trial()
     session.end_trial()
     session.end_trial()
@@ -1058,7 +1061,7 @@ def test_footer_end_trial_restores_raw_mode_when_renderer_teardown_raises() -> N
         raw_mode_fn=lambda: state,
         restore_fn=restored.append,
     )
-    session.enable_footer()
+    session.enable_footer(label="sent")
     session.begin_trial()
     fail_writes = True
 
@@ -1085,7 +1088,7 @@ def test_footer_begin_trial_restores_raw_mode_when_renderer_entry_raises() -> No
         raw_mode_fn=lambda: state,
         restore_fn=restored.append,
     )
-    session.enable_footer()
+    session.enable_footer(label="sent")
 
     with pytest.raises(RuntimeError, match="terminal write failed"):
         session.begin_trial()
@@ -1142,7 +1145,7 @@ def test_footer_reclips_after_width_fn_change() -> None:
         raw_mode_fn=object,
         restore_fn=lambda _state: None,
     )
-    session.enable_footer()
+    session.enable_footer(label="sent")
     session.begin_trial()
     output.clear()
     fd.chunks = [b"abcdef"]
@@ -1229,7 +1232,63 @@ def test_footer_pump_enter_completes_line_reaching_console_same_poll(terminator:
     poll = session.poll()
 
     assert poll.messages == ("hello",)
-    assert output[-1] == "\r\x1b[K> "
+    assert output[-1] == "\r\x1b[K[sent] hello\n\r\x1b[K> "
+
+
+@pytest.mark.parametrize("label", ["sent", "noted"])
+def test_footer_poll_confirms_each_console_feedback_message_with_selected_label(
+    label: str,
+) -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output, label=label)
+    fd.chunks = [b"first\nsecond\n"]
+
+    poll = session.poll()
+
+    assert poll == ConsolePoll(messages=("first", "second"))
+    assert poll.sources == ()
+    assert output == [
+        "\r\x1b[K> ",
+        f"\r\x1b[K[{label}] first\n\r\x1b[K> ",
+        f"\r\x1b[K[{label}] second\n\r\x1b[K> ",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("raw_input", "expected_end"),
+    [
+        (b"\n", EndRequest()),
+        (b"/p careful placement\n", EndRequest(verdict="partial", note="careful placement")),
+    ],
+)
+def test_footer_poll_does_not_confirm_end_requests_or_verdicts(
+    raw_input: bytes, expected_end: EndRequest
+) -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [raw_input]
+
+    poll = session.poll()
+
+    assert poll == ConsolePoll(end=expected_end)
+    assert output == ["\r\x1b[K> "]
+
+
+def test_footer_poll_confirms_console_source_but_only_echoes_voice_source() -> None:
+    output: list[str] = []
+    session, fd = _footer_session(output)
+    fd.chunks = [b"typed\n"]
+    voice = _ScriptedAttachedInput([ConsolePoll(messages=("spoken",), sources=("untrusted",))])
+    session.attach_input(voice, label="voice")
+
+    poll = session.poll()
+
+    assert poll == ConsolePoll(messages=("typed", "spoken"), sources=("console", "voice"))
+    assert output == [
+        "\r\x1b[K> ",
+        "\r\x1b[Kvoice: spoken\n\r\x1b[K> ",
+        "\r\x1b[K[sent] typed\n\r\x1b[K> ",
+    ]
 
 
 def test_footer_pump_bytes_without_newline_echo_but_deliver_nothing() -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -623,6 +623,9 @@ def _footer_session(
         fd_readable=fd.readable,
         fd_read=fd.read,
         width_fn=lambda: width,
+        isatty_fn=lambda: True,
+        raw_mode_fn=object,
+        restore_fn=lambda _state: None,
     )
     session.enable_footer()
     session.begin_trial()
@@ -632,12 +635,26 @@ def _footer_session(
 
 def test_enable_footer_is_noop_on_caller_injected_console() -> None:
     output: list[str] = []
-    session = OperatorSession(console=_RecordingConsole(), write=output.append)
+    raw_calls = 0
+
+    def enter_raw_mode() -> object:
+        nonlocal raw_calls
+        raw_calls += 1
+        return object()
+
+    session = OperatorSession(
+        console=_RecordingConsole(),
+        write=output.append,
+        isatty_fn=lambda: True,
+        raw_mode_fn=enter_raw_mode,
+        restore_fn=lambda _state: None,
+    )
 
     session.enable_footer()
     session.begin_trial()
 
     assert output == []
+    assert raw_calls == 0
 
 
 def test_default_console_dispatch_closures_delegate_to_fd_seams_when_footer_inactive() -> None:
@@ -657,7 +674,13 @@ def test_footer_begin_trial_draws_empty_input_row() -> None:
     output: list[str] = []
     fd = _ScriptedFd()
     session = OperatorSession(
-        write=output.append, fd_readable=fd.readable, fd_read=fd.read, width_fn=lambda: 200
+        write=output.append,
+        fd_readable=fd.readable,
+        fd_read=fd.read,
+        width_fn=lambda: 200,
+        isatty_fn=lambda: True,
+        raw_mode_fn=object,
+        restore_fn=lambda _state: None,
     )
     session.enable_footer()
 
@@ -670,7 +693,13 @@ def test_footer_begin_trial_closes_plain_open_status_then_one_row_branch() -> No
     output: list[str] = []
     fd = _ScriptedFd()
     session = OperatorSession(
-        write=output.append, fd_readable=fd.readable, fd_read=fd.read, width_fn=lambda: 200
+        write=output.append,
+        fd_readable=fd.readable,
+        fd_read=fd.read,
+        width_fn=lambda: 200,
+        isatty_fn=lambda: True,
+        raw_mode_fn=object,
+        restore_fn=lambda _state: None,
     )
     session.status("t = 3s")
     output.clear()
@@ -691,7 +720,13 @@ def test_footer_begin_trial_drain_stops_on_real_eof() -> None:
     output: list[str] = []
     fd = _ScriptedFd([b""])
     session = OperatorSession(
-        write=output.append, fd_readable=fd.readable, fd_read=fd.read, width_fn=lambda: 200
+        write=output.append,
+        fd_readable=fd.readable,
+        fd_read=fd.read,
+        width_fn=lambda: 200,
+        isatty_fn=lambda: True,
+        raw_mode_fn=object,
+        restore_fn=lambda _state: None,
     )
     session.enable_footer()
 
@@ -715,7 +750,14 @@ def test_footer_default_width_fn_reads_terminal_size(monkeypatch: pytest.MonkeyP
     output: list[str] = []
     fd = _ScriptedFd()
     monkeypatch.setattr(shutil, "get_terminal_size", lambda: os.terminal_size((10, 24)))
-    session = OperatorSession(write=output.append, fd_readable=fd.readable, fd_read=fd.read)
+    session = OperatorSession(
+        write=output.append,
+        fd_readable=fd.readable,
+        fd_read=fd.read,
+        isatty_fn=lambda: True,
+        raw_mode_fn=object,
+        restore_fn=lambda _state: None,
+    )
     session.enable_footer()
     session.begin_trial()
     output.clear()
@@ -730,7 +772,13 @@ def test_footer_begin_trial_discards_stale_bytes_with_no_echo_and_clears_state()
     output: list[str] = []
     fd = _ScriptedFd([b"stale", b"\n"])
     session = OperatorSession(
-        write=output.append, fd_readable=fd.readable, fd_read=fd.read, width_fn=lambda: 200
+        write=output.append,
+        fd_readable=fd.readable,
+        fd_read=fd.read,
+        width_fn=lambda: 200,
+        isatty_fn=lambda: True,
+        raw_mode_fn=object,
+        restore_fn=lambda _state: None,
     )
     session.enable_footer()
 
@@ -863,6 +911,190 @@ def test_footer_end_trial_teardown_is_idempotent() -> None:
     assert output == []
 
 
+def test_footer_requires_explicit_enable_even_when_all_runtime_gates_pass() -> None:
+    output: list[str] = []
+    raw_calls = 0
+
+    def enter_raw_mode() -> object:
+        nonlocal raw_calls
+        raw_calls += 1
+        return object()
+
+    session = OperatorSession(
+        write=output.append,
+        fd_readable=lambda: False,
+        isatty_fn=lambda: True,
+        raw_mode_fn=enter_raw_mode,
+        restore_fn=lambda _state: None,
+    )
+
+    session.begin_trial()
+
+    assert output == []
+    assert raw_calls == 0
+
+
+def test_footer_non_tty_gate_falls_back_to_plain_mode_without_raw_entry() -> None:
+    output: list[str] = []
+    raw_calls = 0
+
+    def enter_raw_mode() -> object:
+        nonlocal raw_calls
+        raw_calls += 1
+        return object()
+
+    session = OperatorSession(
+        write=output.append,
+        fd_readable=lambda: False,
+        isatty_fn=lambda: False,
+        raw_mode_fn=enter_raw_mode,
+        restore_fn=lambda _state: None,
+    )
+    session.enable_footer()
+
+    session.begin_trial()
+    session.end_trial()
+
+    assert output == []
+    assert raw_calls == 0
+
+
+def test_footer_missing_termios_gate_falls_back_to_plain_mode_silently() -> None:
+    output: list[str] = []
+
+    def missing_termios() -> object:
+        raise ModuleNotFoundError("termios")
+
+    session = OperatorSession(
+        write=output.append,
+        fd_readable=lambda: False,
+        isatty_fn=lambda: True,
+        raw_mode_fn=missing_termios,
+        restore_fn=lambda _state: None,
+    )
+    session.enable_footer()
+
+    session.begin_trial()
+    session.end_trial()
+
+    assert output == []
+
+
+def test_footer_failed_raw_entry_falls_back_then_retries_next_trial() -> None:
+    output: list[str] = []
+    state = object()
+    attempts = 0
+
+    def enter_raw_mode() -> object:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OSError("tcsetattr failed")
+        return state
+
+    restored: list[object] = []
+    session = OperatorSession(
+        write=output.append,
+        fd_readable=lambda: False,
+        isatty_fn=lambda: True,
+        raw_mode_fn=enter_raw_mode,
+        restore_fn=restored.append,
+    )
+    session.enable_footer()
+
+    session.begin_trial()
+    session.end_trial()
+    assert output == []
+    assert restored == []
+
+    session.begin_trial()
+    assert output == ["\r\x1b[K> "]
+    session.end_trial()
+
+    assert attempts == 2
+    assert restored == [state]
+
+
+def test_footer_restore_runs_once_and_atexit_cannot_replay_cleared_state() -> None:
+    output: list[str] = []
+    state = object()
+    restored: list[object] = []
+    callbacks: list[Callable[[], None]] = []
+    session = OperatorSession(
+        write=output.append,
+        fd_readable=lambda: False,
+        isatty_fn=lambda: True,
+        raw_mode_fn=lambda: state,
+        restore_fn=restored.append,
+        atexit_register=lambda callback: callbacks.append(callback),
+    )
+
+    session.enable_footer()
+    session.enable_footer()
+    session.begin_trial()
+    session.end_trial()
+    session.end_trial()
+    callbacks[0]()
+
+    assert len(callbacks) == 1
+    assert restored == [state]
+
+
+def test_footer_end_trial_restores_raw_mode_when_renderer_teardown_raises() -> None:
+    output: list[str] = []
+    state = object()
+    restored: list[object] = []
+    fail_writes = False
+
+    def write(text: str) -> None:
+        if fail_writes:
+            raise RuntimeError("terminal write failed")
+        output.append(text)
+
+    session = OperatorSession(
+        write=write,
+        fd_readable=lambda: False,
+        isatty_fn=lambda: True,
+        raw_mode_fn=lambda: state,
+        restore_fn=restored.append,
+    )
+    session.enable_footer()
+    session.begin_trial()
+    fail_writes = True
+
+    with pytest.raises(RuntimeError, match="terminal write failed"):
+        session.end_trial()
+
+    assert restored == [state]
+    fail_writes = False
+    session.end_trial()
+    assert restored == [state]
+
+
+def test_footer_begin_trial_restores_raw_mode_when_renderer_entry_raises() -> None:
+    state = object()
+    restored: list[object] = []
+
+    def write(_text: str) -> None:
+        raise RuntimeError("terminal write failed")
+
+    session = OperatorSession(
+        write=write,
+        fd_readable=lambda: False,
+        isatty_fn=lambda: True,
+        raw_mode_fn=lambda: state,
+        restore_fn=restored.append,
+    )
+    session.enable_footer()
+
+    with pytest.raises(RuntimeError, match="terminal write failed"):
+        session.begin_trial()
+
+    assert restored == [state]
+    session.end_trial()
+    assert restored == [state]
+
+
 def test_footer_end_trial_noop_when_footer_never_entered_leaves_plain_status_untouched() -> None:
     output: list[str] = []
     session = OperatorSession(write=output.append)
@@ -906,6 +1138,9 @@ def test_footer_reclips_after_width_fn_change() -> None:
         fd_readable=fd.readable,
         fd_read=fd.read,
         width_fn=lambda: width["cols"],
+        isatty_fn=lambda: True,
+        raw_mode_fn=object,
+        restore_fn=lambda _state: None,
     )
     session.enable_footer()
     session.begin_trial()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1043,6 +1043,34 @@ def test_footer_restore_runs_once_and_atexit_cannot_replay_cleared_state() -> No
     assert restored == [state]
 
 
+def test_footer_begin_trial_reentry_is_guarded_and_preserves_saved_snapshot() -> None:
+    output: list[str] = []
+    state = object()
+    raw_calls = 0
+    restored: list[object] = []
+
+    def enter_raw_mode() -> object:
+        nonlocal raw_calls
+        raw_calls += 1
+        return state
+
+    session = OperatorSession(
+        write=output.append,
+        fd_readable=lambda: False,
+        isatty_fn=lambda: True,
+        raw_mode_fn=enter_raw_mode,
+        restore_fn=restored.append,
+    )
+    session.enable_footer(label="sent")
+    session.begin_trial()
+
+    session.begin_trial()
+
+    assert raw_calls == 1
+    session.end_trial()
+    assert restored == [state]
+
+
 def test_footer_end_trial_restores_raw_mode_when_renderer_teardown_raises() -> None:
     output: list[str] = []
     state = object()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -800,6 +800,15 @@ def test_footer_status_none_collapses_two_row_to_one_row_retaining_input() -> No
     session.status("t = 5s")
     assert output == ["\r\x1b[Kt = 5s\n\r\x1b[K> hi"]
 
+    # Typing after status(None) still echoes correctly, on the retained input row.
+    output.clear()
+    session.status(None)
+    output.clear()
+    fd.chunks = [b"!"]
+    session.poll()
+    assert output == ["\r\x1b[K> hi!"]
+    assert "\x1b[A" not in output[0]
+
 
 def test_footer_input_echo_one_row_state() -> None:
     output: list[str] = []


### PR DESCRIPTION
Closes #311. PR 3 of the #308 arc (plan 0051, renumbered from 0049 after a plans/ collision with main). Footer rendering inside OperatorSession — per-trial cbreak window via a new duck-typed end_trial() rollout hook, minimal line editor feeding the untouched console parser, exact-repaint two-line footer (input row constant, status row optional), [sent]/[noted] confirmations for console-sourced messages only (composes with #316 voice). Plain mode stays byte-identical off-TTY/Windows/no-console.

Plan critique: 10 fresh-context rounds; R10 clean against main @ 4e5cc772. R4-R9 findings and fixes are in the plan: commit history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)