### PR TITLE
agent: interactions function_result requires the function name

### DIFF
--- a/plans/0068-interactions-wire.md
+++ b/plans/0068-interactions-wire.md
@@ -110,6 +110,16 @@ above come from the API reference, not a probe. The implementation therefore:
    endpoint when `GEMINI_API_KEY` is set. First run on a keyed machine is a
    release gate for announcing the wire.
 
+*Smoke-gate results (run on omen, 2026-08-14):* the gate caught one real
+mismatch — `function_result` requires the function `name` (issue #380, fix
+described in the `_call_names` bullet below). Two risks resolved
+harmlessly: responses carry `{"type": "thought", "signature": …}` steps,
+absorbed by the unknown-step tolerance the PR #379 review added (the
+original strict parser would have failed every call), and usage carries
+undocumented counters (`total_tool_use_tokens`, `raw_prompt_token`),
+ignored by the allowlist mapping. `arguments` arrives as a JSON object, as
+documented.
+
 ## Design
 
 ### New module: `plugins/inspect-robots-agent/src/inspect_robots_agent/_interactions.py`
@@ -130,11 +140,18 @@ State, mirroring `GeminiLiveClient`'s identity-prefix discipline:
   trial reset". This is also why `image_horizon` is rejected on this wire
   (below): `_evicted_view` rewrites history and would trip this guard by
   design.
