### PR TITLE
cli: announce the voice model before its startup download

### DIFF
--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -811,9 +811,18 @@ def _build_voice_input(
 def _start_voice_input(
     voice_input: OperatorInput, session: OperatorSession, policy: object
 ) -> None:
-    """Start and attach a voice input, honoring its optional startup hook."""
+    """Start and attach a voice input, honoring its optional startup hook.
+
+    Announces the voice model before the startup hook runs: loading can download
+    model weights on a first run, and the progress bars are otherwise unlabeled.
+    """
     start_hook = getattr(voice_input, "start", None)
     if callable(start_hook):
+        model = getattr(voice_input, "model", None)
+        if isinstance(model, str):
+            session.write_line(
+                f"voice: loading speech-to-text model {model} (a first run downloads it)"
+            )
         try:
             listening_line = start_hook()
         except Exception as exc:

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -3625,6 +3625,7 @@ def test_voice_start_announces_model_before_startup_hook() -> None:
             return None
 
         def start(self) -> str:
+            output.append("start-hook ran")
             return "listening on test microphone"
 
     voice = ModelVoiceInput()
@@ -3634,6 +3635,7 @@ def test_voice_start_announces_model_before_startup_hook() -> None:
 
     assert output == [
         "voice: loading speech-to-text model parakeet-tdt-0.6b-v3 (a first run downloads it)\n",
+        "start-hook ran",
         "listening on test microphone\n",
     ]
 

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -3611,6 +3611,33 @@ def test_hookless_voice_input_still_runs(
     assert capsys.readouterr().out.count("operator console:") == 1
 
 
+def test_voice_start_announces_model_before_startup_hook() -> None:
+    output: list[str] = []
+    session = OperatorSession(write=output.append)
+
+    class ModelVoiceInput:
+        model = "parakeet-tdt-0.6b-v3"
+
+        def poll(self) -> ConsolePoll:
+            return ConsolePoll()
+
+        def begin_trial(self) -> None:
+            return None
+
+        def start(self) -> str:
+            return "listening on test microphone"
+
+    voice = ModelVoiceInput()
+    policy = type("VoicePolicy", (), {"accepts_operator_messages": True})()
+
+    cli._start_voice_input(voice, session, policy)
+
+    assert output == [
+        "voice: loading speech-to-text model parakeet-tdt-0.6b-v3 (a first run downloads it)\n",
+        "listening on test microphone\n",
+    ]
+
+
 def test_non_string_voice_start_result_is_not_printed() -> None:
     output: list[str] = []
     session = OperatorSession(write=output.append)


### PR DESCRIPTION
## Problem

A first `--voice` run downloads the transcription model (Parakeet TDT 0.6B v3 by default) inside the voice input's `start()` hook. Operators saw bare Hugging Face progress bars (`Downloading bytes`, `Fetching 4 files`) with no line saying the download is for voice control, and reported confusion.

## Fix

`_start_voice_input` now writes a session line before invoking the startup hook, naming the model duck-typed from the voice input's `model` attribute:

```
voice: loading speech-to-text model parakeet-tdt-0.6b-v3 (a first run downloads it)
```

Voice inputs without a string `model` attribute print nothing new, so the hookless and non-string startup paths are unchanged.

## Testing

New unit test asserts the notice lands before the `listening on ...` line (ordering is the point: the notice must precede the download). Full suite green at the 100% coverage gate; ruff, format, and strict mypy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)