### PR TITLE
agent: fractional -P effort= for servers that read effort as a number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- **Agent plugin (0.24.0):** `-P effort=` now also takes a number in
+  `[0.0, 1.0)` for servers that read reasoning effort as a fraction rather than
+  a named level, and sends it unquantized so an effort sweep keeps the
+  resolution the server offers. Named levels and the 0.23.0 passthrough rules
+  are unchanged: an omitted flag still omits the field, and `none` still sends
+  the true minimum. Tinker's OpenAI-compatible endpoint accepts `0.0` through
+  `0.99`; wires that take levels only reject a fraction with a guided 4xx naming
+  the wire that accepts one. `-P effort=false` stays an error rather than
+  becoming zero effort (#314).
+
 - **Core (0.44.0):** operator messages now preserve console or attached-input
   provenance through transcripts, policy observations, and evaluation logs.
   `OperatorSession.attach_input()` merges feedback-only sources without risking

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -325,6 +325,14 @@ level; omit the argument to inherit the provider default. Gemini Live has no
 effort field and rejects any explicit effort, so leave it unset on that wire.
 To pin the behavior from before version 0.23, add `-P effort=low`.
 
+Effort also takes a number in `[0.0, 1.0)` for servers that read it as a
+fraction instead of a named level (`-P effort=0.7`). The number is sent
+unquantized, so an effort sweep keeps whatever resolution the server offers.
+Named levels stay the portable choice: every wire and provider accepts some of
+them, while fractional effort is accepted today only by Tinker's
+OpenAI-compatible endpoint (see below). A server that takes levels only rejects
+a fraction with a guided 4xx naming the wire that does accept one.
+
 ## Depth rendering
 
 For each camera, the policy looks for metric depth in
@@ -383,6 +391,16 @@ runs or to pin the plugin's pre-0.23 behavior. The endpoint accepts `low`,
 `medium`, `high`, `xhigh`, and `max`; `minimal` is unsupported. `effort=none`
 is sent as disabled thinking, which Tinker's endpoint has not been observed to
 accept — expect a wire rejection until confirmed otherwise.
+
+Fractional effort is a Tinker feature, but only on its OpenAI-compatible
+endpoint, which reads `reasoning_effort` as a number from `0.0` to `0.99`
+(`0.995` and above are a 422). The Messages endpoint that serves Inkling here
+takes named levels only, so `-P effort=0.7` needs
+`-P wire=chat -P base_url=` pointed at `.../tinker-prod/oai/api/v1`. That
+endpoint silently ignores `tools`, so it cannot currently drive a robot episode:
+the policy sees no tool call and fails after three turns. Treat fractional
+effort on Tinker as usable for prompt-level experiments, and named levels as the
+setting for real rollouts until the Messages endpoint accepts a number.
 
 Tinker currently reports `input_tokens: 0` because input usage appears in its
 cache-creation and cache-read counters. EvalLog input-token statistics and the

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.23.0"
+version = "0.24.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
@@ -101,7 +101,7 @@ class AnthropicClient:
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]],
         temperature: float | None = None,
-        reasoning_effort: str | None = None,
+        reasoning_effort: str | float | None = None,
     ) -> AssistantMessage:
         """Return one assistant turn for the translated chat-format history."""
         # Prune before storing: the reverse order would evict every fresh
@@ -190,7 +190,7 @@ class AnthropicClient:
                 if response.status_code not in _RETRYABLE_STATUSES and response.status_code < 500:
                     raise RuntimeError(
                         f"LLM request rejected — {last_error}"
-                        f"{self._rejection_guidance(response.text, temperature)}"
+                        f"{self._rejection_guidance(response.text, temperature, reasoning_effort)}"
                     )
             if attempt + 1 < self._max_retries:
                 time.sleep(self._backoff_s * 2**attempt)
@@ -211,7 +211,12 @@ class AnthropicClient:
         """Release the underlying HTTP connection pool."""
         self._http.close()
 
-    def _rejection_guidance(self, body: str, temperature: float | None) -> str:
+    def _rejection_guidance(
+        self,
+        body: str,
+        temperature: float | None,
+        reasoning_effort: str | float | None = None,
+    ) -> str:
         """Name the fix for the 4xx bodies this wire provokes, else say nothing."""
         lowered = body.lower()
         if self._speed == "fast" and "speed" in lowered:
@@ -226,6 +231,13 @@ class AnthropicClient:
                 "Fable 5 all do; Opus 4.6 and Sonnet 4.6 accept it); drop -P temperature="
             )
         if "effort" in lowered:
