### PR TITLE
voice: core floor >=0.44 (v0.43.0 predates the operator-input seam)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
-- **Core (0.43.0):** operator messages now preserve console or attached-input
+- **Core (0.44.0):** operator messages now preserve console or attached-input
   provenance through transcripts, policy observations, and evaluation logs.
   `OperatorSession.attach_input()` merges feedback-only sources without risking
   the typed console, the registry exposes an `operator_input` plugin kind, and

--- a/plugins/inspect-robots-voice/pyproject.toml
+++ b/plugins/inspect-robots-voice/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "inspect-robots>=0.43",
+    "inspect-robots>=0.44",
     "numpy>=1.24",
     "sounddevice>=0.4.6",
     "faster-whisper>=1.0",


### PR DESCRIPTION
v0.43.0 was released from a tag cut 20 minutes before #316 merged, so the core seam (`OperatorSession.attach_input`, the `operator_input` registry kind, `--voice`) is not in 0.43.0. Bump the unpublished voice plugin's floor to `>=0.44` and relabel the CHANGELOG core entry before cutting v0.44.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)