-- `_last_interaction_id: str | None` — the chain head. Unlike the Live
-  wire's `_call_names`, no per-call bookkeeping is needed: a
-  `function_result` step carries only `call_id`, which comes straight from
-  the tool message's `tool_call_id` (the policy writes
-  `{"role": "tool", "tool_call_id": call.id, "content": result_text}`).
+- `_last_interaction_id: str | None` — the chain head.
+- `_call_names: dict[str, str]` — call id → function name, recorded at
+  parse time. *Smoke-gate amendment (2026-08-14, issue #380):* R1
+  originally deleted this bookkeeping because the documented contract
+  showed `function_result` carrying only `call_id` — but the live endpoint
+  rejects a name-less step with an opaque 400 and accepts
+  `{"type": "function_result", "name": …, "call_id": …, "result": …}`, so
+  the Live wire's `_call_names` pattern applies here after all: recorded
+  per parsed call, consulted by suffix translation (an unrecorded id
+  raises a guided error), cleared on trial reset and on fold success
+  (pre-fold calls live inside the sanitized prologue and can never
+  legitimately receive a delta result afterward).
 - `_needs_fold: bool` — set when chain loss is detected, cleared only after
   a successful fold. While set, every attempt (including across the retry
   backoff loop) sends the unchained fold, never the chained delta — the

--- a/plugins/inspect-robots-agent/src/inspect_robots_agent/_interactions.py
+++ b/plugins/inspect-robots-agent/src/inspect_robots_agent/_interactions.py
@@ -65,6 +65,11 @@ class InteractionsClient:
         self._streamed: list[dict[str, Any]] = []
         self._last_interaction_id: str | None = None
         self._needs_fold = False
+        # The live endpoint requires the function name on every
+        # function_result step (probed 2026-08-14; a call_id-only step gets
+        # an opaque 400), and the chat-format tool message carries only the
+        # id, so names are recorded at parse time as on the Live wire.
+        self._call_names: dict[str, str] = {}
 
     def complete(
         self,
@@ -80,7 +85,11 @@ class InteractionsClient:
 
         for attempt in range(self._max_retries):
             folding = self._needs_fold
-            input_items = self._fold_input(messages) if folding else _translate_suffix(suffix)
+            input_items = (
+                self._fold_input(messages)
+                if folding
+                else _translate_suffix(suffix, self._call_names)
+            )
             body = self._request_body(
                 messages,
                 tools,
@@ -120,8 +129,14 @@ class InteractionsClient:
                     if folding:
                         self._streamed = list(messages)
                         self._needs_fold = False
+                        # Pre-fold calls live inside the sanitized prologue
+                        # now; only calls parsed from here on can still
+                        # receive a result as a delta.
+                        self._call_names.clear()
                     else:
                         self._streamed.extend(suffix)
+                    for call in result.tool_calls:
+                        self._call_names[call.id] = call.name
                     return result
 
                 last_error = f"HTTP {response.status_code}: {response.text[:500]}"
@@ -165,6 +180,7 @@ class InteractionsClient:
         self._streamed.clear()
         self._last_interaction_id = None
         self._needs_fold = False
+        self._call_names.clear()
 
     def _request_body(
         self,
@@ -256,7 +272,10 @@ def _translate_tool(tool: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _translate_suffix(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _translate_suffix(
+    messages: list[dict[str, Any]],
+    call_names: dict[str, str],
+) -> list[dict[str, Any]]:
     translated: list[dict[str, Any]] = []
     for message in messages:
         role = message.get("role")
@@ -264,10 +283,17 @@ def _translate_suffix(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
             translated.extend(_user_content(message))
         elif role == "tool":
             call_id = str(message["tool_call_id"])
+            name = call_names.get(call_id)
+            if name is None:
+                raise RuntimeError(
+                    f"Interactions has no function name recorded for tool call {call_id!r}"
+                )
             content = message.get("content")
             if not isinstance(content, str):
                 raise RuntimeError(f"Interactions tool result {call_id!r} content must be a string")
-            translated.append({"type": "function_result", "call_id": call_id, "result": content})
+            translated.append(
+                {"type": "function_result", "name": name, "call_id": call_id, "result": content}
+            )
         elif role in {"assistant", "system"}:
             continue
         else:

--- a/plugins/inspect-robots-agent/tests/test_interactions.py
+++ b/plugins/inspect-robots-agent/tests/test_interactions.py
@@ -208,6 +208,7 @@ def test_chained_call_sends_only_tool_and_user_delta_with_scoped_fields() -> Non
     assert second["input"] == [
         {
             "type": "function_result",
+            "name": "move_by",
             "call_id": "tool-call-id",
             "result": "moved",
         },
@@ -463,6 +464,46 @@ def test_empty_delta_guard_rejects_assistant_only_suffix() -> None:
 
     with pytest.raises(RuntimeError, match="no un-streamed user or tool message"):
         client.complete(history, [])
+
+
+def test_tool_result_for_unrecorded_call_id_raises() -> None:
+    client = _client(lambda request: httpx.Response(200, json=_response("i1", _text("ok"))))
+    history = _messages()
+    client.complete(history, [])
+    history.append({"role": "tool", "tool_call_id": "never-issued", "content": "orphan"})
+
+    with pytest.raises(
+        RuntimeError, match="no function name recorded for tool call 'never-issued'"
+    ):
+        client.complete(history, [])
+
+
+def test_fold_clears_recorded_call_names() -> None:
+    responses = iter(
+        [
+            httpx.Response(
+                200,
+                json=_response("i1", _call("pre-fold", "move_by"), status="requires_action"),
+            ),
+            httpx.Response(404, json={"error": {"message": "interaction not found"}}),
+            httpx.Response(200, json=_response("i2", _text("recovered"))),
+        ]
+    )
+    client = _client(lambda request: next(responses))
+    history = _messages()
+    first = client.complete(history, [_schema("move_by")])
+    history.extend(
+        [
+            first.raw(),
+            {"role": "tool", "tool_call_id": "pre-fold", "content": "moved"},
+            {"role": "user", "content": "next observation"},
+        ]
+    )
+    client.complete(history, [_schema("move_by")])
+    history.append({"role": "tool", "tool_call_id": "pre-fold", "content": "stale"})
+
+    with pytest.raises(RuntimeError, match="no function name recorded for tool call 'pre-fold'"):
+        client.complete(history, [_schema("move_by")])
 
 
 def test_rewritten_view_guard_and_identity_based_fresh_trial_reset() -> None:


### PR DESCRIPTION
Closes #380

The interactions wire's live smoke gate (plan 0068's release gate, run on omen) caught a contract mismatch: Google's endpoint 400s a `function_result` step that carries only `call_id`; the function `name` is required alongside it. This restores the Live wire's `_call_names` pattern: call id → name recorded at parse time, consulted by suffix translation (guided error for unrecorded ids), cleared on trial reset and on fold success.

Plan 0068 is amended with the full smoke-gate results: `thought` steps appear in live responses (absorbed by the unknown-step tolerance from the PR #379 review) and usage carries undocumented counters (ignored by the allowlist mapping).

After this fix the smoke probe passes end to end on omen: `Interactions smoke probe passed: Reported smoke probe successfully.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)