+            if isinstance(reasoning_effort, float):
+                return (
+                    "\nfix: the Messages API takes named effort levels only "
+                    "(low, medium, high, xhigh, max); a fractional effort needs "
+                    "-P wire=chat against a server that reads one, such as Tinker's "
+                    "OpenAI-compatible endpoint"
+                )
             return (
                 "\nfix: the Messages API accepts -P effort=none (thinking disabled) or "
                 "low, medium, high, xhigh, and max; minimal is an OpenAI-only value"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_gemini_live.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_gemini_live.py
@@ -74,7 +74,7 @@ class GeminiLiveClient:
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]],
         temperature: float | None = None,
-        reasoning_effort: str | None = None,
+        reasoning_effort: str | float | None = None,
     ) -> AssistantMessage:
         """Return one assistant turn after streaming only the unseen suffix."""
         del reasoning_effort

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_llm.py
@@ -243,7 +243,7 @@ class ChatClient:
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]],
         temperature: float | None = None,
-        reasoning_effort: str | None = None,
+        reasoning_effort: str | float | None = None,
     ) -> AssistantMessage:
         body: dict[str, Any] = {"model": self._provider.model, "messages": messages}
         if tools:

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_responses.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_responses.py
@@ -50,7 +50,7 @@ class ResponsesClient:
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]],
         temperature: float | None = None,
