### PR TITLE
voice 0.5.0: blocking/interrupt/queue speech modes for --speak, interrupt default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- **Voice plugin (0.5.0):** the default `--speak` behavior now interrupts
+  superseded narration so speech stays current. `-S mode=queue` restores the old
+  bounded queueing behavior ([plan 0057](plans/0057-speak-speech-modes.md),
+  [#336](https://github.com/robocurve/inspect-robots/issues/336)).
+
 - **Core:** bare Enter no longer ends an attended episode. Esc ends it in the
   footer (with a 150 ms grace so split arrow-key sequences are not misread), and
   `/stop [note]` ends it from any mode, recording the trailing text to the log
@@ -19,6 +24,12 @@ All notable changes to this project are documented here. The format is based on
   [#333](https://github.com/robocurve/inspect-robots/issues/333)).
 
 ### Added
+
+- **Voice plugin (0.5.0):** `--speak` now supports blocking, interrupt, and queue
+  speech delivery through `-S mode=`, including a bounded fail-open blocking
+  wait and generation-based interruption
+  ([plan 0057](plans/0057-speak-speech-modes.md),
+  [#336](https://github.com/robocurve/inspect-robots/issues/336)).
 
 - **Core:** `inspect-robots run` now accepts `--speak` with repeatable `-S k=v`
   options. The CLI resolves the registered `speaker` sink, starts it

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -188,9 +188,9 @@ feedback-only, so episode end and verdicts remain keyboard actions. See
 [Voice operator input](voice-mode.md) for setup and filtering details.
 
 The plugin also provides `run --speak` for local narration of streamed policy
-notes and terminal summaries. Repeat `-S key=value` to select the output voice,
-speed, volume, device, language, or offline model paths. Speaking works without
-a TTY. See [Speaking policy notes](voice-mode.md#speaking-policy-notes---speak)
+notes and terminal summaries. Repeat `-S key=value` to select the speech mode,
+output voice, speed, volume, device, language, or offline model paths. Speaking
+works without a TTY. See [Speaking policy notes](voice-mode.md#speaking-policy-notes---speak)
 for model setup and the microphone echo caveat.
 
 A session-aware embodiment offers `connect_operator_session(session)`. On
@@ -321,7 +321,7 @@ the zero-config section above); `--instruction "..."` replaces `--task` to
 run a single ad-hoc scene. `--voice` adds local spoken feedback on attended
 runs; repeat `-V key=value` to configure the installed voice plugin. `--speak`
 narrates streamed policy notes on attended or unattended runs; repeat `-S key=value`
-for speaker settings.
+to select the speech mode, output voice, speed, volume, device, language, or offline model paths.
 
 The exit code is `0` on a successful eval, `1` otherwise. When trials errored,
 the summary shows the count (`trials: 4 (2 errored)`) and lists each errored

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -106,8 +106,9 @@ embodiments, and attended operator input:
 - [`inspect-robots-voice`](https://github.com/robocurve/inspect-robots/tree/main/plugins/inspect-robots-voice):
   transcribe local microphone speech into feedback during an attended run with
   `--voice`, or narrate streamed policy notes through local Kokoro speech with
-  `run --speak`. Silence filtering protects the input path, while bounded
-  drop-oldest buffering keeps speech output off the control loop.
+  `run --speak`. Silence filtering protects the input path. Speech synthesis and
+  playback always run on a worker, while blocking speech may wait boundedly on
+  that work from the control thread.
 
 ### `inspect-robots-isaacsim`: the body
 

--- a/docs/guide/voice-mode.md
+++ b/docs/guide/voice-mode.md
@@ -98,6 +98,7 @@ helps catch flags copied onto a non-speaking invocation:
 
 | Key | Default | Meaning |
 | --- | --- | --- |
+| `mode` | `interrupt` | Speech delivery: `blocking`, `interrupt`, or `queue` |
 | `voice` | `af_sarah` | Kokoro voice identifier |
 | `speed` | `1.0` | Positive synthesis speed multiplier |
 | `volume` | `1.0` | Output gain from `0` through `1` |
@@ -111,6 +112,37 @@ For example:
 ```bash
 inspect-robots run --task my-task --policy agent --embodiment my-robot \
     --speak -S voice=af_sarah -S speed=1.1 -S volume=0.8
+```
+
+### Speech modes
+
+Speech delivery defaults to `interrupt`. Each transcript delta cuts off the current utterance,
+discards superseded queued text, and speaks the new delta. Texts from the same delta, such as a
+move note followed by a terminal summary, still play in order.
+
+`blocking` waits for the previous note to finish before it queues the next one. The wait is
+bounded and fail-open. If it times out, the speaker prints one warning, queues the new note
+anyway, and permanently skips the blocking gate for the rest of the run so speech cannot halt
+the robot indefinitely:
+
+```bash
+inspect-robots run --task my-task --policy agent --embodiment my-robot \
+    --speak -S mode=blocking
+```
+
+The blocking gate is skipped on inference turns with no speakable note. Kokoro must synthesize a
+note before playback begins, which typically takes about 1 to 2 seconds, so speech does not start
+at the instant the joints are commanded. Blocking also delays `operator_input.poll()`, increasing
+Esc and `/stop` latency by up to one note duration, plus one 15 second timeout the single time the
+speaker degrades. It inserts multi-second gaps before `embodiment.step()`, so rigs with
+command-cadence watchdogs should prefer `interrupt`.
+
+`queue` restores the previous bounded drop-oldest behavior. Notes play in order but may describe
+older turns when inference runs ahead of narration:
+
+```bash
+inspect-robots run --task my-task --policy agent --embodiment my-robot \
+    --speak -S mode=queue
 ```
 
 The first `--speak` run downloads about 340 MB of pinned Kokoro model files. The cache is
@@ -132,8 +164,9 @@ inspect-robots run --task my-task --policy agent --embodiment my-robot \
 ```
 
 `--speak` and `-S` apply only to `run`; `eval-set` does not accept them. Speech synthesis and
-playback run off the control loop. If either fails after startup, the speaker prints one warning
-and stays disabled for the rest of the run.
+playback always run on the speaker worker, never on the control thread. Only `blocking` may wait
+on that work, boundedly and fail-open. If synthesis or playback fails after startup, the speaker
+prints one warning and stays disabled for the rest of the run.
 
 Using `--speak` and `--voice` together can feed speaker output back into the microphone. Separate
 the microphone and speaker, or use a headset, until playback-aware microphone muting is

--- a/plans/0057-speak-speech-modes.md
+++ b/plans/0057-speak-speech-modes.md
@@ -1,0 +1,347 @@
+# `--speak` speech modes: blocking, interrupt (new default), queue — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In `--speak` runs the narration lags: the bounded queue backlogs and the note
+being spoken can describe a turn 5–10 inferences in the past. Add a `mode` option to the
+speaker sink with three behaviors, selectable from the CLI via the existing repeatable
+`-S k=v` channel (issue #336):
+
+1. **`blocking`** — a note starts speaking at the moment its joint commands are issued
+   (the agent policy emits both in the same turn) and the motors move while it plays.
+   New observations and the next LLM inference may proceed while the note is still
+   playing, but the *next* turn's joint commands wait until the current note finishes;
+   then the joints move and the new note starts.
+2. **`interrupt`** (**new default**) — a newly issued note cuts off whatever is currently
+   being spoken and plays immediately. Narration always describes the current turn.
+3. **`queue`** — today's behavior: notes queue (bounded, drop-oldest) and may lag.
+
+**Shape:** one PR, two packages, almost all plugin.
+
+1. **Voice plugin (`inspect-robots-voice` 0.4.0 → 0.5.0):** `SpeakerSink(mode=...)` plus
+   an utterance-generation abort mechanism in the worker and a bounded pre-enqueue wait
+   for blocking mode. Factory validation for `-S mode=`.
+2. **Core (help text only):** extend the `-S` argparse help on `run` to name the mode
+   option. No behavior, signature, or public-API change; no new core tests needed
+   (argparse help strings are not covered assertions).
+
+**Key architectural fact this plan relies on:** `rollout()` calls the sink's
+`log_policy_messages(t, entries)` immediately after an inference completes and *before*
+`approver.review()` / `embodiment.step()` in the same loop iteration
+(`src/inspect_robots/rollout.py:358-414`). So "block the joints until the previous note
+finishes" is implementable entirely inside the sink: `log_policy_messages` waits
+(bounded) for the in-flight utterance to finish, then enqueues the new note and returns;
+the rollout then executes the joints while the new note plays. Steps that execute the
+rest of an open-loop chunk perform no inference, so the hook does not fire on them and
+they are never delayed. No rollout/eval/core-sink-protocol change.
+
+## Global Constraints
+
+- Core gates (all blocking): `uv run ruff check .`, `uv run ruff format --check .`,
+  `uv run mypy` (strict, src + tests), `uv run pytest --cov -q` at **100% coverage**.
+  The core change is one help string, so this is a formality, but the gates still run.
+- Plugin gates mirror the `plugin-voice` CI job: ruff + ruff format + mypy (plugin
+  config, strict) + pytest with `--cov=inspect_robots_voice`.
+- Plugin tests must keep running without PortAudio/audio hardware/model downloads:
+  injected fakes and threading events, **no sleeps as synchronization** (bounded
+  `Event.wait(timeout=...)` is the tool; a bare `time.sleep` to "give the thread time"
+  is not).
+- D1 docstrings on public defs; contract, not name. Line length 100.
+- No dependency changes, so no `uv lock` churn expected. If a pyproject changes anyway
+  (version bump line only), the lockfile records plugin versions — run `uv lock` and
+  commit it if `git status` shows it dirty.
+- Public core API: no new symbols; `inspect_robots.__all__` and
+  `tests/test_api_snapshot.py` untouched.
+- Writing-style rules for public-facing text (README, docs, CHANGELOG): no em dashes in
+  prose, no decorative emoji, no mid-sentence bold, headers use colons.
+
+## Reference: current speaker behavior (main @ cf2a4dd3)
+
+`plugins/inspect-robots-voice/src/inspect_robots_voice/_speaker.py`:
+
+- `log_policy_messages` extracts note/summary/reason texts and appends to a
+  `deque` bounded at `_QUEUE_SIZE = 4` with drop-oldest (`_dropped` counter). Never
+  blocks, never touches audio.
+- One daemon worker pops a text, sets `_inflight`, synthesizes, plays in
+  `_CHUNK_SECONDS = 0.1` chunks, checking `_stop` between chunks; on any exception it
+  sets `_disabled`, sets `_stop`, clears the queue, notifies, warns once, and exits.
+  A `finally` clears `_inflight` and `notify_all()`s.
+- `on_trial_start` clears the queue and reports the accumulated drop count to stderr.
+- `on_eval_end` drains (queue empty and not inflight, `_DRAIN_TIMEOUT = 15`) only on
+  `status == "success"`, then `close()`.
+- `close()` is idempotent: sets `_stop`, clears, notifies, joins, closes playback.
+
+All coordination already goes through one `threading.Condition` (`self._condition`).
+The plan builds on that; it adds no second lock.
+
+## Design decisions (binding)
+
+1. **Mode selection surface: `-S mode=...`, not a new flag.** The `-S` channel exists,
+   is validated in the plugin factory (typed scalars, unknown-key `TypeError`), and
+   keeps core free of plugin vocabulary. A dedicated `--speak-mode` flag would force
+   core to know and validate plugin enum values, or to pass strings blind with worse
+   errors. Rejected.
+2. **Default flips to `interrupt`.** This changes behavior for existing `--speak` users:
+   backlogged narration is replaced by always-current narration. That is the point of
+   the issue, the maintainer's explicit choice, and a minor-version bump of a 0.x
+   plugin. `-S mode=queue` restores the old behavior; the CHANGELOG says so explicitly.
+3. **Interrupt granularity: between playback chunks and around synthesis, not
+   mid-`engine.synthesize()`.** Kokoro synthesis is a single blocking call (typically
+   well under the length of the audio it produces). The worker aborts a stale utterance
+   at the next 0.1 s chunk boundary and discards a stale synthesis result before playing
+   it. Worst-case residual speech after an interrupt is one chunk (~0.1 s) plus the tail
+   of an already-running synthesize call. Acceptable; anything sharper needs engine
+   cooperation that kokoro-onnx does not offer.
+4. **Interrupt mechanism: a generation counter, not a second Event.** `self._speech_gen:
+   int` incremented under `self._condition`. The worker snapshots the generation when it
+   pops a text and abandons the utterance when `self._speech_gen != gen` (checked
+   wherever `_stop` is checked today: after the pop, after synthesis, between chunks).
+   Reading an `int` attribute is atomic under the GIL; all writes stay under the
+   condition. A per-utterance `Event` object would need careful swap semantics for the
+   same result.
+5. **Interrupt scope: a new *delta* interrupts, texts within one delta queue.** One
+   `log_policy_messages` call can carry several spoken texts (a `note` plus a terminal
+   `summary` in the same turn). Interrupting mid-batch would silence the note the moment
+   the summary arrives, losing this turn's narration to this turn's own text. So in
+   interrupt mode the hook: bumps the generation once, clears the queue once, then
+   enqueues every text of the delta. They play in order; the next delta interrupts them.
+6. **Blocking mode: bounded wait, fail-open, and a permanent degrade path.** The hook
+   waits for `not self._queue and not self._inflight` under the condition, bounded by
+   `_BLOCK_TIMEOUT = 15.0` seconds (matching `_DRAIN_TIMEOUT`; a two-sentence note is
+   5–8 s of audio, so 15 s is real margin, and the constant must be read as a module
+   global at call time — mirroring how `on_eval_end` reads `_DRAIN_TIMEOUT` — so tests
+   can monkeypatch it). Exit behavior is per-predicate:
+   - **Timeout:** stop waiting, enqueue anyway (drop-oldest applies, counted in
+     `_dropped`), print one stderr warning, and set a `self._block_degraded` flag that
+     permanently skips the wait for the rest of the run. The failure this guards
+     against (playback stalled on a dead audio server — `OutputStream.write` blocks
+     rather than raises, so the worker's exception→`_disabled` path never fires) is
+     persistent: without the flag every later turn would eat the full timeout,
+     turning the run into a slideshow. One slow turn, then narration degrades to
+     queue-mode enqueueing while control continues at full rate.
+   - **`_stop` set, `_disabled` set, or worker thread dead:** return *without*
+     enqueueing, matching the existing entry guard — never append to a queue that
+     `close()` just cleared on a sink with no worker.
+   The worker's exception path and `close()` both `notify_all()`, so these wakeups are
+   prompt. Speech must never be able to halt a robot indefinitely: this is a narration
+   feature, not a safety interlock, and the embodiment's own guardrails
+   (Clamp/DeltaLimit, `self_paced` step cadence) remain the real safety layer.
+7. **Blocking-mode drop reporting stays.** If the timeout path ever drops a note it is
+   real signal (TTS wedged, audio device stalled) and the existing
+   `on_trial_start` stderr line reports it.
+8. **`on_trial_start` keeps today's behavior in every mode:** clear the backlog, let
+   the in-flight utterance finish. In interrupt mode the new trial's *first delta*
+   bumps the generation the moment it has something to say, which already guarantees no
+   old note plays over new narration; a bump at `on_trial_start` itself would cut
+   terminal `done()`/`give_up()` summaries during the otherwise-silent reset window,
+   quietly reversing plan 0054's deliberate choice to let them play out. Blocking
+   mode's first hook call of the new trial waits for a still-playing summary, which is
+   exactly blocking semantics.
+9. **Interrupt-mode queue clears are not "drops".** The `_dropped` counter keeps meaning
+   "notes lost to backpressure or timeout", so its stderr report stays actionable. By
+   design interrupt mode discards superseded notes; counting those would make the
+   report fire on every healthy interrupt-mode run. Known edge, accepted: a single
+   interrupt-mode delta carrying more than `_QUEUE_SIZE` texts still hits the
+   drop-oldest bound and counts those drops; real deltas carry one or two texts.
+10. **`_QUEUE_SIZE` bound stays in all modes.** It is load-bearing for queue mode,
+    harmless in interrupt mode (queue is cleared on every delta), and a backstop in
+    blocking mode's timeout path.
+11. **`on_eval_end` drain is unchanged** in all modes: on success, wait for the last
+    note to finish (bounded); otherwise abort. In interrupt mode the queue holds at most
+    the final delta, so the drain is short by construction.
+12. **Mode is constructor state, not mutable at runtime.** No per-trial or per-delta
+    mode switching; one run, one mode.
+13. **Known and accepted properties, to be stated in the docs rather than left
+    implied:**
+    - The blocking gate only fires on deltas that carry speakable text. An inference
+      turn with no note (note-less tool call, malformed arguments, or live streaming
+      disabled after a hook exception) issues its joints without waiting for the
+      previous note.
+    - Speech begins once Kokoro synthesis of the note completes (~1–2 s), not at the
+      literal instant the joints are commanded; the blocking wait covers the previous
+      note's synthesis plus playback.
+    - Blocking mode delays the top-of-loop `operator_input.poll()` for attended runs:
+      Esc//stop response time grows by up to one note duration (and by one
+      `_BLOCK_TIMEOUT` in the degraded case, once). It also deliberately inserts
+      multi-second gaps before `embodiment.step()`; rigs with command-cadence
+      watchdogs should prefer interrupt mode.
+
+## Tasks
+
+### Task 1: `SpeakerSink` mode plumbing and worker generation checks
+
+`plugins/inspect-robots-voice/src/inspect_robots_voice/_speaker.py`
+
+- [ ] Add module constants: `_BLOCK_TIMEOUT = 15.0`, `_MODES = ("blocking", "interrupt",
+      "queue")`, `_DEFAULT_MODE = "interrupt"`. These are the single source of truth:
+      the factory imports them rather than restating literals, and `_BLOCK_TIMEOUT` is
+      read as a module global at wait time (not captured at construction) so the
+      timeout test can monkeypatch it.
+- [ ] `SpeakerSink.__init__`: accept `mode: str = _DEFAULT_MODE`, store `self.mode`;
+      initialize `self._speech_gen = 0` and `self._block_degraded = False`. Guard
+      direct constructors with `if mode not in _MODES: raise ValueError(...)` (the
+      factory owns `-S` validation and raises `TypeError` per its convention; the
+      constructor guard is insurance for programmatic use).
+- [ ] `_worker`: snapshot `gen = self._speech_gen` inside the condition block where the
+      text is popped. Replace every bare `if self._stop.is_set(): return` mid-utterance
+      check with a stale-check that *continues to the next queue item* instead of
+      returning when only the generation moved: stop still returns; generation mismatch
+      abandons the current utterance but keeps the worker alive (`break` out of the
+      chunk loop / skip playing the synthesis result, then fall through to the
+      `finally` and loop again).
+- [ ] `log_policy_messages`: keep the existing extract + liveness guard. Then branch on
+      mode inside the same `with self._condition` block:
+      - `queue`: exactly today's code.
+      - `interrupt`: `self._speech_gen += 1`; `self._queue.clear()` (the clear itself
+        does no `_dropped` counting); then append all texts **via the existing bounded
+        drop-oldest counting append loop** (this is what makes design decision 9's
+        intra-delta-overflow edge true); `notify()`.
+      - `blocking`: unless `self._block_degraded`, run a bounded wait loop (deadline
+        via `time.monotonic()` against the module-global `_BLOCK_TIMEOUT`) on
+        `(self._queue or self._inflight)`. On every wakeup re-check the same compound
+        guard as the hook's entry, in the same order (`thread is None or not
+        thread.is_alive() or self._disabled or self._stop.is_set()` — checking
+        `is_alive` on a thread `close()` nulled must not raise): any of those →
+        **return without enqueueing** (never append to a queue `close()` just cleared
+        on a sink with no worker). On deadline expiry → set
+        `self._block_degraded = True` and remember to warn; the one stderr warning
+        (`speaker: blocking wait timed out; narration may lag`) prints **after
+        releasing the condition**, matching how `on_trial_start` and the worker print
+        outside the lock. Then (normal completion, degraded skip, or timeout
+        fall-through) append all texts with the existing drop-oldest counting bound
+        and `notify()`.
+- [ ] `on_trial_start`: unchanged in all modes (design decision 8).
+- [ ] Update the module docstring (it currently reads "Non-blocking policy-note speech
+      with bounded stale-work loss"), the `SpeakerSink` class docstring ("Speak policy
+      narration asynchronously without delaying the control loop"), and the
+      `log_policy_messages` docstring ("without blocking on audio") — all three state
+      the pre-plan contract and all three are now mode-dependent. The invariant that
+      survives in every mode: the hook never synthesizes or plays audio on the control
+      thread; only blocking mode may *wait* on it, boundedly and fail-open.
+
+### Task 2: factory validation
+
+`plugins/inspect-robots-voice/src/inspect_robots_voice/__init__.py`
+
+- [ ] Add `"mode"` to the allowed `-S` keys. Read `mode = kwargs.get("mode",
+      _DEFAULT_MODE)` (import `_DEFAULT_MODE`/`_MODES` from `_speaker` — one source of
+      truth); require `isinstance(mode, str)` and membership in `_MODES`; `TypeError`
+      otherwise with a message that lists the valid values (match the existing error
+      style: lowercase, states the constraint).
+- [ ] Pass `mode=mode` through to `SpeakerSink`.
+- [ ] Extend the `speaker_sink` docstring's supported-keys sentence with `mode`
+      (string, one of `"blocking"`, `"interrupt"`, `"queue"`, default `"interrupt"`).
+
+### Task 3: plugin tests
+
+`plugins/inspect-robots-voice/tests/test_factory.py`:
+
+- [ ] `mode` accepted for each of the three values; result's `.mode` matches.
+- [ ] Default is `interrupt`.
+- [ ] Non-string mode → `TypeError`; unknown string mode → `TypeError`.
+
+`plugins/inspect-robots-voice/tests/test_speaker.py` (use the existing fake engine /
+fake playback / event patterns):
+
+- [ ] **Existing queue-behavior tests:** audit every test that exercises queueing,
+      drop-oldest, or multi-note ordering and pin `mode="queue"` where the old
+      semantics are the subject under test. Two are known to *fail* (not just drift in
+      meaning) under the new default and must be pinned:
+      `test_trial_start_clears_queued_prior_trial_notes` (the second delta would bump
+      the generation and stale-abandon the held-open utterance right after its
+      synthesis, so `_wait_until(len(playback.writes) == 3)` times out at write 1) and
+      `test_overflow_drops_oldest_and_reports_once_at_next_trial`
+      (five separate deltas would collapse to two utterances with `_dropped == 0`).
+      Tests asserting mode-independent behavior (lifecycle, error disable, close
+      idempotence, drain-on-success) stay on the default and must still pass.
+- [ ] **Interrupt:** with a fake playback that blocks on an event mid-utterance, deliver
+      a second delta; assert the first utterance stops within one chunk (worker moves
+      on), the queue holds only the new delta's texts, the new note plays, and
+      `_dropped` stays 0. Also: a stale synthesis result is discarded (interrupt lands
+      between pop and play), and the worker survives interrupts (plays the next note
+      rather than exiting).
+- [ ] **Interrupt, multi-text delta:** a delta carrying two texts plays both, in order.
+- [ ] **Interrupt trial boundary:** an in-flight utterance from trial N keeps playing
+      across `on_trial_start` (summaries play out, decision 8) and is cut by trial
+      N+1's first delta.
+- [ ] **Blocking:** with an in-flight utterance held open by an event,
+      `log_policy_messages` from a second thread does not return until the utterance
+      completes; after release it enqueues and the note plays. Non-return is inherently
+      a timed negative assertion, which is sanctioned here as the one exception to the
+      no-sleep rule: `assert not returned_event.wait(small_timeout)` (false-pass
+      possible, never false-fail — the same pattern
+      `test_successful_eval_end_drains_inflight_utterance_before_close` already uses).
+      Positive assertions (it *did* return after release) use generous event timeouts.
+- [ ] **Blocking fail-open on worker death:** worker's engine raises while a blocked
+      `log_policy_messages` waits; the call returns promptly (disabled path) without
+      enqueueing, long before the full timeout.
+- [ ] **Blocking fail-open on close:** `close()` from another thread releases a blocked
+      hook promptly, without enqueueing.
+- [ ] **Blocking timeout degrade:** with `_BLOCK_TIMEOUT` monkeypatched tiny and
+      playback held open, the hook returns after the deadline, the note is enqueued
+      (drop-oldest accounting intact), one stderr warning is printed, and the *next*
+      hook call skips the wait entirely (`_block_degraded` behavior).
+- [ ] **Queue mode regression:** `mode="queue"` still drop-oldest-bounds at
+      `_QUEUE_SIZE` and reports drops at trial start.
+
+### Task 4: core help text
+
+`src/inspect_robots/cli.py`:
+
+- [ ] Extend the `-S` help string to mention the mode option, e.g. `"pass an argument
+      to the inspect-robots-voice speaker, e.g. -S mode=blocking|interrupt|queue
+      (requires --speak)"`. Nothing else in core changes.
+
+### Task 5: docs, CHANGELOG, versions, agent guides
+
+- [ ] `docs/guide/voice-mode.md`: add a "Speech modes" subsection under the `--speak`
+      section: the three modes, interrupt as default, one example per non-default mode,
+      blocking mode's bounded fail-open wait and one-time degrade, and the design
+      decision 13 properties (gate skipped on note-less turns, speech starts after
+      synthesis, operator-input latency and watchdog-cadence caveats for blocking).
+      Also **rewrite** the existing sentence "Speech synthesis and playback run off the
+      control loop." (now false for blocking mode) and add a `mode` row to the
+      existing `-S` key table in that file.
+- [ ] `plugins/inspect-robots-voice/README.md`: the README is currently input-only (it
+      never mentions `--speak`). Add a short `--speak` paragraph naming the three
+      modes and the interrupt default, matching the README's existing prose style and
+      the repo writing-style rules; do not add a table.
+- [ ] `docs/guide/plugins.md`: the voice-plugin bullet says "bounded drop-oldest
+      buffering keeps speech output off the control loop", which the new default
+      falsifies twice (mechanism is generation-abort; blocking mode deliberately
+      delays the loop). Rewrite it to mirror the corrected voice-mode.md invariant
+      wording.
+- [ ] `docs/guide/cli.md`: extend the `-S` key enumerations ("select the output voice,
+      speed, volume, device, language, or offline model paths", and the run-section
+      equivalent) to include the speech mode.
+- [ ] `plugins/inspect-robots-voice/CLAUDE.md`: update the `_speaker.py` module-map row
+      and the `SpeakerSink` invariant bullet: the hook never synthesizes or plays audio
+      on the control thread in any mode; blocking mode may wait boundedly; interrupt is
+      the default and aborts via a generation counter.
+- [ ] `plugins/inspect-robots-voice/pyproject.toml` + `__init__.py`: version 0.4.0 →
+      0.5.0 (feature plus default-behavior change on a 0.x plugin), **and** update the
+      hard assertion in `test_factory.py::test_package_exports_and_version` to match.
+      Run `uv lock` if it dirties; commit whatever changes.
+- [ ] `CHANGELOG.md` under `## [Unreleased]`: an Added entry (voice: speech modes) and a
+      Changed entry (voice: default `--speak` behavior is now interrupt; `-S mode=queue`
+      restores the old queueing), linking plan 0057 and issue #336.
+
+### Task 6: verification
+
+- [ ] `uv sync --locked --all-packages --extra dev` in the worktree.
+- [ ] Plugin: ruff check, ruff format --check, mypy (plugin config, src + tests),
+      pytest with coverage over `inspect_robots_voice`.
+- [ ] Core: full gates (`ruff check .`, `ruff format --check .`, `mypy`, `pytest --cov -q`
+      at 100%).
+- [ ] Re-read the final `_speaker.py` top-to-bottom for lock-ordering and
+      wait-predicate correctness (every `wait()` in a loop with a predicate; every
+      state change that a waiter watches followed by a notify under the same lock).
+
+## Out of scope
+
+- `eval-set --speak` (unchanged from plan 0054's scoping).
+- Mid-synthesis interruption (needs engine cooperation kokoro-onnx lacks).
+- Pausing or rate-adapting TTS speed to catch up (a possible future mode).
+- Any rollout/eval/core sink-protocol change.

--- a/plugins/inspect-robots-voice/CLAUDE.md
+++ b/plugins/inspect-robots-voice/CLAUDE.md
@@ -15,7 +15,7 @@ Robots runs. It registers the `voice` factory in `inspect_robots.operator_inputs
 | `src/inspect_robots_voice/_parakeet.py` | onnx-asr Parakeet wrapper with timestamped confidence rejection |
 | `src/inspect_robots_voice/_input.py` | worker-thread orchestration, generation-safe trial resets, output polling, and lifecycle hooks |
 | `src/inspect_robots_voice/_tts.py` | lazy Kokoro engine seam plus pinned, verified, atomic model-file caching |
-| `src/inspect_robots_voice/_speaker.py` | defensive note extraction, bounded narration queue, worker lifecycle, and lazy chunked playback |
+| `src/inspect_robots_voice/_speaker.py` | defensive note extraction, blocking, interrupt, and queue delivery modes, worker lifecycle, and lazy chunked playback |
 | `tests/` | deterministic unit tests using fake devices, models, capture, playback, engines, transcribers, segmenters, and threading events |
 
 ## Invariants
@@ -35,7 +35,8 @@ Robots runs. It registers the `voice` factory in `inspect_robots.operator_inputs
   trial.
 - `close()` is idempotent and never raises. It stops capture and joins the worker.
 - `SpeakerSink.log_policy_messages()` never synthesizes or plays audio on the control thread. Its
-  bounded queue drops the oldest stale note, and only a successful eval end drains before close.
+  blocking mode may wait boundedly and fail-open; the default interrupt mode aborts stale speech
+  through a generation counter. Only a successful eval end drains before close.
 
 ## Working here
 

--- a/plugins/inspect-robots-voice/README.md
+++ b/plugins/inspect-robots-voice/README.md
@@ -48,6 +48,10 @@ inspect-robots run --task my-task --policy agent --embodiment my-robot \
     --voice -V model=medium -V device="USB Microphone" -V compute=int8
 ```
 
+The plugin can also narrate streamed policy notes with `run --speak`. Speech defaults to
+`interrupt`, which cuts off superseded narration. Pass `-S mode=blocking` to wait boundedly for
+each previous note, or `-S mode=queue` to retain bounded drop-oldest queueing.
+
 ## Filtering
 
 Audio is segmented locally with an adaptive energy gate. Parakeet applies duration, blank-text,

--- a/plugins/inspect-robots-voice/pyproject.toml
+++ b/plugins/inspect-robots-voice/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-voice"
-version = "0.4.0"
+version = "0.5.0"
 description = "Local spoken operator feedback for attended Inspect Robots evaluations."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-voice/src/inspect_robots_voice/__init__.py
+++ b/plugins/inspect-robots-voice/src/inspect_robots_voice/__init__.py
@@ -9,12 +9,12 @@ dependencies are loaded only when their component starts.
 from __future__ import annotations
 
 from inspect_robots_voice._input import VoiceInput
-from inspect_robots_voice._speaker import SpeakerSink
+from inspect_robots_voice._speaker import _DEFAULT_MODE, _MODES, SpeakerSink
 from inspect_robots_voice._transcriber import _classify_model
 
 __all__ = ["SpeakerSink", "VoiceInput", "speaker_sink", "voice_input"]
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 ScalarValue = str | int | float | bool | None
 
@@ -25,10 +25,11 @@ def speaker_sink(**kwargs: ScalarValue) -> SpeakerSink:
     Supported keys are ``voice`` (string, default ``"af_sarah"``), ``speed`` (positive
     number, default ``1.0``), ``volume`` (number from 0 through 1, default ``1.0``),
     ``device`` (string or integer, default system output), ``lang`` (string, default
-    ``"en-us"``), and optional ``model`` and ``voices`` file paths. Unknown, incompatible,
-    or incorrectly typed values raise :class:`TypeError`.
+    ``"en-us"``), ``mode`` (string, one of ``"blocking"``, ``"interrupt"``, or ``"queue"``,
+    default ``"interrupt"``), and optional ``model`` and ``voices`` file paths. Unknown,
+    incompatible, or incorrectly typed values raise :class:`TypeError`.
     """
-    allowed = {"voice", "speed", "volume", "device", "lang", "model", "voices"}
+    allowed = {"voice", "speed", "volume", "device", "lang", "model", "voices", "mode"}
     unknown = sorted(set(kwargs) - allowed)
     if unknown:
         raise TypeError(f"unexpected speaker argument(s): {', '.join(unknown)}")
@@ -40,6 +41,7 @@ def speaker_sink(**kwargs: ScalarValue) -> SpeakerSink:
     lang = kwargs.get("lang", "en-us")
     model = kwargs.get("model")
     voices = kwargs.get("voices")
+    mode = kwargs.get("mode", _DEFAULT_MODE)
     if not isinstance(voice, str):
         raise TypeError("voice must be a string")
     if not isinstance(speed, (int, float)) or isinstance(speed, bool):
@@ -62,6 +64,8 @@ def speaker_sink(**kwargs: ScalarValue) -> SpeakerSink:
         raise TypeError("model must be a string or none")
     if voices is not None and not isinstance(voices, str):
         raise TypeError("voices must be a string or none")
+    if not isinstance(mode, str) or mode not in _MODES:
+        raise TypeError(f"mode must be a string and one of: {', '.join(_MODES)}")
     return SpeakerSink(
         voice=voice,
         speed=float(speed),
@@ -70,6 +74,7 @@ def speaker_sink(**kwargs: ScalarValue) -> SpeakerSink:
         lang=lang,
         model=model,
         voices=voices,
+        mode=mode,
     )
 
 

--- a/plugins/inspect-robots-voice/src/inspect_robots_voice/_speaker.py
+++ b/plugins/inspect-robots-voice/src/inspect_robots_voice/_speaker.py
@@ -1,4 +1,4 @@
-"""Non-blocking policy-note speech with bounded stale-work loss."""
+"""Off-thread policy-note audio with selectable delivery and bounded waiting."""
 
 from __future__ import annotations
 
@@ -23,9 +23,12 @@ if TYPE_CHECKING:
 PlaybackDevice = str | int | None
 EngineFactory = Callable[[], TtsEngine]
 _QUEUE_SIZE = 4
+_BLOCK_TIMEOUT = 15.0
 _DRAIN_TIMEOUT = 15.0
 _JOIN_TIMEOUT = 5.0
 _CHUNK_SECONDS = 0.1
+_MODES = ("blocking", "interrupt", "queue")
+_DEFAULT_MODE = "interrupt"
 
 
 class _Playback(Protocol):
@@ -101,7 +104,7 @@ def extract_speech(messages: Sequence[Any]) -> list[str]:
 
 
 class SpeakerSink(NullSink):
-    """Speak policy narration asynchronously without delaying the control loop."""
+    """Play narration off-thread; blocking waits are bounded and fail-open."""
 
     def __init__(
         self,
@@ -113,9 +116,12 @@ class SpeakerSink(NullSink):
         lang: str = "en-us",
         model: str | None = None,
         voices: str | None = None,
+        mode: str = _DEFAULT_MODE,
         engine_factory: EngineFactory | None = None,
         playback_factory: PlaybackFactory | None = None,
     ) -> None:
+        if mode not in _MODES:
+            raise ValueError(f"mode must be one of: {', '.join(_MODES)}")
         self.voice = voice
         self.speed = speed
         self.volume = volume
@@ -123,6 +129,7 @@ class SpeakerSink(NullSink):
         self.lang = lang
         self.model = model
         self.voices = voices
+        self.mode = mode
 
         def build_engine() -> TtsEngine:
             model_path, voices_path = resolve_model_files(self.model, self.voices)
@@ -146,6 +153,8 @@ class SpeakerSink(NullSink):
         self._closed = False
         self._warned = False
         self._dropped = 0
+        self._speech_gen = 0
+        self._block_degraded = False
 
     def start(self) -> None:
         """Build audio resources and start exactly one daemon narration worker."""
@@ -177,21 +186,44 @@ class SpeakerSink(NullSink):
             playback.close()
 
     def log_policy_messages(self, t: int, messages: Sequence[Any]) -> None:
-        """Enqueue spoken fields from one transcript delta without blocking on audio."""
+        """Queue one delta without audio work, waiting boundedly only in blocking mode."""
         del t
         texts = extract_speech(messages)
         if not texts:
             return
+        blocking_timed_out = False
         with self._condition:
             thread = self._thread
             if thread is None or not thread.is_alive() or self._disabled or self._stop.is_set():
                 return
+            if self.mode == "interrupt":
+                self._speech_gen += 1
+                self._queue.clear()
+            elif self.mode == "blocking" and not self._block_degraded:
+                deadline = time.monotonic() + _BLOCK_TIMEOUT
+                while self._queue or self._inflight:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        self._block_degraded = True
+                        blocking_timed_out = True
+                        break
+                    self._condition.wait(timeout=remaining)
+                    thread = self._thread
+                    if (
+                        thread is None
+                        or not thread.is_alive()
+                        or self._disabled
+                        or self._stop.is_set()
+                    ):
+                        return
             for text in texts:
                 if len(self._queue) >= _QUEUE_SIZE:
                     self._queue.popleft()
                     self._dropped += 1
                 self._queue.append(text)
             self._condition.notify()
+        if blocking_timed_out:
+            print("speaker: blocking wait timed out; narration may lag", file=sys.stderr)
 
     def on_trial_start(self, scene_id: str, epoch: int) -> None:
         """Discard queued prior-trial notes and report accumulated overflow once."""
@@ -200,6 +232,7 @@ class SpeakerSink(NullSink):
             self._queue.clear()
             dropped = self._dropped
             self._dropped = 0
+            self._condition.notify_all()
         if dropped:
             suffix = "" if dropped == 1 else "s"
             print(f"speaker: dropped {dropped} stale note{suffix}", file=sys.stderr)
@@ -218,11 +251,11 @@ class SpeakerSink(NullSink):
             self._closed = True
             self._stop.set()
             self._queue.clear()
-            self._condition.notify_all()
             thread = self._thread
             playback = self._playback
             self._thread = None
             self._playback = None
+            self._condition.notify_all()
         if thread is not None:
             with suppress(BaseException):
                 thread.join(timeout=_JOIN_TIMEOUT)
@@ -247,18 +280,26 @@ class SpeakerSink(NullSink):
                 if self._stop.is_set():
                     return
                 text = self._queue.popleft()
+                gen = self._speech_gen
                 self._inflight = True
+                self._condition.notify_all()
             try:
                 if self._stop.is_set():
                     return
+                if self._speech_gen != gen:
+                    continue
                 samples, sample_rate = engine.synthesize(text)
                 if self._stop.is_set():
                     return
+                if self._speech_gen != gen:
+                    continue
                 gained = np.asarray(samples * np.float32(self.volume), dtype=np.float32)
                 chunk_size = max(1, int(sample_rate * _CHUNK_SECONDS))
                 for start in range(0, len(gained), chunk_size):
                     if self._stop.is_set():
                         return
+                    if self._speech_gen != gen:
+                        break
                     playback.write(gained[start : start + chunk_size], sample_rate)
             except Exception as exc:
                 with self._condition:

--- a/plugins/inspect-robots-voice/tests/test_factory.py
+++ b/plugins/inspect-robots-voice/tests/test_factory.py
@@ -11,7 +11,7 @@ from inspect_robots_voice import SpeakerSink, VoiceInput, speaker_sink, voice_in
 
 
 def test_package_exports_and_version() -> None:
-    assert inspect_robots_voice.__version__ == "0.4.0"
+    assert inspect_robots_voice.__version__ == "0.5.0"
     assert inspect_robots_voice.__all__ == [
         "SpeakerSink",
         "VoiceInput",
@@ -32,7 +32,15 @@ def test_speaker_factory_defaults() -> None:
         speaker.lang,
         speaker.model,
         speaker.voices,
-    ) == ("af_sarah", 1.0, 1.0, None, "en-us", None, None)
+        speaker.mode,
+    ) == ("af_sarah", 1.0, 1.0, None, "en-us", None, None, "interrupt")
+
+
+@pytest.mark.parametrize("mode", ["blocking", "interrupt", "queue"])
+def test_speaker_factory_accepts_speech_modes(mode: str) -> None:
+    speaker = speaker_sink(mode=mode)
+
+    assert speaker.mode == mode
 
 
 @pytest.mark.parametrize("device", [None, 4, "USB speaker"])
@@ -70,6 +78,8 @@ def test_speaker_factory_accepts_options_and_device_forms(device: str | int | No
         ({"lang": None}, "lang must be a string"),
         ({"model": 1}, "model must be a string or none"),
         ({"voices": False}, "voices must be a string or none"),
+        ({"mode": 1}, "mode must be a string and one of: blocking, interrupt, queue"),
+        ({"mode": "later"}, "mode must be a string and one of: blocking, interrupt, queue"),
     ],
 )
 def test_speaker_factory_rejects_unknown_or_mistyped_values(

--- a/plugins/inspect-robots-voice/tests/test_speaker.py
+++ b/plugins/inspect-robots-voice/tests/test_speaker.py
@@ -494,6 +494,31 @@ def test_blocking_waits_for_inflight_then_enqueues_and_plays() -> None:
     assert [float(chunk[0]) for chunk, _ in playback.writes] == [1.0] * 3 + [2.0] * 3
 
 
+def test_blocking_skips_gate_for_deltas_without_speakable_text() -> None:
+    engine = _TaggedEngine()
+    playback = _GatedPlayback(gated_writes=1)
+    sink = _sink(engine, playback, mode="blocking")
+    sink.start()
+    sink.log_policy_messages(0, [_assistant(_tool_call("move", {"note": "first"}))])
+    assert playback.entered[0].wait(timeout=1.0)
+    returned = threading.Event()
+
+    def deliver_noteless_delta() -> None:
+        sink.log_policy_messages(1, [_assistant(_tool_call("move", {"note": "   "}))])
+        returned.set()
+
+    hook_thread = threading.Thread(target=deliver_noteless_delta)
+    hook_thread.start()
+    assert returned.wait(timeout=0.5)
+    hook_thread.join(timeout=1.0)
+    with sink._condition:
+        assert list(sink._queue) == []
+    playback.release[0].set()
+    sink.close()
+
+    assert engine.calls == ["first"]
+
+
 def test_blocking_fails_open_when_worker_dies() -> None:
     class FailingBlockingEngine(_BlockingEngine):
         def synthesize(self, text: str) -> tuple[npt.NDArray[np.float32], int]:

--- a/plugins/inspect-robots-voice/tests/test_speaker.py
+++ b/plugins/inspect-robots-voice/tests/test_speaker.py
@@ -95,9 +95,50 @@ class _BlockingEngine(_FakeEngine):
         return np.ones(3, dtype=np.float32), 10
 
 
-def _sink(engine: _FakeEngine, playback: _FakePlayback, *, volume: float = 1.0) -> SpeakerSink:
+class _TaggedEngine(_FakeEngine):
+    def synthesize(self, text: str) -> tuple[npt.NDArray[np.float32], int]:
+        self.calls.append(text)
+        value = float(self.calls.index(text) + 1)
+        return np.full(3, value, dtype=np.float32), 10
+
+
+class _GatedPlayback(_FakePlayback):
+    def __init__(self, gated_writes: int = 0) -> None:
+        super().__init__()
+        self.entered = [threading.Event() for _ in range(gated_writes)]
+        self.release = [threading.Event() for _ in range(gated_writes)]
+        self._writes_condition = threading.Condition()
+
+    def write(self, samples: npt.NDArray[np.float32], sample_rate: int) -> None:
+        with self._writes_condition:
+            super().write(samples, sample_rate)
+            index = len(self.writes) - 1
+            self._writes_condition.notify_all()
+        if index < len(self.entered):
+            self.entered[index].set()
+            self.release[index].wait(timeout=2.0)
+
+    def wait_for_writes(self, count: int, timeout: float = 1.0) -> bool:
+        deadline = time.monotonic() + timeout
+        with self._writes_condition:
+            while len(self.writes) < count:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._writes_condition.wait(timeout=remaining)
+        return True
+
+
+def _sink(
+    engine: _FakeEngine,
+    playback: _FakePlayback,
+    *,
+    volume: float = 1.0,
+    mode: str = "interrupt",
+) -> SpeakerSink:
     return SpeakerSink(
         volume=volume,
+        mode=mode,
         engine_factory=lambda: engine,
         playback_factory=lambda: playback,
     )
@@ -119,7 +160,7 @@ def _log(status: str) -> EvalLog:
 def test_enqueue_is_spoken_in_order_with_volume_gain() -> None:
     engine = _FakeEngine()
     playback = _FakePlayback()
-    sink = _sink(engine, playback, volume=0.25)
+    sink = _sink(engine, playback, volume=0.25, mode="queue")
     sink.start()
 
     sink.log_policy_messages(
@@ -147,7 +188,7 @@ def test_overflow_drops_oldest_and_reports_once_at_next_trial(
 ) -> None:
     engine = _BlockingEngine()
     playback = _FakePlayback()
-    sink = _sink(engine, playback)
+    sink = _sink(engine, playback, mode="queue")
     sink.start()
     sink.log_policy_messages(0, [_assistant(_tool_call("move", {"note": "inflight"}))])
     assert engine.entered.wait(timeout=1.0)
@@ -168,7 +209,7 @@ def test_overflow_drops_oldest_and_reports_once_at_next_trial(
 def test_trial_start_clears_queued_prior_trial_notes() -> None:
     engine = _BlockingEngine()
     playback = _FakePlayback()
-    sink = _sink(engine, playback)
+    sink = _sink(engine, playback, mode="queue")
     sink.start()
     sink.log_policy_messages(0, [_assistant(_tool_call("move", {"note": "inflight"}))])
     assert engine.entered.wait(timeout=1.0)
@@ -177,7 +218,6 @@ def test_trial_start_clears_queued_prior_trial_notes() -> None:
     sink.on_trial_start("new-scene", 0)
     engine.release.set()
     _wait_until(lambda: len(playback.writes) == 3)
-    time.sleep(0.02)
     sink.close()
 
     assert engine.calls == ["inflight"]
@@ -211,8 +251,7 @@ def test_successful_eval_end_drains_inflight_utterance_before_close() -> None:
 
     end_thread = threading.Thread(target=end_eval)
     end_thread.start()
-    time.sleep(0.02)
-    assert not finished.is_set()
+    assert not finished.wait(timeout=0.02)
     assert playback.close_calls == 0
     engine.release.set()
     end_thread.join(timeout=1.0)
@@ -341,3 +380,217 @@ def test_startup_factory_errors_propagate(which: str) -> None:
 
     with pytest.raises(RuntimeError, match=f"{which} unavailable"):
         sink.start()
+
+
+def test_constructor_rejects_unknown_mode() -> None:
+    with pytest.raises(ValueError, match="mode must be one of: blocking, interrupt, queue"):
+        SpeakerSink(mode="unknown")
+
+
+def test_interrupt_cuts_inflight_within_one_chunk_and_plays_new_note() -> None:
+    engine = _TaggedEngine()
+    playback = _GatedPlayback(gated_writes=1)
+    sink = _sink(engine, playback)
+    sink.start()
+    sink.log_policy_messages(0, [_assistant(_tool_call("move", {"note": "old"}))])
+    assert playback.entered[0].wait(timeout=1.0)
+
+    sink.log_policy_messages(1, [_assistant(_tool_call("move", {"note": "new"}))])
+    with sink._condition:
+        assert list(sink._queue) == ["new"]
+        assert sink._dropped == 0
+    playback.release[0].set()
+    assert playback.wait_for_writes(4)
+    sink.close()
+
+    assert engine.calls == ["old", "new"]
+    assert [float(chunk[0]) for chunk, _ in playback.writes] == [1.0, 2.0, 2.0, 2.0]
+    assert sink._thread is None
+
+
+def test_interrupt_discards_stale_synthesis_result_and_worker_survives() -> None:
+    engine = _BlockingEngine()
+    playback = _GatedPlayback()
+    sink = _sink(engine, playback)
+    sink.start()
+    sink.log_policy_messages(0, [_assistant(_tool_call("move", {"note": "stale"}))])
+    assert engine.entered.wait(timeout=1.0)
+
+    sink.log_policy_messages(1, [_assistant(_tool_call("move", {"note": "current"}))])
+    engine.release.set()
+    assert playback.wait_for_writes(3)
+    sink.close()
+
+    assert engine.calls == ["stale", "current"]
+    assert len(playback.writes) == 3
+
+
+def test_interrupt_multi_text_delta_plays_all_texts_in_order() -> None:
+    engine = _FakeEngine()
+    playback = _FakePlayback()
+    sink = _sink(engine, playback)
+    sink.start()
+
+    sink.log_policy_messages(
+        0,
+        [
+            _assistant(
+                _tool_call("move", {"note": "move now"}),
+                _tool_call("done", {"summary": "finished"}),
+            )
+        ],
+    )
+    sink.on_eval_end(_log("success"))
+
+    assert engine.calls == ["move now", "finished"]
+    assert len(playback.writes) == 6
+
+
+def test_interrupt_trial_start_preserves_inflight_until_next_delta() -> None:
+    engine = _TaggedEngine()
+    playback = _GatedPlayback(gated_writes=2)
+    sink = _sink(engine, playback)
+    sink.start()
+    sink.log_policy_messages(0, [_assistant(_tool_call("done", {"summary": "old"}))])
+    assert playback.entered[0].wait(timeout=1.0)
+
+    sink.on_trial_start("next", 1)
+    assert sink._speech_gen == 1
+    playback.release[0].set()
+    assert playback.entered[1].wait(timeout=1.0)
+
+    sink.log_policy_messages(0, [_assistant(_tool_call("move", {"note": "new"}))])
+    playback.release[1].set()
+    assert playback.wait_for_writes(5)
+    sink.close()
+
+    assert engine.calls == ["old", "new"]
+    assert [float(chunk[0]) for chunk, _ in playback.writes] == [1.0, 1.0, 2.0, 2.0, 2.0]
+
+
+def test_blocking_waits_for_inflight_then_enqueues_and_plays() -> None:
+    engine = _TaggedEngine()
+    playback = _GatedPlayback(gated_writes=1)
+    sink = _sink(engine, playback, mode="blocking")
+    sink.start()
+    sink.log_policy_messages(0, [_assistant(_tool_call("move", {"note": "first"}))])
+    assert playback.entered[0].wait(timeout=1.0)
+    returned = threading.Event()
+
+    def enqueue_second() -> None:
+        sink.log_policy_messages(1, [_assistant(_tool_call("move", {"note": "second"}))])
+        returned.set()
+
+    hook_thread = threading.Thread(target=enqueue_second)
+    hook_thread.start()
+    assert not returned.wait(timeout=0.02)
+    playback.release[0].set()
+    assert returned.wait(timeout=1.0)
+    assert playback.wait_for_writes(6)
+    hook_thread.join(timeout=1.0)
+    sink.close()
+
+    assert engine.calls == ["first", "second"]
+    assert [float(chunk[0]) for chunk, _ in playback.writes] == [1.0] * 3 + [2.0] * 3
+
+
+def test_blocking_fails_open_when_worker_dies() -> None:
+    class FailingBlockingEngine(_BlockingEngine):
+        def synthesize(self, text: str) -> tuple[npt.NDArray[np.float32], int]:
+            self.calls.append(text)
+            self.entered.set()
+            self.release.wait(timeout=2.0)
+            raise RuntimeError("failed while hook waited")
+
+    engine = FailingBlockingEngine()
+    playback = _FakePlayback()
+    sink = _sink(engine, playback, mode="blocking")
+    sink.start()
+    sink.log_policy_messages(0, [_assistant(_tool_call("move", {"note": "first"}))])
+    assert engine.entered.wait(timeout=1.0)
+    returned = threading.Event()
+
+    def enqueue_second() -> None:
+        sink.log_policy_messages(1, [_assistant(_tool_call("move", {"note": "second"}))])
+        returned.set()
+
+    hook_thread = threading.Thread(target=enqueue_second)
+    hook_thread.start()
+    assert not returned.wait(timeout=0.02)
+    engine.release.set()
+    assert returned.wait(timeout=1.0)
+    hook_thread.join(timeout=1.0)
+    sink.close()
+
+    assert engine.calls == ["first"]
+    assert list(sink._queue) == []
+
+
+def test_blocking_fails_open_when_close_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _BlockingEngine()
+    playback = _FakePlayback()
+    sink = _sink(engine, playback, mode="blocking")
+    monkeypatch.setattr(speaker_module, "_JOIN_TIMEOUT", 1.0)
+    sink.start()
+    sink.log_policy_messages(0, [_assistant(_tool_call("move", {"note": "first"}))])
+    assert engine.entered.wait(timeout=1.0)
+    returned = threading.Event()
+
+    def enqueue_second() -> None:
+        sink.log_policy_messages(1, [_assistant(_tool_call("move", {"note": "second"}))])
+        returned.set()
+
+    hook_thread = threading.Thread(target=enqueue_second)
+    close_thread = threading.Thread(target=sink.close)
+    hook_thread.start()
+    assert not returned.wait(timeout=0.02)
+    close_thread.start()
+    assert returned.wait(timeout=1.0)
+    engine.release.set()
+    hook_thread.join(timeout=1.0)
+    close_thread.join(timeout=1.0)
+
+    assert engine.calls == ["first"]
+    assert list(sink._queue) == []
+
+
+def test_blocking_timeout_degrades_once_and_keeps_drop_accounting(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    engine = _FakeEngine()
+    playback = _GatedPlayback(gated_writes=1)
+    sink = _sink(engine, playback, mode="blocking")
+    monkeypatch.setattr(speaker_module, "_BLOCK_TIMEOUT", 0.02)
+    sink.start()
+    sink.log_policy_messages(0, [_assistant(_tool_call("move", {"note": "inflight"}))])
+    assert playback.entered[0].wait(timeout=1.0)
+
+    sink.log_policy_messages(1, [_assistant(_tool_call("move", {"note": "timed out"}))])
+    with sink._condition:
+        assert list(sink._queue) == ["timed out"]
+        assert sink._dropped == 0
+    assert capsys.readouterr().err == "speaker: blocking wait timed out; narration may lag\n"
+
+    monkeypatch.setattr(speaker_module, "_BLOCK_TIMEOUT", 10.0)
+    returned = threading.Event()
+
+    def enqueue_degraded() -> None:
+        sink.log_policy_messages(2, [_assistant(_tool_call("move", {"note": "degraded"}))])
+        returned.set()
+
+    hook_thread = threading.Thread(target=enqueue_degraded)
+    hook_thread.start()
+    assert returned.wait(timeout=0.2)
+    hook_thread.join(timeout=1.0)
+    for text in ["three", "four", "five"]:
+        sink.log_policy_messages(3, [_assistant(_tool_call("move", {"note": text}))])
+    with sink._condition:
+        assert list(sink._queue) == ["degraded", "three", "four", "five"]
+        assert sink._dropped == 1
+    assert capsys.readouterr().err == ""
+
+    playback.release[0].set()
+    sink.close()

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -311,7 +311,8 @@ def build_parser() -> argparse.ArgumentParser:
         dest="speak_args",
         action="append",
         metavar="k=v",
-        help="pass an argument to the inspect-robots-voice speaker (requires --speak)",
+        help="pass an argument to the inspect-robots-voice speaker, e.g. "
+        "-S mode=blocking|interrupt|queue (requires --speak)",
     )
     p_run.add_argument(
         "--max-steps",

--- a/uv.lock
+++ b/uv.lock
@@ -915,7 +915,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "inspect-robots-voice"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "plugins/inspect-robots-voice" }
 dependencies = [
     { name = "faster-whisper" },


### PR DESCRIPTION
Closes #336.

In --speak runs the narration queue backlogs: the note being spoken can describe a turn 5-10 inferences in the past. This PR adds a `mode` option to the speaker sink, selected with the existing repeatable `-S` channel.

- **interrupt (new default):** a new transcript delta bumps a generation counter, clears superseded queued text, and aborts the in-flight utterance at chunk granularity (~0.1 s), so speech always describes the current turn. Texts within one delta (note + terminal summary) still play in order, and trial-start keeps letting terminal summaries play out.
- **blocking (`-S mode=blocking`):** `log_policy_messages` fires after inference and before `embodiment.step()`, so the hook waits boundedly (15 s, fail-open) for the previous note to finish before enqueueing; the next turn's joints then move while the new note speaks. On timeout it warns once and permanently degrades to non-waiting enqueue so a wedged audio device can never turn the run into a slideshow. `_stop`/disabled/dead-worker wakeups return without enqueueing.
- **queue (`-S mode=queue`):** the previous bounded drop-oldest behavior.

Design: [plan 0057](plans/0057-speak-speech-modes.md) (two independent critique rounds applied). Core change is the `-S` help string only; everything else is the voice plugin (0.4.0 -> 0.5.0), tests, and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)