### PR TITLE
chore(website): bump js-yaml to 4.3.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10716,9 +10716,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Resolves Dependabot alert 13: js-yaml quadratic CPU in !!omap resolution (CVE-2026-59870, high). Lockfile-only bump to the first patched version 4.3.1; the site's single js-yaml copy is build tooling, so no runtime exposure for package users. Website build verified locally (gen_api_docs + npm ci + npm run build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)