### PR TITLE
voice 0.5.1: operator-ended trials cut --speak narration immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+
+- **Voice plugin (0.5.1):** operator-ended trials now cut `--speak` narration
+  instead of draining it at eval end
+  ([plan 0059](plans/0059-speak-operator-end-cut.md),
+  [#343](https://github.com/robocurve/inspect-robots/issues/343)).
+
 ### Changed
 
 - **Voice plugin (0.5.0):** the default `--speak` behavior now interrupts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project are documented here. The format is based on
 
 - **Voice plugin (0.5.1):** operator-ended trials now cut `--speak` narration
   instead of draining it at eval end
-  ([plan 0059](plans/0059-speak-operator-end-cut.md),
+  ([plan 0061](plans/0061-speak-operator-end-cut.md),
   [#343](https://github.com/robocurve/inspect-robots/issues/343)).
 
 ### Changed

--- a/docs/guide/voice-mode.md
+++ b/docs/guide/voice-mode.md
@@ -147,8 +147,9 @@ inspect-robots run --task my-task --policy agent --embodiment my-robot \
 
 Ending a trial from the console cuts narration immediately in every mode; only natural
 completions drain the final summary. Because the cut lands after grading, the tail of one note
-may still be audible through the verdict prompt in the default `interrupt` mode, while the whole
-`mode=queue` backlog (up to 4 notes) keeps playing until the verdict is entered. The operator's
+may still be audible through the verdict prompt in the default `interrupt` mode, while the
+`mode=queue` backlog (up to 4 queued notes plus the one in flight) keeps playing until the
+verdict is entered. The operator's
 own `/stop` note text is never spoken because the speaker reads policy narration only.
 
 The first `--speak` run downloads about 340 MB of pinned Kokoro model files. The cache is

--- a/docs/guide/voice-mode.md
+++ b/docs/guide/voice-mode.md
@@ -145,6 +145,12 @@ inspect-robots run --task my-task --policy agent --embodiment my-robot \
     --speak -S mode=queue
 ```
 
+Ending a trial from the console cuts narration immediately in every mode; only natural
+completions drain the final summary. Because the cut lands after grading, the tail of one note
+may still be audible through the verdict prompt in the default `interrupt` mode, while the whole
+`mode=queue` backlog (up to 4 notes) keeps playing until the verdict is entered. The operator's
+own `/stop` note text is never spoken because the speaker reads policy narration only.
+
 The first `--speak` run downloads about 340 MB of pinned Kokoro model files. The cache is
 `$XDG_CACHE_HOME/inspect-robots-voice/`, or `~/.cache/inspect-robots-voice/` when
 `XDG_CACHE_HOME` is unset. To pre-seed a rig, copy both release files into that directory with

--- a/plans/0059-speak-operator-end-cut.md
+++ b/plans/0059-speak-operator-end-cut.md
@@ -1,0 +1,152 @@
+# Operator-ended trials cut `--speak` narration immediately — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Rig operators report that ending a run from the console (Esc or `/stop`) does
+not stop narration: the in-flight note keeps playing and the run only exits after
+`on_eval_end`'s success-path drain waits for speech to finish (`_DRAIN_TIMEOUT = 15.0`).
+The drain exists so a natural `done()`/`give_up()` summary plays out; an operator-ended
+trial is the opposite case — the human explicitly asked the run to stop. Cut speech the
+moment the sink learns the trial was operator-terminated. (Issue #343.)
+
+**Shape:** voice plugin only (`inspect-robots-voice` 0.5.0 → 0.5.1). No core changes at
+all: `SpeakerSink` already receives `on_trial_end(record)` through the `LogSink`
+protocol (currently inherited as `NullSink`'s no-op), `TrialRecord.termination_reason`
+carries the reason, and `OPERATOR_END == "operator_end"` is public core API
+(`inspect_robots.types`, re-exported in `inspect_robots.__all__`).
+
+## Mechanism and ordering facts (verified against main @ 6008edb1)
+
+- `rollout()` sets `record.termination_reason = OPERATOR_END` and breaks on an
+  end-poll (`src/inspect_robots/rollout.py:320-334`). It does not call any sink hook at
+  the break.
+- `eval()` delivers `bus.on_trial_end(record)` per trial (`src/inspect_robots/eval.py:529`)
+  **after** the grading hook (`before_scoring`, line 478) — so with an attended
+  `operator` grader, the verdict prompt happens before the sink hears about the trial
+  end. Consequence (documented, accepted): the tail of the in-flight note can still
+  play while the operator answers the verdict prompt; the cut lands before the eval's
+  exit path (the drain), which is where the reported multi-second wait lives. Cutting
+  earlier would need a new core seam or reordering `on_trial_end` before grading, which
+  would change what every sink sees in the record (no `operator_judgement` yet) — out
+  of scope.
+- The worker's generation checks (`self._speech_gen != gen` after pop, after
+  synthesis, between chunks) run in **every** mode — plan 0057 added the mechanism for
+  interrupt mode but did not gate it by mode. A generation bump therefore cuts speech
+  in blocking and queue modes too, with no worker changes.
+- Residual latency after the cut: at most one 0.1 s playback chunk, or the remainder of
+  an already-running `engine.synthesize()` call (whose result is then discarded). Both
+  are far below one note's playback time, and `_drain` waits on `queue or _inflight`,
+  so `on_eval_end` returns as soon as the abandonment lands.
+
+## Design decisions (binding)
+
+1. **The cut applies in all three modes.** Operator intent outranks delivery-mode
+   semantics — queue mode's "old behavior" contract is about how *live* notes are
+   delivered, not about overriding an explicit stop. Docs say so.
+2. **Only `OPERATOR_END` cuts.** `policy_stop` (the policy's own `done()`/`give_up()`)
+   and embodiment termination keep today's behavior: the terminal summary plays and a
+   successful eval end drains it. `record.terminated`/`truncated` flags are not
+   consulted; the reason string is the contract. Note the string has three producers
+   (console end-poll, `action.meta["stop_reason"]`, embodiment
+   `result.termination_reason`), so a policy or embodiment reporting the literal
+   `"operator_end"` also cuts — desirable (an embodiment-side operator e-stop should
+   silence narration too) and accepted.
+3. **The cut is a generation bump + queue clear + `notify_all`, under the condition.**
+   Identical mechanics to an interrupt-mode delta. All sink hooks run synchronously on
+   the one control thread, so no blocking-mode waiter can actually be parked while
+   `on_trial_end` runs; `notify_all` (matching `on_trial_start`) is costless,
+   symmetric, and defensive against future threaded callers, and the waiter-release
+   property is covered by a defensive test of a production-unreachable interleaving.
+   A woken waiter re-checks `queue or _inflight` and proceeds only once the worker's
+   abandonment *lands* (next chunk boundary or synthesis return) — that residual is
+   the same one-chunk/synthesis-remainder bound stated above. No `_dropped` counting:
+   this is a deliberate discard, same rationale as interrupt-mode clears (plan 0057
+   decision 9). The hook must never assume duck-typed extras beyond the `TrialRecord`
+   dataclass fields: `_EvalSinkBus.on_trial_end` has no exception isolation, so an
+   `AttributeError` here would surface into the eval loop.
+4. **No drain-skip logic in `on_eval_end`.** After the cut the queue is empty and
+   `_inflight` clears within one chunk/synthesis-return, so the existing drain
+   degenerates to a near-no-op on its own. One mechanism, not two.
+5. **Multi-trial runs:** a cut at trial N's end does not affect trial N+1's narration
+   (its deltas arrive with the new generation). No trial-start changes.
+
+## Tasks
+
+### Task 1: `_speaker.py`
+
+- [ ] Import `OPERATOR_END` from `inspect_robots.types` at module scope (core is
+      already a module-scope import source here via `inspect_robots.logging.sink`; the
+      lazy-import invariant covers audio/model deps only).
+- [ ] Add `on_trial_end(self, record: TrialRecord) -> None` (type via the existing
+      `TYPE_CHECKING` block, importing `TrialRecord` from `inspect_robots.rollout`):
+      if `record.termination_reason != OPERATOR_END`, return; else under
+      `self._condition`: `self._speech_gen += 1`, `self._queue.clear()`,
+      `notify_all()`. Docstring states the contract: an operator-ended trial silences
+      narration in every mode; natural completions still play out.
+- [ ] Module docstring: add one sentence for the operator-end cut.
+
+### Task 2: tests (`tests/test_speaker.py`)
+
+- [ ] Helper to build a minimal `TrialRecord` with a given `termination_reason`
+      (`termination_reason` is a defaulted constructor field:
+      `TrialRecord(scene_id=..., epoch=..., seed=..., termination_reason=...)`).
+- [ ] **Fix the existing test the hook breaks:**
+      `test_trial_end_does_not_clear_just_enqueued_summary` currently calls
+      `sink.on_trial_end(cast(TrialRecord, object()))`; the new hook's
+      `record.termination_reason` access raises `AttributeError` on it. Update it to
+      pass a real `TrialRecord` with reason `None` (it then doubles as part of the
+      non-operator-reason coverage).
+- [ ] **Cut on operator end (default mode):** gated in-flight utterance plus a queued
+      text; `on_trial_end(operator_end record)`; assert queue empties; then release
+      the gate and assert the utterance was abandoned (no post-cut writes) and a
+      subsequent successful `on_eval_end` returns without waiting (bounded event
+      asserts, existing `_GatedPlayback` pattern).
+- [ ] **Cut applies in queue mode:** same shape with `mode="queue"`.
+- [ ] **Cut releases a blocking-mode waiter (defensive):** blocking sink, gated
+      in-flight utterance, a hook call parked in the blocking wait on another thread;
+      `on_trial_end(operator_end record)`, **then release the gate**; assert the
+      waiter returns promptly after the worker's abandonment lands and that no
+      post-cut chunks were written. (The waiter cannot re-proceed before the
+      abandonment lands — `_inflight` holds until then — so the gate release is part
+      of the test, not an afterthought. This interleaving is unreachable in
+      production, where all hooks share the control thread; the test pins the
+      defensive property.)
+- [ ] **Non-operator reasons do not cut:** `on_trial_end` with `termination_reason`
+      of `None` and of `"policy_stop"` leaves queue and generation untouched
+      (assert `_speech_gen` unchanged), and drain-on-success still plays the summary
+      (the existing drain test already covers the positive path; keep it green).
+
+### Task 3: docs, CHANGELOG, version
+
+- [ ] `docs/guide/voice-mode.md`: one short paragraph in the speech-modes section:
+      ending a trial from the console cuts narration immediately in every mode; only
+      natural completions drain the final summary. Be mode-accurate about the verdict
+      prompt: in the default interrupt mode the tail of one note may still be audible
+      through it, while in `mode=queue` the whole backlog (up to 4 notes) keeps
+      playing until the verdict is entered, because the cut lands after grading. Also
+      note the operator's own `/stop` note text is never spoken (the speaker reads
+      policy narration only).
+- [ ] `plugins/inspect-robots-voice/CLAUDE.md`: extend the `SpeakerSink` invariant
+      bullet with the operator-end cut.
+- [ ] `CHANGELOG.md` `## [Unreleased]` → Fixed: voice 0.5.1, operator-ended trials cut
+      `--speak` narration instead of draining it at eval end (plan 0059, #343).
+- [ ] Version 0.5.0 → 0.5.1 in plugin pyproject + `__init__.py` + the
+      `test_package_exports_and_version` assertion; `uv lock` if dirtied. (0.5.0 was
+      published to PyPI in the v0.47.1 release run on 2026-08-07, so a distinct 0.5.1
+      is required; re-verify `gh release list` at merge time per the concurrent-release
+      convention.)
+
+### Task 4: verification
+
+- [ ] Plugin gates: ruff check, ruff format --check, mypy (plugin config, src+tests),
+      pytest `--cov=inspect_robots_voice`.
+- [ ] Core gates unchanged but run anyway: `ruff check .`, `ruff format --check .`,
+      `mypy`, `pytest --cov -q` at 100%.
+
+## Out of scope
+
+- Cutting speech before the verdict prompt (needs a core seam or `on_trial_end`
+  reordering; revisit only if operators still complain after this lands).
+- Making the blocking-mode in-loop wait responsive to pending operator input (the
+  documented Esc-latency caveat of plan 0057 stands).

--- a/plans/0061-speak-operator-end-cut.md
+++ b/plans/0061-speak-operator-end-cut.md
@@ -130,7 +130,7 @@ carries the reason, and `OPERATOR_END == "operator_end"` is public core API
 - [ ] `plugins/inspect-robots-voice/CLAUDE.md`: extend the `SpeakerSink` invariant
       bullet with the operator-end cut.
 - [ ] `CHANGELOG.md` `## [Unreleased]` → Fixed: voice 0.5.1, operator-ended trials cut
-      `--speak` narration instead of draining it at eval end (plan 0059, #343).
+      `--speak` narration instead of draining it at eval end (plan 0061, #343).
 - [ ] Version 0.5.0 → 0.5.1 in plugin pyproject + `__init__.py` + the
       `test_package_exports_and_version` assertion; `uv lock` if dirtied. (0.5.0 was
       published to PyPI in the v0.47.1 release run on 2026-08-07, so a distinct 0.5.1

--- a/plugins/inspect-robots-voice/CLAUDE.md
+++ b/plugins/inspect-robots-voice/CLAUDE.md
@@ -36,7 +36,8 @@ Robots runs. It registers the `voice` factory in `inspect_robots.operator_inputs
 - `close()` is idempotent and never raises. It stops capture and joins the worker.
 - `SpeakerSink.log_policy_messages()` never synthesizes or plays audio on the control thread. Its
   blocking mode may wait boundedly and fail-open; the default interrupt mode aborts stale speech
-  through a generation counter. Only a successful eval end drains before close.
+  through a generation counter. Operator-ended trials cut narration in every mode; natural
+  completions drain only on a successful eval end before close.
 
 ## Working here
 

--- a/plugins/inspect-robots-voice/pyproject.toml
+++ b/plugins/inspect-robots-voice/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-voice"
-version = "0.5.0"
+version = "0.5.1"
 description = "Local spoken operator feedback for attended Inspect Robots evaluations."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-voice/src/inspect_robots_voice/__init__.py
+++ b/plugins/inspect-robots-voice/src/inspect_robots_voice/__init__.py
@@ -14,7 +14,7 @@ from inspect_robots_voice._transcriber import _classify_model
 
 __all__ = ["SpeakerSink", "VoiceInput", "speaker_sink", "voice_input"]
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 ScalarValue = str | int | float | bool | None
 

--- a/plugins/inspect-robots-voice/src/inspect_robots_voice/_speaker.py
+++ b/plugins/inspect-robots-voice/src/inspect_robots_voice/_speaker.py
@@ -1,4 +1,7 @@
-"""Off-thread policy-note audio with selectable delivery and bounded waiting."""
+"""Off-thread policy-note audio with selectable delivery and bounded waiting.
+
+Operator-ended trials cut narration in every delivery mode.
+"""
 
 from __future__ import annotations
 
@@ -15,10 +18,12 @@ import numpy as np
 import numpy.typing as npt
 
 from inspect_robots.logging.sink import NullSink
+from inspect_robots.types import OPERATOR_END
 from inspect_robots_voice._tts import KokoroEngine, TtsEngine, resolve_model_files
 
 if TYPE_CHECKING:
     from inspect_robots.log import EvalLog
+    from inspect_robots.rollout import TrialRecord
 
 PlaybackDevice = str | int | None
 EngineFactory = Callable[[], TtsEngine]
@@ -236,6 +241,15 @@ class SpeakerSink(NullSink):
         if dropped:
             suffix = "" if dropped == 1 else "s"
             print(f"speaker: dropped {dropped} stale note{suffix}", file=sys.stderr)
+
+    def on_trial_end(self, record: TrialRecord) -> None:
+        """Silence operator-ended narration in every mode while natural endings play out."""
+        if record.termination_reason != OPERATOR_END:
+            return
+        with self._condition:
+            self._speech_gen += 1
+            self._queue.clear()
+            self._condition.notify_all()
 
     def on_eval_end(self, log: EvalLog) -> None:
         """Drain successful narration within a bound, or abort every other terminal status."""

--- a/plugins/inspect-robots-voice/tests/test_factory.py
+++ b/plugins/inspect-robots-voice/tests/test_factory.py
@@ -11,7 +11,7 @@ from inspect_robots_voice import SpeakerSink, VoiceInput, speaker_sink, voice_in
 
 
 def test_package_exports_and_version() -> None:
-    assert inspect_robots_voice.__version__ == "0.5.0"
+    assert inspect_robots_voice.__version__ == "0.5.1"
     assert inspect_robots_voice.__all__ == [
         "SpeakerSink",
         "VoiceInput",

--- a/plugins/inspect-robots-voice/tests/test_speaker.py
+++ b/plugins/inspect-robots-voice/tests/test_speaker.py
@@ -15,6 +15,7 @@ import pytest
 import inspect_robots_voice._speaker as speaker_module
 from inspect_robots.log import EvalLog
 from inspect_robots.rollout import TrialRecord
+from inspect_robots.types import OPERATOR_END
 from inspect_robots_voice._speaker import SpeakerSink, extract_speech
 
 
@@ -157,6 +158,15 @@ def _log(status: str) -> EvalLog:
     return cast(EvalLog, SimpleNamespace(status=status))
 
 
+def _record(termination_reason: str | None = None) -> TrialRecord:
+    return TrialRecord(
+        scene_id="scene",
+        epoch=0,
+        seed=0,
+        termination_reason=termination_reason,
+    )
+
+
 def test_enqueue_is_spoken_in_order_with_volume_gain() -> None:
     engine = _FakeEngine()
     playback = _FakePlayback()
@@ -230,8 +240,127 @@ def test_trial_end_does_not_clear_just_enqueued_summary() -> None:
     sink.start()
     sink.log_policy_messages(4, [_assistant(_tool_call("done", {"summary": "all done"}))])
 
-    sink.on_trial_end(cast(TrialRecord, object()))
+    sink.on_trial_end(_record())
     _wait_until(lambda: engine.calls == ["all done"] and len(playback.writes) == 3)
+    sink.close()
+
+
+def _assert_operator_end_cuts_narration(mode: str | None = None) -> None:
+    engine = _FakeEngine()
+    playback = _GatedPlayback(gated_writes=1)
+    sink = _sink(engine, playback) if mode is None else _sink(engine, playback, mode=mode)
+    sink.start()
+    sink.log_policy_messages(
+        0,
+        [
+            _assistant(
+                _tool_call("move", {"note": "inflight"}),
+                _tool_call("move", {"note": "queued"}),
+            )
+        ],
+    )
+    assert playback.entered[0].wait(timeout=1.0)
+    with sink._condition:
+        assert list(sink._queue) == ["queued"]
+        generation = sink._speech_gen
+
+    sink.on_trial_end(_record(OPERATOR_END))
+
+    with sink._condition:
+        assert list(sink._queue) == []
+        assert sink._speech_gen == generation + 1
+    playback.release[0].set()
+    finished = threading.Event()
+
+    def end_eval() -> None:
+        sink.on_eval_end(_log("success"))
+        finished.set()
+
+    end_thread = threading.Thread(target=end_eval)
+    end_thread.start()
+    assert finished.wait(timeout=1.0)
+    end_thread.join(timeout=1.0)
+
+    assert engine.calls == ["inflight"]
+    assert len(playback.writes) == 1
+    assert playback.close_calls == 1
+
+
+def test_operator_end_cuts_default_interrupt_narration() -> None:
+    _assert_operator_end_cuts_narration()
+
+
+def test_operator_end_cuts_queue_mode_narration() -> None:
+    _assert_operator_end_cuts_narration("queue")
+
+
+def test_operator_end_releases_blocking_waiter_after_abandonment() -> None:
+    class GateSecondSynthesis(_TaggedEngine):
+        def __init__(self) -> None:
+            super().__init__()
+            self.second_entered = threading.Event()
+            self.second_release = threading.Event()
+
+        def synthesize(self, text: str) -> tuple[npt.NDArray[np.float32], int]:
+            samples, sample_rate = super().synthesize(text)
+            if len(self.calls) == 2:
+                self.second_entered.set()
+                self.second_release.wait(timeout=2.0)
+            return samples, sample_rate
+
+    engine = GateSecondSynthesis()
+    playback = _GatedPlayback(gated_writes=1)
+    sink = _sink(engine, playback, mode="blocking")
+    sink.start()
+    sink.log_policy_messages(0, [_assistant(_tool_call("move", {"note": "inflight"}))])
+    assert playback.entered[0].wait(timeout=1.0)
+    returned = threading.Event()
+
+    def enqueue_second() -> None:
+        sink.log_policy_messages(1, [_assistant(_tool_call("move", {"note": "second"}))])
+        returned.set()
+
+    hook_thread = threading.Thread(target=enqueue_second)
+    hook_thread.start()
+    assert not returned.wait(timeout=0.02)
+    sink.on_trial_end(_record(OPERATOR_END))
+    assert not returned.wait(timeout=0.02)
+
+    playback.release[0].set()
+    assert returned.wait(timeout=1.0)
+    assert engine.second_entered.wait(timeout=1.0)
+    hook_thread.join(timeout=1.0)
+    closed = threading.Event()
+
+    def close_sink() -> None:
+        sink.close()
+        closed.set()
+
+    close_thread = threading.Thread(target=close_sink)
+    close_thread.start()
+    assert sink._stop.wait(timeout=1.0)
+    engine.second_release.set()
+    assert closed.wait(timeout=1.0)
+    close_thread.join(timeout=1.0)
+
+    assert engine.calls == ["inflight", "second"]
+    assert len(playback.writes) == 1
+
+
+@pytest.mark.parametrize("termination_reason", [None, "policy_stop"])
+def test_non_operator_trial_end_leaves_narration_untouched(
+    termination_reason: str | None,
+) -> None:
+    sink = _sink(_FakeEngine(), _FakePlayback(), mode="queue")
+    with sink._condition:
+        sink._queue.extend(["inflight", "summary"])
+        sink._speech_gen = 7
+
+    sink.on_trial_end(_record(termination_reason))
+
+    with sink._condition:
+        assert list(sink._queue) == ["inflight", "summary"]
+        assert sink._speech_gen == 7
     sink.close()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -915,7 +915,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "inspect-robots-voice"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "plugins/inspect-robots-voice" }
 dependencies = [
     { name = "faster-whisper" },


### PR DESCRIPTION
Closes #343.

Operator feedback: ending a run from the console (Esc or /stop) kept narrating, and the run only exited after the success-path drain in `on_eval_end` waited (up to 15 s) for speech to finish. The drain exists so a natural `done()`/`give_up()` summary plays out; an operator-ended trial is the opposite case.

Fix, plugin-only: `SpeakerSink.on_trial_end` cuts speech (generation bump + queue clear + notify, the same mechanism interrupt mode already uses) when `record.termination_reason == OPERATOR_END`, in all three speech modes. The eval-end drain then has nothing to wait for. Natural completions are unchanged.

Known, documented gap: `on_trial_end` is delivered after grading, so the tail of the in-flight note (interrupt) or the queued backlog (queue mode) can still play through the verdict prompt; the multi-second exit wait is gone either way.

Design: [plan 0061](plans/0061-speak-operator-end-cut.md), one independent critique round applied. Voice 0.4.0's 0.5.0 successor bump: 0.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)