### PR TITLE
style(core): modernize isinstance type checks to Python 3.10+ union syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **Core & Plugins:** modernized `isinstance` checks to Python 3.10+ union syntax (`X | Y`), addressing Ruff UP038 lints across the core framework and plugins.
 - **Voice plugin (0.5.1):** operator-ended trials now cut `--speak` narration
   instead of draining it at eval end
   ([plan 0061](plans/0061-speak-operator-end-cut.md),

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_capture.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_capture.py
@@ -97,7 +97,7 @@ class WireCapture:
             self._relative_path = (Path("wire") / run_id / safe_trial_id / "calls.jsonl").as_posix()
         except BaseException as exc:
             self._disable(exc)
-            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+            if isinstance(exc, KeyboardInterrupt | SystemExit):
                 raise
 
     def record(
@@ -144,7 +144,7 @@ class WireCapture:
             self._rows_written = True
         except BaseException as exc:
             self._disable(exc)
-            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+            if isinstance(exc, KeyboardInterrupt | SystemExit):
                 raise
 
     def end_trial(self) -> str | None:
@@ -159,7 +159,7 @@ class WireCapture:
             return pointer
         except BaseException as exc:
             self._disable(exc)
-            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+            if isinstance(exc, KeyboardInterrupt | SystemExit):
                 raise
             return pointer
 

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_tools.py
@@ -401,7 +401,7 @@ class Toolset:
                 return ToolResult(
                     error=f"unknown dimension {label!r}; valid names: {', '.join(self._labels)}"
                 )
-            if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            if isinstance(raw, bool) or not isinstance(raw, int | float):
                 return ToolResult(error=f"value for {label!r} must be a finite number, got {raw!r}")
             try:
                 # Arbitrary-precision JSON integers overflow float() (and crash

--- a/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
+++ b/plugins/inspect-robots-isaacsim/src/inspect_robots_isaacsim/embodiment.py
@@ -93,7 +93,7 @@ def _disable_debug_vis(cfg: Any) -> None:
         if isinstance(obj, dict):
             stack.extend(obj.values())
             continue
-        if isinstance(obj, (list, tuple, set)):
+        if isinstance(obj, list | tuple | set):
             stack.extend(obj)
             continue
         obj_vars = getattr(obj, "__dict__", None)
@@ -102,7 +102,7 @@ def _disable_debug_vis(cfg: Any) -> None:
         for key, value in obj_vars.items():
             if key == "debug_vis" and value is True:
                 obj.debug_vis = False
-            elif isinstance(value, (dict, list, tuple, set)) or hasattr(value, "__dict__"):
+            elif isinstance(value, dict | list | tuple | set) or hasattr(value, "__dict__"):
                 stack.append(value)
 
 

--- a/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
+++ b/plugins/inspect-robots-isaacsim/tests/test_isaacsim_embodiment.py
@@ -242,7 +242,7 @@ def test_no_ram_leak_over_many_steps() -> None:
     # The adapter itself must hold no per-step accumulation.
     assert fake.step_calls == 3200
     for value in vars(emb).values():
-        assert not isinstance(value, (list, dict)) or len(value) <= 1
+        assert not isinstance(value, list | dict) or len(value) <= 1
 
 
 def test_disable_debug_vis_walks_nested_configs() -> None:

--- a/plugins/inspect-robots-ros/src/inspect_robots_ros/_client.py
+++ b/plugins/inspect-robots-ros/src/inspect_robots_ros/_client.py
@@ -282,7 +282,7 @@ class RosbridgeClient:
         try:
             while True:
                 raw = ws.recv()
-                if not isinstance(raw, (str, bytes)):
+                if not isinstance(raw, str | bytes):
                     raise RosbridgeError(
                         "invalid_frame",
                         f"rosbridge sent unsupported frame type {type(raw).__name__}",

--- a/plugins/inspect-robots-ros/src/inspect_robots_ros/embodiment.py
+++ b/plugins/inspect-robots-ros/src/inspect_robots_ros/embodiment.py
@@ -86,7 +86,7 @@ def _parse_numeric_list(value: NumericList | None, arg: str) -> tuple[float, ...
     raw: Sequence[Any]
     if isinstance(value, str):
         raw = tuple(item.strip() for item in value.split(",") if item.strip())
-    elif isinstance(value, (int, float)):
+    elif isinstance(value, int | float):
         raw = (value,)
     else:
         raw = value

--- a/plugins/inspect-robots-ros/tests/_stub_server.py
+++ b/plugins/inspect-robots-ros/tests/_stub_server.py
@@ -129,7 +129,7 @@ class StubRosbridgeServer:
             self._subscriptions[ws] = {}
         try:
             for raw in ws:
-                if not isinstance(raw, (str, bytes)):
+                if not isinstance(raw, str | bytes):
                     continue
                 operation = json.loads(raw)
                 if not isinstance(operation, dict):

--- a/plugins/inspect-robots-voice/src/inspect_robots_voice/__init__.py
+++ b/plugins/inspect-robots-voice/src/inspect_robots_voice/__init__.py
@@ -44,11 +44,11 @@ def speaker_sink(**kwargs: ScalarValue) -> SpeakerSink:
     mode = kwargs.get("mode", _DEFAULT_MODE)
     if not isinstance(voice, str):
         raise TypeError("voice must be a string")
-    if not isinstance(speed, (int, float)) or isinstance(speed, bool):
+    if not isinstance(speed, int | float) or isinstance(speed, bool):
         raise TypeError("speed must be a number")
     if speed <= 0:
         raise TypeError("speed must be positive")
-    if not isinstance(volume, (int, float)) or isinstance(volume, bool):
+    if not isinstance(volume, int | float) or isinstance(volume, bool):
         raise TypeError("volume must be a number")
     if not 0 <= volume <= 1:
         raise TypeError("volume must be between 0 and 1")

--- a/plugins/inspect-robots-xpolicylab/src/inspect_robots_xpolicylab/_client.py
+++ b/plugins/inspect-robots-xpolicylab/src/inspect_robots_xpolicylab/_client.py
@@ -136,7 +136,7 @@ class PolicyClient:
                 if remaining <= 0:
                     raise TimeoutError
                 raw = ws.recv(timeout=remaining)
-                if not isinstance(raw, (bytes, bytearray)):
+                if not isinstance(raw, bytes | bytearray):
                     continue  # protocol is binary-only; ignore stray text frames
                 try:
                     reply = decode_frame(bytes(raw))

--- a/plugins/inspect-robots-xpolicylab/src/inspect_robots_xpolicylab/_protocol.py
+++ b/plugins/inspect-robots-xpolicylab/src/inspect_robots_xpolicylab/_protocol.py
@@ -146,7 +146,7 @@ class Frame:
 
 def _encode_hook(obj: Any) -> Any:
     # Same restriction as upstream: object-dtype arrays cannot round-trip.
-    if isinstance(obj, (np.ndarray, np.generic)) and obj.dtype.kind == "O":
+    if isinstance(obj, np.ndarray | np.generic) and obj.dtype.kind == "O":
         raise WsError("invalid_frame", "object dtype numpy arrays are not supported")
     return msgpack_numpy.encode(obj)
 

--- a/plugins/inspect-robots-xpolicylab/tests/_stub_server.py
+++ b/plugins/inspect-robots-xpolicylab/tests/_stub_server.py
@@ -64,7 +64,7 @@ class StubPolicyServer:
 
     def _handler(self, ws: ServerConnection) -> None:
         for raw in ws:
-            if not isinstance(raw, (bytes, bytearray)):
+            if not isinstance(raw, bytes | bytearray):
                 continue
             frame = decode_frame(bytes(raw))
             self.frames.append(frame)

--- a/src/inspect_robots/_html.py
+++ b/src/inspect_robots/_html.py
@@ -638,7 +638,7 @@ def _render_tool_call(raw_call: object) -> str:
             )
         elif isinstance(value, list):
             chips.append(_call_chip(key, ", ".join(str(item) for item in value)))
-        elif value is None or isinstance(value, (str, int, float, bool)):
+        elif value is None or isinstance(value, str | int | float | bool):
             chips.append(_call_chip(key, value))
         else:
             return f"{notes}{_raw_tool_call(name, arguments)}"
@@ -650,7 +650,7 @@ def _render_tool_call(raw_call: object) -> str:
 
 def _is_number(value: object) -> bool:
     """Accept real JSON numbers while excluding booleans from numeric chips."""
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
+    return isinstance(value, int | float) and not isinstance(value, bool)
 
 
 def _call_chip(key: object, value: object) -> str:
@@ -1245,7 +1245,7 @@ def _render_wire_call(
     shown_status = "null" if status is None else status
     shown_duration = (
         f"{_number(duration)} s"
-        if isinstance(duration, (int, float)) and not isinstance(duration, bool)
+        if isinstance(duration, int | float) and not isinstance(duration, bool)
         else "n/a"
     )
     summary = (

--- a/src/inspect_robots/_summarize.py
+++ b/src/inspect_robots/_summarize.py
@@ -101,7 +101,7 @@ def _parallel_value(values: tuple[Any, ...], index: int) -> Any:
 
 def _step_count(scores: dict[str, float]) -> str:
     value = scores.get("episode_length")
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
+    if isinstance(value, int | float) and not isinstance(value, bool):
         return f"{value:g}"
     return "not recorded"
 

--- a/src/inspect_robots/_video.py
+++ b/src/inspect_robots/_video.py
@@ -121,7 +121,7 @@ def default_fps(embodiment_info: Mapping[str, Any]) -> tuple[float, str]:
     """
     rate = embodiment_info.get("control_hz")
     if (
-        isinstance(rate, (int, float))
+        isinstance(rate, int | float)
         and not isinstance(rate, bool)
         and rate > 0
         and math.isfinite(rate)

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -1018,7 +1018,7 @@ def _seconds_horizon(log: EvalLog) -> tuple[float, int, float | None] | None:
     max_seconds = log.eval.max_seconds
     max_steps = log.eval.max_steps
     if not (
-        isinstance(max_seconds, (int, float))
+        isinstance(max_seconds, int | float)
         and not isinstance(max_seconds, bool)
         and math.isfinite(max_seconds)
         and max_seconds > 0
@@ -1031,7 +1031,7 @@ def _seconds_horizon(log: EvalLog) -> tuple[float, int, float | None] | None:
     rate = log.eval.embodiment_info.get("control_hz")
     valid_rate = (
         float(rate)
-        if isinstance(rate, (int, float))
+        if isinstance(rate, int | float)
         and not isinstance(rate, bool)
         and math.isfinite(rate)
         and rate > 0
@@ -1097,7 +1097,7 @@ def _print_step_limit_notice(log: EvalLog, is_adhoc: bool) -> None:
         parenthetical = f"max_steps={max_steps}"
         rate = log.eval.embodiment_info.get("control_hz")
         if (
-            isinstance(rate, (int, float))
+            isinstance(rate, int | float)
             and not isinstance(rate, bool)
             and math.isfinite(rate)
             and rate > 0
@@ -1253,7 +1253,7 @@ def _print_wire_table(trials: list[_WireTrial]) -> None:
             duration = row.get("duration_s")
             shown_duration = (
                 f"{duration:.3f}s"
-                if isinstance(duration, (int, float)) and not isinstance(duration, bool)
+                if isinstance(duration, int | float) and not isinstance(duration, bool)
                 else "-"
             )
             status = "-" if row.get("status") is None else str(row["status"])

--- a/src/inspect_robots/logging/json_log.py
+++ b/src/inspect_robots/logging/json_log.py
@@ -54,7 +54,7 @@ def _sanitize(obj: object) -> object:
         return obj if math.isfinite(obj) else None
     if isinstance(obj, dict):
         return {key: _sanitize(value) for key, value in obj.items()}
-    if isinstance(obj, (list, tuple)):
+    if isinstance(obj, list | tuple):
         return [_sanitize(value) for value in obj]
     return obj
 


### PR DESCRIPTION
## Summary

Modernizes 25 `isinstance(obj, (typeA, typeB))` type checks to Python 3.10+ union syntax (`isinstance(obj, typeA | typeB)`), satisfying Ruff rule UP038 across the core framework and first-party plugins.

## Changes

- Modernized `isinstance` calls across core modules (`_html.py`, `_summarize.py`, `_video.py`, `cli.py`, `json_log.py`) and plugins (`inspect-robots-ros`, `inspect-robots-voice`, `inspect-robots-xpolicylab`, `inspect-robots-agent`, `inspect-robots-isaacsim`).
- Updated `CHANGELOG.md` under `[Unreleased]` -> `Fixed`.

## Checklist

- [x] `pre-commit install` done; hooks pass
- [x] Tests added/updated
- [x] Coverage stays at **100%** (`pytest --cov`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `mypy` passes (strict)
- [x] `CHANGELOG.md` updated under "Unreleased"
- [x] Public API changes are reflected in `inspect_robots.__all__` and the API-snapshot test
- [x] Core stays NumPy-only (new deps are optional extras, lazily imported)

## Related

Closes #357
