### PR TITLE
voice 0.3.0: Parakeet TDT 0.6B v3 default backend via onnx-asr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- **Voice plugin (0.3.0):** Parakeet TDT 0.6B v3 through onnx-asr is now the
+  default transcription backend. Its lower published word error rate and faster
+  CPU inference replace faster-whisper `small`, while `-V model=small` remains
+  the escape hatch to the previous behavior. This default change is breaking:
+  explicit Whisper-only options such as `-V language=fr`, `-V compute=int8`,
+  and `-V asr_device=cuda` now also require selecting a Whisper model, where
+  0.2.0 accepted them without an explicit model. Parakeet TDT 0.6B v3 weights
+  are provided by NVIDIA under the CC-BY-4.0 license and download from the
+  Hugging Face hub on first use
+  ([plan 0053](plans/0053-voice-parakeet-backend.md),
+  [#324](https://github.com/robocurve/inspect-robots/issues/324)).
+
 - **Voice plugin (0.2.0):** Whisper now runs on CPU by default with a new
   `asr_device` option (`-V asr_device=cuda` opts into GPU); a missing PortAudio
   library fails with per-OS install commands instead of a bare loader error; a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,8 @@ rollout, scores it, and writes an immutable `EvalLog`. Mirrors Inspect AI's
   SDKs; registered as `agent`), and
   `plugins/inspect-robots-capx/` (CaP-X code-as-policy over perception and IK
   HTTP servers; registered as `capx`), and
-  `plugins/inspect-robots-voice/` (local microphone capture and faster-whisper
-  transcription; registered as the `voice` operator input).
+  `plugins/inspect-robots-voice/` (local microphone capture and local transcription,
+  with Parakeet as the default; registered as the `voice` operator input).
 
 ## Working here
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,24 @@ inspect-robots run --policy agent --rerun-connect \
     --instruction "place the fork on the plate"
 ```
 
+### Talk to the policy while it runs
+
+With the [voice plugin](plugins/inspect-robots-voice/) installed, `--voice`
+keeps the microphone open for the whole run and delivers each spoken remark to
+the policy at its next inference, transcribed locally (no keys, no network).
+Silence sends nothing, and voice is feedback-only: ending an episode and
+recording verdicts stay on the keyboard.
+
+```bash
+pip install inspect-robots-voice
+inspect-robots run --policy agent -P model=anthropic/claude-opus-5 \
+    --voice \
+    --instruction "place the fork on the plate"
+```
+
+Typed console feedback keeps working alongside; both land in the transcript
+and the eval log with their source recorded.
+
 ### Retry with learning
 
 Summarize a failed log into a learnings file, then pass those notes to the

--- a/docs/guide/voice-mode.md
+++ b/docs/guide/voice-mode.md
@@ -25,7 +25,7 @@ sudo dnf install portaudio        # Fedora
 brew install portaudio            # macOS
 ```
 
-Named faster-whisper models may be downloaded when voice input starts for the first time.
+Model weights may be downloaded when voice input starts for the first time.
 
 ## Run
 
@@ -46,13 +46,20 @@ work.
 Repeat `-V key=value` to configure the voice plugin. Values use the same scalar coercion as
 `-P` and `-E`.
 
-| Key | Default | Meaning |
-| --- | --- | --- |
-| `model` | `small` | faster-whisper model size or local model path |
-| `device` | system default | sounddevice input index or case-insensitive name substring |
-| `language` | `en` | transcription language |
-| `compute` | `auto` | CTranslate2 compute type |
-| `asr_device` | `cpu` | where Whisper runs: `cpu` (default, no CUDA needed), `cuda`, or `auto` (needs the CUDA runtime libraries) |
+| Key | Default | Backend | Meaning |
+| --- | --- | --- | --- |
+| `model` | `parakeet-tdt-0.6b-v3` | both | Parakeet alias or `nemo-` name, or a faster-whisper model size or local path |
+| `device` | system default | both | sounddevice input index or case-insensitive name substring |
+| `language` | `none` | whisper | explicit transcription language; Parakeet auto-detects language |
+| `compute` | `auto` | whisper | CTranslate2 compute type |
+| `asr_device` | `cpu` | whisper | where Whisper runs: `cpu` (default, no CUDA needed), `cuda`, or `auto` (needs the CUDA runtime libraries) |
+
+Parakeet TDT 0.6B v3 is the default. Its int8 ONNX weights download once from the Hugging Face
+hub on first use and use about 640 MB. To use Whisper instead, pass `-V model=small` or another
+faster-whisper model name or local path. Explicit `language`, `compute`, and non-CPU `asr_device`
+values require a Whisper model.
+
+Parakeet TDT 0.6B v3 weights are provided by NVIDIA under the CC-BY-4.0 license.
 
 For example:
 
@@ -73,10 +80,14 @@ after at least 100 ms above the learned noise threshold, prepends 300 ms of audi
 after 700 ms below the threshold. An utterance is force-closed at 30 seconds so a stuck-open
 gate cannot grow without bound. The noise estimate adapts only while speech is not open.
 
-Each closed candidate then passes faster-whisper's bundled Silero VAD. The plugin rejects audio
-shorter than 0.4 seconds, blank text, segments with no-speech probability above 0.6, segments
-with average log probability below -1.0, and exact silence hallucinations such as `Thank you.`,
-`you`, and `Thanks for watching!`. Rejected candidates disappear silently.
+Each closed candidate shorter than 0.4 seconds is rejected before transcription. Both backends
+also reject blank text and exact silence hallucinations such as `Thank you.`, `you`, and
+`Thanks for watching!`.
+
+Parakeet relies on the energy gate and its transducer decoder, then applies a coarse garbage
+check that rejects mean token log probability below -2.5 when token probabilities are available.
+Whisper also runs its bundled Silero VAD and rejects segments with no-speech probability above
+0.6 or average log probability below -1.0. Rejected candidates disappear silently.
 
 ## Feedback-only behavior
 

--- a/docs/guide/voice-mode.md
+++ b/docs/guide/voice-mode.md
@@ -50,7 +50,7 @@ Repeat `-V key=value` to configure the voice plugin. Values use the same scalar 
 | --- | --- | --- | --- |
 | `model` | `parakeet-tdt-0.6b-v3` | both | Parakeet alias or `nemo-` name, or a faster-whisper model size or local path |
 | `device` | system default | both | sounddevice input index or case-insensitive name substring |
-| `language` | `none` | whisper | explicit transcription language; Parakeet auto-detects language |
+| `language` | `none` | whisper | explicit transcription language (Whisper uses `en` when unset); Parakeet auto-detects |
 | `compute` | `auto` | whisper | CTranslate2 compute type |
 | `asr_device` | `cpu` | whisper | where Whisper runs: `cpu` (default, no CUDA needed), `cuda`, or `auto` (needs the CUDA runtime libraries) |
 

--- a/plans/0053-voice-parakeet-backend.md
+++ b/plans/0053-voice-parakeet-backend.md
@@ -170,10 +170,14 @@ the faster-whisper dependency (Whisper stays the multilingual-explicit and GPU o
 
 ### Task 3: backend selection + factory validation
 
-- [ ] `_transcriber.py`: `resolve_transcriber(model, compute, language, asr_device)`
-  — parakeet-name detection (case-insensitive substring), alias canonicalization per
-  decision 1, `TypeError`s per decision 5 for parakeet + whisper-only options;
-  returns `ParakeetTranscriber` or `WhisperTranscriber`.
+- [ ] `_transcriber.py`: a single shared private classifier `_classify_model(model)
+  -> str | None` implementing the full decision-1 precedence (path separator →
+  whisper i.e. `None`; alias map; `nemo-` passthrough lowercased; unknown
+  parakeet-ish name → the decision-1 `TypeError`; else whisper i.e. `None`), returning
+  the canonical parakeet name or `None` for whisper. `resolve_transcriber(model,
+  compute, language, asr_device)` calls it and constructs `ParakeetTranscriber` or
+  `WhisperTranscriber`; it performs no decision-5 option validation (that lives in
+  `voice_input`, next bullets).
 - [ ] `_input.py`: default `_transcriber_factory` delegates to `resolve_transcriber`;
   `VoiceInput` default `model` becomes `"parakeet-tdt-0.6b-v3"`; `language` default
   becomes `None` (threaded through the factory type and `WhisperTranscriber`'s
@@ -183,7 +187,13 @@ the faster-whisper dependency (Whisper stays the multilingual-explicit and GPU o
   `isinstance(language, str)` check (`__init__.py:46-47`) widens to `str | None`;
   cross-backend `TypeError`s per decision 5 are value-based (non-`None` language,
   non-`"auto"` compute, non-`"cpu"` asr_device with a parakeet model), all raised
-  here, none in `resolve_transcriber`.
+  here, none in `resolve_transcriber`. **`voice_input` gates them on the shared
+  `_classify_model` helper** — never a naive substring check, which would misclassify
+  a whisper CT2 path like `/models/parakeet-ct2` — and calling the helper here also
+  surfaces the decision-1 unknown-parakeet-name `TypeError` at factory time (the CLI
+  resolves `voice_input(**kvs)` long before `start()`), satisfying decision 1's
+  "fail at the factory" promise. When both could apply (unknown parakeet-ish name AND
+  a whisper-only option), the decision-1 name error wins — the classifier runs first.
 - [ ] Tests: alias table (`parakeet`, `parakeet-tdt-0.6b-v3`, `nemo-parakeet-tdt-0.6b-v3`,
   mixed case) → ParakeetTranscriber with the canonical name; unknown parakeet-ish name
   (`parakeet-tdt-1.1b`) → `TypeError` listing supported names; `small`/
@@ -191,8 +201,13 @@ the faster-whisper dependency (Whisper stays the multilingual-explicit and GPU o
   "parakeet", e.g. `/models/parakeet-ct2`) → WhisperTranscriber with today's exact
   arguments; factory defaults (`model`, `language=None`) updated; each cross-backend
   `TypeError` (message asserted) plus the accepted no-ops (`asr_device=cpu`,
-  `compute=auto`, `language=None` with parakeet); whisper `language=None` resolves to
-  `"en"`; explicit whisper language passes through. **Delete the now-inverted
+  `compute=auto`, `language=None` with parakeet); whisper-only option values with a
+  path model whose basename contains "parakeet" (e.g.
+  `voice_input(model="/models/parakeet-ct2", language="fr", asr_device="cuda")`) are
+  **accepted** (the classifier, not a substring, gates the rules); unknown
+  parakeet-ish name + whisper-only option raises the decision-1 name error, not the
+  decision-5 one; whisper `language=None` resolves to `"en"`; explicit whisper
+  language passes through. **Delete the now-inverted
   rejection-matrix row** `({"language": None}, "language must be a string")` at
   tests/test_factory.py:52.
 - [ ] `tests/test_input.py`: the two listening-line literals asserting

--- a/plans/0053-voice-parakeet-backend.md
+++ b/plans/0053-voice-parakeet-backend.md
@@ -58,18 +58,32 @@ int8 ONNX download is ~640 MB one-time via the HF hub cache.
 
 ## Design decisions (and why)
 
-1. **Backend is inferred from the model name; no new flag.** A model string containing
-   `"parakeet"` (case-insensitive) selects the onnx-asr backend; anything else keeps
-   faster-whisper. Friendly aliases map onto the canonical onnx-asr name:
-   `"parakeet"` and `"parakeet-tdt-0.6b-v3"` → `"nemo-parakeet-tdt-0.6b-v3"`; a string
-   already starting with `"nemo-"` passes through untouched. The default `model`
-   becomes `"parakeet-tdt-0.6b-v3"`. Escape hatch stays one flag:
+1. **Backend is inferred from the model name; no new flag.** Precedence, evaluated on
+   the raw string:
+   - contains a path separator (`/` or `\`) → whisper (filesystem CT2 paths always
+     mean whisper, even a path like `/models/parakeet-ct2`);
+   - case-insensitive exact alias: `"parakeet"` or `"parakeet-tdt-0.6b-v3"` →
+     canonical `"nemo-parakeet-tdt-0.6b-v3"`, parakeet backend;
+   - case-insensitive prefix `"nemo-"` → parakeet backend, name passed through
+     lowercased (onnx-asr's registry is lowercase);
+   - any other string containing `"parakeet"` (e.g. `"parakeet-tdt-1.1b"`) →
+     `TypeError` listing the supported parakeet names, so typos fail at the factory,
+     not minutes later inside `start()`;
+   - everything else → whisper, exactly as today.
+   The default `model` becomes `"parakeet-tdt-0.6b-v3"`. Escape hatch stays one flag:
    `-V model=small` (or any Whisper size/path) restores 0.2.0 behavior exactly.
 2. **Selection lives in `_transcriber.py` as `resolve_transcriber(model, compute,
    language, asr_device) -> _Transcriber`,** and `_input.py`'s default
    `_transcriber_factory` simply calls it. The `TranscriberFactory` seam, `VoiceInput`,
    the worker, and every orchestration invariant are untouched — this PR changes which
-   object comes out of an existing seam, nothing else.
+   object comes out of an existing seam, nothing else. **Import topology (no cycle):**
+   `_parakeet.py` imports the shared private pre-check helpers from `_transcriber.py`
+   at module top (one direction), and `resolve_transcriber` imports
+   `ParakeetTranscriber` with a function-local
+   `from inspect_robots_voice._parakeet import ParakeetTranscriber` — never at
+   `_transcriber.py` module top. `resolve_transcriber` does selection and
+   canonicalization only; all cross-backend option policy lives in `voice_input`
+   (decision 5).
 3. **`ParakeetTranscriber` lives in a new `_parakeet.py`** (module map updated), lazy
    `import onnx_asr` at construction, `load_model(name, quantization="int8",
    providers=["CPUExecutionProvider"])` then `.with_timestamps()`. `transcribe()`
@@ -82,25 +96,36 @@ int8 ONNX download is ~640 MB one-time via the HF hub cache.
    pre-check (shared constant), empty/whitespace-text rejection, and the hallucination
    blocklist (free belt-and-suspenders; harmless on a transducer). Add: mean token
    logprob rejection, `mean(result.logprobs) < -2.5` → `None`, but **only when
-   `logprobs` is non-`None`** — a deliberately loose, uncalibrated threshold (we chose
+   `logprobs` is truthy** (`if logprobs:` — `None` AND the empty list both skip the
+   check; `mean([])` is NaN/raises depending on the implementation, and a missing list
+   deliberately fails open) — a deliberately loose, uncalibrated threshold (we chose
    not to bench; document it as a coarse garbage-catch, not a tuned filter). Drop:
    `no_speech_prob` and `avg_logprob` (Whisper-specific; onnx-asr exposes neither), and
    `vad_filter` (no equivalent; the energy gate plus transducer behavior covers it).
 5. **Cross-backend option semantics are validated loudly at the factory, not silently
-   ignored.** `language` changes type to `str | None`, default `None`:
-   - Whisper: `None` resolves to `"en"` (today's default preserved); explicit strings
-     pass through unchanged.
-   - Parakeet: v3 auto-detects among 25 languages; `None` is correct, and an explicit
-     `-V language=...` with a parakeet model raises
+   ignored — by VALUE, uniformly, in `voice_input` only.** The rule for every
+   whisper-only option is the same: with a parakeet model, a value other than the
+   backend-neutral default raises `TypeError`; the neutral default itself is always
+   accepted, whether typed or omitted. This makes the CLI's `_parse_kvs` coercion a
+   non-issue (`-V language=none` coerces to Python `None`, which IS the neutral value,
+   so a user typing the parakeet-correct thing is accepted, never scolded) and needs no
+   key-presence machinery (which `resolve_transcriber` could not perform anyway, since
+   it receives resolved values).
+   - `language` changes type to `str | None`, default `None`. Whisper: `None` resolves
+     to `"en"` inside `WhisperTranscriber` (today's behavior preserved); explicit
+     strings pass through. Parakeet: v3 auto-detects among 25 languages, so `None` is
+     correct; a non-`None` language with a parakeet model raises
      `TypeError("parakeet models auto-detect language; drop -V language or pick a
      whisper model")`.
-   - `asr_device`: Parakeet runs CPU-only in this plan (CUDA needs `onnxruntime-gpu`,
-     which we do not ship); `-V asr_device=...` other than `"cpu"` with a parakeet
-     model raises `TypeError("the parakeet backend runs on the CPU; use a whisper
-     model for -V asr_device=cuda")`. `compute` similarly applies to Whisper only;
-     explicit non-default `compute` with parakeet raises `TypeError`. Detecting
-     "explicit non-default" is trivial because the factory reads `kwargs` — presence
-     of the key is the signal, never the value.
+   - `asr_device`: parakeet runs CPU-only in this plan (CUDA needs `onnxruntime-gpu`,
+     which we do not ship); a value other than `"cpu"` with a parakeet model raises
+     `TypeError("the parakeet backend runs on the CPU; use a whisper model for
+     -V asr_device=cuda")`.
+   - `compute`: whisper-only (CTranslate2 compute type); a value other than `"auto"`
+     with a parakeet model raises `TypeError("compute applies to whisper models; the
+     parakeet backend is fixed to int8")`.
+   So `-V asr_device=cpu`, `-V compute=auto`, and `-V language=none` are all accepted
+   no-ops with parakeet — consistent by construction.
 6. **Version and licensing:** plugin 0.3.0 (default-model change is behavior-visible;
    0.x minor). README and the voice-mode docs page gain a one-line attribution:
    Parakeet TDT 0.6B v3 weights by NVIDIA, licensed CC-BY-4.0, downloaded from the
@@ -121,7 +146,10 @@ the faster-whisper dependency (Whisper stays the multilingual-explicit and GPU o
 ### Task 1: dependency + scaffolding
 
 - [ ] `plugins/inspect-robots-voice/pyproject.toml`: add `onnx-asr[cpu,hub]>=0.12,<1`
-  to dependencies; bump version to `0.3.0`; `uv lock`.
+  to dependencies; bump version to `0.3.0`; `uv lock`. Expect the lock to move
+  onnxruntime on the py3.10 resolution only (onnx-asr pins `onnxruntime<1.24` there;
+  the advisory py3.10 CI tier covers it) — resolver-checked compatible with
+  faster-whisper 1.2.1's `onnxruntime>=1.14,<2`.
 - [ ] Bump `__version__` in `__init__.py` and the version-pinning test in
   `tests/test_factory.py` (it asserts the literal).
 
@@ -137,8 +165,8 @@ the faster-whisper dependency (Whisper stays the multilingual-explicit and GPU o
 - [ ] Tests (fake model objects only; never import onnx_asr): accept/reject matrix —
   normal sentence accepted; empty text; whitespace; blocklist phrase as entire text;
   short-audio pre-check (no model call at all); mean-logprob below threshold rejected;
-  `logprobs=None` accepted when text is fine; sample_rate=16000 passed through;
-  audio reshaped to mono float32.
+  `logprobs=None` accepted when text is fine; `logprobs=[]` accepted (fail-open, no
+  NaN warning); sample_rate=16000 passed through; audio reshaped to mono float32.
 
 ### Task 3: backend selection + factory validation
 
@@ -151,25 +179,50 @@ the faster-whisper dependency (Whisper stays the multilingual-explicit and GPU o
   becomes `None` (threaded through the factory type and `WhisperTranscriber`'s
   `None -> "en"` resolution).
 - [ ] `__init__.py`: `voice_input` — default `model` `"parakeet-tdt-0.6b-v3"`;
-  `language` accepts `str | None` (default `None`); cross-backend `TypeError`s per
-  decision 5 use key-presence in `kwargs`, so `-V asr_device=cpu` with parakeet is
-  fine but any explicit `language`/`compute`/`asr_device=cuda` with parakeet errors.
+  `language` accepts `str | None` (default `None`): the existing
+  `isinstance(language, str)` check (`__init__.py:46-47`) widens to `str | None`;
+  cross-backend `TypeError`s per decision 5 are value-based (non-`None` language,
+  non-`"auto"` compute, non-`"cpu"` asr_device with a parakeet model), all raised
+  here, none in `resolve_transcriber`.
 - [ ] Tests: alias table (`parakeet`, `parakeet-tdt-0.6b-v3`, `nemo-parakeet-tdt-0.6b-v3`,
-  mixed case) → ParakeetTranscriber with the canonical name; `small`/`distil-small.en`/
-  a filesystem path → WhisperTranscriber with today's exact arguments; factory defaults
-  (`model`, `language=None`) updated; each cross-backend `TypeError` (message asserted);
-  whisper `language=None` resolves to `"en"`; explicit whisper language passes through.
+  mixed case) → ParakeetTranscriber with the canonical name; unknown parakeet-ish name
+  (`parakeet-tdt-1.1b`) → `TypeError` listing supported names; `small`/
+  `distil-small.en`/a filesystem path (including one whose basename contains
+  "parakeet", e.g. `/models/parakeet-ct2`) → WhisperTranscriber with today's exact
+  arguments; factory defaults (`model`, `language=None`) updated; each cross-backend
+  `TypeError` (message asserted) plus the accepted no-ops (`asr_device=cpu`,
+  `compute=auto`, `language=None` with parakeet); whisper `language=None` resolves to
+  `"en"`; explicit whisper language passes through. **Delete the now-inverted
+  rejection-matrix row** `({"language": None}, "language must be a string")` at
+  tests/test_factory.py:52.
+- [ ] `tests/test_input.py`: the two listening-line literals asserting
+  `(model=small)` (lines ~293 and ~325, defaults-built `VoiceInput`) become
+  `(model=parakeet-tdt-0.6b-v3)`; factory-override lambdas pick up the
+  `language: str | None` type.
 
 ### Task 4: docs, attribution, changelog, module maps
 
 - [ ] `docs/guide/voice-mode.md`: default model row and backend column in the `-V`
   table (which keys apply to parakeet vs whisper), download size note, escape hatch
-  (`-V model=small`), CC-BY-4.0 attribution line.
-- [ ] Plugin `README.md`: default-model paragraph + attribution line.
-- [ ] Plugin `CLAUDE.md`: module map row for `_parakeet.py`; invariant list gains
-  `onnx_asr` in the lazy-import rule.
+  (`-V model=small`), CC-BY-4.0 attribution line. **Rewrite the prose that becomes
+  false for the new default:** the "Silence filtering" section (lines ~76-79)
+  currently presents Silero VAD, `no_speech_prob`, and `avg_logprob` as the pipeline —
+  restate it per backend (parakeet: energy gate + duration + blocklist + coarse mean
+  token logprob; whisper: today's text); line ~28's "Named faster-whisper models may
+  be downloaded" becomes backend-neutral.
+- [ ] Plugin `README.md`: default-model paragraph + attribution line, and reword the
+  faster-whisper/VAD framing at lines ~5, ~9, ~46 so the description matches the new
+  default.
+- [ ] Plugin `CLAUDE.md`: module map row for `_parakeet.py`; reword the
+  `_transcriber.py` row (it is now whisper wrapper + backend selection + shared
+  gauntlet pieces); invariant list gains `onnx_asr` in the lazy-import rule.
+- [ ] Root `CLAUDE.md`: the plugins blurb says "microphone capture and faster-whisper
+  transcription" — becomes backend-neutral ("local transcription", parakeet default).
 - [ ] `CHANGELOG.md`: voice 0.3.0 entry (default flip, why, escape hatch, attribution),
-  linking issue #324 and this plan.
+  linking issue #324 and this plan, and **naming the breaking change**: with the new
+  default model, explicit whisper-only options (`-V language=fr`, `-V compute=int8`,
+  `-V asr_device=cuda`) now require also selecting a whisper model, where 0.2.0
+  accepted them bare.
 
 ### Task 5: gates
 

--- a/plans/0053-voice-parakeet-backend.md
+++ b/plans/0053-voice-parakeet-backend.md
@@ -1,0 +1,182 @@
+# Voice: Parakeet TDT 0.6B v3 backend via onnx-asr, as the new default — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the voice plugin's default transcription model. faster-whisper `small`
+was the conservative launch choice; published 2026 numbers place NVIDIA Parakeet TDT
+0.6B v3 ahead on every axis that matters for spoken operator feedback: ~6.3% average WER
+on the Open ASR Leaderboard (better than Whisper large-v3, far better than `small`),
+roughly 30x real-time on CPU (vs ~8x), no fixed 30-second window (short utterances cost
+their real length), and a transducer decoder that cannot confabulate text from silence
+(the Whisper hallucination class our blocklist patches). Decision basis is the published
+numbers **by explicit owner decision (no local benchmark)**; the residual risk (rig-noise
+behavior) is mitigated by keeping Whisper one flag away. (Issue #324.)
+
+**Shape:** one PR, plugin-only (`plugins/inspect-robots-voice/` → 0.3.0). No core changes.
+
+**Tech Stack:** `onnx-asr[cpu,hub]>=0.12,<1` — pure Python, runs on onnxruntime + NumPy,
+no torch and no NeMo. `onnxruntime` and `huggingface_hub` are already in the plugin's
+tree transitively via faster-whisper, so the marginal dependency weight is one small
+pure-Python package. Model weights are CC-BY-4.0 (attribution required, see Task 4);
+int8 ONNX download is ~640 MB one-time via the HF hub cache.
+
+## Global Constraints
+
+- Plugin gates: `ruff check` + `ruff format --check` + mypy (plugin config, strict, src
+  and tests) + pytest, scoped to `plugins/inspect-robots-voice`; core gates must stay
+  green untouched (`pytest --cov` at 100% remains core-only).
+- Lazy imports: `onnx_asr` joins `sounddevice`/`faster_whisper` under the existing
+  invariant — never imported at module top, never imported by tests (fakes only), so CI
+  needs no model downloads and `core-only-import` is unaffected.
+- D1 docstrings, line length 100, repo writing style for README/docs text (no em dashes
+  in prose, no dangling header colons).
+- `uv lock` after the pyproject change.
+- No behavior change for anyone passing `-V model=<whisper name>`: the Whisper path,
+  its gauntlet, and its defaults are untouched.
+
+## Reference: current state (main @ 0ce79eb1, voice 0.2.0)
+
+- `_transcriber.py`: `WhisperTranscriber(model, compute, language, asr_device="cpu")`
+  with injectable `_model_factory`; gauntlet = empty-text, `no_speech_prob > 0.6`,
+  `avg_logprob < -1.0`, `< 0.4 s`, hallucination blocklist; `vad_filter=True`.
+- `_input.py`: `TranscriberFactory = Callable[[str, str, str, str], _Transcriber]`;
+  `VoiceInput(model="small", device=None, language="en", compute="auto",
+  asr_device="cpu")`; `start()` builds the transcriber via the factory seam.
+- `__init__.py`: `voice_input(**kwargs)` validates the scalar union per key; allowed =
+  {model, device, language, compute, asr_device}; unknown/mis-typed → `TypeError`.
+- Probed `onnx-asr` 0.12.0 API (exact, verified against the installed package):
+  - `onnx_asr.load_model("nemo-parakeet-tdt-0.6b-v3", quantization="int8",
+    providers=["CPUExecutionProvider"]) -> TextResultsAsrAdapter`
+  - `.with_timestamps() -> TimestampedResultsAsrAdapter` (its results carry logprobs;
+    the adapter passes `need_logprobs="yes"` internally)
+  - `.recognize(waveform: npt.NDArray[np.float32] | ..., *, sample_rate=16000)` accepts
+    a mono float32 array directly and returns `TimestampedResult` for a single input
+  - `TimestampedResult` dataclass fields: `text: str`, `timestamps: list[float] | None`,
+    `tokens: list[str] | None`, `logprobs: list[float] | None`
+
+## Design decisions (and why)
+
+1. **Backend is inferred from the model name; no new flag.** A model string containing
+   `"parakeet"` (case-insensitive) selects the onnx-asr backend; anything else keeps
+   faster-whisper. Friendly aliases map onto the canonical onnx-asr name:
+   `"parakeet"` and `"parakeet-tdt-0.6b-v3"` → `"nemo-parakeet-tdt-0.6b-v3"`; a string
+   already starting with `"nemo-"` passes through untouched. The default `model`
+   becomes `"parakeet-tdt-0.6b-v3"`. Escape hatch stays one flag:
+   `-V model=small` (or any Whisper size/path) restores 0.2.0 behavior exactly.
+2. **Selection lives in `_transcriber.py` as `resolve_transcriber(model, compute,
+   language, asr_device) -> _Transcriber`,** and `_input.py`'s default
+   `_transcriber_factory` simply calls it. The `TranscriberFactory` seam, `VoiceInput`,
+   the worker, and every orchestration invariant are untouched — this PR changes which
+   object comes out of an existing seam, nothing else.
+3. **`ParakeetTranscriber` lives in a new `_parakeet.py`** (module map updated), lazy
+   `import onnx_asr` at construction, `load_model(name, quantization="int8",
+   providers=["CPUExecutionProvider"])` then `.with_timestamps()`. `transcribe()`
+   mirrors the Whisper contract (`(audio) -> str | None`): reshape to mono float32,
+   apply the shared pre-checks, call `recognize(samples, sample_rate=16000)`, apply the
+   Parakeet gauntlet, return stripped text or `None`. int8 quantization is fixed (not
+   configurable): it is the published CPU-deployment shape and a 4x smaller download;
+   a knob can come later if anyone asks.
+4. **Parakeet gauntlet: architecture does most of the work.** Keep: min-duration
+   pre-check (shared constant), empty/whitespace-text rejection, and the hallucination
+   blocklist (free belt-and-suspenders; harmless on a transducer). Add: mean token
+   logprob rejection, `mean(result.logprobs) < -2.5` → `None`, but **only when
+   `logprobs` is non-`None`** — a deliberately loose, uncalibrated threshold (we chose
+   not to bench; document it as a coarse garbage-catch, not a tuned filter). Drop:
+   `no_speech_prob` and `avg_logprob` (Whisper-specific; onnx-asr exposes neither), and
+   `vad_filter` (no equivalent; the energy gate plus transducer behavior covers it).
+5. **Cross-backend option semantics are validated loudly at the factory, not silently
+   ignored.** `language` changes type to `str | None`, default `None`:
+   - Whisper: `None` resolves to `"en"` (today's default preserved); explicit strings
+     pass through unchanged.
+   - Parakeet: v3 auto-detects among 25 languages; `None` is correct, and an explicit
+     `-V language=...` with a parakeet model raises
+     `TypeError("parakeet models auto-detect language; drop -V language or pick a
+     whisper model")`.
+   - `asr_device`: Parakeet runs CPU-only in this plan (CUDA needs `onnxruntime-gpu`,
+     which we do not ship); `-V asr_device=...` other than `"cpu"` with a parakeet
+     model raises `TypeError("the parakeet backend runs on the CPU; use a whisper
+     model for -V asr_device=cuda")`. `compute` similarly applies to Whisper only;
+     explicit non-default `compute` with parakeet raises `TypeError`. Detecting
+     "explicit non-default" is trivial because the factory reads `kwargs` — presence
+     of the key is the signal, never the value.
+6. **Version and licensing:** plugin 0.3.0 (default-model change is behavior-visible;
+   0.x minor). README and the voice-mode docs page gain a one-line attribution:
+   Parakeet TDT 0.6B v3 weights by NVIDIA, licensed CC-BY-4.0, downloaded from the
+   Hugging Face hub on first use (~640 MB int8). Docs table updates: `model` default,
+   which `-V` keys apply to which backend, and the escape hatch.
+7. **Startup line unchanged in shape:** `listening on <device>
+   (model=parakeet-tdt-0.6b-v3)` — the alias the user typed (or defaulted to) is shown,
+   not the canonical `nemo-` name, matching what they would pass to `-V model=`.
+
+## Out of scope (YAGNI)
+
+GPU execution providers for Parakeet, quantization knobs, onnx-asr's VAD adapter,
+canary/other onnx-asr model families, batch recognition, streaming partials, removing
+the faster-whisper dependency (Whisper stays the multilingual-explicit and GPU option).
+
+## Tasks
+
+### Task 1: dependency + scaffolding
+
+- [ ] `plugins/inspect-robots-voice/pyproject.toml`: add `onnx-asr[cpu,hub]>=0.12,<1`
+  to dependencies; bump version to `0.3.0`; `uv lock`.
+- [ ] Bump `__version__` in `__init__.py` and the version-pinning test in
+  `tests/test_factory.py` (it asserts the literal).
+
+### Task 2: `_parakeet.py` + shared gauntlet pieces
+
+- [ ] Extract the shared pre-check constants/helpers used by both backends
+  (min-duration, blocklist membership) so `_parakeet.py` imports them from
+  `_transcriber.py` rather than duplicating (keep them private; no API change).
+- [ ] `_parakeet.py`: `ParakeetTranscriber(model: str)` per decisions 3-4, with an
+  injectable `_model_factory` seam mirroring `WhisperTranscriber`'s (the factory
+  returns an object with `recognize(samples, *, sample_rate) -> TimestampedResult`-
+  shaped results; type it with a local Protocol).
+- [ ] Tests (fake model objects only; never import onnx_asr): accept/reject matrix —
+  normal sentence accepted; empty text; whitespace; blocklist phrase as entire text;
+  short-audio pre-check (no model call at all); mean-logprob below threshold rejected;
+  `logprobs=None` accepted when text is fine; sample_rate=16000 passed through;
+  audio reshaped to mono float32.
+
+### Task 3: backend selection + factory validation
+
+- [ ] `_transcriber.py`: `resolve_transcriber(model, compute, language, asr_device)`
+  — parakeet-name detection (case-insensitive substring), alias canonicalization per
+  decision 1, `TypeError`s per decision 5 for parakeet + whisper-only options;
+  returns `ParakeetTranscriber` or `WhisperTranscriber`.
+- [ ] `_input.py`: default `_transcriber_factory` delegates to `resolve_transcriber`;
+  `VoiceInput` default `model` becomes `"parakeet-tdt-0.6b-v3"`; `language` default
+  becomes `None` (threaded through the factory type and `WhisperTranscriber`'s
+  `None -> "en"` resolution).
+- [ ] `__init__.py`: `voice_input` — default `model` `"parakeet-tdt-0.6b-v3"`;
+  `language` accepts `str | None` (default `None`); cross-backend `TypeError`s per
+  decision 5 use key-presence in `kwargs`, so `-V asr_device=cpu` with parakeet is
+  fine but any explicit `language`/`compute`/`asr_device=cuda` with parakeet errors.
+- [ ] Tests: alias table (`parakeet`, `parakeet-tdt-0.6b-v3`, `nemo-parakeet-tdt-0.6b-v3`,
+  mixed case) → ParakeetTranscriber with the canonical name; `small`/`distil-small.en`/
+  a filesystem path → WhisperTranscriber with today's exact arguments; factory defaults
+  (`model`, `language=None`) updated; each cross-backend `TypeError` (message asserted);
+  whisper `language=None` resolves to `"en"`; explicit whisper language passes through.
+
+### Task 4: docs, attribution, changelog, module maps
+
+- [ ] `docs/guide/voice-mode.md`: default model row and backend column in the `-V`
+  table (which keys apply to parakeet vs whisper), download size note, escape hatch
+  (`-V model=small`), CC-BY-4.0 attribution line.
+- [ ] Plugin `README.md`: default-model paragraph + attribution line.
+- [ ] Plugin `CLAUDE.md`: module map row for `_parakeet.py`; invariant list gains
+  `onnx_asr` in the lazy-import rule.
+- [ ] `CHANGELOG.md`: voice 0.3.0 entry (default flip, why, escape hatch, attribution),
+  linking issue #324 and this plan.
+
+### Task 5: gates
+
+- [ ] `uv run --no-sync ruff check plugins/inspect-robots-voice` and
+  `ruff format --check`.
+- [ ] `uv run --no-sync mypy --config-file plugins/inspect-robots-voice/pyproject.toml
+  plugins/inspect-robots-voice/src/inspect_robots_voice
+  plugins/inspect-robots-voice/tests`.
+- [ ] `uv run --no-sync python -m pytest plugins/inspect-robots-voice/tests -q`.
+- [ ] Full core suite untouched and green: `uv run --no-sync pytest --cov -q` (100%).

--- a/plugins/inspect-robots-voice/CLAUDE.md
+++ b/plugins/inspect-robots-voice/CLAUDE.md
@@ -11,14 +11,16 @@ merges its non-blocking polls with the typed console.
 | `src/inspect_robots_voice/__init__.py` | public factory, `-V` scalar type validation, and package exports |
 | `src/inspect_robots_voice/_capture.py` | sounddevice input-device resolution and bounded PortAudio callback queue with drop-oldest backpressure |
 | `src/inspect_robots_voice/_segmenter.py` | pure NumPy adaptive energy gate with pre-roll, hangover, and hard utterance cap |
-| `src/inspect_robots_voice/_transcriber.py` | faster-whisper wrapper and silence, confidence, duration, and hallucination rejection |
+| `src/inspect_robots_voice/_transcriber.py` | faster-whisper wrapper, backend selection, and shared duration and hallucination rejection |
+| `src/inspect_robots_voice/_parakeet.py` | onnx-asr Parakeet wrapper with timestamped confidence rejection |
 | `src/inspect_robots_voice/_input.py` | worker-thread orchestration, generation-safe trial resets, output polling, and lifecycle hooks |
 | `tests/` | deterministic unit tests using fake devices, models, capture, transcribers, segmenters, and threading events |
 
 ## Invariants
 
-- `sounddevice` and `faster_whisper` are lazy imports. Never import either at module scope. Tests
-  must run without PortAudio, audio hardware, model downloads, or importing those packages.
+- `sounddevice`, `faster_whisper`, and `onnx_asr` are lazy imports. Never import them at module
+  scope. Tests must run without PortAudio, audio hardware, model downloads, or importing those
+  packages.
 - `EnergyGate` is pure NumPy and has no I/O. The worker is the sole owner of its state and of
   capture-queue draining during normal operation.
 - `begin_trial()` changes the generation and clears accepted output under the shared lock, then

--- a/plugins/inspect-robots-voice/README.md
+++ b/plugins/inspect-robots-voice/README.md
@@ -31,7 +31,7 @@ Voice mode requires an attended terminal. Repeat `-V key=value` to configure it:
 | --- | --- | --- | --- |
 | `model` | `parakeet-tdt-0.6b-v3` | both | Parakeet alias or `nemo-` name, or a faster-whisper model size or local path |
 | `device` | system default | both | sounddevice input index or case-insensitive name substring |
-| `language` | `none` | whisper | explicit transcription language; Parakeet auto-detects language |
+| `language` | `none` | whisper | explicit transcription language (Whisper uses `en` when unset); Parakeet auto-detects |
 | `compute` | `auto` | whisper | CTranslate2 compute type |
 | `asr_device` | `cpu` | whisper | `cpu`, `cuda`, or `auto` |
 

--- a/plugins/inspect-robots-voice/README.md
+++ b/plugins/inspect-robots-voice/README.md
@@ -2,11 +2,12 @@
 
 Local spoken operator feedback for attended
 [Inspect Robots](https://github.com/robocurve/inspect-robots) evaluations. The plugin keeps the
-microphone open during a run, transcribes accepted utterances with faster-whisper, and sends them
-through the same operator-message channel as typed console feedback.
+microphone open during a run, transcribes accepted utterances locally, and sends them through the
+same operator-message channel as typed console feedback. Parakeet TDT 0.6B v3 is the default;
+faster-whisper models remain selectable by model name or local path.
 
 Voice input is feedback-only. Spoken words cannot end a trial or record a verdict. Silence and
-likely Whisper hallucinations produce no message.
+low-confidence transcription candidates produce no message.
 
 ## Install
 
@@ -26,12 +27,19 @@ inspect-robots run --task my-task --policy agent --embodiment my-robot --voice
 
 Voice mode requires an attended terminal. Repeat `-V key=value` to configure it:
 
-| Key | Default | Meaning |
-| --- | --- | --- |
-| `model` | `small` | faster-whisper model size or local model path |
-| `device` | system default | sounddevice input index or case-insensitive name substring |
-| `language` | `en` | transcription language |
-| `compute` | `auto` | CTranslate2 compute type |
+| Key | Default | Backend | Meaning |
+| --- | --- | --- | --- |
+| `model` | `parakeet-tdt-0.6b-v3` | both | Parakeet alias or `nemo-` name, or a faster-whisper model size or local path |
+| `device` | system default | both | sounddevice input index or case-insensitive name substring |
+| `language` | `none` | whisper | explicit transcription language; Parakeet auto-detects language |
+| `compute` | `auto` | whisper | CTranslate2 compute type |
+| `asr_device` | `cpu` | whisper | `cpu`, `cuda`, or `auto` |
+
+The default int8 Parakeet weights download once from the Hugging Face hub on first use and use
+about 640 MB. Pass `-V model=small` to restore the previous Whisper default. Explicit `language`,
+`compute`, and non-CPU `asr_device` values require a Whisper model.
+
+Parakeet TDT 0.6B v3 weights are provided by NVIDIA under the CC-BY-4.0 license.
 
 For example:
 
@@ -42,10 +50,10 @@ inspect-robots run --task my-task --policy agent --embodiment my-robot \
 
 ## Filtering
 
-Audio is segmented locally with an adaptive energy gate. Each candidate then passes
-faster-whisper's bundled VAD plus duration, confidence, no-speech, and known silence-hallucination
-checks. Rejected candidates disappear silently so the policy receives only accepted operator
-utterances.
+Audio is segmented locally with an adaptive energy gate. Parakeet applies duration, blank-text,
+coarse mean-token-confidence, and known silence-hallucination checks. Whisper keeps its bundled
+VAD plus duration, confidence, no-speech, and known silence-hallucination checks. Rejected
+candidates disappear silently so the policy receives only accepted operator utterances.
 
 Transcription runs in a worker thread. The rollout loop never waits for speech recognition, and a
 voice pipeline failure disables voice input without disabling typed console feedback.

--- a/plugins/inspect-robots-voice/pyproject.toml
+++ b/plugins/inspect-robots-voice/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-voice"
-version = "0.2.0"
+version = "0.3.0"
 description = "Local spoken operator feedback for attended Inspect Robots evaluations."
 dynamic = ["readme"]
 requires-python = ">=3.10"
@@ -22,6 +22,7 @@ classifiers = [
 dependencies = [
     "inspect-robots>=0.44",
     "numpy>=1.24",
+    "onnx-asr[cpu,hub]>=0.12,<1",
     "sounddevice>=0.4.6",
     "faster-whisper>=1.0",
 ]
@@ -58,7 +59,7 @@ known-first-party = ["inspect_robots", "inspect_robots_voice"]
 strict = true
 
 [[tool.mypy.overrides]]
-module = ["sounddevice.*", "faster_whisper.*"]
+module = ["sounddevice.*", "faster_whisper.*", "onnx_asr.*"]
 ignore_missing_imports = true
 
 [tool.hatch.metadata.hooks.fancy-pypi-readme]

--- a/plugins/inspect-robots-voice/src/inspect_robots_voice/__init__.py
+++ b/plugins/inspect-robots-voice/src/inspect_robots_voice/__init__.py
@@ -8,10 +8,11 @@ model dependencies are loaded only when voice input starts.
 from __future__ import annotations
 
 from inspect_robots_voice._input import VoiceInput
+from inspect_robots_voice._transcriber import _classify_model
 
 __all__ = ["VoiceInput", "voice_input"]
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 ScalarValue = str | int | float | bool | None
 
@@ -19,20 +20,19 @@ ScalarValue = str | int | float | bool | None
 def voice_input(**kwargs: ScalarValue) -> VoiceInput:
     """Build voice input from validated ``-V`` options.
 
-    Supported keys are ``model`` (string, default ``"small"``), ``device`` (string or integer,
-    default system input), ``language`` (string, default ``"en"``), ``compute`` (string,
-    default ``"auto"``), and ``asr_device`` (string, default ``"cpu"``; pass ``"cuda"`` or
-    ``"auto"`` to run Whisper on a GPU, which needs the CUDA runtime libraries installed).
-    Unknown or incorrectly typed keys raise :class:`TypeError`.
+    Supported keys are ``model`` (string, default ``"parakeet-tdt-0.6b-v3"``), ``device``
+    (string or integer, default system input), ``language`` (string or ``None``, default
+    ``None``), ``compute`` (string, default ``"auto"``), and ``asr_device`` (string, default
+    ``"cpu"``). Unknown, incompatible, or incorrectly typed values raise :class:`TypeError`.
     """
     allowed = {"model", "device", "language", "compute", "asr_device"}
     unknown = sorted(set(kwargs) - allowed)
     if unknown:
         raise TypeError(f"unexpected voice argument(s): {', '.join(unknown)}")
 
-    model = kwargs.get("model", "small")
+    model = kwargs.get("model", "parakeet-tdt-0.6b-v3")
     device = kwargs.get("device")
-    language = kwargs.get("language", "en")
+    language = kwargs.get("language")
     compute = kwargs.get("compute", "auto")
     asr_device = kwargs.get("asr_device", "cpu")
     if not isinstance(model, str):
@@ -43,12 +43,26 @@ def voice_input(**kwargs: ScalarValue) -> VoiceInput:
         or (isinstance(device, int) and not isinstance(device, bool))
     ):
         raise TypeError("device must be a string, integer, or none")
-    if not isinstance(language, str):
-        raise TypeError("language must be a string")
+    if language is not None and not isinstance(language, str):
+        raise TypeError("language must be a string or none")
     if not isinstance(compute, str):
         raise TypeError("compute must be a string")
     if not isinstance(asr_device, str):
         raise TypeError("asr_device must be a string")
+    parakeet_model = _classify_model(model)
+    if parakeet_model is not None:
+        if language is not None:
+            raise TypeError(
+                "parakeet models auto-detect language; drop -V language or pick a whisper model"
+            )
+        if asr_device != "cpu":
+            raise TypeError(
+                "the parakeet backend runs on the CPU; use a whisper model for -V asr_device=cuda"
+            )
+        if compute != "auto":
+            raise TypeError(
+                "compute applies to whisper models; the parakeet backend is fixed to int8"
+            )
     return VoiceInput(
         model=model, device=device, language=language, compute=compute, asr_device=asr_device
     )

--- a/plugins/inspect-robots-voice/src/inspect_robots_voice/_input.py
+++ b/plugins/inspect-robots-voice/src/inspect_robots_voice/_input.py
@@ -15,7 +15,7 @@ import numpy.typing as npt
 from inspect_robots.console import ConsolePoll
 from inspect_robots_voice._capture import Device, MicrophoneCapture
 from inspect_robots_voice._segmenter import EnergyGate
-from inspect_robots_voice._transcriber import WhisperTranscriber
+from inspect_robots_voice._transcriber import resolve_transcriber
 
 AudioArray = npt.NDArray[np.float32]
 
@@ -47,7 +47,7 @@ class _Segmenter(Protocol):
 
 
 CaptureFactory = Callable[[Device, int, queue.Queue[AudioArray]], _Capture]
-TranscriberFactory = Callable[[str, str, str, str], _Transcriber]
+TranscriberFactory = Callable[[str, str, str | None, str], _Transcriber]
 SegmenterFactory = Callable[[], _Segmenter]
 
 
@@ -57,8 +57,10 @@ def _capture_factory(
     return MicrophoneCapture(device, sample_rate, audio_queue, blocksize=_BLOCK_SAMPLES)
 
 
-def _transcriber_factory(model: str, compute: str, language: str, asr_device: str) -> _Transcriber:
-    return WhisperTranscriber(model, compute, language, asr_device)
+def _transcriber_factory(
+    model: str, compute: str, language: str | None, asr_device: str
+) -> _Transcriber:
+    return resolve_transcriber(model, compute, language, asr_device)
 
 
 class VoiceInput:
@@ -67,9 +69,9 @@ class VoiceInput:
     def __init__(
         self,
         *,
-        model: str = "small",
+        model: str = "parakeet-tdt-0.6b-v3",
         device: Device = None,
-        language: str = "en",
+        language: str | None = None,
         compute: str = "auto",
         asr_device: str = "cpu",
         _capture_factory_override: CaptureFactory | None = None,

--- a/plugins/inspect-robots-voice/src/inspect_robots_voice/_parakeet.py
+++ b/plugins/inspect-robots-voice/src/inspect_robots_voice/_parakeet.py
@@ -1,0 +1,70 @@
+"""Lazy ONNX Parakeet transcription with duration and confidence rejection."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from statistics import fmean
+from typing import Protocol, cast
+
+import numpy as np
+import numpy.typing as npt
+
+from inspect_robots_voice._transcriber import (
+    _SAMPLE_RATE,
+    _is_audio_too_short,
+    _is_hallucination,
+)
+
+_MIN_MEAN_LOGPROB = -2.5
+
+
+class _TimestampedResult(Protocol):
+    text: str
+    logprobs: list[float] | None
+
+
+class _Model(Protocol):
+    def recognize(
+        self, samples: npt.NDArray[np.float32], *, sample_rate: int
+    ) -> _TimestampedResult: ...
+
+
+ModelFactory = Callable[[str], _Model]
+
+
+def _load_model(model: str) -> _Model:
+    import onnx_asr
+
+    loaded = onnx_asr.load_model(
+        model,
+        quantization="int8",
+        providers=["CPUExecutionProvider"],
+    )
+    return cast(_Model, loaded.with_timestamps())
+
+
+class ParakeetTranscriber:
+    """Transcribe 16 kHz mono utterances and reject coarse low-confidence output."""
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        _model_factory: ModelFactory | None = None,
+    ) -> None:
+        factory = _load_model if _model_factory is None else _model_factory
+        self._model = factory(model)
+
+    def transcribe(self, audio: npt.ArrayLike) -> str | None:
+        """Return accepted text, or ``None`` for silence and unreliable candidates."""
+        samples = np.asarray(audio, dtype=np.float32).reshape(-1)
+        if _is_audio_too_short(samples):
+            return None
+        result = self._model.recognize(samples, sample_rate=_SAMPLE_RATE)
+        text = result.text.strip()
+        if not text or _is_hallucination(text):
+            return None
+        logprobs = result.logprobs
+        if logprobs and fmean(logprobs) < _MIN_MEAN_LOGPROB:
+            return None
+        return text

--- a/plugins/inspect-robots-voice/src/inspect_robots_voice/_transcriber.py
+++ b/plugins/inspect-robots-voice/src/inspect_robots_voice/_transcriber.py
@@ -1,4 +1,4 @@
-"""Lazy faster-whisper transcription with silence and confidence rejection."""
+"""Select local transcription backends and filter unreliable Whisper output."""
 
 from __future__ import annotations
 
@@ -45,7 +45,35 @@ class _Model(Protocol):
     ) -> tuple[Iterable[_Segment], object]: ...
 
 
+class _Transcriber(Protocol):
+    def transcribe(self, audio: npt.ArrayLike) -> str | None: ...
+
+
 ModelFactory = Callable[[str, str, str], _Model]
+
+
+def _is_audio_too_short(samples: npt.NDArray[np.float32]) -> bool:
+    return len(samples) / _SAMPLE_RATE < _MIN_AUDIO_SECONDS
+
+
+def _is_hallucination(text: str) -> bool:
+    return text.casefold() in _HALLUCINATIONS
+
+
+def _classify_model(model: str) -> str | None:
+    if "/" in model or "\\" in model:
+        return None
+    normalized = model.casefold()
+    if normalized in {"parakeet", "parakeet-tdt-0.6b-v3"}:
+        return "nemo-parakeet-tdt-0.6b-v3"
+    if normalized.startswith("nemo-"):
+        return model.lower()
+    if "parakeet" in normalized:
+        raise TypeError(
+            f"unsupported parakeet model {model!r}; supported parakeet names are "
+            "'parakeet', 'parakeet-tdt-0.6b-v3', or a name starting with 'nemo-'"
+        )
+    return None
 
 
 def _load_model(model: str, compute: str, asr_device: str) -> _Model:
@@ -61,19 +89,19 @@ class WhisperTranscriber:
         self,
         model: str,
         compute: str,
-        language: str,
+        language: str | None,
         asr_device: str = "cpu",
         *,
         _model_factory: ModelFactory | None = None,
     ) -> None:
         factory = _load_model if _model_factory is None else _model_factory
         self._model = factory(model, compute, asr_device)
-        self._language = language
+        self._language = "en" if language is None else language
 
     def transcribe(self, audio: npt.ArrayLike) -> str | None:
         """Return accepted text, or ``None`` for silence and unreliable candidates."""
         samples = np.asarray(audio, dtype=np.float32).reshape(-1)
-        if len(samples) / _SAMPLE_RATE < _MIN_AUDIO_SECONDS:
+        if _is_audio_too_short(samples):
             return None
         raw_segments, _info = self._model.transcribe(
             samples,
@@ -88,6 +116,19 @@ class WhisperTranscriber:
             return None
         if any(segment.avg_logprob < _MIN_AVG_LOGPROB for segment in segments):
             return None
-        if text.casefold() in _HALLUCINATIONS:
+        if _is_hallucination(text):
             return None
         return text
+
+
+def resolve_transcriber(
+    model: str, compute: str, language: str | None, asr_device: str
+) -> _Transcriber:
+    """Construct the transcription backend selected by the raw model name."""
+    parakeet_model = _classify_model(model)
+    if parakeet_model is None:
+        return WhisperTranscriber(model, compute, language, asr_device)
+
+    from inspect_robots_voice._parakeet import ParakeetTranscriber
+
+    return ParakeetTranscriber(parakeet_model)

--- a/plugins/inspect-robots-voice/tests/test_factory.py
+++ b/plugins/inspect-robots-voice/tests/test_factory.py
@@ -9,7 +9,7 @@ from inspect_robots_voice import VoiceInput, voice_input
 
 
 def test_package_exports_and_version() -> None:
-    assert inspect_robots_voice.__version__ == "0.2.0"
+    assert inspect_robots_voice.__version__ == "0.3.0"
     assert inspect_robots_voice.__all__ == ["VoiceInput", "voice_input"]
 
 
@@ -34,9 +34,9 @@ def test_factory_accepts_supported_device_forms(device: str | int | None) -> Non
 def test_factory_defaults() -> None:
     voice = voice_input()
     assert (voice.model, voice.device, voice.language, voice.compute, voice.asr_device) == (
-        "small",
+        "parakeet-tdt-0.6b-v3",
         None,
-        "en",
+        None,
         "auto",
         "cpu",
     )
@@ -49,7 +49,7 @@ def test_factory_defaults() -> None:
         ({"model": 1}, "model must be a string"),
         ({"device": True}, "device must be"),
         ({"device": 1.5}, "device must be"),
-        ({"language": None}, "language must be a string"),
+        ({"language": 1}, "language must be a string or none"),
         ({"compute": False}, "compute must be a string"),
         ({"asr_device": 1}, "asr_device must be a string"),
     ],
@@ -59,3 +59,67 @@ def test_factory_rejects_unknown_or_mistyped_values(
 ) -> None:
     with pytest.raises(TypeError, match=message):
         voice_input(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"language": None},
+        {"asr_device": "cpu"},
+        {"compute": "auto"},
+        {"language": None, "asr_device": "cpu", "compute": "auto"},
+    ],
+)
+def test_factory_accepts_backend_neutral_parakeet_values(
+    kwargs: dict[str, str | None],
+) -> None:
+    voice = voice_input(**kwargs)
+    assert voice.model == "parakeet-tdt-0.6b-v3"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {"language": "fr"},
+            "parakeet models auto-detect language; drop -V language or pick a whisper model",
+        ),
+        (
+            {"asr_device": "cuda"},
+            "the parakeet backend runs on the CPU; use a whisper model for -V asr_device=cuda",
+        ),
+        (
+            {"compute": "int8"},
+            "compute applies to whisper models; the parakeet backend is fixed to int8",
+        ),
+    ],
+)
+def test_factory_rejects_whisper_only_values_for_parakeet(
+    kwargs: dict[str, str], message: str
+) -> None:
+    with pytest.raises(TypeError) as exc_info:
+        voice_input(**kwargs)
+    assert str(exc_info.value) == message
+
+
+def test_factory_accepts_whisper_only_values_for_parakeet_named_path() -> None:
+    voice = voice_input(
+        model="/models/parakeet-ct2",
+        language="fr",
+        compute="int8",
+        asr_device="cuda",
+    )
+
+    assert voice.model == "/models/parakeet-ct2"
+    assert voice.language == "fr"
+    assert voice.compute == "int8"
+    assert voice.asr_device == "cuda"
+
+
+def test_unknown_parakeet_name_error_wins_over_backend_option_error() -> None:
+    with pytest.raises(TypeError) as exc_info:
+        voice_input(model="parakeet-tdt-1.1b", language="fr")
+
+    message = str(exc_info.value)
+    assert "unsupported parakeet model" in message
+    assert "auto-detect language" not in message

--- a/plugins/inspect-robots-voice/tests/test_input.py
+++ b/plugins/inspect-robots-voice/tests/test_input.py
@@ -290,7 +290,7 @@ def test_worker_drains_capture_and_close_is_idempotent_and_joins() -> None:
     output = _CheckingDeque(voice._lock, accepted)
     voice._output = cast(deque[str], output)
 
-    assert voice.start() == "listening on test microphone (model=small)"
+    assert voice.start() == "listening on test microphone (model=parakeet-tdt-0.6b-v3)"
     thread = voice._thread
     assert thread is not None
     assert accepted.wait(timeout=2)
@@ -322,7 +322,7 @@ def test_second_start_reuses_live_capture() -> None:
     finally:
         voice.close()
 
-    assert first == second == "listening on test microphone (model=small)"
+    assert first == second == "listening on test microphone (model=parakeet-tdt-0.6b-v3)"
     assert len(captures) == 1
 
 

--- a/plugins/inspect-robots-voice/tests/test_parakeet.py
+++ b/plugins/inspect-robots-voice/tests/test_parakeet.py
@@ -1,0 +1,89 @@
+"""Parakeet rejection gauntlet against timestamped fake model output."""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from inspect_robots_voice._parakeet import ParakeetTranscriber
+from inspect_robots_voice._transcriber import _HALLUCINATIONS
+
+
+@dataclass
+class _Result:
+    text: str
+    logprobs: list[float] | None = None
+
+
+class _Model:
+    def __init__(self, result: _Result) -> None:
+        self.result = result
+        self.calls: list[tuple[npt.NDArray[np.float32], int]] = []
+
+    def recognize(self, samples: npt.NDArray[np.float32], *, sample_rate: int) -> _Result:
+        self.calls.append((samples, sample_rate))
+        return self.result
+
+
+def _transcriber(result: _Result) -> tuple[ParakeetTranscriber, _Model, list[str]]:
+    model = _Model(result)
+    names: list[str] = []
+
+    def factory(name: str) -> _Model:
+        names.append(name)
+        return model
+
+    transcriber = ParakeetTranscriber("nemo-parakeet-tdt-0.6b-v3", _model_factory=factory)
+    return transcriber, model, names
+
+
+def _audio(seconds: float = 0.5) -> npt.NDArray[np.float64]:
+    return np.zeros((1, round(16_000 * seconds)), dtype=np.float64)
+
+
+def test_normal_sentence_is_accepted_with_mono_float32_audio_at_16_khz() -> None:
+    transcriber, model, names = _transcriber(_Result(" Keep the wrist level. ", [-0.3, -0.5]))
+
+    assert transcriber.transcribe(_audio()) == "Keep the wrist level."
+    assert names == ["nemo-parakeet-tdt-0.6b-v3"]
+    assert len(model.calls) == 1
+    samples, sample_rate = model.calls[0]
+    assert samples.shape == (8_000,)
+    assert samples.dtype == np.float32
+    assert sample_rate == 16_000
+
+
+@pytest.mark.parametrize("text", ["", "   "])
+def test_empty_or_whitespace_text_is_rejected(text: str) -> None:
+    transcriber, _model, _names = _transcriber(_Result(text, [-0.5]))
+    assert transcriber.transcribe(_audio()) is None
+
+
+@pytest.mark.parametrize("phrase", sorted(_HALLUCINATIONS))
+def test_entire_hallucination_phrase_is_rejected_case_insensitively(phrase: str) -> None:
+    transcriber, _model, _names = _transcriber(_Result(phrase.upper(), [-0.5]))
+    assert transcriber.transcribe(_audio()) is None
+
+
+def test_audio_shorter_than_four_tenths_is_rejected_before_model_call() -> None:
+    transcriber, model, _names = _transcriber(_Result("too short", [-0.5]))
+
+    assert transcriber.transcribe(_audio(0.399)) is None
+    assert model.calls == []
+
+
+def test_mean_log_probability_below_threshold_is_rejected() -> None:
+    transcriber, _model, _names = _transcriber(_Result("uncertain", [-2.4, -2.7]))
+    assert transcriber.transcribe(_audio()) is None
+
+
+@pytest.mark.parametrize("logprobs", [None, []])
+def test_missing_or_empty_logprobs_fail_open(logprobs: list[float] | None) -> None:
+    transcriber, _model, _names = _transcriber(_Result("accepted", logprobs))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert transcriber.transcribe(_audio()) == "accepted"

--- a/plugins/inspect-robots-voice/tests/test_transcriber.py
+++ b/plugins/inspect-robots-voice/tests/test_transcriber.py
@@ -1,4 +1,4 @@
-"""Whisper rejection gauntlet against canned model output."""
+"""Backend selection and Whisper rejection against canned model output."""
 
 from __future__ import annotations
 
@@ -7,8 +7,16 @@ from typing import Any
 
 import numpy as np
 import pytest
+from pytest import MonkeyPatch
 
-from inspect_robots_voice._transcriber import _HALLUCINATIONS, WhisperTranscriber
+import inspect_robots_voice._parakeet as parakeet_module
+import inspect_robots_voice._transcriber as transcriber_module
+from inspect_robots_voice._transcriber import (
+    _HALLUCINATIONS,
+    WhisperTranscriber,
+    _classify_model,
+    resolve_transcriber,
+)
 
 
 @dataclass
@@ -109,3 +117,94 @@ def test_model_loads_on_cpu_by_default_and_honors_asr_device() -> None:
     WhisperTranscriber("small", "auto", "en", "cuda", _model_factory=factory)
 
     assert seen == ["cpu", "cuda"]
+
+
+def test_whisper_none_language_resolves_to_english_and_explicit_language_passes_through() -> None:
+    model = _Model([_Segment("accepted")])
+    default_language = WhisperTranscriber(
+        "small", "auto", None, _model_factory=lambda _name, _compute, _asr: model
+    )
+    explicit_language = WhisperTranscriber(
+        "small", "auto", "fr", _model_factory=lambda _name, _compute, _asr: model
+    )
+
+    assert default_language.transcribe(_audio()) == "accepted"
+    assert explicit_language.transcribe(_audio()) == "accepted"
+    assert [call["language"] for call in model.calls] == ["en", "fr"]
+
+
+@pytest.mark.parametrize(
+    ("model", "canonical"),
+    [
+        ("parakeet", "nemo-parakeet-tdt-0.6b-v3"),
+        ("PARAKEET", "nemo-parakeet-tdt-0.6b-v3"),
+        ("parakeet-tdt-0.6b-v3", "nemo-parakeet-tdt-0.6b-v3"),
+        ("Parakeet-TDT-0.6B-V3", "nemo-parakeet-tdt-0.6b-v3"),
+        ("nemo-parakeet-tdt-0.6b-v3", "nemo-parakeet-tdt-0.6b-v3"),
+        ("NeMo-PaRaKeEt-CuStOm", "nemo-parakeet-custom"),
+    ],
+)
+def test_classifier_canonicalizes_parakeet_names(model: str, canonical: str) -> None:
+    assert _classify_model(model) == canonical
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["small", "distil-small.en", "/models/parakeet-ct2", r"C:\models\parakeet-ct2"],
+)
+def test_classifier_selects_whisper_names_and_paths(model: str) -> None:
+    assert _classify_model(model) is None
+
+
+def test_classifier_rejects_unknown_parakeetish_name_with_supported_names() -> None:
+    with pytest.raises(TypeError) as exc_info:
+        resolve_transcriber("parakeet-tdt-1.1b", "auto", None, "cpu")
+
+    message = str(exc_info.value)
+    assert "parakeet" in message
+    assert "parakeet-tdt-0.6b-v3" in message
+    assert "nemo-" in message
+
+
+@pytest.mark.parametrize(
+    ("model", "canonical"),
+    [
+        ("parakeet", "nemo-parakeet-tdt-0.6b-v3"),
+        ("PARAKEET", "nemo-parakeet-tdt-0.6b-v3"),
+        ("parakeet-tdt-0.6b-v3", "nemo-parakeet-tdt-0.6b-v3"),
+        ("PARAKEET-TDT-0.6B-V3", "nemo-parakeet-tdt-0.6b-v3"),
+        ("nemo-parakeet-tdt-0.6b-v3", "nemo-parakeet-tdt-0.6b-v3"),
+        ("NeMo-PaRaKeEt-CuStOm", "nemo-parakeet-custom"),
+    ],
+)
+def test_resolver_constructs_parakeet_with_canonical_name(
+    monkeypatch: MonkeyPatch, model: str, canonical: str
+) -> None:
+    constructed: list[str] = []
+    sentinel = object()
+
+    def fake_parakeet(name: str) -> object:
+        constructed.append(name)
+        return sentinel
+
+    monkeypatch.setattr(parakeet_module, "ParakeetTranscriber", fake_parakeet)
+
+    assert resolve_transcriber(model, "int8", "fr", "cuda") is sentinel
+    assert constructed == [canonical]
+
+
+@pytest.mark.parametrize("model", ["small", "distil-small.en", "/models/parakeet-ct2"])
+def test_resolver_constructs_whisper_with_exact_arguments(
+    monkeypatch: MonkeyPatch, model: str
+) -> None:
+    calls: list[tuple[str, str, str | None, str]] = []
+    sentinel = object()
+
+    def fake_whisper(name: str, compute: str, language: str | None, asr_device: str) -> object:
+        calls.append((name, compute, language, asr_device))
+        return sentinel
+
+    monkeypatch.setattr(transcriber_module, "WhisperTranscriber", fake_whisper)
+
+    assert resolve_transcriber(model, "int8", "fr", "cuda") is sentinel
+    assert calls == [(model, "int8", "fr", "cuda")]

--- a/uv.lock
+++ b/uv.lock
@@ -302,6 +302,18 @@ wheels = [
 ]
 
 [[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -477,7 +489,7 @@ dependencies = [
     { name = "av", version = "18.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "ctranslate2" },
     { name = "huggingface-hub" },
-    { name = "onnxruntime", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tokenizers" },
     { name = "tqdm" },
@@ -626,6 +638,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/64/bfe23dab749cb2342e1e13b61c9e684ce46b4d189c7d433cd26f76f52baf/huggingface_hub-1.26.1.tar.gz", hash = "sha256:7c28860777594ac679233f571552d0e46df34ed4e4239e844190fad3ca05e4cd", size = 936700, upload-time = "2026-08-06T09:42:24.859Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/a7/b519cd01e57b685c5f3e9db02cb1bd7aaade35fb6554e0d36bee6d6aae28/huggingface_hub-1.26.1-py3-none-any.whl", hash = "sha256:d8676e4ec96c1e481a22a93232bd86d73bbac643fb767399aefaeaa503890fb0", size = 780754, upload-time = "2026-08-06T09:42:22.497Z" },
+]
+
+[[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
 ]
 
 [[package]]
@@ -840,13 +864,14 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "inspect-robots-voice"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "plugins/inspect-robots-voice" }
 dependencies = [
     { name = "faster-whisper" },
     { name = "inspect-robots" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "onnx-asr", extra = ["cpu", "hub"] },
     { name = "sounddevice" },
 ]
 
@@ -864,6 +889,7 @@ requires-dist = [
     { name = "inspect-robots", editable = "." },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "numpy", specifier = ">=1.24" },
+    { name = "onnx-asr", extras = ["cpu", "hub"], specifier = ">=0.12,<1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
@@ -1315,13 +1341,37 @@ wheels = [
 ]
 
 [[package]]
+name = "onnx-asr"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/11/136f556cda02ecc172674dcea79232e9e84e74b951bbcd2e2722117f633b/onnx_asr-0.12.0.tar.gz", hash = "sha256:c1fcacddbced392f9f769ed5c6223f4ce739a6e4549346de33b9b520d4ead713", size = 45991, upload-time = "2026-07-15T00:09:58.852Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/60/2fa469a2ee674c35ab48821a1039762ae7b9d0b88188ac1012e779477f76/onnx_asr-0.12.0-py3-none-any.whl", hash = "sha256:5e7ceca454609819ea7833f61e2302e0c8f6ece4f8a78b66c5daba53cb51de4a", size = 3980006, upload-time = "2026-07-15T00:09:57.322Z" },
+]
+
+[package.optional-dependencies]
+cpu = [
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+hub = [
+    { name = "huggingface-hub" },
+]
+
+[[package]]
 name = "onnxruntime"
-version = "1.24.3"
+version = "1.23.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
+    { name = "coloredlogs" },
     { name = "flatbuffers" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
     { name = "packaging" },
@@ -1329,30 +1379,28 @@ dependencies = [
     { name = "sympy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/41/3253db975a90c3ce1d475e2a230773a21cd7998537f0657947df6fb79861/onnxruntime-1.24.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3e6456801c66b095c5cd68e690ca25db970ea5202bd0c5b84a2c3ef7731c5a3c", size = 17332766, upload-time = "2026-03-05T17:18:59.714Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/c5/3af6b325f1492d691b23844d88ed26844c1164620860c5efe95c0e22782d/onnxruntime-1.24.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b2ebc54c6d8281dccff78d4b06e47d4cf07535937584ab759448390a70f4978", size = 15130330, upload-time = "2026-03-05T16:34:53.831Z" },
-    { url = "https://files.pythonhosted.org/packages/03/4b/f96b46c1866a293ed23ca2cf5e5a63d413ad3a951da60dd877e3c56cbbca/onnxruntime-1.24.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb56575d7794bf0781156955610c9e651c9504c64d42ec880784b6106244882d", size = 17213247, upload-time = "2026-03-05T17:17:59.812Z" },
-    { url = "https://files.pythonhosted.org/packages/36/13/27cf4d8df2578747584e8758aeb0b673b60274048510257f1f084b15e80e/onnxruntime-1.24.3-cp311-cp311-win_amd64.whl", hash = "sha256:c958222ef9eff54018332beecd32d5d94a3ab079d8821937b333811bf4da0d39", size = 12595530, upload-time = "2026-03-05T17:18:49.356Z" },
-    { url = "https://files.pythonhosted.org/packages/19/8c/6d9f31e6bae72a8079be12ed8ba36c4126a571fad38ded0a1b96f60f6896/onnxruntime-1.24.3-cp311-cp311-win_arm64.whl", hash = "sha256:a8f761857ebaf58a85b9e42422d03207f1d39e6bb8fecfdbf613bac5b9710723", size = 12261715, upload-time = "2026-03-05T17:18:39.699Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/7f/dfdc4e52600fde4c02d59bfe98c4b057931c1114b701e175aee311a9bc11/onnxruntime-1.24.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:0d244227dc5e00a9ae15a7ac1eba4c4460d7876dfecafe73fb00db9f1d914d91", size = 17342578, upload-time = "2026-03-05T17:19:02.403Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/dc/1f5489f7b21817d4ad352bf7a92a252bd5b438bcbaa7ad20ea50814edc79/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a9847b870b6cb462652b547bc98c49e0efb67553410a082fde1918a38707452", size = 15150105, upload-time = "2026-03-05T16:34:56.897Z" },
-    { url = "https://files.pythonhosted.org/packages/28/7c/fd253da53594ab8efbefdc85b3638620ab1a6aab6eb7028a513c853559ce/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b354afce3333f2859c7e8706d84b6c552beac39233bcd3141ce7ab77b4cabb5d", size = 17237101, upload-time = "2026-03-05T17:18:02.561Z" },
-    { url = "https://files.pythonhosted.org/packages/71/5f/eaabc5699eeed6a9188c5c055ac1948ae50138697a0428d562ac970d7db5/onnxruntime-1.24.3-cp312-cp312-win_amd64.whl", hash = "sha256:44ea708c34965439170d811267c51281d3897ecfc4aa0087fa25d4a4c3eb2e4a", size = 12597638, upload-time = "2026-03-05T17:18:52.141Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/5c/d8066c320b90610dbeb489a483b132c3b3879b2f93f949fb5d30cfa9b119/onnxruntime-1.24.3-cp312-cp312-win_arm64.whl", hash = "sha256:48d1092b44ca2ba6f9543892e7c422c15a568481403c10440945685faf27a8d8", size = 12270943, upload-time = "2026-03-05T17:18:42.006Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8d/487ece554119e2991242d4de55de7019ac6e47ee8dfafa69fcf41d37f8ed/onnxruntime-1.24.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:34a0ea5ff191d8420d9c1332355644148b1bf1a0d10c411af890a63a9f662aa7", size = 17342706, upload-time = "2026-03-05T16:35:10.813Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/25/8b444f463c1ac6106b889f6235c84f01eec001eaf689c3eff8c69cf48fae/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fd2ec7bb0fabe42f55e8337cfc9b1969d0d14622711aac73d69b4bd5abb5ed7", size = 15149956, upload-time = "2026-03-05T16:34:59.264Z" },
-    { url = "https://files.pythonhosted.org/packages/34/fc/c9182a3e1ab46940dd4f30e61071f59eee8804c1f641f37ce6e173633fb6/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df8e70e732fe26346faaeec9147fa38bef35d232d2495d27e93dd221a2d473a9", size = 17237370, upload-time = "2026-03-05T17:18:05.258Z" },
-    { url = "https://files.pythonhosted.org/packages/05/7e/3b549e1f4538514118bff98a1bcd6481dd9a17067f8c9af77151621c9a5c/onnxruntime-1.24.3-cp313-cp313-win_amd64.whl", hash = "sha256:2d3706719be6ad41d38a2250998b1d87758a20f6ea4546962e21dc79f1f1fd2b", size = 12597939, upload-time = "2026-03-05T17:18:54.772Z" },
-    { url = "https://files.pythonhosted.org/packages/80/41/9696a5c4631a0caa75cc8bc4efd30938fd483694aa614898d087c3ee6d29/onnxruntime-1.24.3-cp313-cp313-win_arm64.whl", hash = "sha256:b082f3ba9519f0a1a1e754556bc7e635c7526ef81b98b3f78da4455d25f0437b", size = 12270705, upload-time = "2026-03-05T17:18:44.774Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/65/a26c5e59e3b210852ee04248cf8843c81fe7d40d94cf95343b66efe7eec9/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72f956634bc2e4bd2e8b006bef111849bd42c42dea37bd0a4c728404fdaf4d34", size = 15161796, upload-time = "2026-03-05T16:35:02.871Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/25/2035b4aa2ccb5be6acf139397731ec507c5f09e199ab39d3262b22ffa1ac/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78d1f25eed4ab9959db70a626ed50ee24cf497e60774f59f1207ac8556399c4d", size = 17240936, upload-time = "2026-03-05T17:18:09.534Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/a4/b3240ea84b92a3efb83d49cc16c04a17ade1ab47a6a95c4866d15bf0ac35/onnxruntime-1.24.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a6b4bce87d96f78f0a9bf5cefab3303ae95d558c5bfea53d0bf7f9ea207880a8", size = 17344149, upload-time = "2026-03-05T16:35:13.382Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/4a/4b56757e51a56265e8c56764d9c36d7b435045e05e3b8a38bedfc5aedba3/onnxruntime-1.24.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d48f36c87b25ab3b2b4c88826c96cf1399a5631e3c2c03cc27d6a1e5d6b18eb4", size = 15151571, upload-time = "2026-03-05T16:35:05.679Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/14/c6fb84980cec8f682a523fcac7c2bdd6b311e7f342c61ce48d3a9cb87fc6/onnxruntime-1.24.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e104d33a409bf6e3f30f0e8198ec2aaf8d445b8395490a80f6e6ad56da98e400", size = 17238951, upload-time = "2026-03-05T17:18:12.394Z" },
-    { url = "https://files.pythonhosted.org/packages/57/14/447e1400165aca8caf35dabd46540eb943c92f3065927bb4d9bcbc91e221/onnxruntime-1.24.3-cp314-cp314-win_amd64.whl", hash = "sha256:e785d73fbd17421c2513b0bb09eb25d88fa22c8c10c3f5d6060589efa5537c5b", size = 12903820, upload-time = "2026-03-05T17:18:57.123Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/ec/6b2fa5702e4bbba7339ca5787a9d056fc564a16079f8833cc6ba4798da1c/onnxruntime-1.24.3-cp314-cp314-win_arm64.whl", hash = "sha256:951e897a275f897a05ffbcaa615d98777882decaeb80c9216c68cdc62f849f53", size = 12594089, upload-time = "2026-03-05T17:18:47.169Z" },
-    { url = "https://files.pythonhosted.org/packages/12/dc/cd06cba3ddad92ceb17b914a8e8d49836c79e38936e26bde6e368b62c1fe/onnxruntime-1.24.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d4e70ce578aa214c74c7a7a9226bc8e229814db4a5b2d097333b81279ecde36", size = 15162789, upload-time = "2026-03-05T16:35:08.282Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/d6/413e98ab666c6fb9e8be7d1c6eb3bd403b0bea1b8d42db066dab98c7df07/onnxruntime-1.24.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02aaf6ddfa784523b6873b4176a79d508e599efe12ab0ea1a3a6e7314408b7aa", size = 17240738, upload-time = "2026-03-05T17:18:15.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
+    { url = "https://files.pythonhosted.org/packages/db/db/81bf3d7cecfbfed9092b6b4052e857a769d62ed90561b410014e0aae18db/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:b28740f4ecef1738ea8f807461dd541b8287d5650b5be33bca7b474e3cbd1f36", size = 19153079, upload-time = "2025-10-27T23:05:57.686Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4d/a382452b17cf70a2313153c520ea4c96ab670c996cb3a95cc5d5ac7bfdac/onnxruntime-1.23.2-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f7d1fe034090a1e371b7f3ca9d3ccae2fabae8c1d8844fb7371d1ea38e8e8d2", size = 15219883, upload-time = "2025-10-22T03:46:21.66Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/56/179bf90679984c85b417664c26aae4f427cba7514bd2d65c43b181b7b08b/onnxruntime-1.23.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4ca88747e708e5c67337b0f65eed4b7d0dd70d22ac332038c9fc4635760018f7", size = 17370357, upload-time = "2025-10-22T03:46:57.968Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6d/738e50c47c2fd285b1e6c8083f15dac1a5f6199213378a5f14092497296d/onnxruntime-1.23.2-cp310-cp310-win_amd64.whl", hash = "sha256:0be6a37a45e6719db5120e9986fcd30ea205ac8103fd1fb74b6c33348327a0cc", size = 13467651, upload-time = "2025-10-27T23:06:11.904Z" },
+    { url = "https://files.pythonhosted.org/packages/44/be/467b00f09061572f022ffd17e49e49e5a7a789056bad95b54dfd3bee73ff/onnxruntime-1.23.2-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:6f91d2c9b0965e86827a5ba01531d5b669770b01775b23199565d6c1f136616c", size = 17196113, upload-time = "2025-10-22T03:47:33.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a8/3c23a8f75f93122d2b3410bfb74d06d0f8da4ac663185f91866b03f7da1b/onnxruntime-1.23.2-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:87d8b6eaf0fbeb6835a60a4265fde7a3b60157cf1b2764773ac47237b4d48612", size = 19153857, upload-time = "2025-10-22T03:46:37.578Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d8/506eed9af03d86f8db4880a4c47cd0dffee973ef7e4f4cff9f1d4bcf7d22/onnxruntime-1.23.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbfd2fca76c855317568c1b36a885ddea2272c13cb0e395002c402f2360429a6", size = 15220095, upload-time = "2025-10-22T03:46:24.769Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/80/113381ba832d5e777accedc6cb41d10f9eca82321ae31ebb6bcede530cea/onnxruntime-1.23.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da44b99206e77734c5819aa2142c69e64f3b46edc3bd314f6a45a932defc0b3e", size = 17372080, upload-time = "2025-10-22T03:47:00.265Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/db/1b4a62e23183a0c3fe441782462c0ede9a2a65c6bbffb9582fab7c7a0d38/onnxruntime-1.23.2-cp311-cp311-win_amd64.whl", hash = "sha256:902c756d8b633ce0dedd889b7c08459433fbcf35e9c38d1c03ddc020f0648c6e", size = 13468349, upload-time = "2025-10-22T03:47:25.783Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9e/f748cd64161213adeef83d0cb16cb8ace1e62fa501033acdd9f9341fff57/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b8f029a6b98d3cf5be564d52802bb50a8489ab73409fa9db0bf583eabb7c2321", size = 17195929, upload-time = "2025-10-22T03:47:36.24Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9d/a81aafd899b900101988ead7fb14974c8a58695338ab6a0f3d6b0100f30b/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:218295a8acae83905f6f1aed8cacb8e3eb3bd7513a13fe4ba3b2664a19fc4a6b", size = 19157705, upload-time = "2025-10-22T03:46:40.415Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/4e40f2fba272a6698d62be2cd21ddc3675edfc1a4b9ddefcc4648f115315/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76ff670550dc23e58ea9bc53b5149b99a44e63b34b524f7b8547469aaa0dcb8c", size = 15226915, upload-time = "2025-10-22T03:46:27.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/88/9cc25d2bafe6bc0d4d3c1db3ade98196d5b355c0b273e6a5dc09c5d5d0d5/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f9b4ae77f8e3c9bee50c27bc1beede83f786fe1d52e99ac85aa8d65a01e9b77", size = 17382649, upload-time = "2025-10-22T03:47:02.782Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b4/569d298f9fc4d286c11c45e85d9ffa9e877af12ace98af8cab52396e8f46/onnxruntime-1.23.2-cp312-cp312-win_amd64.whl", hash = "sha256:25de5214923ce941a3523739d34a520aac30f21e631de53bba9174dc9c004435", size = 13470528, upload-time = "2025-10-22T03:47:28.106Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/41/fba0cabccecefe4a1b5fc8020c44febb334637f133acefc7ec492029dd2c/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:2ff531ad8496281b4297f32b83b01cdd719617e2351ffe0dba5684fb283afa1f", size = 17196337, upload-time = "2025-10-22T03:46:35.168Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f9/2d49ca491c6a986acce9f1d1d5fc2099108958cc1710c28e89a032c9cfe9/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:162f4ca894ec3de1a6fd53589e511e06ecdc3ff646849b62a9da7489dee9ce95", size = 19157691, upload-time = "2025-10-22T03:46:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a1/428ee29c6eaf09a6f6be56f836213f104618fb35ac6cc586ff0f477263eb/onnxruntime-1.23.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45d127d6e1e9b99d1ebeae9bcd8f98617a812f53f46699eafeb976275744826b", size = 15226898, upload-time = "2025-10-22T03:46:30.039Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/2b/b57c8a2466a3126dbe0a792f56ad7290949b02f47b86216cd47d857e4b77/onnxruntime-1.23.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8bace4e0d46480fbeeb7bbe1ffe1f080e6663a42d1086ff95c1551f2d39e7872", size = 17382518, upload-time = "2025-10-22T03:47:05.407Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/93/aba75358133b3a941d736816dd392f687e7eab77215a6e429879080b76b6/onnxruntime-1.23.2-cp313-cp313-win_amd64.whl", hash = "sha256:1f9cc0a55349c584f083c1c076e611a7c35d5b867d5d6e6d6c823bf821978088", size = 13470276, upload-time = "2025-10-22T03:47:31.193Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3d/6830fa61c69ca8e905f237001dbfc01689a4e4ab06147020a4518318881f/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d2385e774f46ac38f02b3a91a91e30263d41b2f1f4f26ae34805b2a9ddef466", size = 15229610, upload-time = "2025-10-22T03:46:32.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ca/862b1e7a639460f0ca25fd5b6135fb42cf9deea86d398a92e44dfda2279d/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2b9233c4947907fd1818d0e581c049c41ccc39b2856cc942ff6d26317cee145", size = 17394184, upload-time = "2025-10-22T03:47:08.127Z" },
 ]
 
 [[package]]
@@ -1658,6 +1706,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyreadline3"
+version = "3.5.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/6d/f94028646d7bbe6d9d873c47ee7c246f2d29129d253f0d96cb6fcab70733/pyreadline3-3.5.6.tar.gz", hash = "sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf", size = 100368, upload-time = "2026-05-14T17:55:04.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/5e/35c856e186b74678c24927847ad9895a51f1bc02a0c6126477a6c6040064/pyreadline3-3.5.6-py3-none-any.whl", hash = "sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d", size = 85243, upload-time = "2026-05-14T17:55:03.262Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #324.

Implements plans/0053-voice-parakeet-backend.md: the voice plugin's default transcription model becomes NVIDIA Parakeet TDT 0.6B v3, run through onnx-asr (pure Python, onnxruntime + NumPy, no torch/NeMo). Whisper stays one flag away (`-V model=small`) and keeps the explicit-language and GPU paths. Decision made on published benchmark numbers by owner call; no local benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)