### PR TITLE
agent: -P effort= passthrough — unset omits the field, none sends the true minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,13 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- **Agent plugin (0.23.0):** an unset `effort` now omits the field and inherits
+  the provider default (breaking; add `-P effort=low` to pin the previous
+  behavior). `effort=none` sends the true minimum on every HTTP wire, including
+  `thinking: {"type": "disabled"}` on Messages; programmatic `None` normalizes
+  to `"none"`, and Gemini Live now rejects explicit `effort=none` instead of
+  silently accepting it ([plan 0049](plans/0049-effort-passthrough.md), #317).
+
 - Verdict and grader-notes prompts moved from CLI internals to
   `OperatorSession`; their behavior and transcript events are unchanged
   ([plan 0048](plans/0048-operator-session.md), #308).

--- a/plans/0049-effort-passthrough.md
+++ b/plans/0049-effort-passthrough.md
@@ -1,0 +1,160 @@
+# Effort passthrough Implementation Plan
+
+> **For agentic workers:** Implement task-by-task in order; each task is
+> test-first and ends in its own commit. Steps use checkbox (`- [ ]`) syntax
+> for tracking.
+
+**Goal:** `-P effort=` becomes what-you-type-is-what-the-model-gets. Today an
+unset flag injects an explicit `"low"` on the wire, while `-P effort=none` is
+coerced by the CLI scalar parser to Python `None`, which the policy interprets
+as "omit the field" — so the operator who asked for zero reasoning silently
+gets the provider's default. After this plan: an **unset** flag omits the
+effort field entirely (provider default, matching how `temperature` already
+behaves), `-P effort=none` sends the true minimum (`reasoning_effort: "none"`
+on chat, `reasoning: {"effort": "none"}` on responses, and
+`thinking: {"type": "disabled"}` on messages — the only faithful "none" the
+Anthropic API has), and the named levels are unchanged. Closes #317.
+
+**Architecture:** one normalization point in `LLMAgentPolicy.__init__`
+(`plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py:376-387`):
+a received `effort=None` — reachable only via the CLI's `none`/`null`
+coercion or a deliberate programmatic call — normalizes to the string
+`"none"` before validation; `_UNSET` resolves to `None`, which every wire
+client already treats as "omit the field". Downstream, the only wire that
+needs a code change is messages: `_AnthropicClient.complete`
+(`_anthropic.py:117-141`) maps `reasoning_effort == "none"` to
+`thinking: {"type": "disabled"}` with no `output_config`, and keeps
+`thinking: {"type": "adaptive"}` for `None` and the named levels (explicit
+adaptive stays: omitting `thinking` means thinking-off on Opus 4.8/4.7,
+which is a level choice, not a default). The chat and responses clients
+already omit on `None` and pass strings through untouched. `AgentPolicyConfig
+.effort` defaults to `None` and records the *normalized* value, so the eval
+log shows the truth. The per-run constancy of effort means a
+thinking-disabled run never has signed thinking blocks in the replay cache,
+so no replay changes are needed.
+
+**Breaking change (behavior, not API):** scripts that omit `-P effort=`
+today run at `low`; after this they run at the provider default (for
+Inkling that is documented as *high*). The changelog and README call this
+out with the one-line fix: add `-P effort=low` to pin the old behavior.
+Programmatic callers passing `effort=None` previously meant "omit"; they now
+mean the level `"none"`. Interaction: PR #315 (`feat/continuous-effort`)
+touches the same validation block; whichever lands second rebases.
+
+**Tech stack:** stdlib only, all inside `plugins/inspect-robots-agent`.
+pytest with the existing fake-client patterns in
+`plugins/inspect-robots-agent/tests/`.
+
+## Global Constraints
+
+- Gates (all blocking), run from the worktree root. The root mypy/pytest
+  configs do NOT cover the plugin (root `testpaths=["tests"]`, coverage
+  `source=["inspect_robots"]`), so the plugin gates must be the CI commands
+  (`.github/workflows/ci.yml`, agent-plugin job; equivalent modulo
+  --no-sync/-q flags):
+  - `uv run --no-sync ruff check plugins/inspect-robots-agent` and
+    `uv run --no-sync ruff format --check plugins/inspect-robots-agent`.
+  - `uv run mypy --config-file plugins/inspect-robots-agent/pyproject.toml plugins/inspect-robots-agent/src`
+  - `uv run --no-sync pytest plugins/inspect-robots-agent/tests -q` with the
+    plugin's coverage flags (100% line coverage is the plugin bar).
+- No changes outside `plugins/inspect-robots-agent/` except
+  `CHANGELOG.md` and this plan file. In particular the core CLI parser
+  (`src/inspect_robots/defaults.py::_parse_value`) is deliberately untouched:
+  its `none → None` coercion is load-bearing for every other `-E`/`-P`
+  surface (YAM config documents literal `none` as "library default").
+- The capx plugin (`plugins/inspect-robots-capx/src/inspect_robots_capx/
+  policy.py:120`) duplicates the old semantics. Out of scope here — it lacks
+  the `_Unset` marker so unset and explicit `None` are indistinguishable —
+  but the follow-up issue must be filed when this PR opens.
+
+## Task 1: Constructor normalization + resolution
+
+**Files:** `policy.py`, `tests/test_policy_e2e.py`
+
+- [ ] Tests first, in `test_policy_e2e.py` (extend the existing
+  `test_effort_defaults_low_and_is_tunable` cluster at ~:2473, renaming it to
+  match the new contract, e.g. `test_effort_passthrough_matrix`):
+  - unset (`effort` kwarg not passed) → chat body has **no**
+    `reasoning_effort` key AND `logs[0].eval.policy_config["effort"] is None`.
+  - `effort=None` (programmatic; what the CLI delivers for `-P effort=none`)
+    → `reasoning_effort == "none"` on the wire AND
+    `policy_config["effort"] == "none"`.
+  - `effort="none"` (quoted escape hatch, must keep working) → same as above.
+  - `effort="high"` → unchanged explicit passthrough.
+  - invalid value (`effort="turbo"`) → `ConfigError` whose message names the
+    accepted levels and says "omit -P effort= to use the provider default"
+    (the old "or None to omit the field" wording must be gone).
+  - `wire="gemini-live"` with `effort=None` → `ConfigError` (today `None`
+    slips through because the guard tests `effort is not None`); with
+    `effort="low"` → still `ConfigError`; with effort unset → constructs fine.
+- [ ] Implement in `policy.py`:
+  - Normalize before validation:
+    `effort_level = "none" if effort is None else effort` for non-`_Unset`
+    input; validate membership on the normalized value.
+  - `resolved_effort: str | None = None` when unset (all wires — the
+    `wire == "gemini-live"` special case collapses into the general rule).
+  - gemini-live guard becomes `if wire == "gemini-live" and effort is not
+    _UNSET` (explicit `none` is still an effort request the Live wire cannot
+    honor).
+  - Update the stale comment at ~:604 ("default to low reasoning effort") to
+    describe passthrough, and the `AgentPolicyConfig.effort` field: default
+    `None`, docstring "resolved effort level; `None` means the field is
+    omitted and the provider default applies".
+- [ ] Gates pass; commit.
+
+## Task 2: Messages wire — `"none"` → thinking disabled
+
+**Files:** `_anthropic.py`, `tests/test_anthropic.py`
+
+- [ ] Tests first, in `test_anthropic.py` (fake-transport `_client` pattern,
+  see ~:111):
+  - `reasoning_effort="none"` → body has `thinking == {"type": "disabled"}`
+    and **no** `output_config` key.
+  - `reasoning_effort="low"` → `thinking == {"type": "adaptive"}` and
+    `output_config == {"effort": "low"}` (existing assertion at ~:125 stays).
+  - `reasoning_effort=None` → adaptive, no `output_config` (provider
+    default).
+  - The effort-4xx guidance test (~:750) updates: the hint must name
+    `minimal` as the OpenAI-only value and must no longer claim `none` is
+    unsupported (it now maps to thinking-disabled client-side).
+- [ ] Implement in `_anthropic.py::complete`: branch on
+  `reasoning_effort == "none"` when building `body` — set
+  `thinking: {"type": "disabled"}`, skip `output_config`; otherwise keep the
+  current adaptive + optional `output_config` behavior. Update the module
+  docstring (it currently documents always-adaptive) and the `_guided_fix`
+  effort wording at ~:226.
+- [ ] Gates pass; commit.
+
+## Task 3: Docs, changelog, version
+
+**Files:** `plugins/inspect-robots-agent/README.md`,
+`plugins/inspect-robots-agent/pyproject.toml`, `CHANGELOG.md`
+
+- [ ] README: rewrite the effort paragraph (~:311-321): unset = provider
+  default (parallel to `temperature`), `-P effort=none` now sends the true
+  minimum with the per-wire mapping table, the `-P effort="'none'"` quoting
+  escape hatch is no longer needed but still valid, and "add `-P effort=low`
+  to pin the pre-0.23 behavior". Update the Inkling section (~:370-376):
+  unset now inherits Inkling's own default (high per Tinker's cookbook) — the
+  latency warning moves here. Update the GPT-5.x section (~:444-459): the
+  `-P effort=none` advice there becomes literally correct; drop the quoting
+  caveat. Check the Anthropic section (~:426) still reads correctly now that
+  `none` is legal on `wire=messages`.
+- [ ] `pyproject.toml`: version 0.22.0 → 0.23.0.
+- [ ] `CHANGELOG.md`: **Changed** entry under Unreleased, "Agent plugin
+  (0.23.0)", covering: unset effort passes through to the provider default
+  (breaking; pin with `-P effort=low`), `effort=none` sends true none on all
+  HTTP wires including `thinking: disabled` on messages, `None` normalizes
+  to `"none"`, and the gemini-live `effort=none` loophole closes
+  ([plan 0049](plans/0049-effort-passthrough.md), #317).
+- [ ] Gates pass (ruff format touches README code fences if any); commit.
+
+## Out of scope
+
+- Core CLI parser changes (`_parse_value`) — the coercion stays; the policy
+  absorbs it.
+- capx plugin parity — follow-up issue, filed at PR-open time.
+- Any run-header/console printing of resolved effort — the value already
+  lands in `EvalSpec.policy_config` in the eval log; surfacing it in the CLI
+  banner is core-repo work and a separate discussion.
+- Fractional efforts (PR #315) — orthogonal; rebase coordination only.

--- a/plans/0049-effort-passthrough.md
+++ b/plans/0049-effort-passthrough.md
@@ -21,7 +21,7 @@ a received `effort=None` — reachable only via the CLI's `none`/`null`
 coercion or a deliberate programmatic call — normalizes to the string
 `"none"` before validation; `_UNSET` resolves to `None`, which every wire
 client already treats as "omit the field". Downstream, the only wire that
-needs a code change is messages: `_AnthropicClient.complete`
+needs a code change is messages: `AnthropicClient.complete`
 (`_anthropic.py:117-141`) maps `reasoning_effort == "none"` to
 `thinking: {"type": "disabled"}` with no `output_config`, and keeps
 `thinking: {"type": "adaptive"}` for `None` and the named levels (explicit
@@ -98,7 +98,10 @@ pytest with the existing fake-client patterns in
     branch becomes an explicit `ConfigError` assertion; its
     `config.effort == "low"` assertions for chat/responses/anthropic
     (~:808-810) become `is None`. Fold whatever it still covers into the
-    passthrough matrix rather than duplicating it.
+    passthrough matrix rather than duplicating it — with one exception: its
+    per-wire `image_horizon` default assertions (~:803-810, live → `None`,
+    HTTP wires → `2`) cover behavior this plan does not touch and must
+    survive the rewrite in `test_gemini_live.py`, not move files.
   - `test_existing_invalid_effort_and_horizon_messages_are_preserved`
     (~:834): pins the old error string ("or None to omit the field",
     ~:843-846); update the expected wording to the new message.

--- a/plans/0049-effort-passthrough.md
+++ b/plans/0049-effort-passthrough.md
@@ -56,7 +56,10 @@ pytest with the existing fake-client patterns in
     `uv run --no-sync ruff format --check plugins/inspect-robots-agent`.
   - `uv run mypy --config-file plugins/inspect-robots-agent/pyproject.toml plugins/inspect-robots-agent/src`
   - `uv run --no-sync pytest plugins/inspect-robots-agent/tests -q` with the
-    plugin's coverage flags (100% line coverage is the plugin bar).
+    CI coverage flags **including `--cov-fail-under=0`** (plugin coverage is
+    report-only per `.github/workflows/ci.yml:325-331` — there is no 100%
+    plugin gate, and omitting the flag would wrongly inherit the root
+    `fail_under = 100`, which is scoped to `source=["inspect_robots"]`).
 - No changes outside `plugins/inspect-robots-agent/` except
   `CHANGELOG.md` and this plan file. In particular the core CLI parser
   (`src/inspect_robots/defaults.py::_parse_value`) is deliberately untouched:
@@ -69,7 +72,8 @@ pytest with the existing fake-client patterns in
 
 ## Task 1: Constructor normalization + resolution
 
-**Files:** `policy.py`, `tests/test_policy_e2e.py`
+**Files:** `policy.py`, `tests/test_policy_e2e.py`,
+`tests/test_gemini_live.py`
 
 - [ ] Tests first, in `test_policy_e2e.py` (extend the existing
   `test_effort_defaults_low_and_is_tunable` cluster at ~:2473, renaming it to
@@ -87,6 +91,17 @@ pytest with the existing fake-client patterns in
   - `wire="gemini-live"` with `effort=None` → `ConfigError` (today `None`
     slips through because the guard tests `effort is not None`); with
     `effort="low"` → still `ConfigError`; with effort unset → constructs fine.
+- [ ] Rewrite the two existing tests this contract change breaks, both in
+  `tests/test_gemini_live.py`:
+  - `test_per_wire_default_resolution_and_explicit_none` (~:766): its
+    gemini-live `effort=None` construction (~:773-781) now raises — that
+    branch becomes an explicit `ConfigError` assertion; its
+    `config.effort == "low"` assertions for chat/responses/anthropic
+    (~:808-810) become `is None`. Fold whatever it still covers into the
+    passthrough matrix rather than duplicating it.
+  - `test_existing_invalid_effort_and_horizon_messages_are_preserved`
+    (~:834): pins the old error string ("or None to omit the field",
+    ~:843-846); update the expected wording to the new message.
 - [ ] Implement in `policy.py`:
   - Normalize before validation:
     `effort_level = "none" if effort is None else effort` for non-`_Unset`
@@ -100,6 +115,12 @@ pytest with the existing fake-client patterns in
     describe passthrough, and the `AgentPolicyConfig.effort` field: default
     `None`, docstring "resolved effort level; `None` means the field is
     omitted and the provider default applies".
+  - The chat-wire 4xx hint at `_llm.py:292-296` ("switch to /v1/responses …
+    or -P effort=none") stays **verbatim**: its trigger requires the server
+    text to name both `reasoning_effort` and `/v1/responses` (the GPT-5.x
+    tools rejection), and under the new semantics `-P effort=none` sends the
+    literal `"none"` that endpoint asks for — the hint becomes *more*
+    correct, not stale. Do not "fix" it; `test_llm.py:528-539` pins it.
 - [ ] Gates pass; commit.
 
 ## Task 2: Messages wire — `"none"` → thinking disabled
@@ -117,12 +138,20 @@ pytest with the existing fake-client patterns in
   - The effort-4xx guidance test (~:750) updates: the hint must name
     `minimal` as the OpenAI-only value and must no longer claim `none` is
     unsupported (it now maps to thinking-disabled client-side).
-- [ ] Implement in `_anthropic.py::complete`: branch on
+  - `speed="fast"` combined with `reasoning_effort="none"` → body carries
+    both `speed: "fast"` and `thinking: {"type": "disabled"}`. Decided
+    stance: **allow and pass through** — the plugin's philosophy after this
+    plan is passthrough, client-side combo guards contradict it, and if the
+    server rejects the pairing the existing `_rejection_guidance` speed
+    branch (~:215) already explains fast-mode constraints. The test pins the
+    passthrough so the stance is explicit.
+- [ ] Implement in `AnthropicClient.complete`: branch on
   `reasoning_effort == "none"` when building `body` — set
   `thinking: {"type": "disabled"}`, skip `output_config`; otherwise keep the
-  current adaptive + optional `output_config` behavior. Update the module
-  docstring (it currently documents always-adaptive) and the `_guided_fix`
-  effort wording at ~:226.
+  current adaptive + optional `output_config` behavior. Rewrite the inline
+  always-adaptive rationale comment at ~:120-123 (the module docstring does
+  not mention thinking and needs no change) and the `_rejection_guidance`
+  effort wording at ~:226-230.
 - [ ] Gates pass; commit.
 
 ## Task 3: Docs, changelog, version
@@ -138,8 +167,12 @@ pytest with the existing fake-client patterns in
   unset now inherits Inkling's own default (high per Tinker's cookbook) — the
   latency warning moves here. Update the GPT-5.x section (~:444-459): the
   `-P effort=none` advice there becomes literally correct; drop the quoting
-  caveat. Check the Anthropic section (~:426) still reads correctly now that
-  `none` is legal on `wire=messages`.
+  caveat. **Rewrite ~:420-421** ("This wire always requests adaptive
+  thinking… Use `-P wire=chat`" for pre-4.6 models): after Task 2 the wire
+  requests adaptive only when effort is not `"none"`, and `-P effort=none`
+  makes pre-4.6 models usable on `wire=messages`. Check the xhigh/max
+  sentence (~:426) still reads correctly now that `none` is legal on
+  `wire=messages`.
 - [ ] `pyproject.toml`: version 0.22.0 → 0.23.0.
 - [ ] `CHANGELOG.md`: **Changed** entry under Unreleased, "Agent plugin
   (0.23.0)", covering: unset effort passes through to the provider default
@@ -152,8 +185,14 @@ pytest with the existing fake-client patterns in
 ## Out of scope
 
 - Core CLI parser changes (`_parse_value`) — the coercion stays; the policy
-  absorbs it.
-- capx plugin parity — follow-up issue, filed at PR-open time.
+  absorbs it. Its docstring example (`src/inspect_robots/defaults.py:50-56`,
+  "sends the wire string none instead of omitting the parameter") goes stale
+  for this flag; recorded as a core follow-up on #317, not edited here.
+- Core log-view effort extractor (`src/inspect_robots/_html.py:626-636`)
+  reads `reasoning_effort`/`reasoning.effort`/`output_config.effort` only, so
+  an `effort=none` messages run renders as effort "n/a" in the wire view;
+  same core follow-up on #317.
+- capx plugin parity — follow-up issue #319, filed.
 - Any run-header/console printing of resolved effort — the value already
   lands in `EvalSpec.policy_config` in the eval log; surfacing it in the CLI
   banner is core-repo work and a separate discussion.

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -380,8 +380,9 @@ With effort unset, Inkling inherits Tinker's own default, documented as high in
 the thinking-effort cookbook. That can increase control latency because the arm
 stands still while the model thinks; pass `-P effort=low` for latency-sensitive
 runs or to pin the plugin's pre-0.23 behavior. The endpoint accepts `low`,
-`medium`, `high`, `xhigh`, and `max`; `effort=none` is translated to disabled
-thinking, while `minimal` remains unsupported.
+`medium`, `high`, `xhigh`, and `max`; `minimal` is unsupported. `effort=none`
+is sent as disabled thinking, which Tinker's endpoint has not been observed to
+accept — expect a wire rejection until confirmed otherwise.
 
 Tinker currently reports `input_tokens: 0` because input usage appears in its
 cache-creation and cache-read counters. EvalLog input-token statistics and the

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -308,17 +308,22 @@ integer token counters returned by the wire. The Messages wire
 includes input, output, cache-creation, and cache-read tokens; other wires
 currently record `llm_calls` only. Trials with no LLM calls omit the key.
 
-Reasoning effort defaults to `low` on the HTTP wires: robot control is
-latency-sensitive (the arm stands still while the model thinks), safety
-guardrails sit below the model either way, and frontier models at low effort
-remain strong at this task shape. Raise it for hard manipulation problems
-(`-P effort=high`) or pass `-P effort=none` to omit the parameter for
-endpoints that reject it (the CLI reads a bare `none` as null). To send the
-literal wire value `none` and disable reasoning, quote it:
-`-P effort="'none'"`. GPT-5.x on chat completions requires the literal `none`
-when function tools are in play (any other value, or omitting the field, is a
-400). In Python, `effort=None` omits the field and `effort="none"` sends the
-wire value. Gemini Live has no effort field, so leave it unset on that wire.
+Like `temperature`, reasoning effort is omitted when `-P effort=` is unset, so
+the provider's own default applies. Explicit named levels (`minimal`, `low`,
+`medium`, `high`, `xhigh`, and `max`) pass through unchanged. A bare
+`-P effort=none` now requests the true minimum on every HTTP wire:
+
+| Wire | Request field |
+| --- | --- |
+| `chat` | `reasoning_effort: "none"` |
+| `responses` | `reasoning: {"effort": "none"}` |
+| `messages` | `thinking: {"type": "disabled"}` (no `output_config`) |
+
+The older quoted spelling, `-P effort="'none'"`, remains valid but is no longer
+needed. In Python, both `effort=None` and `effort="none"` request the `none`
+level; omit the argument to inherit the provider default. Gemini Live has no
+effort field and rejects any explicit effort, so leave it unset on that wire.
+To pin the behavior from before version 0.23, add `-P effort=low`.
 
 ## Depth rendering
 
@@ -371,10 +376,12 @@ inspect-robots "pick up the cube" --policy agent \
     --embodiment cubepick
 ```
 
-The plugin defaults to `effort=low` for latency-sensitive robot control.
-Tinker's thinking-effort cookbook documents Inkling's own default as high, so
-pass `-P effort=` deliberately when comparing results. The endpoint accepts
-`low`, `medium`, `high`, `xhigh`, and `max`; it rejects `none` and `minimal`.
+With effort unset, Inkling inherits Tinker's own default, documented as high in
+the thinking-effort cookbook. That can increase control latency because the arm
+stands still while the model thinks; pass `-P effort=low` for latency-sensitive
+runs or to pin the plugin's pre-0.23 behavior. The endpoint accepts `low`,
+`medium`, `high`, `xhigh`, and `max`; `effort=none` is translated to disabled
+thinking, while `minimal` remains unsupported.
 
 Tinker currently reports `input_tokens: 0` because input usage appears in its
 cache-creation and cache-read counters. EvalLog input-token statistics and the
@@ -417,8 +424,10 @@ while standard quota sits idle. It is available on Claude Opus 5 and Opus 4.8,
 on the Claude API only: not Bedrock, Vertex, Foundry, or Claude Platform on
 AWS. A rejection that names fast mode is turned into an error naming the fix.
 
-This wire always requests adaptive thinking, which pre-4.6 models such as
-Sonnet 4.5 and Haiku 4.5 do not support. Use `-P wire=chat` for those.
+With effort unset or set to a named level, this wire requests adaptive
+thinking. Pre-4.6 models such as Sonnet 4.5 and Haiku 4.5 do not support
+adaptive thinking; pass `-P effort=none` to disable thinking and use them on
+`wire=messages`, or use `-P wire=chat`.
 
 The Messages API requires an output cap, so `-P max_output_tokens=` defaults to
 `16000` here. Thinking bills against that same cap, and a response truncated at
@@ -459,3 +468,7 @@ inspect-robots "pick up the cube" --policy agent \
     -P model=openai/gpt-5.6-sol -P wire=responses -P effort=medium \
     --embodiment cubepick
 ```
+
+To stay on Chat Completions and disable reasoning instead, pass
+`-P effort=none`. It sends the literal `reasoning_effort: "none"`; no nested
+quoting is required.

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.22.0"
+version = "0.23.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_anthropic.py
@@ -117,10 +117,12 @@ class AnthropicClient:
         body: dict[str, Any] = {
             "model": self._provider.model,
             "max_tokens": self._max_output_tokens,
-            # Explicit, not omitted: omitting only means adaptive on Opus 5.
-            # On Opus 4.8 and 4.7 it means thinking off, which would silently
-            # halve this wire's target set and make the replay cache dead code.
-            "thinking": {"type": "adaptive"},
+            # The Messages API spells the true minimum as thinking-disabled.
+            # Otherwise request adaptive explicitly: omitting thinking means
+            # thinking off on Opus 4.8 and 4.7, not the provider default.
+            "thinking": (
+                {"type": "disabled"} if reasoning_effort == "none" else {"type": "adaptive"}
+            ),
             "messages": translated,
         }
         if system is not None:
@@ -135,7 +137,7 @@ class AnthropicClient:
             body["tools"] = _translate_tools(tools)
         if temperature is not None:
             body["temperature"] = temperature
-        if reasoning_effort is not None:
+        if reasoning_effort is not None and reasoning_effort != "none":
             body["output_config"] = {"effort": reasoning_effort}
         if self._speed is not None:
             body["speed"] = self._speed
@@ -225,8 +227,8 @@ class AnthropicClient:
             )
         if "effort" in lowered:
             return (
-                "\nfix: the Messages API accepts -P effort= low, medium, high, "
-                "xhigh, or max; none and minimal are OpenAI-only values"
+                "\nfix: the Messages API accepts -P effort=none (thinking disabled) or "
+                "low, medium, high, xhigh, and max; minimal is an OpenAI-only value"
             )
         return ""
 

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -233,7 +233,9 @@ class AgentPolicyConfig(PolicyConfig):
     #: wires, where nothing constrained the output.
     max_output_tokens: int | None = None
     max_llm_calls: int = 100
-    effort: str | None = "low"
+    #: Resolved effort level; ``None`` means the field is omitted and the
+    #: provider default applies.
+    effort: str | None = None
     max_speed_frac: float = 0.1
     transcript_echo: bool = False
     images: str = "always"
@@ -373,15 +375,16 @@ class LLMAgentPolicy(PolicyBase):
             wire = _WIRE_ALIASES.get(wire, wire)
             if wire not in _WIRE_FORMATS:
                 raise ConfigError(f"wire must be one of {sorted(_WIRE_FORMATS)}, got {wire!r}")
-        if effort is not _UNSET and effort is not None and effort not in _EFFORT_LEVELS:
-            raise ConfigError(
-                f"effort must be one of {sorted(_EFFORT_LEVELS)}, or None to omit "
-                f"the field, got {effort!r}"
-            )
-        resolved_effort: str | None = None if wire == "gemini-live" else "low"
+        resolved_effort: str | None = None
         if not isinstance(effort, _Unset):
-            resolved_effort = effort
-        if wire == "gemini-live" and effort is not _UNSET and effort is not None:
+            effort_level = "none" if effort is None else effort
+            if effort_level not in _EFFORT_LEVELS:
+                raise ConfigError(
+                    f"effort must be one of {sorted(_EFFORT_LEVELS)}, got {effort!r}.\n"
+                    "fix: omit -P effort= to use the provider default"
+                )
+            resolved_effort = effort_level
+        if wire == "gemini-live" and effort is not _UNSET:
             raise ConfigError(
                 "effort is not supported on wire='gemini-live'.\nfix: drop -P effort="
             )
@@ -601,9 +604,8 @@ class LLMAgentPolicy(PolicyBase):
             self._client = ChatClient(provider, transport=transport, capture=self._capture)
         self._max_llm_calls = max_llm_calls
         self._temperature = temperature
-        # Robot control is latency-sensitive: default to low reasoning effort
-        # (the arm stands still while the model thinks; safety guardrails sit
-        # below the model, so effort trades thinking time, not safety).
+        # Preserve the operator's requested effort exactly; when it is unset,
+        # omit the field so the provider's own default applies.
         self._effort = resolved_effort
         self._max_speed_frac = max_speed_frac
         self._transcript_echo = transcript_echo

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -72,8 +72,9 @@ _GEMINI_LIVE_BASE = (
 
 # reasoning_effort values accepted across OpenAI-compatible endpoints
 # (Anthropic compat maps these to thinking effort; OpenRouter forwards them).
-# The Messages wire reuses the set as output_config.effort. Anthropic rejects
-# "none"/"minimal", and its endpoint requires streaming for the cap xhigh/max
+# The Messages wire reuses the set: "none" becomes thinking-disabled client-side
+# and the rest go out as output_config.effort, of which Anthropic rejects
+# "minimal", and its endpoint requires streaming for the cap xhigh/max
 # need; Tinker accepts xhigh/max without streaming. Rejections get guided errors.
 _EFFORT_LEVELS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max"})
 _WIRE_FORMATS = frozenset({"chat", "responses", "messages", "gemini-live"})

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -143,9 +143,20 @@ def test_optional_fields_omitted_when_unset() -> None:
     _client(handler).complete([_USER], [])
 
     body = json.loads(seen[0].content)
+    assert body["thinking"] == {"type": "adaptive"}
     assert "tools" not in body
     assert "output_config" not in body
     assert "system" not in body
+
+
+def test_none_effort_disables_thinking_without_output_config() -> None:
+    seen, handler = _capture(_anthropic_response(_text("hi"), stop_reason="end_turn"))
+
+    _client(handler).complete([_USER], [], reasoning_effort="none")
+
+    body = json.loads(seen[0].content)
+    assert body["thinking"] == {"type": "disabled"}
+    assert "output_config" not in body
 
 
 def test_temperature_forwarded_when_set() -> None:
@@ -163,6 +174,17 @@ def test_fast_mode_sends_speed_and_beta_header() -> None:
 
     assert json.loads(seen[0].content)["speed"] == "fast"
     assert seen[0].headers["anthropic-beta"] == "fast-mode-2026-02-01"
+
+
+def test_fast_mode_passes_through_with_none_effort() -> None:
+    seen, handler = _capture(_anthropic_response(_text("hi"), stop_reason="end_turn"))
+
+    _client(handler, speed="fast").complete([_USER], [], reasoning_effort="none")
+
+    body = json.loads(seen[0].content)
+    assert body["speed"] == "fast"
+    assert body["thinking"] == {"type": "disabled"}
+    assert "output_config" not in body
 
 
 def test_empty_api_key_omits_header() -> None:
@@ -751,8 +773,11 @@ def test_effort_4xx_names_the_accepted_values() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(400, text="output_config.effort: invalid value 'minimal'")
 
-    with pytest.raises(RuntimeError, match=r"none and minimal are OpenAI-only values"):
+    with pytest.raises(RuntimeError) as excinfo:
         _client(handler).complete([_USER], [], reasoning_effort="minimal")
+
+    assert "minimal is an OpenAI-only value" in str(excinfo.value)
+    assert "none and minimal" not in str(excinfo.value)
 
 
 def test_temperature_guidance_only_when_temperature_was_sent() -> None:

--- a/plugins/inspect-robots-agent/tests/test_gemini_live.py
+++ b/plugins/inspect-robots-agent/tests/test_gemini_live.py
@@ -770,14 +770,18 @@ def test_per_wire_default_resolution_and_explicit_none() -> None:
         wire_capture=False,
         env={"GEMINI_API_KEY": "g"},
     )
-    explicit_none = LLMAgentPolicy(
-        model="m",
-        base_url="ws://stub.test",
-        wire="gemini-live",
-        effort=None,
-        image_horizon=None,
-        wire_capture=False,
-        env={},
+    with pytest.raises(ConfigError) as explicit_none_error:
+        LLMAgentPolicy(
+            model="m",
+            base_url="ws://stub.test",
+            wire="gemini-live",
+            effort=None,
+            image_horizon=None,
+            wire_capture=False,
+            env={},
+        )
+    assert str(explicit_none_error.value) == (
+        "effort is not supported on wire='gemini-live'.\nfix: drop -P effort="
     )
     chat = LLMAgentPolicy(model="m", base_url="http://stub.test", wire_capture=False, env={})
     responses = LLMAgentPolicy(
@@ -796,18 +800,13 @@ def test_per_wire_default_resolution_and_explicit_none() -> None:
     )
 
     assert isinstance(live.config, AgentPolicyConfig)
-    assert isinstance(explicit_none.config, AgentPolicyConfig)
     assert isinstance(chat.config, AgentPolicyConfig)
     assert isinstance(responses.config, AgentPolicyConfig)
     assert isinstance(anthropic.config, AgentPolicyConfig)
     assert (live.config.effort, live.config.image_horizon) == (None, None)
-    assert (explicit_none.config.effort, explicit_none.config.image_horizon) == (
-        None,
-        None,
-    )
-    assert (chat.config.effort, chat.config.image_horizon) == ("low", 2)
-    assert (responses.config.effort, responses.config.image_horizon) == ("low", 2)
-    assert (anthropic.config.effort, anthropic.config.image_horizon) == ("low", 2)
+    assert (chat.config.effort, chat.config.image_horizon) == (None, 2)
+    assert (responses.config.effort, responses.config.image_horizon) == (None, 2)
+    assert (anthropic.config.effort, anthropic.config.image_horizon) == (None, 2)
 
 
 def test_live_rejects_explicit_effort_and_image_horizon_with_guidance() -> None:
@@ -842,7 +841,7 @@ def test_existing_invalid_effort_and_horizon_messages_are_preserved() -> None:
         LLMAgentPolicy(**common, effort="default")
     assert str(effort_error.value) == (
         "effort must be one of ['high', 'low', 'max', 'medium', 'minimal', 'none', "
-        "'xhigh'], or None to omit the field, got 'default'"
+        "'xhigh'], got 'default'.\nfix: omit -P effort= to use the provider default"
     )
     with pytest.raises(ConfigError) as horizon_error:
         LLMAgentPolicy(**common, image_horizon=0)

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,7 +6,7 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.22.0"
+    assert inspect_robots_agent.__version__ == "0.23.0"
     assert callable(inspect_robots_agent.agent_policy)
     assert inspect_robots_agent.__all__ == [
         "ENV_MODEL",

--- a/plugins/inspect-robots-agent/tests/test_policy_e2e.py
+++ b/plugins/inspect-robots-agent/tests/test_policy_e2e.py
@@ -2470,31 +2470,62 @@ def test_on_demand_prompt_and_no_tool_nudge_describe_chaining() -> None:
     )
 
 
-def test_effort_defaults_low_and_is_tunable(tmp_path: Path) -> None:
+def test_effort_passthrough_matrix(tmp_path: Path) -> None:
     script = _Script([_tool_response("done", {"summary": "ok"})])
     logs = ir_eval(_task(), _policy(script), CubePickEmbodiment(), log_dir=str(tmp_path))
-    # Robot control is latency-sensitive: low effort by default (guardrails
-    # sit below the model, so this trades thinking time, not safety).
-    assert script.requests[0]["reasoning_effort"] == "low"
-    assert logs[0].eval.policy_config["effort"] == "low"
-
-    script = _Script([_tool_response("done", {"summary": "ok"})])
-    ir_eval(_task(), _policy(script, effort="high"), CubePickEmbodiment(), log_dir=str(tmp_path))
-    assert script.requests[0]["reasoning_effort"] == "high"
-
-    script = _Script([_tool_response("done", {"summary": "ok"})])
-    ir_eval(_task(), _policy(script, effort=None), CubePickEmbodiment(), log_dir=str(tmp_path))
     assert "reasoning_effort" not in script.requests[0]
+    assert logs[0].eval.policy_config["effort"] is None
 
-    # "none" is a wire value, distinct from None (omit the field): GPT-5.x
-    # rejects function tools on chat completions unless reasoning_effort is
-    # explicitly "none", and omitting the field 400s the same way.
     script = _Script([_tool_response("done", {"summary": "ok"})])
-    ir_eval(_task(), _policy(script, effort="none"), CubePickEmbodiment(), log_dir=str(tmp_path))
+    logs = ir_eval(
+        _task(),
+        _policy(script, effort=None),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+    )
     assert script.requests[0]["reasoning_effort"] == "none"
+    assert logs[0].eval.policy_config["effort"] == "none"
 
-    with pytest.raises(ConfigError, match=r"or None to omit the field, got 'turbo'"):
+    script = _Script([_tool_response("done", {"summary": "ok"})])
+    logs = ir_eval(
+        _task(),
+        _policy(script, effort="none"),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+    )
+    assert script.requests[0]["reasoning_effort"] == "none"
+    assert logs[0].eval.policy_config["effort"] == "none"
+
+    script = _Script([_tool_response("done", {"summary": "ok"})])
+    logs = ir_eval(
+        _task(),
+        _policy(script, effort="high"),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+    )
+    assert script.requests[0]["reasoning_effort"] == "high"
+    assert logs[0].eval.policy_config["effort"] == "high"
+
+    with pytest.raises(ConfigError) as invalid:
         _policy(_Script([]), effort="turbo")
+    assert str(invalid.value) == (
+        "effort must be one of ['high', 'low', 'max', 'medium', 'minimal', 'none', "
+        "'xhigh'], got 'turbo'.\nfix: omit -P effort= to use the provider default"
+    )
+
+    live_kwargs: dict[str, Any] = {
+        "model": "m",
+        "base_url": "ws://stub.test",
+        "wire": "gemini-live",
+        "wire_capture": False,
+        "env": {},
+    }
+    with pytest.raises(ConfigError, match="effort is not supported"):
+        LLMAgentPolicy(**live_kwargs, effort=None)
+    with pytest.raises(ConfigError, match="effort is not supported"):
+        LLMAgentPolicy(**live_kwargs, effort="low")
+    live = LLMAgentPolicy(**live_kwargs)
+    assert live.config.effort is None
 
 
 def test_registry_resolves_agent_policy() -> None:

--- a/plugins/inspect-robots-agent/tests/test_responses.py
+++ b/plugins/inspect-robots-agent/tests/test_responses.py
@@ -643,9 +643,10 @@ def test_policy_uses_responses_wire_through_act_and_records_config() -> None:
 
     assert requests[0].url.path == "/v1/responses"
     body = json.loads(requests[0].content)
-    assert body["reasoning"] == {"effort": "low"}
+    assert "reasoning" not in body
     assert isinstance(policy.config, AgentPolicyConfig)
     assert policy.config.wire == "responses"
+    assert policy.config.effort is None
 
 
 def test_policy_rejects_invalid_wire_and_defaults_config_to_chat() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.22.0"
+version = "0.23.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #317.

What the operator types is what the model gets:

| Operator input | Wire |
|---|---|
| *(flag omitted)* | effort field omitted → provider default (matches `temperature`) |
| `-P effort=none` | `reasoning_effort: "none"` (chat), `reasoning: {"effort": "none"}` (responses), `thinking: {"type": "disabled"}` (messages) |
| `-P effort=low`…`max` | unchanged |

**Breaking (behavior):** scripts that omit `-P effort=` ran at `low`; they now run at the provider default. Pin with `-P effort=low`. Programmatic `effort=None` now means the level `"none"`, not "omit".

Plan: [plans/0049-effort-passthrough.md](https://github.com/robocurve/inspect-robots/blob/feat/effort-passthrough/plans/0049-effort-passthrough.md)

Coordination: touches the same validation block as #315 (fractional effort); whichever lands second rebases. capx-plugin parity is a follow-up (filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)