### PR TITLE
Close registry-owned policies after evaluation

### DIFF
--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import time
 import uuid
 import warnings
@@ -249,10 +250,10 @@ def eval(
 
     ``task``/``policy``/``embodiment`` may be objects or **registry names**
     (e.g. ``policy="scripted"``), resolved through the registry — the Inspect-style
-    ergonomic that keeps logs and the CLI reproducible. An embodiment resolved
-    from a registry name is owned by ``eval()`` and is closed when the run
-    finishes (even on a halt); a caller-constructed embodiment object stays
-    open — the caller owns its lifecycle.
+    ergonomic that keeps logs and the CLI reproducible. Policies and embodiments
+    resolved from registry names are owned by ``eval()`` and closed when the run
+    finishes (even on a halt); caller-constructed objects stay open — the caller
+    owns their lifecycle.
 
     ``seed=None`` draws a fresh seed from the OS and records it in the log, so
     an "unseeded" run remains reproducible after the fact (and is distinct from
@@ -310,6 +311,7 @@ def eval(
     from inspect_robots.registry import resolve
 
     before_scoring = _grading_hook(grader, before_scoring)
+    owns_policy = isinstance(policy, str)
     owns_embodiment = isinstance(embodiment, str)
     task = cast(Task, resolve("task", task)) if isinstance(task, str) else task
     policy = cast(Policy, resolve("policy", policy)) if isinstance(policy, str) else policy
@@ -336,10 +338,29 @@ def eval(
             before_scoring=before_scoring,
         )
     finally:
-        # Close what we opened: a registry-resolved embodiment is released even
-        # when the run halts, so a real robot never leaks its connection.
+        # Close what we opened. Release the embodiment first so a policy cleanup
+        # failure cannot leave real hardware or its transport active.
+        active_error = sys.exc_info()[1]
+        cleanup_error: BaseException | None = None
         if owns_embodiment:
-            embodiment.close()
+            try:
+                embodiment.close()
+            except BaseException as exc:
+                cleanup_error = exc
+        if owns_policy:
+            close_policy = getattr(policy, "close", None)
+            if callable(close_policy):
+                try:
+                    close_policy()
+                except BaseException as exc:
+                    if cleanup_error is None:
+                        cleanup_error = exc
+        if cleanup_error is not None and active_error is None:
+            raise cleanup_error
+        if cleanup_error is not None and active_error is not None:
+            add_note = getattr(active_error, "add_note", None)
+            if callable(add_note):
+                add_note(f"Inspect cleanup also failed: {cleanup_error!r}")
 
 
 def _run_eval(

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -313,14 +313,16 @@ def eval(
     owns_policy = isinstance(policy, str)
     owns_embodiment = isinstance(embodiment, str)
     task = cast(Task, resolve("task", task)) if isinstance(task, str) else task
-    policy = cast(Policy, resolve("policy", policy)) if isinstance(policy, str) else policy
-    embodiment = (
-        cast(Embodiment, resolve("embodiment", embodiment))
-        if isinstance(embodiment, str)
-        else embodiment
-    )
+    owned_policy: Policy | None = None
+    owned_embodiment: Embodiment | None = None
     active_error: BaseException | None = None
     try:
+        if isinstance(policy, str):
+            policy = cast(Policy, resolve("policy", policy))
+            owned_policy = policy
+        if isinstance(embodiment, str):
+            embodiment = cast(Embodiment, resolve("embodiment", embodiment))
+            owned_embodiment = embodiment
         return _run_eval(
             task,
             policy,
@@ -344,13 +346,13 @@ def eval(
         # Close what we opened. Release the embodiment first so a policy cleanup
         # failure cannot leave real hardware or its transport active.
         cleanup_error: BaseException | None = None
-        if owns_embodiment:
+        if owns_embodiment and owned_embodiment is not None:
             try:
-                embodiment.close()
+                owned_embodiment.close()
             except BaseException as exc:
                 cleanup_error = exc
-        if owns_policy:
-            close_policy = getattr(policy, "close", None)
+        if owns_policy and owned_policy is not None:
+            close_policy = getattr(owned_policy, "close", None)
             if callable(close_policy):
                 try:
                     close_policy()

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 import time
 import uuid
 import warnings
@@ -320,6 +319,7 @@ def eval(
         if isinstance(embodiment, str)
         else embodiment
     )
+    active_error: BaseException | None = None
     try:
         return _run_eval(
             task,
@@ -337,10 +337,12 @@ def eval(
             operator_input=operator_input,
             before_scoring=before_scoring,
         )
+    except BaseException as exc:
+        active_error = exc
+        raise
     finally:
         # Close what we opened. Release the embodiment first so a policy cleanup
         # failure cannot leave real hardware or its transport active.
-        active_error = sys.exc_info()[1]
         cleanup_error: BaseException | None = None
         if owns_embodiment:
             try:

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -594,6 +594,43 @@ def test_eval_closes_registry_resolved_policy_and_embodiment(
     assert events == ["embodiment", "policy"]
 
 
+def test_eval_closes_registry_resolved_policy_when_embodiment_factory_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from inspect_robots import registry
+
+    events: list[str] = []
+    policy = _TrackedClosablePolicy(events, close_error=RuntimeError("policy close exploded"))
+
+    class _NotedFactoryError(RuntimeError):
+        def __init__(self, message: str) -> None:
+            super().__init__(message)
+            self.notes: list[str] = []
+
+        def add_note(self, note: str) -> None:
+            self.notes.append(note)
+
+    factory_error = _NotedFactoryError("embodiment factory exploded")
+
+    def raise_from_embodiment_factory() -> _TrackedClosableEmbodiment:
+        raise factory_error
+
+    monkeypatch.setitem(registry._FACTORIES["policy"], "closable-policy", lambda: policy)
+    monkeypatch.setitem(
+        registry._FACTORIES["embodiment"],
+        "failing-embodiment",
+        raise_from_embodiment_factory,
+    )
+
+    with pytest.raises(RuntimeError, match="embodiment factory exploded") as excinfo:
+        eval(_task(max_steps=1), "closable-policy", "failing-embodiment", log_dir=str(tmp_path))
+
+    assert excinfo.value is factory_error
+    assert policy.close_calls == 1
+    assert events == ["policy"]
+    assert any("policy close exploded" in note for note in factory_error.notes)
+
+
 def test_eval_does_not_close_caller_constructed_policy(tmp_path: Path) -> None:
     events: list[str] = []
     policy = _TrackedClosablePolicy(events)
@@ -650,6 +687,24 @@ def test_eval_attempts_owned_policy_cleanup_after_embodiment_close_error(
 ) -> None:
     events: list[str] = []
     policy = _TrackedClosablePolicy(events)
+    embodiment = _TrackedClosableEmbodiment(
+        events, close_error=RuntimeError("embodiment close exploded")
+    )
+    _register_owned_eval_components(monkeypatch, policy, embodiment)
+
+    with pytest.raises(RuntimeError, match="embodiment close exploded"):
+        eval(_task(max_steps=1), "closable-policy", "closable-embodiment", log_dir=str(tmp_path))
+
+    assert policy.close_calls == 1
+    assert embodiment.close_calls == 1
+    assert events == ["embodiment", "policy"]
+
+
+def test_eval_preserves_first_cleanup_error_when_both_owned_closes_raise(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    events: list[str] = []
+    policy = _TrackedClosablePolicy(events, close_error=RuntimeError("policy close exploded"))
     embodiment = _TrackedClosableEmbodiment(
         events, close_error=RuntimeError("embodiment close exploded")
     )

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -621,6 +621,30 @@ def test_eval_closes_embodiment_before_reraising_owned_policy_close_error(
     assert events == ["embodiment", "policy"]
 
 
+def test_successful_eval_reraises_owned_policy_close_error_inside_outer_except(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    events: list[str] = []
+    policy = _TrackedClosablePolicy(events, close_error=RuntimeError("policy close exploded"))
+    embodiment = _TrackedClosableEmbodiment(events)
+    _register_owned_eval_components(monkeypatch, policy, embodiment)
+    outer_error = RuntimeError("outer handler")
+
+    try:
+        raise outer_error
+    except RuntimeError:
+        with pytest.raises(RuntimeError, match="policy close exploded"):
+            eval(
+                _task(max_steps=1),
+                "closable-policy",
+                "closable-embodiment",
+                log_dir=str(tmp_path),
+            )
+
+    assert getattr(outer_error, "__notes__", ()) == ()
+    assert events == ["embodiment", "policy"]
+
+
 def test_eval_attempts_owned_policy_cleanup_after_embodiment_close_error(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -521,6 +521,147 @@ class _ClosableEmbodiment(CubePickEmbodiment):
 embodiment_decorator("closable-cubepick")(_ClosableEmbodiment)
 
 
+class _TrackedClosablePolicy(ScriptedPolicy):
+    """A policy whose optional cleanup hook records the lifecycle boundary."""
+
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        bind_error: Exception | None = None,
+        close_error: Exception | None = None,
+    ):
+        super().__init__()
+        self.bind_error = bind_error
+        self.close_error = close_error
+        self.close_calls = 0
+        self.events = events
+
+    def bind(self, embodiment_info: object) -> None:
+        del embodiment_info
+        if self.bind_error is not None:
+            raise self.bind_error
+
+    def close(self) -> None:
+        self.close_calls += 1
+        self.events.append("policy")
+        if self.close_error is not None:
+            raise self.close_error
+
+
+class _TrackedClosableEmbodiment(CubePickEmbodiment):
+    """A real toy embodiment with observable cleanup for eval ownership tests."""
+
+    def __init__(self, events: list[str], *, close_error: Exception | None = None):
+        super().__init__()
+        self.close_calls = 0
+        self.events = events
+        self.close_error = close_error
+
+    def close(self) -> None:
+        self.close_calls += 1
+        self.events.append("embodiment")
+        if self.close_error is not None:
+            raise self.close_error
+
+
+def _register_owned_eval_components(
+    monkeypatch: pytest.MonkeyPatch,
+    policy: _TrackedClosablePolicy,
+    embodiment: _TrackedClosableEmbodiment,
+) -> None:
+    """Install per-test factories while leaving eval's real registry resolution intact."""
+    from inspect_robots import registry
+
+    monkeypatch.setitem(registry._FACTORIES["policy"], "closable-policy", lambda: policy)
+    monkeypatch.setitem(
+        registry._FACTORIES["embodiment"], "closable-embodiment", lambda: embodiment
+    )
+
+
+def test_eval_closes_registry_resolved_policy_and_embodiment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    events: list[str] = []
+    policy = _TrackedClosablePolicy(events)
+    embodiment = _TrackedClosableEmbodiment(events)
+    _register_owned_eval_components(monkeypatch, policy, embodiment)
+
+    eval(_task(max_steps=1), "closable-policy", "closable-embodiment", log_dir=str(tmp_path))
+
+    assert policy.close_calls == 1
+    assert embodiment.close_calls == 1
+    assert events == ["embodiment", "policy"]
+
+
+def test_eval_does_not_close_caller_constructed_policy(tmp_path: Path) -> None:
+    events: list[str] = []
+    policy = _TrackedClosablePolicy(events)
+    embodiment = _TrackedClosableEmbodiment(events)
+
+    eval(_task(max_steps=1), policy, embodiment, log_dir=str(tmp_path))
+
+    assert policy.close_calls == 0
+    assert embodiment.close_calls == 0
+
+
+def test_eval_closes_embodiment_before_reraising_owned_policy_close_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    events: list[str] = []
+    policy = _TrackedClosablePolicy(events, close_error=RuntimeError("policy close exploded"))
+    embodiment = _TrackedClosableEmbodiment(events)
+    _register_owned_eval_components(monkeypatch, policy, embodiment)
+
+    with pytest.raises(RuntimeError, match="policy close exploded"):
+        eval(_task(max_steps=1), "closable-policy", "closable-embodiment", log_dir=str(tmp_path))
+
+    assert policy.close_calls == 1
+    assert embodiment.close_calls == 1
+    assert events == ["embodiment", "policy"]
+
+
+def test_eval_attempts_owned_policy_cleanup_after_embodiment_close_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    events: list[str] = []
+    policy = _TrackedClosablePolicy(events)
+    embodiment = _TrackedClosableEmbodiment(
+        events, close_error=RuntimeError("embodiment close exploded")
+    )
+    _register_owned_eval_components(monkeypatch, policy, embodiment)
+
+    with pytest.raises(RuntimeError, match="embodiment close exploded"):
+        eval(_task(max_steps=1), "closable-policy", "closable-embodiment", log_dir=str(tmp_path))
+
+    assert policy.close_calls == 1
+    assert embodiment.close_calls == 1
+    assert events == ["embodiment", "policy"]
+
+
+def test_eval_preserves_active_error_when_owned_policy_close_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    events: list[str] = []
+    policy = _TrackedClosablePolicy(
+        events,
+        bind_error=RuntimeError("evaluation exploded"),
+        close_error=RuntimeError("policy close exploded"),
+    )
+    embodiment = _TrackedClosableEmbodiment(events)
+    _register_owned_eval_components(monkeypatch, policy, embodiment)
+
+    with pytest.raises(RuntimeError, match="evaluation exploded") as excinfo:
+        eval(_task(max_steps=1), "closable-policy", "closable-embodiment", log_dir=str(tmp_path))
+
+    assert policy.close_calls == 1
+    assert embodiment.close_calls == 1
+    assert events == ["embodiment", "policy"]
+    if hasattr(excinfo.value, "add_note"):
+        notes = getattr(excinfo.value, "__notes__", ())
+        assert any("policy close exploded" in note for note in notes)
+
+
 def test_eval_binds_adaptive_policy_before_compat(tmp_path: Path) -> None:
     """A bind() hook runs after resolution and before compat (plan 0008 §3c).
 


### PR DESCRIPTION
Closes only policies resolved by eval, mirrors existing embodiment ownership, preserves caller-owned policy lifecycles, and guarantees both cleanup paths are attempted on failure. Cleanup remains embodiment-first. The Dropbear adapter does not depend on this contribution.