-        reasoning_effort: str | None = None,
+        reasoning_effort: str | float | None = None,
     ) -> AssistantMessage:
         """Return one assistant turn for the translated chat-format history."""
         history_call_ids = _history_call_ids(messages)

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -77,6 +77,13 @@ _GEMINI_LIVE_BASE = (
 # "minimal", and its endpoint requires streaming for the cap xhigh/max
 # need; Tinker accepts xhigh/max without streaming. Rejections get guided errors.
 _EFFORT_LEVELS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max"})
+# Some servers also take a continuous effort alongside the named levels: Tinker's
+# OpenAI-compatible endpoint accepts a fraction (probed 2026-08-06 — 0.0 through
+# 0.99 return 200, 0.995 and above 422). A fraction is passed through untouched
+# rather than quantized into a level, so a sweep keeps the resolution the server
+# offers. The range is half-open by construction: 1.0 means "past max effort",
+# and servers that cap lower reject it with a guided 4xx.
+_EFFORT_FRACTION_LIMIT = 1.0
 _WIRE_FORMATS = frozenset({"chat", "responses", "messages", "gemini-live"})
 _WIRE_ALIASES = {"anthropic": "messages"}
 _AGENT_NATIVE_WIRES = frozenset({"chat", "messages"})
@@ -145,6 +152,33 @@ _PRE_CHECK_PROMPT_CLAUSE = (
 _ON_DEMAND_NUDGE = (
     "Respond with one motion tool call, one motion followed by take_pic, or take_pic alone."
 )
+
+
+def _validated_effort(effort: object) -> str | float:
+    """Return the wire value for an accepted effort, else raise ``ConfigError``.
+
+    Accepts a named level verbatim, or a number in ``[0.0, 1.0)`` normalized to
+    ``float`` for the servers that read effort as a fraction. ``bool`` is not a
+    number here: ``-P effort=false`` parses to ``False``, which would otherwise
+    silently mean zero effort instead of failing as the typo it is.
+    """
+    if isinstance(effort, str):
+        if effort in _EFFORT_LEVELS:
+            return effort
+    # The range check rejects nan and inf too: every nan comparison is False, and
+    # inf fails the upper bound.
+    elif (
+        isinstance(effort, int | float)
+        and not isinstance(effort, bool)
+        and 0.0 <= effort < _EFFORT_FRACTION_LIMIT
+    ):
+        return float(effort)
+    raise ConfigError(
+        f"effort must be one of {sorted(_EFFORT_LEVELS)}, or a number in "
+        f"[0.0, {_EFFORT_FRACTION_LIMIT}) on servers that take a fractional "
+        f"effort, got {effort!r}.\n"
+        "fix: omit -P effort= to use the provider default"
+    )
 
 
 def _sanitize(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -235,8 +269,9 @@ class AgentPolicyConfig(PolicyConfig):
     max_output_tokens: int | None = None
     max_llm_calls: int = 100
     #: Resolved effort level; ``None`` means the field is omitted and the
-    #: provider default applies.
-    effort: str | None = None
+    #: provider default applies. A number is a fractional effort, recorded as
+    #: sent rather than snapped to a level.
+    effort: str | float | None = None
     max_speed_frac: float = 0.1
     transcript_echo: bool = False
     images: str = "always"
@@ -287,7 +322,7 @@ class LLMAgentPolicy(PolicyBase):
         max_output_tokens: int | None = None,
         max_llm_calls: int = 100,
         temperature: float | None = None,
-        effort: str | None | _Unset = _UNSET,
+        effort: str | float | None | _Unset = _UNSET,
         max_speed_frac: float = 0.1,
         transcript_echo: bool = False,
         images: str = "always",
@@ -376,15 +411,9 @@ class LLMAgentPolicy(PolicyBase):
             wire = _WIRE_ALIASES.get(wire, wire)
             if wire not in _WIRE_FORMATS:
                 raise ConfigError(f"wire must be one of {sorted(_WIRE_FORMATS)}, got {wire!r}")
-        resolved_effort: str | None = None
+        resolved_effort: str | float | None = None
         if not isinstance(effort, _Unset):
-            effort_level = "none" if effort is None else effort
-            if effort_level not in _EFFORT_LEVELS:
-                raise ConfigError(
-                    f"effort must be one of {sorted(_EFFORT_LEVELS)}, got {effort!r}.\n"
-                    "fix: omit -P effort= to use the provider default"
-                )
-            resolved_effort = effort_level
+            resolved_effort = _validated_effort("none" if effort is None else effort)
         if wire == "gemini-live" and effort is not _UNSET:
             raise ConfigError(
                 "effort is not supported on wire='gemini-live'.\nfix: drop -P effort="

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -780,6 +780,20 @@ def test_effort_4xx_names_the_accepted_values() -> None:
     assert "none and minimal" not in str(excinfo.value)
 
 
+def test_fractional_effort_is_sent_verbatim_and_its_4xx_names_the_wire_that_takes_it() -> None:
+    seen, ok_handler = _capture(_anthropic_response(_text("hi"), stop_reason="end_turn"))
+    _client(ok_handler).complete([_USER], [], reasoning_effort=0.7)
+    # Passed through unquantized: the level set is not this wire's only vocabulary
+    # to a gateway that forwards a fraction on.
+    assert json.loads(seen[0].content)["output_config"] == {"effort": 0.7}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(422, text="output_config.effort: Input should be 'low', 'medium'")
+
+    with pytest.raises(RuntimeError, match=r"a fractional effort needs -P wire=chat"):
+        _client(handler).complete([_USER], [], reasoning_effort=0.7)
+
+
 def test_temperature_guidance_only_when_temperature_was_sent() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(400, text="temperature is not supported")

--- a/plugins/inspect-robots-agent/tests/test_gemini_live.py
+++ b/plugins/inspect-robots-agent/tests/test_gemini_live.py
@@ -841,7 +841,8 @@ def test_existing_invalid_effort_and_horizon_messages_are_preserved() -> None:
         LLMAgentPolicy(**common, effort="default")
     assert str(effort_error.value) == (
         "effort must be one of ['high', 'low', 'max', 'medium', 'minimal', 'none', "
-        "'xhigh'], got 'default'.\nfix: omit -P effort= to use the provider default"
+        "'xhigh'], or a number in [0.0, 1.0) on servers that take a fractional "
+        "effort, got 'default'.\nfix: omit -P effort= to use the provider default"
     )
     with pytest.raises(ConfigError) as horizon_error:
         LLMAgentPolicy(**common, image_horizon=0)

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,7 +6,7 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.23.0"
+    assert inspect_robots_agent.__version__ == "0.24.0"
     assert callable(inspect_robots_agent.agent_policy)
     assert inspect_robots_agent.__all__ == [
         "ENV_MODEL",

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -2510,7 +2510,8 @@ def test_effort_passthrough_matrix(tmp_path: Path) -> None:
         _policy(_Script([]), effort="turbo")
     assert str(invalid.value) == (
         "effort must be one of ['high', 'low', 'max', 'medium', 'minimal', 'none', "
-        "'xhigh'], got 'turbo'.\nfix: omit -P effort= to use the provider default"
+        "'xhigh'], or a number in [0.0, 1.0) on servers that take a fractional "
+        "effort, got 'turbo'.\nfix: omit -P effort= to use the provider default"
     )
 
     live_kwargs: dict[str, Any] = {
@@ -2526,6 +2527,27 @@ def test_effort_passthrough_matrix(tmp_path: Path) -> None:
         LLMAgentPolicy(**live_kwargs, effort="low")
     live = LLMAgentPolicy(**live_kwargs)
     assert live.config.effort is None
+
+
+def test_fractional_effort_is_passed_through_and_bounded(tmp_path: Path) -> None:
+    # Tinker's OpenAI-compatible endpoint reads effort as a fraction, so a number
+    # reaches the wire as a number instead of being snapped to a named level.
+    script = _Script([_tool_response("done", {"summary": "ok"})])
+    policy = _policy(script, effort=0.7)
+    logs = ir_eval(_task(), policy, CubePickEmbodiment(), log_dir=str(tmp_path))
+    assert script.requests[0]["reasoning_effort"] == 0.7
+    assert logs[0].eval.policy_config["effort"] == 0.7
+
+    # `-P effort=0` parses to int 0, which is zero effort, not an omitted field.
+    script = _Script([_tool_response("done", {"summary": "ok"})])
+    ir_eval(_task(), _policy(script, effort=0), CubePickEmbodiment(), log_dir=str(tmp_path))
+    assert script.requests[0]["reasoning_effort"] == 0.0
+
+    # 1.0 is past the top of the range every probed server accepts, and a bool is
+    # a mistyped flag rather than a fraction (`-P effort=false` parses to False).
+    for rejected in (1.0, -0.1, float("nan"), float("inf"), True, False, "0.7"):
+        with pytest.raises(ConfigError, match=r"a number in \[0\.0, 1\.0\)"):
+            _policy(_Script([]), effort=rejected)
 
 
 def test_registry_resolves_agent_policy() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.23.0"
+version = "0.24.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #314.

## What

`-P effort=` now takes a number in `[0.0, 1.0)` in addition to the named
levels. The number is normalized to `float` and sent unquantized, so an effort
sweep keeps whatever resolution the server offers:

```bash
inspect-robots run --policy agent -P model=thinkingmachines/Inkling -P effort=0.7 ...
```

Named levels are unchanged and stay the portable choice. Validation now lives in
one `_validated_effort()` helper instead of a set-membership test inline in the
constructor.

## Why a number at all

Probed against Tinker on 2026-08-06 with `thinkingmachines/Inkling`:

| endpoint | `0.7` | `0.995` / `1.0` | `"high"` |
|---|---|---|---|
| `.../anthropic/api/v1` (Messages) | 422, levels only | — | 200 |
| `.../oai/api/v1` (chat) | 200 | 422 | 200 |

The accepted fractional range there is `0.0` through `0.99`. The upper bound
here is `1.0` rather than `0.99` on purpose: `1.0` is past the top of the range
on every server probed, while a provider-specific cap below it belongs to the
provider, which reports it as a 4xx we already guide on.

## Honest limitation

A fraction cannot drive a real rollout on Inkling today. The Messages endpoint
that serves it rejects a number, and the OpenAI-compatible endpoint that accepts
one silently ignores `tools`, so the policy sees no tool call and fails after
three turns. This PR removes the client-side blocker and documents that state in
the plugin README, so a fraction is usable for prompt-level experiments now and
for rollouts if or when the Messages endpoint takes one.

## Details

- Guided 4xx on the Messages wire distinguishes the two cases: a rejected
  fraction now names `-P wire=chat` and the endpoint that reads one, while a
  rejected `none`/`minimal` keeps the existing OpenAI-only-values message.
- `bool` is not treated as a number: `-P effort=false` parses to `False` and
  stays a `ConfigError` instead of silently meaning zero effort. Same treatment
  `image_horizon` already gives `True`.
- `nan` and `inf` fall out of the range check without a special case.
- The four wire clients widen `reasoning_effort` to `str | float | None`;
  `AgentPolicyConfig.effort` likewise, so the value round-trips into the log.
- Not in scope: the capx policy keeps its own level-only effort validation. It
  imports only public names from this plugin, so sharing the check would mean
  either duplicating it or widening a public API, neither of which belongs in
  this change.

## Test

Agent plugin suite: 481 passed. `ruff check`, `ruff format --check`, and strict
`mypy` clean. New coverage: fraction reaches the wire and the log unquantized,
`effort=0` sends `0.0` rather than omitting the field, each of `1.0`, `-0.1`,
`nan`, `inf`, `True`, `False`, and `"0.7"` raises, and the Messages-wire
fractional 4xx guidance fires. `uv.lock` refreshed for the plugin version bump
to 0.23.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)