### PR TITLE
agent: wire=interactions — Gemini Interactions API as a stateful HTTP wire

### DIFF
--- a/plans/0066-interactions-wire.md
+++ b/plans/0066-interactions-wire.md
@@ -1,0 +1,262 @@
+# 0066 — wire=interactions: Gemini Interactions API as a stateful HTTP wire
+
+- **Status:** draft (R0, not yet critiqued)
+- **Issue:** #378
+
+## Problem
+
+The agent plugin speaks four wires: `chat`, `responses`, `messages`, and
+`gemini-live`. Google's Interactions API is now GA and is the recommended
+surface for the latest Gemini models; notably `gemini-3.7-flash` does **not**
+support the Live API, so the only way to drive it today is the stateless
+OpenAI-compat `chat` wire, which re-uploads the (image-bearing) request view
+on every step and leans on `image_horizon` eviction to stay affordable.
+
+The Interactions API offers server-side conversation state: each call can
+chain to the previous one with `previous_interaction_id`, so the request
+carries only the new observation and function results. Google's docs state
+stateful chaining "allows the system to more easily utilize implicit caching
+for the conversation history, which improves performance and reduces costs."
+That is the same property the `gemini-live` wire buys via a websocket, but
+for GA HTTP models, with per-request retry semantics instead of a fragile
+long-lived socket.
+
+## Contract (from Google's API reference, ai.google.dev/api/interactions-api)
+
+- `POST https://generativelanguage.googleapis.com/v1beta/interactions`,
+  API-key auth via the `x-goog-api-key` header (the Gemini native-REST
+  convention; the Live wire's `?key=` query form is websocket-specific).
+- Request: `model` (bare id, e.g. `gemini-3.7-flash`), `input` (string, or
+  array of content blocks / steps), `previous_interaction_id` (optional),
+  `tools` (function tools: `{"type": "function", "name", "description",
+  "parameters"}` — flat, *not* nested under `"function"` like Chat
+  Completions), `system_instruction` (string), `generation_config`
+  (`thinking_level` ∈ minimal/low/medium/high, `temperature`,
+  `max_output_tokens`, `tool_choice`), `store` (bool, default true),
+  `stream` (bool; we do not stream).
+- Input content blocks: `{"type": "text", "text": ...}` and
+  `{"type": "image", "mime_type": "image/png", "data": "<base64>"}`.
+  Function results are steps: `{"type": "function_result", "call_id": ...,
+  "result": ...}`.
+- Response: `id`, `status` (`completed`, `requires_action`, `failed`,
+  `incomplete`, `budget_exceeded`, …), `steps` array containing
+  `{"type": "function_call", "id", "name", "arguments": {…}}` steps and
+  `{"type": "model_output", "content": [{"type": "text", "text": …}, …]}`
+  steps, and `usage` (`total_input_tokens`, `total_output_tokens`,
+  `total_cached_tokens`, `total_thought_tokens`, `total_tokens`).
+- Statefulness: `tools`, `system_instruction`, and `generation_config` are
+  interaction-scoped (never inherited across the chain), so every request
+  re-sends them; only the conversation history lives server-side.
+
+### Contract risks (unverified against the live endpoint)
+
+No `GEMINI_API_KEY` was available on the authoring machine, so the shapes
+above come from the API reference, not a probe. The implementation therefore:
+
+1. parses defensively — a response missing `steps`, or a step of an unknown
+   type, raises `RuntimeError` naming the field and quoting the first 500
+   characters of the body, never a `KeyError` traceback;
+2. accepts `arguments` as either a JSON object (documented) or a string
+   (Chat-Completions habit), normalizing to the JSON-text `ToolCall.arguments`
+   contract either way;
+3. ships with `tests/manual_interactions_smoke.py` (excluded from pytest
+   collection by its non-`test_` name), a ~40-line script that exercises one
+   basic call, one chained call, and one function round-trip against the real
+   endpoint when `GEMINI_API_KEY` is set. First run on a keyed machine is a
+   release gate for announcing the wire.
+
+## Design
+
+### New module: `plugins/inspect-robots-agent/src/inspect_robots_agent/_interactions.py`
+
+`InteractionsClient`, same `complete(messages, tools, temperature,
+reasoning_effort) -> AssistantMessage` contract as the other clients, httpx
+only. Constructor `(provider, *, timeout_s=120.0, max_retries=3,
+backoff_s=1.0, transport=None, capture=None)` — `transport` for
+`httpx.MockTransport` tests, mirroring `ChatClient`.
+
+State, mirroring `GeminiLiveClient`'s identity-prefix discipline:
+
+- `_streamed: list[dict]` — references (not copies) of the chat-format
+  messages already absorbed by the server chain. A changed prefix means a new
+  trial: reset `_streamed`, `_last_interaction_id`, and `_call_ids`. The
+  rewritten-view guard is identical to the Live wire's: same first message
+  object but non-prefix history raises "rewritten conversation view without a
+  trial reset". This is also why `image_horizon` is rejected on this wire
+  (below): `_evicted_view` rewrites history and would trip this guard by
+  design.
+- `_last_interaction_id: str | None` — the chain head.
+- Bare model: `provider.model.removeprefix("google/")`, as in the Live wire.
+
+Request construction per `complete()` call:
+
+- Suffix = `messages[len(_streamed):]`. Translate, in order:
+  - `system` (only ever message 0, only on an unchained request) → the
+    `system_instruction` field, not an input block;
+  - `user` → content blocks (string content → one text block; list content →
+    text parts verbatim, `image_url` data-URL parts decoded into
+    `{"type": "image", "mime_type": <from the data URL>, "data": <base64>}`;
+    any other part type raises, as in the Live translator);
+  - `tool` → `{"type": "function_result", "call_id": <tool_call_id>,
+    "result": <content>}` (content must be `str`, else raise);
+  - `assistant` → skipped (the server already has it when chained; on an
+    unchained fold it arrives inside the sanitized prologue).
+- Body: `model`, `input` (the translated block/step array), `store: true`,
+  `tools` (translated from Chat-Completions shape to the flat Interactions
+  shape, every request), `system_instruction` (every request, from
+  `messages[0]` when it is a system message), `generation_config` with
+  `temperature` and/or `thinking_level` when set, and
+  `previous_interaction_id` when `_last_interaction_id` is set.
+- `reasoning_effort` arrives already validated by the policy (below) as one
+  of minimal/low/medium/high and goes out as
+  `generation_config.thinking_level`.
+
+Response handling:
+
+- 200 → parse JSON. `status` of `completed` or `requires_action` → walk
+  `steps`: collect every `function_call` step into a `ToolCall` (arguments
+  normalized to JSON text), concatenate every `model_output` step's text
+  blocks into `content`. Any other terminal `status` raises `RuntimeError`
+  naming it. On success: `_last_interaction_id = response["id"]`,
+  `_streamed.extend(suffix)` — the cursor advances only on a parsed 200, so
+  a failed attempt resends the same delta (one POST is atomic server-side;
+  there is no partial-absorb case like the Live socket's).
+- 429/5xx/transport error → bounded retry with exponential backoff
+  (`backoff_s * 2**attempt`), as in `ChatClient`.
+- Chain loss — HTTP 404, or a 400 whose body mentions
+  `previous_interaction`: rebuild as an *unchained* fold (below) and retry
+  within the same attempt loop.
+- Other 4xx → immediate `RuntimeError` with the truncated body (the
+  request's fault; retrying cannot help). When the body mentions
+  `thinking_level`, append a fix line naming the levels this model accepts
+  may differ (e.g. 3.7-flash serves low/medium/high).
+
+Fold recovery (chain loss only), mirroring `_send_recovery`:
+
+- Anchor = last `user` message. Input =
+  `[text: _RECOVERY_PROLOGUE, *json-lines of _sanitize(history minus system
+  and anchor), text: _RECOVERY_CONTINUATION, *anchor's translated blocks]`,
+  no `previous_interaction_id`. Reuse the Live wire's prologue strings
+  (import them) so transcripts read identically. `_sanitize` is imported
+  deferred inside the function, exactly as `_gemini_live.py` does, to avoid
+  the import cycle. On success the cursor covers the full message list.
+
+Usage mapping (per call, summed by the policy):
+`total_input_tokens → input_tokens`, `total_output_tokens → output_tokens`,
+`total_cached_tokens → cache_read_input_tokens`,
+`total_thought_tokens → thought_tokens`, `total_tokens → total_tokens`.
+Non-int values are skipped, as in the Live wire's `_add_usage`.
+
+Capture: one `capture.record(...)` per attempt with
+`endpoint="/interactions"`, the exact request body, status, and response
+text — the same shape `ChatClient` records.
+
+`close()`: closes the httpx client. No per-trial teardown hook is needed —
+the identity-prefix check already resets chain state on the next trial's
+first call, and unlike the Live socket there is no half-dead transport to
+drop, so `on_trial_end` stays untouched.
+
+### `policy.py` changes
+
+- `_WIRE_FORMATS` gains `"interactions"`.
+- `_INTERACTIONS_BASE = "https://generativelanguage.googleapis.com/v1beta"`.
+- Construction guards (same order block as the existing wire checks):
+  - `effort`: on `wire="interactions"`, only minimal/low/medium/high pass;
+    `none`, `xhigh`, `max`, and fractions raise `ConfigError` with
+    "fix: pass -P effort=minimal|low|medium|high (maps to thinking_level),
+    or drop -P effort=". Unset stays unset (provider default).
+  - `image_horizon`: explicit value raises, default resolves to `None` —
+    same shape as the `gemini-live` guard, with the fix text naming
+    server-side history as the reason (frames already absorbed by the chain
+    cannot be evicted client-side).
+  - `base_url`: when given, must start with `http://` or `https://`
+    (a ws:// URL gets "fix: wire='interactions' is HTTP; drop -P base_url=
+    or pass the Live wire a websocket endpoint via -P wire=gemini-live").
+  - `api_key_env` default when `base_url` is set without one:
+    `GEMINI_API_KEY` (same clause as the `gemini-live` branch).
+- Resolution: like `gemini-live` — without an explicit `base_url`,
+  resolution must land on `_GOOGLE_BASE`, else `ConfigError`
+  ("wire='interactions' needs Google's direct provider.\nfix: use
+  -P model=google/... and set $GEMINI_API_KEY"); then the provider is
+  re-based onto `_INTERACTIONS_BASE`. The `resolve_provider` failure remap
+  the Live wire does is extended to cover this wire.
+- Client selection: `wire == "interactions"` →
+  `InteractionsClient(provider, transport=transport, capture=self._capture)`.
+- `speed` / `max_output_tokens` stay messages-only (no scope creep; the
+  Interactions `generation_config.max_output_tokens` can come later).
+- `AgentPolicyConfig` needs no new fields; `wire` records the choice.
+
+### `_capture.py` change
+
+`_replace_blobs` gains the Interactions image shape: a dict with
+`"type": "image"` and a *string* `"data"` value (no `"source"` sub-dict)
+gets `data` replaced by the blob sentinel. The existing Anthropic branch
+(`"type": "image"` with `source.type == "base64"`) is untouched; the new
+branch fires only when `"source"` is absent and `"data"` is a `str`, so the
+two cannot collide. Module docstring's supported-shapes sentence gains
+"Interactions".
+
+### Docs
+
+- Plugin README: new row in the `-P wire=` table
+  (`interactions` | `/interactions` | Google's stateful HTTP API: server-side
+  history for GA Gemini models, e.g. `gemini-3.7-flash`); a short section
+  after the Gemini Robotics ER 2 one with a full example command; the
+  effort section gains the thinking_level mapping sentence; the
+  image_horizon table row's "unset on `gemini-live`" note extends to this
+  wire.
+- `__init__.py` module docstring sentence listing wires gains
+  `interactions`.
+- Plugin `pyproject.toml`: minor version bump (new feature), per the
+  release convention for `plugins/*`.
+
+## Tests (`plugins/inspect-robots-agent/tests/test_interactions.py` + policy tests)
+
+Client tests run against `httpx.MockTransport` handlers that assert on the
+request body and script responses:
+
+1. First call: body carries `model` (prefix stripped), `store: true`, flat
+   `tools`, `system_instruction` from the system message, translated
+   text+image input blocks, no `previous_interaction_id`; `x-goog-api-key`
+   header set from the provider key.
+2. Chained call: after a 200 with `id: "i1"`, the next `complete()` sends
+   `previous_interaction_id: "i1"` and only the delta (the new tool result
+   as a `function_result` step with the recorded `call_id`, plus the new
+   user observation), while still re-sending `tools` and
+   `system_instruction`.
+3. Function-call parsing: a `requires_action` response with two
+   `function_call` steps yields two `ToolCall`s with JSON-text arguments;
+   object and string `arguments` both normalize.
+4. Text parsing: `model_output` text blocks concatenate; empty steps yield
+   `content=None` and no calls.
+5. Usage mapping: the five counters land under the normalized names;
+   missing/non-int counters are skipped.
+6. Retry: one 500 then a 200 succeeds; three 500s raise after
+   `max_retries`; a plain 400 raises immediately with the body excerpt.
+7. Chain-loss fold: a 404 on a chained call triggers an unchained retry
+   whose input starts with the recovery prologue and ends with the anchor
+   user message's blocks; a subsequent call chains to the fold's new id.
+8. Rewritten-view guard and fresh-trial reset: same two behaviors the Live
+   client pins.
+9. Terminal failure statuses (`failed`) raise with the status named.
+10. Capture: a recorded row has `endpoint="/interactions"` and the image
+    `data` replaced by a `$blob:` sentinel (also covers the `_capture.py`
+    branch).
+11. Policy construction: effort accept/reject matrix, image_horizon
+    rejection, ws base_url rejection, non-Google resolution rejection with
+    the guided message, `api_key_env` default with explicit base_url, and
+    client-type selection.
+
+Gates: plugin pytest, `ruff check`, `ruff format --check`, strict mypy —
+same bars the plugin already passes; no core `src/inspect_robots` changes,
+so the 100% core coverage gate is unaffected.
+
+## Out of scope
+
+- Streaming (`stream: true`), `background`, response_format, and agent ids.
+- Deleting stored interactions at trial end (Google owns retention; a
+  follow-up could DELETE the chain head on `on_trial_end` if retention
+  becomes a concern).
+- Making `interactions` the default wire for `google/*` (chat remains the
+  default; this wire is explicit opt-in, like `gemini-live`).
+- `max_output_tokens` support outside `wire=messages`.

--- a/plans/0068-interactions-wire.md
+++ b/plans/0068-interactions-wire.md
@@ -92,9 +92,15 @@ long-lived socket.
 No `GEMINI_API_KEY` was available on the authoring machine, so the shapes
 above come from the API reference, not a probe. The implementation therefore:
 
-1. parses defensively — a response missing `steps`, or a step of an unknown
-   type, raises `RuntimeError` naming the field and quoting the first 500
-   characters of the body, never a `KeyError` traceback;
+1. parses defensively — a response missing `steps`, or a known step type
+   with an invalid shape, raises `RuntimeError` naming the field and
+   quoting the first 500 characters of the body, never a `KeyError`
+   traceback; *unknown* step types are skipped rather than raised
+   (implementation-review amendment: the Responses wire already tolerates
+   OpenAI's sibling `reasoning` items the same way, and this wire's
+   `thinking_level` makes server-added thinking steps the most likely
+   surprise — hard-failing a 200 on them would kill trials on the wire's
+   headline feature);
 2. accepts `arguments` as either a JSON object (documented) or a string
    (Chat-Completions habit), normalizing to the JSON-text `ToolCall.arguments`
    contract either way;

--- a/plans/0068-interactions-wire.md
+++ b/plans/0068-interactions-wire.md
@@ -1,6 +1,6 @@
 # 0068 — wire=interactions: Gemini Interactions API as a stateful HTTP wire
 
-- **Status:** draft (R1 applied, awaiting re-critique)
+- **Status:** approved (R3 clean; four folded nits)
 - **Issue:** #378
 - **Critique rounds:** R1: 4 substantive (no policy-level e2e coverage for
   the new wire — the e2e parametrization now includes `interactions` and a
@@ -32,7 +32,15 @@
   reads `messages[0]` directly; the `incomplete` rationale wrongly claimed
   no wire inspects finish reasons — the Messages wire does, the precedent
   cited is now chat/responses; an empty-delta guard matching the Live
-  wire's is now specified) — all resolved below.
+  wire's is now specified) — all resolved below. R3: verified all R2
+  resolutions hold against plan text and code; clean on substantive
+  findings, with four folded nits (the empty-delta guard's "as the Live
+  wire pins its own" cited a test that does not exist — the false
+  precedent claim is dropped, the new test requirement stands; stale
+  status line; the README image_horizon row's "`2` on HTTP wires" default
+  wording becomes false once this HTTP wire defaults to unset — the docs
+  item now covers rewording the default column; "the recorded call_id"
+  leftover phrasing in test 2).
 
 ## Problem
 
@@ -157,7 +165,7 @@ Request construction per `complete()` call:
   - A suffix whose translation yields an empty `input` array raises
     "wire='interactions' has no un-streamed user or tool message to send",
     the Live wire's guard adapted; structurally unreachable through
-    `act()`, pinned by a client-level test as the Live wire pins its own.
+    `act()`, pinned by a client-level test.
 - Body: `model`, `input` (the translated block/step array), `store: true`,
   `tools` (translated from Chat-Completions shape to the flat Interactions
   shape, every request), `system_instruction` (every request, from
@@ -277,7 +285,10 @@ two cannot collide. Module docstring's supported-shapes sentence gains
   history for GA Gemini models, e.g. `gemini-3.7-flash`); a short section
   after the Gemini Robotics ER 2 one with a full example command; the
   effort section gains the thinking_level mapping sentence; the
-  image_horizon table row's "unset on `gemini-live`" note extends to this
+  image_horizon table row's default column is reworded — "`2` on HTTP
+  wires" becomes false once this HTTP wire defaults to unset (e.g. "`2` on
+  the stateless HTTP wires; unset on `gemini-live` and `interactions`") —
+  and its "unset on `gemini-live`" note extends to this
   wire.
 - `__init__.py` module docstring sentence listing wires gains
   `interactions`.
@@ -295,7 +306,8 @@ request body and script responses:
    header set from the provider key.
 2. Chained call: after a 200 with `id: "i1"`, the next `complete()` sends
    `previous_interaction_id: "i1"` and only the delta (the new tool result
-   as a `function_result` step with the recorded `call_id`, plus the new
+   as a `function_result` step whose `call_id` is the tool message's
+   `tool_call_id`, plus the new
    user observation), while still re-sending `tools` and
    `system_instruction`.
 3. Function-call parsing: a `requires_action` response with two

--- a/plans/0068-interactions-wire.md
+++ b/plans/0068-interactions-wire.md
@@ -15,7 +15,24 @@
   temperature/thinking_level body placement and the thinking_level 4xx fix
   line get dedicated tests; keyless explicit endpoints omit the
   `x-goog-api-key` header; the fold prologue is one joined text block,
-  matching the Live wire's `"\n".join`) — all resolved below.
+  matching the Live wire's `"\n".join`) — all resolved below. R2: verified
+  all R1 resolutions hold (fold state machine, `_call_ids` deletion,
+  `incomplete` nudge-path consistency, renumbering, body-placement pins,
+  keyless header, joined prologue); 2 substantive (chain-loss
+  classification fired on *unchained* 404s too — a first-call 404 from a
+  bad model id or wrong proxy path would loop useless folds; the trigger is
+  now gated on the failed attempt having sent `previous_interaction_id`,
+  and the unchained-404 case is pinned as an immediate error; extending the
+  e2e wire parametrization was unimplementable — that test passes explicit
+  `image_horizon=1` and asserts on elision text, both impossible on this
+  wire, so the plan now specifies a separate scripted interactions e2e test
+  and leaves the existing parametrization untouched) plus three folded nits
+  (the system-instruction wording read as a contradiction — suffix
+  translation *skips* system messages and `system_instruction` always
+  reads `messages[0]` directly; the `incomplete` rationale wrongly claimed
+  no wire inspects finish reasons — the Messages wire does, the precedent
+  cited is now chat/responses; an empty-delta guard matching the Live
+  wire's is now specified) — all resolved below.
 
 ## Problem
 
@@ -113,13 +130,22 @@ State, mirroring `GeminiLiveClient`'s identity-prefix discipline:
   *next* `complete()` call then opens with the fold, so the trial can still
   make progress if the rollout retries the policy step. A fold attempt that
   fails with a transient 5xx keeps the flag set and is retried as a fold.
+  Chain loss is only recognized when the failed attempt actually sent
+  `previous_interaction_id` — a 404 on an unchained request (bad model id,
+  wrong explicit-proxy path, or the fold itself) is the request's own
+  fault and takes the plain-4xx immediate-raise path; folding there would
+  loop identical failures and poison every later call (the Live wire's
+  `bool(self._streamed)` gate is the same idea).
 - Bare model: `provider.model.removeprefix("google/")`, as in the Live wire.
 
 Request construction per `complete()` call:
 
 - Suffix = `messages[len(_streamed):]`. Translate, in order:
-  - `system` (only ever message 0, only on an unchained request) → the
-    `system_instruction` field, not an input block;
+  - `system` → skipped by suffix translation entirely (never an input
+    block); the body's `system_instruction` field always reads
+    `messages[0]` directly when it is a system message, on chained and
+    unchained requests alike, because the field is interaction-scoped and
+    never inherited across the chain;
   - `user` → content blocks (string content → one text block; list content →
     text parts verbatim, `image_url` data-URL parts decoded into
     `{"type": "image", "mime_type": <from the data URL>, "data": <base64>}`;
@@ -128,6 +154,10 @@ Request construction per `complete()` call:
     "result": <content>}` (content must be `str`, else raise);
   - `assistant` → skipped (the server already has it when chained; on an
     unchained fold it arrives inside the sanitized prologue).
+  - A suffix whose translation yields an empty `input` array raises
+    "wire='interactions' has no un-streamed user or tool message to send",
+    the Live wire's guard adapted; structurally unreachable through
+    `act()`, pinned by a client-level test as the Live wire pins its own.
 - Body: `model`, `input` (the translated block/step array), `store: true`,
   `tools` (translated from Chat-Completions shape to the flat Interactions
   shape, every request), `system_instruction` (every request, from
@@ -146,7 +176,10 @@ Response handling:
   `model_output` step's text blocks into `content`. `incomplete` (an
   output-cap truncation) is parsed rather than raised so a partial text
   turn takes the policy's existing no-tool-call nudge path instead of
-  aborting the trial — no other wire inspects finish reasons either. Any
+  aborting the trial — the chat wire ignores `finish_reason` and the
+  Responses wire raises only on `status == "failed"`, so tolerance is the
+  HTTP-wire precedent (the Messages wire's strict `stop_reason` gate is
+  the outlier, tied to its explicit output cap). Any
   other `status` (`failed`, `budget_exceeded`, …) raises `RuntimeError`
   naming it. On success: `_last_interaction_id = response["id"]`,
   `_streamed.extend(suffix)` — the cursor advances only on a parsed 200, so
@@ -155,8 +188,10 @@ Response handling:
 - 429/5xx/transport error → bounded retry with exponential backoff
   (`backoff_s * 2**attempt`), as in `ChatClient`.
 - Chain loss — HTTP 404, or a 400 whose body mentions
-  `previous_interaction`: set `_needs_fold` and continue the attempt loop,
-  which now sends the unchained fold (state machine above).
+  `previous_interaction`, *on an attempt that sent
+  `previous_interaction_id`*: set `_needs_fold` and continue the attempt
+  loop, which now sends the unchained fold (state machine above). The same
+  statuses on an unchained attempt take the plain-4xx path below.
 - Other 4xx → immediate `RuntimeError` with the truncated body (the
   request's fault; retrying cannot help). When the body mentions
   `thinking_level`, append a fix line naming the levels this model accepts
@@ -279,7 +314,10 @@ request body and script responses:
    call chains to the fold's new id. Fold persistence: chain loss followed
    by a 500 on the fold attempt retries the *fold* (never the chained
    delta); chain loss on the final attempt raises, and the next
-   `complete()` call opens with the fold.
+   `complete()` call opens with the fold. Gating: a 404 on an *unchained*
+   request (first call of a trial) raises immediately with the body
+   excerpt and never folds. Empty-delta guard: a suffix with nothing
+   sendable raises the "no un-streamed user or tool message" error.
 8. Rewritten-view guard and fresh-trial reset: same two behaviors the Live
    client pins.
 9. Terminal failure statuses (`failed`) raise with the status named;
@@ -295,15 +333,22 @@ request body and script responses:
     rejection, ws base_url rejection, non-Google resolution rejection with
     the guided message, `api_key_env` default with explicit base_url, and
     client-type selection.
-13. Policy-level e2e: the `test_policy_e2e.py` wire parametrization gains
-    `interactions` (full act() → MockTransport → capture round-trip:
-    tool-call turn, tool result, next observation chained as a delta), and
-    an interactions analog of the Live wire's
-    `test_policy_text_turn_takes_existing_nudge_path_end_to_end` pins the
-    no-tool-call nudge advancing the cursor — this wire is the only HTTP
-    wire that skips assistant messages when building input, so the
-    policy↔client integration must be driven through `act()`, not only
-    `complete()`.
+13. Policy-level e2e: a dedicated scripted test (in
+    `test_interactions.py`, policy-level, MockTransport) rather than an
+    extension of `test_policy_e2e.py`'s wire parametrization — that
+    parametrized test constructs the policy with explicit
+    `image_horizon=1` and asserts on `_evicted_view`'s elision text, both
+    impossible on this wire, so it stays untouched. The dedicated test
+    drives `act()` end to end: a tool-call turn, its tool result and next
+    observation going out as a chained delta (`previous_interaction_id`
+    set, assistant message absent from `input`), and the capture rows
+    blob-inlined round-trip. A second policy-level test is the
+    interactions analog of the Live wire's
+    `test_policy_text_turn_takes_existing_nudge_path_end_to_end`
+    (in `test_gemini_live.py`), pinning the no-tool-call nudge advancing
+    the cursor — this wire is the only HTTP wire that skips assistant
+    messages when building input, so the policy↔client integration must
+    be driven through `act()`, not only `complete()`.
 
 Gates: plugin pytest, `ruff check`, `ruff format --check`, strict mypy —
 same bars the plugin already passes; no core `src/inspect_robots` changes,

--- a/plans/0068-interactions-wire.md
+++ b/plans/0068-interactions-wire.md
@@ -1,7 +1,21 @@
-# 0066 — wire=interactions: Gemini Interactions API as a stateful HTTP wire
+# 0068 — wire=interactions: Gemini Interactions API as a stateful HTTP wire
 
-- **Status:** draft (R0, not yet critiqued)
+- **Status:** draft (R1 applied, awaiting re-critique)
 - **Issue:** #378
+- **Critique rounds:** R1: 4 substantive (no policy-level e2e coverage for
+  the new wire — the e2e parametrization now includes `interactions` and a
+  Live-analog nudge-path policy test is added; the fold state machine was
+  under-specified — a persistent `_needs_fold` flag now mirrors the Live
+  wire's `_needs_recovery`, including the final-attempt and
+  fold-then-transient-failure paths; `_call_ids` was named but never
+  defined — deleted, `function_result.call_id` comes straight from the tool
+  message's `tool_call_id`; `incomplete` responses killed the trial — now
+  parsed like `completed` so the policy's nudge path can recover) plus four
+  folded nits (renumbered 0066→0068 after the origin collision;
+  temperature/thinking_level body placement and the thinking_level 4xx fix
+  line get dedicated tests; keyless explicit endpoints omit the
+  `x-goog-api-key` header; the fold prologue is one joined text block,
+  matching the Live wire's `"\n".join`) — all resolved below.
 
 ## Problem
 
@@ -79,13 +93,26 @@ State, mirroring `GeminiLiveClient`'s identity-prefix discipline:
 
 - `_streamed: list[dict]` — references (not copies) of the chat-format
   messages already absorbed by the server chain. A changed prefix means a new
-  trial: reset `_streamed`, `_last_interaction_id`, and `_call_ids`. The
+  trial: reset `_streamed`, `_last_interaction_id`, and `_needs_fold`. The
   rewritten-view guard is identical to the Live wire's: same first message
   object but non-prefix history raises "rewritten conversation view without a
   trial reset". This is also why `image_horizon` is rejected on this wire
   (below): `_evicted_view` rewrites history and would trip this guard by
   design.
-- `_last_interaction_id: str | None` — the chain head.
+- `_last_interaction_id: str | None` — the chain head. Unlike the Live
+  wire's `_call_names`, no per-call bookkeeping is needed: a
+  `function_result` step carries only `call_id`, which comes straight from
+  the tool message's `tool_call_id` (the policy writes
+  `{"role": "tool", "tool_call_id": call.id, "content": result_text}`).
+- `_needs_fold: bool` — set when chain loss is detected, cleared only after
+  a successful fold. While set, every attempt (including across the retry
+  backoff loop) sends the unchained fold, never the chained delta — the
+  Live wire's persistent `_needs_recovery` flag, same rationale: a chained
+  resend would 404 again and burn the remaining attempts. Chain loss
+  detected on the final attempt sets the flag and lets the call fail; the
+  *next* `complete()` call then opens with the fold, so the trial can still
+  make progress if the rollout retries the policy step. A fold attempt that
+  fails with a transient 5xx keeps the flag set and is retried as a fold.
 - Bare model: `provider.model.removeprefix("google/")`, as in the Live wire.
 
 Request construction per `complete()` call:
@@ -113,10 +140,14 @@ Request construction per `complete()` call:
 
 Response handling:
 
-- 200 → parse JSON. `status` of `completed` or `requires_action` → walk
-  `steps`: collect every `function_call` step into a `ToolCall` (arguments
-  normalized to JSON text), concatenate every `model_output` step's text
-  blocks into `content`. Any other terminal `status` raises `RuntimeError`
+- 200 → parse JSON. `status` of `completed`, `requires_action`, or
+  `incomplete` → walk `steps`: collect every `function_call` step into a
+  `ToolCall` (arguments normalized to JSON text), concatenate every
+  `model_output` step's text blocks into `content`. `incomplete` (an
+  output-cap truncation) is parsed rather than raised so a partial text
+  turn takes the policy's existing no-tool-call nudge path instead of
+  aborting the trial — no other wire inspects finish reasons either. Any
+  other `status` (`failed`, `budget_exceeded`, …) raises `RuntimeError`
   naming it. On success: `_last_interaction_id = response["id"]`,
   `_streamed.extend(suffix)` — the cursor advances only on a parsed 200, so
   a failed attempt resends the same delta (one POST is atomic server-side;
@@ -124,8 +155,8 @@ Response handling:
 - 429/5xx/transport error → bounded retry with exponential backoff
   (`backoff_s * 2**attempt`), as in `ChatClient`.
 - Chain loss — HTTP 404, or a 400 whose body mentions
-  `previous_interaction`: rebuild as an *unchained* fold (below) and retry
-  within the same attempt loop.
+  `previous_interaction`: set `_needs_fold` and continue the attempt loop,
+  which now sends the unchained fold (state machine above).
 - Other 4xx → immediate `RuntimeError` with the truncated body (the
   request's fault; retrying cannot help). When the body mentions
   `thinking_level`, append a fix line naming the levels this model accepts
@@ -133,13 +164,16 @@ Response handling:
 
 Fold recovery (chain loss only), mirroring `_send_recovery`:
 
-- Anchor = last `user` message. Input =
-  `[text: _RECOVERY_PROLOGUE, *json-lines of _sanitize(history minus system
-  and anchor), text: _RECOVERY_CONTINUATION, *anchor's translated blocks]`,
-  no `previous_interaction_id`. Reuse the Live wire's prologue strings
-  (import them) so transcripts read identically. `_sanitize` is imported
-  deferred inside the function, exactly as `_gemini_live.py` does, to avoid
-  the import cycle. On success the cursor covers the full message list.
+- Anchor = last `user` message. Input = one text block holding
+  `"\n".join([_RECOVERY_PROLOGUE, *one json.dumps line per message of
+  _sanitize(history minus system and anchor), _RECOVERY_CONTINUATION])` —
+  the same single joined prologue the Live wire builds — followed by the
+  anchor user message's translated blocks (images included). No
+  `previous_interaction_id`. Reuse the Live wire's prologue strings (import
+  them) so transcripts read identically. `_sanitize` is imported deferred
+  inside the function, exactly as `_gemini_live.py` does, to avoid the
+  import cycle. On success the cursor covers the full message list and
+  `_needs_fold` clears.
 
 Usage mapping (per call, summed by the policy):
 `total_input_tokens → input_tokens`, `total_output_tokens → output_tokens`,
@@ -150,6 +184,11 @@ Non-int values are skipped, as in the Live wire's `_add_usage`.
 Capture: one `capture.record(...)` per attempt with
 `endpoint="/interactions"`, the exact request body, status, and response
 text — the same shape `ChatClient` records.
+
+Auth: the `x-goog-api-key` header is set only when `provider.api_key` is
+non-empty; a keyless explicit endpoint (the local-proxy case
+`resolve_provider` explicitly supports) sends no auth header, mirroring
+`ChatClient`'s Bearer omission.
 
 `close()`: closes the httpx client. No per-trial teardown hook is needed —
 the identity-prefix check already resets chain state on the next trial's
@@ -232,20 +271,39 @@ request body and script responses:
 5. Usage mapping: the five counters land under the normalized names;
    missing/non-int counters are skipped.
 6. Retry: one 500 then a 200 succeeds; three 500s raise after
-   `max_retries`; a plain 400 raises immediately with the body excerpt.
+   `max_retries`; a plain 400 raises immediately with the body excerpt; a
+   400 mentioning `thinking_level` carries the appended fix line.
 7. Chain-loss fold: a 404 on a chained call triggers an unchained retry
-   whose input starts with the recovery prologue and ends with the anchor
-   user message's blocks; a subsequent call chains to the fold's new id.
+   whose input is one prologue text block (prologue, sanitized json-lines,
+   continuation) followed by the anchor user message's blocks; a subsequent
+   call chains to the fold's new id. Fold persistence: chain loss followed
+   by a 500 on the fold attempt retries the *fold* (never the chained
+   delta); chain loss on the final attempt raises, and the next
+   `complete()` call opens with the fold.
 8. Rewritten-view guard and fresh-trial reset: same two behaviors the Live
    client pins.
-9. Terminal failure statuses (`failed`) raise with the status named.
+9. Terminal failure statuses (`failed`) raise with the status named;
+   `incomplete` parses like `completed` and returns the partial text.
 10. Capture: a recorded row has `endpoint="/interactions"` and the image
     `data` replaced by a `$blob:` sentinel (also covers the `_capture.py`
     branch).
-11. Policy construction: effort accept/reject matrix, image_horizon
+11. Body placement: `temperature` and a validated effort land under
+    `generation_config` as `temperature`/`thinking_level`; both absent when
+    unset (the `test_llm.py` equivalents for this wire). Keyless explicit
+    endpoint sends no `x-goog-api-key` header.
+12. Policy construction: effort accept/reject matrix, image_horizon
     rejection, ws base_url rejection, non-Google resolution rejection with
     the guided message, `api_key_env` default with explicit base_url, and
     client-type selection.
+13. Policy-level e2e: the `test_policy_e2e.py` wire parametrization gains
+    `interactions` (full act() → MockTransport → capture round-trip:
+    tool-call turn, tool result, next observation chained as a delta), and
+    an interactions analog of the Live wire's
+    `test_policy_text_turn_takes_existing_nudge_path_end_to_end` pins the
+    no-tool-call nudge advancing the cursor — this wire is the only HTTP
+    wire that skips assistant messages when building input, so the
+    policy↔client integration must be driven through `act()`, not only
+    `complete()`.
 
 Gates: plugin pytest, `ruff check`, `ruff format --check`, strict mypy —
 same bars the plugin already passes; no core `src/inspect_robots` changes,

--- a/plugins/inspect-robots-agent/README.md
+++ b/plugins/inspect-robots-agent/README.md
@@ -66,6 +66,22 @@ cannot be evicted by the client. Live usage counts include the empty resumed
 generation and the observation-triggered generation on a normal step, so
 input token totals cover two generations per step.
 
+### Gemini Interactions API
+
+Use Google's stateful HTTP API for GA Gemini models that do not support the
+Live wire, including `gemini-3.7-flash`:
+
+```bash
+inspect-robots "pick up the cube" --policy agent \
+    -P model=google/gemini-3.7-flash -P wire=interactions \
+    -P effort=low --embodiment cubepick
+```
+
+The Interactions wire sends only each new observation and tool result while
+Google retains the conversation history behind an interaction id. Leave
+`image_horizon` unset because frames already absorbed by that server-side
+history cannot be evicted client-side.
+
 The wire format defaults to Chat Completions for broad OpenAI-compatible
 endpoint support:
 
@@ -75,6 +91,7 @@ endpoint support:
 | `responses` | `/responses` | A direct OpenAI or compatible endpoint requires the Responses API |
 | `messages` (`anthropic` alias) | `/messages` | Anthropic, Tinker, or a compatible Messages endpoint |
 | `gemini-live` | `BidiGenerateContent` (WSS) | Google's Live API: required for the `-streaming-` robotics model ids |
+| `interactions` | `/interactions` | Google's stateful HTTP API: server-side history for GA Gemini models, e.g. `gemini-3.7-flash` |
 
 ## How it works
 
@@ -267,9 +284,11 @@ on Anthropic's API; Tinker accepts and silently ignores it.
 | Image option | Default | Behavior |
 |---|---|---|
 | `-P images=` | `always` | Attach every observation's frames; use `on_demand` for model-requested frames |
-| `-P image_horizon=` | `2` on HTTP wires | Keep frames from the newest two image-bearing messages in each outgoing request; unset on `gemini-live` |
+| `-P image_horizon=` | `2` on the stateless HTTP wires; unset on `gemini-live` and `interactions` | Keep frames from the newest two image-bearing messages in each outgoing request; unset on `gemini-live` and `interactions` |
 
-On the HTTP wires, set `-P image_horizon=none` to send the full image history.
+On the stateless HTTP wires, set `-P image_horizon=none` to send the full image
+history. `image_horizon` is unset and rejects an explicit value on
+`gemini-live` and `interactions`.
 Do not use a bare `-P image_horizon=`: the CLI parses it as an empty string,
 which the policy rejects. Full history grows request bodies by about 420 KB
 per observation with three cameras and can reach a 413 response around 85
@@ -311,13 +330,17 @@ currently record `llm_calls` only. Trials with no LLM calls omit the key.
 Like `temperature`, reasoning effort is omitted when `-P effort=` is unset, so
 the provider's own default applies. Explicit named levels (`minimal`, `low`,
 `medium`, `high`, `xhigh`, and `max`) pass through unchanged. A bare
-`-P effort=none` now requests the true minimum on every HTTP wire:
+`-P effort=none` now requests the true minimum on the stateless HTTP wires:
 
 | Wire | Request field |
 | --- | --- |
 | `chat` | `reasoning_effort: "none"` |
 | `responses` | `reasoning: {"effort": "none"}` |
 | `messages` | `thinking: {"type": "disabled"}` (no `output_config`) |
+
+On `wire=interactions`, `minimal`, `low`, `medium`, and `high` map to
+`generation_config.thinking_level`. Other named levels, `none`, and fractional
+effort are rejected because the accepted thinking levels are model-specific.
 
 The older quoted spelling, `-P effort="'none'"`, remains valid but is no longer
 needed. In Python, both `effort=None` and `effort="none"` request the `none`

--- a/plugins/inspect-robots-agent/pyproject.toml
+++ b/plugins/inspect-robots-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inspect-robots-agent"
-version = "0.24.0"
+version = "0.25.0"
 description = "LLM agent policy for Inspect Robots: frontier LLMs (Claude, GPT, anything OpenAI-compatible) drive any registered embodiment through tool calls."
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/__init__.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/__init__.py
@@ -27,6 +27,7 @@ from importlib.metadata import version
 
 from inspect_robots_agent._anthropic import AnthropicClient
 from inspect_robots_agent._gemini_live import GeminiLiveClient
+from inspect_robots_agent._interactions import InteractionsClient
 from inspect_robots_agent._llm import (
     ENV_MODEL,
     AssistantMessage,
@@ -45,6 +46,7 @@ __all__ = [
     "AssistantMessage",
     "ChatClient",
     "GeminiLiveClient",
+    "InteractionsClient",
     "LLMAgentPolicy",
     "Provider",
     "ResponsesClient",

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/__init__.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/__init__.py
@@ -4,7 +4,8 @@ An LLM behind a supported API (OpenRouter, OpenAI, local vLLM/Ollama,
 Anthropic, Tinker, or compatible gateways) drives whatever embodiment it is
 paired with: each tool call becomes one smooth, approver-checked action
 chunk. ``-P wire=messages`` selects the Messages API; the permanent
-``anthropic`` alias remains accepted. Registered as the policy ``agent``::
+``anthropic`` alias remains accepted. ``-P wire=interactions`` selects
+Google's stateful Interactions HTTP API. Registered as the policy ``agent``::
 
     inspect-robots "pick up the cube" --policy agent \
         -P model=anthropic/claude-fable-5 --embodiment cubepick

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_capture.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_capture.py
@@ -11,7 +11,7 @@ that parses as a JSON object is stored as that object at any HTTP status;
 non-object or invalid JSON is stored as its first 2000 text characters, and a
 missing response is stored as null.
 
-Inline PNG payloads in supported chat, Responses, Anthropic, and Gemini Live
+Inline PNG payloads in supported chat, Responses, Anthropic, Gemini Live, and Interactions
 image parts are replaced in a deep copy of the request by
 ``$blob:<sha256>``. Data-URL prefixes and all other part keys remain intact.
 Readers find references by scanning string values for the unanchored pattern
@@ -208,6 +208,10 @@ class WireCapture:
                     payload = source.get("data")
                     if isinstance(payload, str):
                         source["data"] = self._store_blob(payload)
+                elif "source" not in value:
+                    payload = value.get("data")
+                    if isinstance(payload, str):
+                        value["data"] = self._store_blob(payload)
             for child in value.values():
                 self._replace_blobs(child)
         elif isinstance(value, list):

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_interactions.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_interactions.py
@@ -1,0 +1,386 @@
+"""Stateful Gemini Interactions HTTP client with bounded fold recovery.
+
+The policy's append-only chat-format list remains the conversation source of
+truth. This boundary sends only new user and tool entries while Google's
+interaction chain is intact, then folds the authoritative history into a
+fresh unchained request when the remote chain is lost.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import httpx
+
+from inspect_robots_agent._gemini_live import _RECOVERY_CONTINUATION, _RECOVERY_PROLOGUE
+from inspect_robots_agent._llm import AssistantMessage, Provider, ToolCall
+
+from ._capture import WireCapture
+
+_SUCCESS_STATUSES = frozenset({"completed", "requires_action", "incomplete"})
+_USAGE_KEYS = {
+    "total_input_tokens": "input_tokens",
+    "total_output_tokens": "output_tokens",
+    "total_cached_tokens": "cache_read_input_tokens",
+    "total_thought_tokens": "thought_tokens",
+    "total_tokens": "total_tokens",
+}
+
+
+class InteractionsClient:
+    """Send append-only chat deltas over Google's stateful Interactions API.
+
+    The streamed cursor contains references, not copied values. A changed
+    prefix therefore starts a new chain even when two trials have
+    byte-identical prompts. Lost server chains recover by folding the full
+    authoritative view into one unchained request.
+    """
+
+    def __init__(
+        self,
+        provider: Provider,
+        *,
+        timeout_s: float = 120.0,
+        max_retries: int = 3,
+        backoff_s: float = 1.0,
+        transport: httpx.BaseTransport | None = None,
+        capture: WireCapture | None = None,
+    ) -> None:
+        self._provider = provider
+        self._model = provider.model.removeprefix("google/")
+        self._max_retries = max_retries
+        self._backoff_s = backoff_s
+        self._capture = capture
+        headers = {}
+        if provider.api_key:
+            headers["x-goog-api-key"] = provider.api_key
+        self._http = httpx.Client(
+            base_url=provider.base_url,
+            headers=headers,
+            timeout=timeout_s,
+            transport=transport,
+        )
+        self._streamed: list[dict[str, Any]] = []
+        self._last_interaction_id: str | None = None
+        self._needs_fold = False
+
+    def complete(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        temperature: float | None = None,
+        reasoning_effort: str | float | None = None,
+    ) -> AssistantMessage:
+        """Return one assistant turn after sending only the unseen suffix."""
+        self._check_identity_prefix(messages)
+        suffix = messages[len(self._streamed) :]
+        last_error = "unknown error"
+
+        for attempt in range(self._max_retries):
+            folding = self._needs_fold
+            input_items = self._fold_input(messages) if folding else _translate_suffix(suffix)
+            body = self._request_body(
+                messages,
+                tools,
+                input_items,
+                temperature,
+                reasoning_effort,
+                include_previous=not folding,
+            )
+            sent_previous = "previous_interaction_id" in body
+            t_start = time.time() if self._capture is not None else 0.0
+            try:
+                response = self._http.post("/interactions", json=body)
+            except httpx.TransportError as exc:
+                last_error = str(exc)
+                self._record_attempt(
+                    attempt,
+                    body,
+                    None,
+                    None,
+                    last_error,
+                    t_start,
+                    time.time() - t_start if self._capture is not None else 0.0,
+                )
+            else:
+                self._record_attempt(
+                    attempt,
+                    body,
+                    response.status_code,
+                    response.text,
+                    None,
+                    t_start,
+                    time.time() - t_start if self._capture is not None else 0.0,
+                )
+                if response.status_code == 200:
+                    result, interaction_id = _parse_response(response)
+                    self._last_interaction_id = interaction_id
+                    if folding:
+                        self._streamed = list(messages)
+                        self._needs_fold = False
+                    else:
+                        self._streamed.extend(suffix)
+                    return result
+
+                last_error = f"HTTP {response.status_code}: {response.text[:500]}"
+                chain_lost = sent_previous and (
+                    response.status_code == 404
+                    or (
+                        response.status_code == 400
+                        and "previous_interaction" in response.text.lower()
+                    )
+                )
+                if chain_lost:
+                    self._needs_fold = True
+                elif response.status_code not in (429,) and response.status_code < 500:
+                    guidance = ""
+                    if "thinking_level" in response.text.lower():
+                        guidance = (
+                            "\nfix: supported thinking_level values vary by model; "
+                            "gemini-3.7-flash accepts low|medium|high"
+                        )
+                    raise RuntimeError(f"LLM request rejected — {last_error}{guidance}")
+
+            if attempt + 1 < self._max_retries:
+                time.sleep(self._backoff_s * 2**attempt)
+
+        raise RuntimeError(f"LLM request failed after {self._max_retries} attempts — {last_error}")
+
+    def close(self) -> None:
+        """Close the underlying blocking HTTP client."""
+        self._http.close()
+
+    def _check_identity_prefix(self, messages: list[dict[str, Any]]) -> None:
+        prefix_matches = len(messages) >= len(self._streamed) and all(
+            messages[index] is streamed for index, streamed in enumerate(self._streamed)
+        )
+        if prefix_matches:
+            return
+        if messages and self._streamed and messages[0] is self._streamed[0]:
+            raise RuntimeError(
+                "Interactions received a rewritten conversation view without a trial reset"
+            )
+        self._streamed.clear()
+        self._last_interaction_id = None
+        self._needs_fold = False
+
+    def _request_body(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        input_items: list[dict[str, Any]],
+        temperature: float | None,
+        reasoning_effort: str | float | None,
+        *,
+        include_previous: bool,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "model": self._model,
+            "input": input_items,
+            "store": True,
+            "tools": [_translate_tool(tool) for tool in tools],
+        }
+        if messages and messages[0].get("role") == "system":
+            body["system_instruction"] = str(messages[0].get("content", ""))
+        generation_config: dict[str, Any] = {}
+        if temperature is not None:
+            generation_config["temperature"] = temperature
+        if reasoning_effort is not None:
+            generation_config["thinking_level"] = reasoning_effort
+        if generation_config:
+            body["generation_config"] = generation_config
+        if include_previous and self._last_interaction_id is not None:
+            body["previous_interaction_id"] = self._last_interaction_id
+        return body
+
+    def _fold_input(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        anchor_index = next(
+            (
+                index
+                for index in range(len(messages) - 1, -1, -1)
+                if messages[index].get("role") == "user"
+            ),
+            None,
+        )
+        if anchor_index is None:
+            raise RuntimeError("Interactions fold recovery requires at least one user message")
+
+        # Deferred to avoid policy.py -> _interactions.py -> policy.py at import.
+        from inspect_robots_agent.policy import _sanitize
+
+        start = 1 if messages[0].get("role") == "system" else 0
+        folded = _sanitize(messages[start:anchor_index] + messages[anchor_index + 1 :])
+        lines = [
+            _RECOVERY_PROLOGUE,
+            *(json.dumps(message) for message in folded),
+            _RECOVERY_CONTINUATION,
+        ]
+        return [
+            {"type": "text", "text": "\n".join(lines)},
+            *_user_content(messages[anchor_index]),
+        ]
+
+    def _record_attempt(
+        self,
+        attempt: int,
+        body: dict[str, Any],
+        status: int | None,
+        response_text: str | None,
+        error: str | None,
+        t_start: float,
+        duration_s: float,
+    ) -> None:
+        if self._capture is None:
+            return
+        self._capture.record(
+            attempt=attempt,
+            endpoint="/interactions",
+            request=body,
+            status=status,
+            response_text=response_text,
+            error=error,
+            t_start=t_start,
+            duration_s=duration_s,
+        )
+
+
+def _translate_tool(tool: dict[str, Any]) -> dict[str, Any]:
+    function = tool["function"]
+    return {
+        "type": "function",
+        "name": function["name"],
+        "description": function["description"],
+        "parameters": function["parameters"],
+    }
+
+
+def _translate_suffix(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    translated: list[dict[str, Any]] = []
+    for message in messages:
+        role = message.get("role")
+        if role == "user":
+            translated.extend(_user_content(message))
+        elif role == "tool":
+            call_id = str(message["tool_call_id"])
+            content = message.get("content")
+            if not isinstance(content, str):
+                raise RuntimeError(f"Interactions tool result {call_id!r} content must be a string")
+            translated.append({"type": "function_result", "call_id": call_id, "result": content})
+        elif role in {"assistant", "system"}:
+            continue
+        else:
+            raise RuntimeError(f"unsupported chat message role {role!r}")
+    if not translated:
+        raise RuntimeError("wire='interactions' has no un-streamed user or tool message to send")
+    return translated
+
+
+def _user_content(message: dict[str, Any]) -> list[dict[str, Any]]:
+    content = message.get("content")
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    if isinstance(content, list):
+        return [_content_part(part) for part in content]
+    raise RuntimeError(f"unsupported Interactions user content {content!r}")
+
+
+def _content_part(part: Any) -> dict[str, Any]:
+    if not isinstance(part, dict):
+        raise RuntimeError(f"unsupported content part type {type(part).__name__!r}")
+    part_type = part.get("type")
+    if part_type == "text":
+        return {"type": "text", "text": part["text"]}
+    if part_type == "image_url":
+        image_url = part.get("image_url")
+        url = str(image_url.get("url", "")) if isinstance(image_url, dict) else ""
+        header, separator, data = url.partition(",")
+        if not separator or not header.startswith("data:") or not header.endswith(";base64"):
+            raise RuntimeError(f"image content part is not a base64 data URI: {url[:60]!r}")
+        mime_type = header[len("data:") : -len(";base64")]
+        if not mime_type:
+            raise RuntimeError(f"image content part has no data-URI MIME type: {url[:60]!r}")
+        return {"type": "image", "mime_type": mime_type, "data": data}
+    raise RuntimeError(f"unsupported content part type {part_type!r}")
+
+
+def _parse_response(response: httpx.Response) -> tuple[AssistantMessage, str]:
+    try:
+        payload = response.json()
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise RuntimeError(
+            f"Interactions response has invalid JSON: {response.text[:500]!r}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise _shape_error("response object", response.text)
+    status = payload.get("status")
+    if not isinstance(status, str):
+        raise _shape_error("status", response.text)
+    if status not in _SUCCESS_STATUSES:
+        raise RuntimeError(f"Interactions response ended with status {status!r}")
+    steps = payload.get("steps")
+    if not isinstance(steps, list):
+        raise _shape_error("steps", response.text)
+    interaction_id = payload.get("id")
+    if not isinstance(interaction_id, str):
+        raise _shape_error("id", response.text)
+
+    text_parts: list[str] = []
+    calls: list[ToolCall] = []
+    for step in steps:
+        if not isinstance(step, dict):
+            raise _shape_error("steps[]", response.text)
+        step_type = step.get("type")
+        if step_type == "function_call":
+            call_id = step.get("id")
+            name = step.get("name")
+            arguments = step.get("arguments")
+            if not isinstance(call_id, str):
+                raise _shape_error("steps[].id", response.text)
+            if not isinstance(name, str):
+                raise _shape_error("steps[].name", response.text)
+            if isinstance(arguments, dict):
+                normalized_arguments = json.dumps(arguments)
+            elif isinstance(arguments, str):
+                normalized_arguments = arguments
+            else:
+                raise _shape_error("steps[].arguments", response.text)
+            calls.append(ToolCall(id=call_id, name=name, arguments=normalized_arguments))
+        elif step_type == "model_output":
+            content = step.get("content")
+            if not isinstance(content, list):
+                raise _shape_error("steps[].content", response.text)
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text")
+                    if not isinstance(text, str):
+                        raise _shape_error("steps[].content[].text", response.text)
+                    text_parts.append(text)
+        else:
+            raise _shape_error("steps[].type", response.text)
+
+    usage = _normalized_usage(payload.get("usage"))
+    return (
+        AssistantMessage(
+            content="".join(text_parts) if text_parts else None,
+            tool_calls=tuple(calls),
+            usage=usage or None,
+        ),
+        interaction_id,
+    )
+
+
+def _shape_error(field: str, body: str) -> RuntimeError:
+    return RuntimeError(f"Interactions response has missing or invalid {field}: {body[:500]!r}")
+
+
+def _normalized_usage(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    usage: dict[str, int] = {}
+    for source, target in _USAGE_KEYS.items():
+        counter = value.get(source)
+        if isinstance(counter, int) and not isinstance(counter, bool):
+            usage[target] = counter
+    return usage

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_interactions.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_interactions.py
@@ -357,8 +357,9 @@ def _parse_response(response: httpx.Response) -> tuple[AssistantMessage, str]:
                     if not isinstance(text, str):
                         raise _shape_error("steps[].content[].text", response.text)
                     text_parts.append(text)
-        else:
-            raise _shape_error("steps[].type", response.text)
+        # Unknown step types (e.g. server-added thinking output once
+        # thinking_level is set) are skipped, matching the Responses wire's
+        # tolerance for OpenAI's reasoning items.
 
     usage = _normalized_usage(payload.get("usage"))
     return (

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/policy.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
 from inspect_robots_agent._anthropic import _DEFAULT_MAX_OUTPUT_TOKENS, AnthropicClient
 from inspect_robots_agent._depth import depth_parts, resolve_depth
 from inspect_robots_agent._gemini_live import GeminiLiveClient
+from inspect_robots_agent._interactions import InteractionsClient
 from inspect_robots_agent._llm import (
     _DIRECT_PROVIDERS,
     _OPENROUTER_BASE,
@@ -73,6 +74,9 @@ _GEMINI_LIVE_BASE = (
     "google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
 )
 
+#: Google's native stateful HTTP endpoint, after direct-provider resolution.
+_INTERACTIONS_BASE = "https://generativelanguage.googleapis.com/v1beta"
+
 # reasoning_effort values accepted across OpenAI-compatible endpoints
 # (Anthropic compat maps these to thinking effort; OpenRouter forwards them).
 # The Messages wire reuses the set: "none" becomes thinking-disabled client-side
@@ -87,7 +91,7 @@ _EFFORT_LEVELS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh",
 # offers. The range is half-open by construction: 1.0 means "past max effort",
 # and servers that cap lower reject it with a guided 4xx.
 _EFFORT_FRACTION_LIMIT = 1.0
-_WIRE_FORMATS = frozenset({"chat", "responses", "messages", "gemini-live"})
+_WIRE_FORMATS = frozenset({"chat", "responses", "messages", "gemini-live", "interactions"})
 _WIRE_ALIASES = {"anthropic": "messages"}
 _AGENT_NATIVE_WIRES = frozenset({"chat", "messages"})
 _MESSAGES_CAPABLE_PREFIXES = frozenset(
@@ -421,6 +425,19 @@ class LLMAgentPolicy(PolicyBase):
             raise ConfigError(
                 "effort is not supported on wire='gemini-live'.\nfix: drop -P effort="
             )
+        if wire == "interactions" and resolved_effort not in {
+            None,
+            "minimal",
+            "low",
+            "medium",
+            "high",
+        }:
+            raise ConfigError(
+                "effort on wire='interactions' must be minimal, low, medium, or high, "
+                f"got {resolved_effort!r}.\n"
+                "fix: pass -P effort=minimal|low|medium|high (maps to thinking_level), "
+                "or drop -P effort="
+            )
         if speed is not None and speed not in _SPEEDS:
             raise ConfigError(f"speed must be one of {sorted(_SPEEDS)}, or None, got {speed!r}")
         if images not in _IMAGE_MODES:
@@ -467,7 +484,7 @@ class LLMAgentPolicy(PolicyBase):
                 "image_horizon must be an int >= 1, or None to send full image history.\n"
                 "fix: pass -P image_horizon=N or -P image_horizon=none"
             )
-        resolved_image_horizon: int | None = None if wire == "gemini-live" else 2
+        resolved_image_horizon: int | None = None if wire in {"gemini-live", "interactions"} else 2
         if not isinstance(image_horizon, _Unset):
             resolved_image_horizon = image_horizon
         if wire == "gemini-live" and image_horizon is not _UNSET and image_horizon is not None:
@@ -477,12 +494,25 @@ class LLMAgentPolicy(PolicyBase):
                 "compression is the equivalent mechanism because already-streamed "
                 "frames cannot be evicted"
             )
+        if wire == "interactions" and image_horizon is not _UNSET and image_horizon is not None:
+            raise ConfigError(
+                "image_horizon is not supported on wire='interactions'.\n"
+                "fix: drop -P image_horizon=; the Interactions API's server-side history "
+                "is the equivalent mechanism because frames already absorbed by the chain "
+                "cannot be evicted client-side"
+            )
 
         if wire == "gemini-live" and base_url and not base_url.startswith(("ws://", "wss://")):
             raise ConfigError(
                 "wire='gemini-live' requires a ws:// or wss:// base_url, got "
                 f"{base_url!r}.\nfix: drop -P base_url= to use Google's Live API, "
                 "or pass a websocket endpoint"
+            )
+        if wire == "interactions" and base_url and not base_url.startswith(("http://", "https://")):
+            raise ConfigError(
+                "wire='interactions' requires an http:// or https:// base_url, got "
+                f"{base_url!r}.\nfix: wire='interactions' is HTTP; drop -P base_url= "
+                "or pass the Live wire a websocket endpoint via -P wire=gemini-live"
             )
 
         # resolve_provider reads api_key_env only when base_url is set, where
@@ -499,6 +529,8 @@ class LLMAgentPolicy(PolicyBase):
             effective_key_env = "ANTHROPIC_API_KEY"
         if wire == "gemini-live" and base_url and not api_key_env:
             effective_key_env = "GEMINI_API_KEY"
+        if wire == "interactions" and base_url and not api_key_env:
+            effective_key_env = "GEMINI_API_KEY"
         try:
             provider = resolve_provider(
                 model=requested_model,
@@ -508,8 +540,13 @@ class LLMAgentPolicy(PolicyBase):
                 native_wires=_AGENT_NATIVE_WIRES,
             )
         except ConfigError as exc:
-            if wire != "gemini-live" or base_url:
+            if wire not in {"gemini-live", "interactions"} or base_url:
                 raise
+            if wire == "interactions":
+                raise ConfigError(
+                    "wire='interactions' needs Google's direct provider.\n"
+                    "fix: use -P model=google/... and set $GEMINI_API_KEY"
+                ) from exc
             raise ConfigError(
                 "wire='gemini-live' needs Google's direct Live API provider.\n"
                 "fix: use -P model=google/... and set $GEMINI_API_KEY"
@@ -612,6 +649,17 @@ class LLMAgentPolicy(PolicyBase):
                 api_key=provider.api_key,
                 model=provider.model,
             )
+        if wire == "interactions" and not base_url:
+            if provider.base_url != _GOOGLE_BASE:
+                raise ConfigError(
+                    "wire='interactions' needs Google's direct provider.\n"
+                    "fix: use -P model=google/... and set $GEMINI_API_KEY"
+                )
+            provider = Provider(
+                base_url=_INTERACTIONS_BASE,
+                api_key=provider.api_key,
+                model=provider.model,
+            )
 
         resolved_max_output_tokens = (
             (max_output_tokens if max_output_tokens is not None else _DEFAULT_MAX_OUTPUT_TOKENS)
@@ -619,7 +667,9 @@ class LLMAgentPolicy(PolicyBase):
             else None
         )
         self._capture = WireCapture() if wire_capture else None
-        self._client: ChatClient | ResponsesClient | AnthropicClient | GeminiLiveClient
+        self._client: (
+            ChatClient | ResponsesClient | AnthropicClient | GeminiLiveClient | InteractionsClient
+        )
         if wire == "messages":
             assert resolved_max_output_tokens is not None
             self._client = AnthropicClient(
@@ -633,6 +683,8 @@ class LLMAgentPolicy(PolicyBase):
             self._client = ResponsesClient(provider, transport=transport, capture=self._capture)
         elif wire == "gemini-live":
             self._client = GeminiLiveClient(provider, capture=self._capture)
+        elif wire == "interactions":
+            self._client = InteractionsClient(provider, transport=transport, capture=self._capture)
         else:
             self._client = ChatClient(provider, transport=transport, capture=self._capture)
         self._max_llm_calls = max_llm_calls

--- a/plugins/inspect-robots-agent/tests/manual_interactions_smoke.py
+++ b/plugins/inspect-robots-agent/tests/manual_interactions_smoke.py
@@ -1,0 +1,61 @@
+"""Probe the real Gemini Interactions endpoint before announcing wire support."""
+
+from __future__ import annotations
+
+import os
+
+from inspect_robots_agent._interactions import InteractionsClient
+from inspect_robots_agent._llm import Provider
+from inspect_robots_agent.policy import _INTERACTIONS_BASE
+
+
+def main() -> int:
+    """Exercise basic, chained, and function-result calls when a key is available."""
+    key = os.environ.get("GEMINI_API_KEY")
+    if not key:
+        print("GEMINI_API_KEY is unset; skipping Interactions smoke probe")
+        return 0
+
+    model = os.environ.get("INSPECT_ROBOTS_MODEL", "google/gemini-3.7-flash")
+    client = InteractionsClient(Provider(base_url=_INTERACTIONS_BASE, api_key=key, model=model))
+    messages = [
+        {"role": "system", "content": "Answer briefly and follow function requests."},
+        {"role": "user", "content": "Reply with the word ready."},
+    ]
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "report_smoke",
+            "description": "Report that the smoke probe reached its function step.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    try:
+        first = client.complete(messages, [])
+        messages.extend([first.raw(), {"role": "user", "content": "Now reply chained."}])
+        second = client.complete(messages, [])
+        messages.extend(
+            [
+                second.raw(),
+                {"role": "user", "content": "Call report_smoke with no arguments."},
+            ]
+        )
+        function_turn = client.complete(messages, [tool])
+        if not function_turn.tool_calls:
+            raise RuntimeError("Interactions smoke probe did not receive a function call")
+        call = function_turn.tool_calls[0]
+        messages.extend(
+            [
+                function_turn.raw(),
+                {"role": "tool", "tool_call_id": call.id, "content": "smoke passed"},
+            ]
+        )
+        final = client.complete(messages, [tool])
+        print(f"Interactions smoke probe passed: {final.content or 'function round-trip complete'}")
+        return 0
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/inspect-robots-agent/tests/test_anthropic.py
+++ b/plugins/inspect-robots-agent/tests/test_anthropic.py
@@ -1110,7 +1110,8 @@ def test_unknown_wire_lists_only_canonical_names() -> None:
         _policy(wire="unknown")
 
     assert str(excinfo.value) == (
-        "wire must be one of ['chat', 'gemini-live', 'messages', 'responses'], got 'unknown'"
+        "wire must be one of ['chat', 'gemini-live', 'interactions', 'messages', "
+        "'responses'], got 'unknown'"
     )
 
 

--- a/plugins/inspect-robots-agent/tests/test_interactions.py
+++ b/plugins/inspect-robots-agent/tests/test_interactions.py
@@ -1,0 +1,780 @@
+"""Gemini Interactions wire behavior and policy integration (plan 0068)."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import pytest
+
+import inspect_robots_agent._gemini_live as live_module
+from inspect_robots.errors import ConfigError
+from inspect_robots.mock import CubePickEmbodiment
+from inspect_robots.rollout import TrialRecord
+from inspect_robots.scene import Scene
+from inspect_robots_agent import LLMAgentPolicy
+from inspect_robots_agent._capture import WireCapture
+from inspect_robots_agent._interactions import InteractionsClient
+from inspect_robots_agent._llm import Provider
+from inspect_robots_agent.policy import _INTERACTIONS_BASE, AgentPolicyConfig
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\ninteractions-test"
+_PNG_PAYLOAD = base64.b64encode(_PNG_BYTES).decode("ascii")
+_BLOB_RE = re.compile(r"\$blob:([0-9a-f]{64})")
+
+
+def _response(
+    interaction_id: str,
+    *steps: dict[str, Any],
+    status: str = "completed",
+    usage: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": interaction_id,
+        "status": status,
+        "steps": list(steps),
+    }
+    if usage is not None:
+        payload["usage"] = usage
+    return payload
+
+
+def _call(
+    call_id: str = "call_1",
+    name: str = "done",
+    arguments: dict[str, Any] | str | None = None,
+) -> dict[str, Any]:
+    return {
+        "type": "function_call",
+        "id": call_id,
+        "name": name,
+        "arguments": {} if arguments is None else arguments,
+    }
+
+
+def _text(*parts: str) -> dict[str, Any]:
+    return {
+        "type": "model_output",
+        "content": [{"type": "text", "text": part} for part in parts],
+    }
+
+
+def _schema(name: str = "done") -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": f"{name} the task",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def _messages(*extra: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {"role": "system", "content": "drive safely"},
+        {"role": "user", "content": "Goal: inspect"},
+        *extra,
+    ]
+
+
+def _image_message(text: str, payload: str = _PNG_PAYLOAD) -> dict[str, Any]:
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": text},
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{payload}"},
+            },
+        ],
+    }
+
+
+def _client(
+    handler: Callable[[httpx.Request], httpx.Response],
+    *,
+    api_key: str = "sk-test",
+    max_retries: int = 3,
+    capture: WireCapture | None = None,
+) -> InteractionsClient:
+    return InteractionsClient(
+        Provider(
+            base_url="http://llm.test/v1beta",
+            api_key=api_key,
+            model="google/gemini-3.7-flash",
+        ),
+        max_retries=max_retries,
+        backoff_s=0.0,
+        transport=httpx.MockTransport(handler),
+        capture=capture,
+    )
+
+
+def _body(request: httpx.Request) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(request.content))
+
+
+def _wire_rows(path: Path) -> list[dict[str, Any]]:
+    return [cast(dict[str, Any], json.loads(line)) for line in path.read_text().splitlines()]
+
+
+def _inline_blobs(value: Any, blob_dir: Path) -> Any:
+    if isinstance(value, str):
+
+        def replace_blob(match: re.Match[str]) -> str:
+            payload = (blob_dir / f"{match.group(1)}.png").read_bytes()
+            return base64.b64encode(payload).decode("ascii")
+
+        return _BLOB_RE.sub(replace_blob, value)
+    if isinstance(value, list):
+        return [_inline_blobs(item, blob_dir) for item in value]
+    if isinstance(value, dict):
+        return {key: _inline_blobs(item, blob_dir) for key, item in value.items()}
+    return value
+
+
+def test_first_call_translates_body_tools_system_image_and_auth() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json=_response("i1", _text("ok")))
+
+    client = _client(handler)
+    client.complete(_messages(_image_message("Current observation.")), [_schema()])
+
+    (request,) = seen
+    assert request.url == httpx.URL("http://llm.test/v1beta/interactions")
+    assert request.headers["x-goog-api-key"] == "sk-test"
+    body = _body(request)
+    assert body == {
+        "model": "gemini-3.7-flash",
+        "input": [
+            {"type": "text", "text": "Goal: inspect"},
+            {"type": "text", "text": "Current observation."},
+            {"type": "image", "mime_type": "image/png", "data": _PNG_PAYLOAD},
+        ],
+        "store": True,
+        "tools": [
+            {
+                "type": "function",
+                "name": "done",
+                "description": "done the task",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ],
+        "system_instruction": "drive safely",
+    }
+    assert "previous_interaction_id" not in body
+
+
+def test_chained_call_sends_only_tool_and_user_delta_with_scoped_fields() -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(_body(request))
+        if len(bodies) == 1:
+            return httpx.Response(
+                200,
+                json=_response(
+                    "i1",
+                    _call("tool-call-id", "move_by", {"deltas": {"dx": 0.1}}),
+                    status="requires_action",
+                ),
+            )
+        return httpx.Response(200, json=_response("i2", _text("done")))
+
+    client = _client(handler)
+    history = _messages({"role": "user", "content": "old observation"})
+    first = client.complete(history, [_schema("move_by")])
+    history.extend(
+        [
+            first.raw(),
+            {"role": "tool", "tool_call_id": "tool-call-id", "content": "moved"},
+            {"role": "user", "content": "new observation"},
+        ]
+    )
+
+    client.complete(history, [_schema("move_by")])
+
+    second = bodies[1]
+    assert second["previous_interaction_id"] == "i1"
+    assert second["input"] == [
+        {
+            "type": "function_result",
+            "call_id": "tool-call-id",
+            "result": "moved",
+        },
+        {"type": "text", "text": "new observation"},
+    ]
+    assert second["tools"] == bodies[0]["tools"]
+    assert second["system_instruction"] == "drive safely"
+
+
+def test_function_calls_normalize_object_and_string_arguments() -> None:
+    payload = _response(
+        "i1",
+        _call("one", "move_by", {"deltas": {"dx": 0.1}}),
+        _call("two", "take_pic", '{"camera":"top"}'),
+        status="requires_action",
+    )
+    result = _client(lambda request: httpx.Response(200, json=payload)).complete(_messages(), [])
+
+    assert [call.id for call in result.tool_calls] == ["one", "two"]
+    assert [call.name for call in result.tool_calls] == ["move_by", "take_pic"]
+    assert [json.loads(call.arguments) for call in result.tool_calls] == [
+        {"deltas": {"dx": 0.1}},
+        {"camera": "top"},
+    ]
+
+
+def test_text_blocks_concatenate_and_empty_steps_return_empty_message() -> None:
+    responses = iter(
+        [
+            _response("i1", _text("one", " two")),
+            _response("i2"),
+        ]
+    )
+    client = _client(lambda request: httpx.Response(200, json=next(responses)))
+
+    first = client.complete(_messages(), [])
+    second = client.complete(json.loads(json.dumps(_messages())), [])
+
+    assert first.content == "one two"
+    assert first.tool_calls == ()
+    assert second.content is None
+    assert second.tool_calls == ()
+
+
+def test_usage_counters_are_normalized_and_non_int_values_skipped() -> None:
+    usage = {
+        "total_input_tokens": 10,
+        "total_output_tokens": 4,
+        "total_cached_tokens": 3,
+        "total_thought_tokens": 2,
+        "total_tokens": 16,
+        "ignored": 99,
+    }
+    result = _client(
+        lambda request: httpx.Response(200, json=_response("i1", usage=usage))
+    ).complete(_messages(), [])
+    assert result.usage == {
+        "input_tokens": 10,
+        "output_tokens": 4,
+        "cache_read_input_tokens": 3,
+        "thought_tokens": 2,
+        "total_tokens": 16,
+    }
+
+    result = _client(
+        lambda request: httpx.Response(
+            200,
+            json=_response(
+                "i2",
+                usage={
+                    "total_input_tokens": "10",
+                    "total_output_tokens": True,
+                    "total_tokens": None,
+                },
+            ),
+        )
+    ).complete(_messages(), [])
+    assert result.usage is None
+
+
+def test_transient_retry_success_and_exhaustion() -> None:
+    calls = 0
+
+    def succeeds(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(500, text="temporary")
+        return httpx.Response(200, json=_response("i1", _text("ok")))
+
+    assert _client(succeeds).complete(_messages(), []).content == "ok"
+    assert calls == 2
+
+    failed_calls = 0
+
+    def unavailable(request: httpx.Request) -> httpx.Response:
+        nonlocal failed_calls
+        failed_calls += 1
+        return httpx.Response(503, text="down")
+
+    with pytest.raises(RuntimeError, match=r"failed after 3 attempts.*503"):
+        _client(unavailable).complete(_messages(), [])
+    assert failed_calls == 3
+
+
+def test_plain_and_thinking_level_400_errors_fail_fast_with_guidance() -> None:
+    calls = 0
+
+    def rejected(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(400, text="bad tool schema")
+
+    with pytest.raises(RuntimeError, match="bad tool schema"):
+        _client(rejected).complete(_messages(), [])
+    assert calls == 1
+
+    client = _client(lambda request: httpx.Response(400, text="unsupported thinking_level minimal"))
+    with pytest.raises(RuntimeError) as exc_info:
+        client.complete(_messages(), [])
+    assert str(exc_info.value).endswith(
+        "fix: supported thinking_level values vary by model; "
+        "gemini-3.7-flash accepts low|medium|high"
+    )
+
+
+def test_chain_loss_folds_sanitized_history_then_chains_to_new_head() -> None:
+    bodies: list[dict[str, Any]] = []
+    old_payload = base64.b64encode(b"old image").decode("ascii")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(_body(request))
+        index = len(bodies)
+        if index == 1:
+            return httpx.Response(200, json=_response("i1", _call("move", "move_by")))
+        if index == 2:
+            return httpx.Response(404, text="interaction expired")
+        if index == 3:
+            return httpx.Response(200, json=_response("folded", _text("recovered")))
+        return httpx.Response(200, json=_response("i3", _text("next")))
+
+    client = _client(handler, max_retries=3)
+    history = _messages(_image_message("older observation", old_payload))
+    first = client.complete(history, [])
+    history.extend(
+        [
+            first.raw(),
+            {"role": "tool", "tool_call_id": "move", "content": "played"},
+            _image_message("newest observation"),
+        ]
+    )
+
+    client.complete(history, [])
+
+    assert bodies[1]["previous_interaction_id"] == "i1"
+    fold = bodies[2]
+    assert "previous_interaction_id" not in fold
+    assert len(fold["input"]) == 3
+    prologue = fold["input"][0]["text"]
+    lines = prologue.splitlines()
+    assert lines[0] == live_module._RECOVERY_PROLOGUE
+    assert lines[-1] == live_module._RECOVERY_CONTINUATION
+    assert all(isinstance(json.loads(line), dict) for line in lines[1:-1])
+    assert all(json.loads(line).get("role") != "system" for line in lines[1:-1])
+    assert "[image omitted: streamed camera frame]" in prologue
+    assert old_payload not in json.dumps(fold)
+    assert fold["input"][1:] == [
+        {"type": "text", "text": "newest observation"},
+        {"type": "image", "mime_type": "image/png", "data": _PNG_PAYLOAD},
+    ]
+
+    history.extend(
+        [
+            {"role": "assistant", "content": "recovered"},
+            {"role": "user", "content": "one more observation"},
+        ]
+    )
+    client.complete(history, [])
+    assert bodies[3]["previous_interaction_id"] == "folded"
+    assert bodies[3]["input"] == [{"type": "text", "text": "one more observation"}]
+
+
+def test_fold_persists_across_transient_failure_and_400_chain_loss() -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(_body(request))
+        index = len(bodies)
+        if index == 1:
+            return httpx.Response(200, json=_response("i1", _text("first")))
+        if index == 2:
+            return httpx.Response(400, text="unknown previous_interaction_id")
+        if index == 3:
+            return httpx.Response(500, text="fold temporarily unavailable")
+        return httpx.Response(200, json=_response("folded", _text("ok")))
+
+    client = _client(handler, max_retries=4)
+    history = _messages()
+    first = client.complete(history, [])
+    history.extend([first.raw(), {"role": "user", "content": "new observation"}])
+
+    client.complete(history, [])
+
+    assert "previous_interaction_id" in bodies[1]
+    assert "previous_interaction_id" not in bodies[2]
+    assert "previous_interaction_id" not in bodies[3]
+    assert bodies[2]["input"] == bodies[3]["input"]
+
+
+def test_final_attempt_chain_loss_leaves_fold_for_next_complete() -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(_body(request))
+        if len(bodies) == 1:
+            return httpx.Response(200, json=_response("i1", _text("first")))
+        if len(bodies) == 2:
+            return httpx.Response(404, text="expired")
+        return httpx.Response(200, json=_response("folded", _text("recovered")))
+
+    client = _client(handler, max_retries=1)
+    history = _messages()
+    first = client.complete(history, [])
+    history.extend([first.raw(), {"role": "user", "content": "new observation"}])
+
+    with pytest.raises(RuntimeError, match="404"):
+        client.complete(history, [])
+    client.complete(history, [])
+
+    assert bodies[1]["previous_interaction_id"] == "i1"
+    assert "previous_interaction_id" not in bodies[2]
+    assert live_module._RECOVERY_PROLOGUE in bodies[2]["input"][0]["text"]
+
+
+def test_unchained_404_fails_immediately_without_fold() -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(_body(request))
+        return httpx.Response(404, text="model path missing")
+
+    with pytest.raises(RuntimeError, match="model path missing"):
+        _client(handler).complete(_messages(), [])
+    assert len(bodies) == 1
+    assert live_module._RECOVERY_PROLOGUE not in json.dumps(bodies)
+
+
+def test_empty_delta_guard_rejects_assistant_only_suffix() -> None:
+    client = _client(lambda request: httpx.Response(200, json=_response("i1", _text("plain text"))))
+    history = _messages()
+    first = client.complete(history, [])
+    history.append(first.raw())
+
+    with pytest.raises(RuntimeError, match="no un-streamed user or tool message"):
+        client.complete(history, [])
+
+
+def test_rewritten_view_guard_and_identity_based_fresh_trial_reset() -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(_body(request))
+        return httpx.Response(200, json=_response(f"i{len(bodies)}", _text("ok")))
+
+    client = _client(handler)
+    history = _messages({"role": "user", "content": "observation"})
+    client.complete(history, [])
+    rewritten = [history[0], *json.loads(json.dumps(history[1:]))]
+
+    with pytest.raises(RuntimeError, match="rewritten conversation view"):
+        client.complete(rewritten, [])
+
+    fresh = json.loads(json.dumps(history))
+    client.complete(fresh, [])
+    assert len(bodies) == 2
+    assert "previous_interaction_id" not in bodies[1]
+    assert bodies[1]["input"] == bodies[0]["input"]
+
+
+def test_failed_status_raises_and_incomplete_returns_partial_text() -> None:
+    failed = _client(lambda request: httpx.Response(200, json=_response("i1", status="failed")))
+    with pytest.raises(RuntimeError, match="status 'failed'"):
+        failed.complete(_messages(), [])
+
+    incomplete = _client(
+        lambda request: httpx.Response(
+            200,
+            json=_response("i2", _text("partial"), status="incomplete"),
+        )
+    ).complete(_messages(), [])
+    assert incomplete.content == "partial"
+
+
+@pytest.mark.parametrize(
+    "payload, field",
+    [
+        ({"id": "i1", "status": "completed"}, "steps"),
+        (
+            _response("i1", {"type": "unexpected", "value": "x"}),
+            r"steps\[\]\.type",
+        ),
+    ],
+)
+def test_malformed_response_shapes_raise_runtime_errors(
+    payload: dict[str, Any], field: str
+) -> None:
+    client = _client(lambda request: httpx.Response(200, json=payload))
+    with pytest.raises(RuntimeError, match=field):
+        client.complete(_messages(), [])
+
+
+def test_capture_records_interactions_endpoint_and_flat_image_blob(tmp_path: Path) -> None:
+    capture = WireCapture()
+    capture.begin_trial(str(tmp_path), "run-1", "scene-e0")
+    client = _client(
+        lambda request: httpx.Response(200, json=_response("i1", _text("ok"))),
+        capture=capture,
+    )
+
+    client.complete(_messages(_image_message("look")), [])
+    capture.end_trial()
+
+    (row,) = _wire_rows(tmp_path / "wire/run-1/scene-e0/calls.jsonl")
+    assert row["endpoint"] == "/interactions"
+    image = next(part for part in row["request"]["input"] if part["type"] == "image")
+    digest = hashlib.sha256(_PNG_BYTES).hexdigest()
+    assert image == {
+        "type": "image",
+        "mime_type": "image/png",
+        "data": f"$blob:{digest}",
+    }
+    assert (tmp_path / f"wire/run-1/blobs/{digest}.png").read_bytes() == _PNG_BYTES
+
+
+def test_generation_config_placement_keyless_header_omission_and_close() -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "x-goog-api-key" not in request.headers
+        bodies.append(_body(request))
+        return httpx.Response(200, json=_response(f"i{len(bodies)}"))
+
+    client = _client(handler, api_key="")
+    client.complete(_messages(), [], temperature=0.2, reasoning_effort="medium")
+    client.complete(json.loads(json.dumps(_messages())), [])
+
+    assert bodies[0]["generation_config"] == {
+        "temperature": 0.2,
+        "thinking_level": "medium",
+    }
+    assert "temperature" not in bodies[0]
+    assert "thinking_level" not in bodies[0]
+    assert "generation_config" not in bodies[1]
+    client.close()
+    assert client._http.is_closed
+
+
+@pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high"])
+def test_policy_accepts_interactions_effort_levels(effort: str) -> None:
+    policy = LLMAgentPolicy(
+        model="m",
+        base_url="http://llm.test/v1beta",
+        wire="interactions",
+        effort=effort,
+        wire_capture=False,
+        env={},
+    )
+    assert isinstance(policy.config, AgentPolicyConfig)
+    assert policy.config.effort == effort
+    assert policy.config.image_horizon is None
+
+
+@pytest.mark.parametrize("effort", ["none", "xhigh", "max", 0.5, None])
+def test_policy_rejects_interactions_unsupported_effort(
+    effort: str | float | None,
+) -> None:
+    with pytest.raises(ConfigError) as exc_info:
+        LLMAgentPolicy(
+            model="m",
+            base_url="http://llm.test/v1beta",
+            wire="interactions",
+            effort=effort,
+            wire_capture=False,
+            env={},
+        )
+    assert str(exc_info.value).endswith(
+        "fix: pass -P effort=minimal|low|medium|high (maps to thinking_level), or drop -P effort="
+    )
+
+
+def test_policy_interactions_horizon_and_ws_base_url_guards() -> None:
+    with pytest.raises(ConfigError) as horizon_error:
+        LLMAgentPolicy(
+            model="m",
+            base_url="http://llm.test/v1beta",
+            wire="interactions",
+            image_horizon=2,
+            env={},
+        )
+    assert "frames already absorbed by the chain cannot be evicted client-side" in str(
+        horizon_error.value
+    )
+
+    with pytest.raises(ConfigError) as base_error:
+        LLMAgentPolicy(
+            model="m",
+            base_url="wss://llm.test/interactions",
+            wire="interactions",
+            env={},
+        )
+    assert str(base_error.value).endswith(
+        "fix: wire='interactions' is HTTP; drop -P base_url= or pass the Live wire "
+        "a websocket endpoint via -P wire=gemini-live"
+    )
+
+
+def test_policy_interactions_resolution_key_default_and_client_selection() -> None:
+    with pytest.raises(ConfigError) as provider_error:
+        LLMAgentPolicy(
+            model="openai/gpt-test",
+            wire="interactions",
+            env={"OPENAI_API_KEY": "openai-secret"},
+        )
+    assert str(provider_error.value) == (
+        "wire='interactions' needs Google's direct provider.\n"
+        "fix: use -P model=google/... and set $GEMINI_API_KEY"
+    )
+
+    explicit = LLMAgentPolicy(
+        model="google/gemini-test",
+        base_url="https://proxy.test/v1beta",
+        wire="interactions",
+        wire_capture=False,
+        env={"GEMINI_API_KEY": "gemini-secret", "OPENROUTER_API_KEY": "wrong-secret"},
+    )
+    assert isinstance(explicit._client, InteractionsClient)
+    assert explicit._client._provider.api_key == "gemini-secret"
+
+    direct = LLMAgentPolicy(
+        model="google/gemini-3.7-flash",
+        wire="interactions",
+        wire_capture=False,
+        env={"GEMINI_API_KEY": "gemini-secret"},
+    )
+    assert isinstance(direct._client, InteractionsClient)
+    assert isinstance(direct.config, AgentPolicyConfig)
+    assert direct.config.base_url == _INTERACTIONS_BASE
+    assert direct.config.model == "gemini-3.7-flash"
+    assert direct.config.effort is None
+
+
+def test_policy_act_chains_delta_and_capture_round_trips_blobs(tmp_path: Path) -> None:
+    raw_requests: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raw_requests.append(_body(request))
+        if len(raw_requests) == 1:
+            return httpx.Response(
+                200,
+                json=_response(
+                    "i1",
+                    _call(
+                        "move-call",
+                        "move_by",
+                        {
+                            "deltas": {"dx": 0.02, "dy": 0.02},
+                            "note": "The cube is ahead, so I will move toward it.",
+                        },
+                    ),
+                    status="requires_action",
+                ),
+            )
+        return httpx.Response(
+            200,
+            json=_response(
+                "i2",
+                _call(
+                    "done-call",
+                    "done",
+                    {"summary": "finished", "hindsight": "none"},
+                ),
+                status="requires_action",
+            ),
+        )
+
+    policy = LLMAgentPolicy(
+        model="test/model",
+        base_url="http://llm.test/v1beta",
+        wire="interactions",
+        depth="off",
+        transport=httpx.MockTransport(handler),
+        env={},
+    )
+    embodiment = CubePickEmbodiment()
+    policy.bind(embodiment.info)
+    scene = Scene(id="s0", instruction="reach the cube")
+    policy.reset(scene)
+    policy.on_trial_start("s0", 0, str(tmp_path), "run-1")
+
+    first_chunk = policy.act(embodiment.reset(scene, seed=0))
+    next_observation = embodiment.step(first_chunk.actions[-1]).observation
+    stop_chunk = policy.act(next_observation)
+
+    assert stop_chunk.actions[0].meta["request_stop"] is True
+    second = raw_requests[1]
+    assert second["previous_interaction_id"] == "i1"
+    assert second["input"][0]["type"] == "function_result"
+    assert second["input"][0]["call_id"] == "move-call"
+    assert any(part.get("type") == "image" for part in second["input"])
+    assert all(part.get("type") != "function_call" for part in second["input"])
+    assert "The cube is ahead" not in json.dumps(second["input"])
+
+    record = TrialRecord(scene_id="s0", epoch=0, seed=0, status="success")
+    policy.on_trial_end(record, str(tmp_path), "run-1")
+    pointer = record.metadata["wire_capture"]
+    assert isinstance(pointer, str)
+    capture_path = tmp_path / pointer
+    rows = _wire_rows(capture_path)
+    assert [row["endpoint"] for row in rows] == ["/interactions", "/interactions"]
+    blob_dir = capture_path.parent.parent / "blobs"
+    assert [_inline_blobs(row["request"], blob_dir) for row in rows] == raw_requests
+
+
+def test_policy_text_turn_takes_existing_nudge_path_end_to_end() -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(_body(request))
+        if len(bodies) == 1:
+            return httpx.Response(
+                200,
+                json=_response(
+                    "i1",
+                    _text("I should use a tool"),
+                    status="incomplete",
+                ),
+            )
+        return httpx.Response(
+            200,
+            json=_response(
+                "i2",
+                _call(
+                    "done-call",
+                    "done",
+                    {"summary": "ok", "hindsight": "none"},
+                ),
+                status="requires_action",
+            ),
+        )
+
+    policy = LLMAgentPolicy(
+        model="test/model",
+        base_url="http://llm.test/v1beta",
+        wire="interactions",
+        wire_capture=False,
+        transport=httpx.MockTransport(handler),
+        env={},
+    )
+    embodiment = CubePickEmbodiment()
+    policy.bind(embodiment.info)
+    scene = Scene(id="s0", instruction="inspect")
+    policy.reset(scene)
+
+    chunk = policy.act(embodiment.reset(scene, seed=0))
+
+    assert chunk.actions[0].meta["request_stop"] is True
+    assert bodies[1]["previous_interaction_id"] == "i1"
+    assert bodies[1]["input"] == [{"type": "text", "text": "Respond with exactly one tool call."}]
+    assert "I should use a tool" not in json.dumps(bodies[1]["input"])

--- a/plugins/inspect-robots-agent/tests/test_interactions.py
+++ b/plugins/inspect-robots-agent/tests/test_interactions.py
@@ -18,9 +18,8 @@ from inspect_robots.errors import ConfigError
 from inspect_robots.mock import CubePickEmbodiment
 from inspect_robots.rollout import TrialRecord
 from inspect_robots.scene import Scene
-from inspect_robots_agent import LLMAgentPolicy
+from inspect_robots_agent import InteractionsClient, LLMAgentPolicy
 from inspect_robots_agent._capture import WireCapture
-from inspect_robots_agent._interactions import InteractionsClient
 from inspect_robots_agent._llm import Provider
 from inspect_robots_agent.policy import _INTERACTIONS_BASE, AgentPolicyConfig
 
@@ -502,22 +501,24 @@ def test_failed_status_raises_and_incomplete_returns_partial_text() -> None:
     assert incomplete.content == "partial"
 
 
-@pytest.mark.parametrize(
-    "payload, field",
-    [
-        ({"id": "i1", "status": "completed"}, "steps"),
-        (
-            _response("i1", {"type": "unexpected", "value": "x"}),
-            r"steps\[\]\.type",
-        ),
-    ],
-)
-def test_malformed_response_shapes_raise_runtime_errors(
-    payload: dict[str, Any], field: str
-) -> None:
-    client = _client(lambda request: httpx.Response(200, json=payload))
-    with pytest.raises(RuntimeError, match=field):
+def test_missing_steps_raise_and_unknown_step_types_are_skipped() -> None:
+    client = _client(lambda request: httpx.Response(200, json={"id": "i1", "status": "completed"}))
+    with pytest.raises(RuntimeError, match="steps"):
         client.complete(_messages(), [])
+
+    tolerant = _client(
+        lambda request: httpx.Response(
+            200,
+            json=_response(
+                "i2",
+                {"type": "thinking", "content": [{"type": "text", "text": "pondering"}]},
+                {"type": "model_output", "content": [{"type": "text", "text": "done"}]},
+            ),
+        )
+    )
+    message = tolerant.complete(_messages(), [])
+    assert message.content == "done"
+    assert message.tool_calls == ()
 
 
 def test_capture_records_interactions_endpoint_and_flat_image_blob(tmp_path: Path) -> None:

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -6,7 +6,7 @@ def test_package_imports_and_exports() -> None:
 
     # Pinned so a version bump that misses either side fails loudly (the
     # 0.1.0 hardcode shipped stale through two releases unnoticed).
-    assert inspect_robots_agent.__version__ == "0.24.0"
+    assert inspect_robots_agent.__version__ == "0.25.0"
     assert callable(inspect_robots_agent.agent_policy)
     assert inspect_robots_agent.__all__ == [
         "ENV_MODEL",

--- a/plugins/inspect-robots-agent/tests/test_package.py
+++ b/plugins/inspect-robots-agent/tests/test_package.py
@@ -15,6 +15,7 @@ def test_package_imports_and_exports() -> None:
         "AssistantMessage",
         "ChatClient",
         "GeminiLiveClient",
+        "InteractionsClient",
         "LLMAgentPolicy",
         "Provider",
         "ResponsesClient",

--- a/uv.lock
+++ b/uv.lock
@@ -315,7 +315,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly" },
+    { name = "humanfriendly", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -430,15 +430,15 @@ name = "csvw"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "babel" },
-    { name = "isodate" },
-    { name = "jsonschema" },
-    { name = "language-tags" },
-    { name = "python-dateutil" },
-    { name = "rdflib" },
-    { name = "rfc3986" },
-    { name = "termcolor" },
-    { name = "uritemplate" },
+    { name = "babel", marker = "python_full_version < '3.15'" },
+    { name = "isodate", marker = "python_full_version < '3.15'" },
+    { name = "jsonschema", marker = "python_full_version < '3.15'" },
+    { name = "language-tags", marker = "python_full_version < '3.15'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.15'" },
+    { name = "rdflib", marker = "python_full_version < '3.15'" },
+    { name = "rfc3986", marker = "python_full_version < '3.15'" },
+    { name = "termcolor", marker = "python_full_version < '3.15'" },
+    { name = "uritemplate", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/f1/95a10e22505e84bf346dd8df41d9c6135aea564d83d8e39b79b0851ba4db/csvw-4.1.0.tar.gz", hash = "sha256:bfe2b64442552b392577a8d30edf886510c8d05e665606fa5caa1508365fd700", size = 83167, upload-time = "2026-07-06T08:37:26.378Z" }
 wheels = [
@@ -524,7 +524,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -696,7 +696,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -787,7 +787,7 @@ provides-extras = ["all", "dev", "docs", "rerun", "viz"]
 
 [[package]]
 name = "inspect-robots-agent"
-version = "0.24.0"
+version = "0.25.0"
 source = { editable = "plugins/inspect-robots-agent" }
 dependencies = [
     { name = "httpx" },
@@ -1008,11 +1008,11 @@ name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing" },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "rpds-py", version = "2026.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "attrs", marker = "python_full_version < '3.15'" },
+    { name = "jsonschema-specifications", marker = "python_full_version < '3.15'" },
+    { name = "referencing", marker = "python_full_version < '3.15'" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "rpds-py", version = "2026.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -1024,7 +1024,7 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing" },
+    { name = "referencing", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
@@ -1036,12 +1036,12 @@ name = "kokoro-onnx"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "espeakng-loader" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "phonemizer-fork" },
+    { name = "espeakng-loader", marker = "python_full_version < '3.15'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.15'" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.15'" },
+    { name = "phonemizer-fork", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/18/277bd18aeeceaf5c46a51bb50c1cbdccdad8cab7fd1d58f0173bbeeec708/kokoro_onnx-0.5.0.tar.gz", hash = "sha256:5beb15f085e2828ed8d493f792c079af857103ab2dceaa1e112b1760587ac96a", size = 84570, upload-time = "2026-01-30T03:05:45.6Z" }
 wheels = [
@@ -1496,12 +1496,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "coloredlogs" },
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
+    { name = "coloredlogs", marker = "python_full_version < '3.11'" },
+    { name = "flatbuffers", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "protobuf", marker = "python_full_version < '3.11'" },
+    { name = "sympy", marker = "python_full_version < '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
@@ -1537,10 +1537,10 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.15'",
 ]
 dependencies = [
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "protobuf" },
+    { name = "flatbuffers", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/4d/5014667e2a3a77d6e1b74cc3d88948d06163b8e0a33a84c85073322b5dec/onnxruntime-1.28.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:f5c5daabd28aad610f83fdcf32acec8fb57e6adc6c6a39fe2a3c755db957b410", size = 19130506, upload-time = "2026-07-25T01:22:34.489Z" },
@@ -1592,11 +1592,11 @@ name = "phonemizer-fork"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "dlinfo" },
-    { name = "joblib" },
-    { name = "segments" },
-    { name = "typing-extensions" },
+    { name = "attrs", marker = "python_full_version < '3.15'" },
+    { name = "dlinfo", marker = "python_full_version < '3.15'" },
+    { name = "joblib", marker = "python_full_version < '3.15'" },
+    { name = "segments", marker = "python_full_version < '3.15'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/fa/9294d2f11890ca49d0bdac7a4da60cbe5686629bfd4987cae0ad75e051cc/phonemizer_fork-3.3.2.tar.gz", hash = "sha256:10e16e827d0443b087062e21b55e805c00989cf1343b2e81e734cae5f6c0cf69", size = 300989, upload-time = "2025-01-30T13:02:31.201Z" }
 wheels = [
@@ -1904,7 +1904,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
+    { name = "six", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
@@ -1993,8 +1993,8 @@ name = "rdflib"
 version = "7.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "isodate", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "pyparsing" },
+    { name = "isodate", marker = "python_full_version < '3.11'" },
+    { name = "pyparsing", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/f5/18bb77b7af9526add0c727a3b2048959847dc5fb030913e2918bf384fec3/rdflib-7.6.0.tar.gz", hash = "sha256:6c831288d5e4a5a7ece85d0ccde9877d512a3d0f02d7c06455d00d6d0ea379df", size = 4943826, upload-time = "2026-02-13T07:15:55.938Z" }
 wheels = [
@@ -2006,10 +2006,10 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "rpds-py", version = "2026.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version != '3.13.*'" },
+    { name = "attrs", marker = "python_full_version < '3.15'" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "rpds-py", version = "2026.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.15'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -2447,8 +2447,8 @@ name = "segments"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "csvw" },
-    { name = "regex" },
+    { name = "csvw", marker = "python_full_version < '3.15'" },
+    { name = "regex", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/57/85cac3a8e32370e88fa5fa92812edb6025db7fcbed51452bd56ee1524957/segments-2.4.0.tar.gz", hash = "sha256:bba71f5520ddd54c8aa2f4d765a60618c6862162d6e7356a4a097f2223166f5b", size = 18662, upload-time = "2026-03-07T10:01:28.925Z" }
 wheels = [
@@ -2494,7 +2494,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath" },
+    { name = "mpmath", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [


### PR DESCRIPTION
Closes #378

Adds `-P wire=interactions` to the agent plugin: Google's Interactions API as a stateful HTTP wire. Calls chain with `previous_interaction_id` so conversation history (including camera frames) lives server-side; each step uploads only the new observation and function results, and stateful chaining lets Google's implicit caching cover the history prefix. This is the only stateful path for GA models like `gemini-3.7-flash`, which the Live API does not serve.

Design doc: `plans/0066-interactions-wire.md` (critique loop in progress; implementation follows).

- New `InteractionsClient` (httpx only), identity-prefix chain tracking with fold recovery on chain loss, mirroring the `gemini-live` wire's discipline
- `effort` maps to `generation_config.thinking_level` (minimal/low/medium/high); `image_horizon` rejected (server-side history cannot be evicted)
- Wire capture support incl. the Interactions inline-image shape
- Plugin README docs + minor version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)