### PR TITLE
chatwire: retry with max_completion_tokens when a 400 names it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **Core:** the shared chat wire behind task generation, the `vlm` grader,
+  and summarize now retries once with `max_completion_tokens` when a 400
+  response names that parameter, so OpenAI reasoning models that reject
+  `max_tokens` work without rerouting through a proxy
+  ([plan 0073](plans/0073-chatwire-max-completion-tokens.md),
+  [#390](https://github.com/robocurve/inspect-robots/issues/390)).
+
 - **Core:** the operator footer now echoes typing on a background cadence, so
   feedback is visible while an agent policy is blocked in inference instead of
   appearing only when the robot moves

--- a/plans/0073-chatwire-max-completion-tokens.md
+++ b/plans/0073-chatwire-max-completion-tokens.md
@@ -28,7 +28,16 @@ strict; pytest at 100% coverage.
 **Spec:** issue #390 + this plan (the plan is the spec, per repo
 convention).
 
-**Critique:** pending (rounds recorded here as they complete).
+**Critique:** round 1 (fresh-context subagent) verified every factual
+claim against the code (callers, tests, `__all__`, CHANGELOG format, no
+collision with the in-flight #388 taskgen-args work beyond a trivial
+CHANGELOG merge) and found 3 minor issues, all fixed in this revision:
+the both-400 test now scripts two different 400 bodies so it can prove
+the retry response is the one surfaced (binding decision 3 was otherwise
+unverifiable); the TDD must-fail claim is scoped to the three tests that
+actually fail pre-change, with the other two labeled regression guards;
+and the residual reasoning-token-exhaustion failure mode is named in
+Out of scope so it is not rediscovered as a bug in this fix.
 
 ## Global constraints
 
@@ -37,7 +46,8 @@ convention).
 - The module stays dependency-free (stdlib only); the `http_post`
   injection seam keeps its `HttpPost` signature so existing callers and
   tests are unaffected.
-- Ruff D1: any new function gets a contract-stating docstring.
+- New helpers get contract-stating docstrings (ruff D1 exempts
+  underscore-prefixed functions, but the module's own style keeps them).
 - No public API change (`chat_completion` signature untouched;
   `inspect_robots.__all__` untouched).
 - Error wording: existing guided-error text (`what` prefix, `fix_hint`)
@@ -88,7 +98,9 @@ convention).
 
    ```python
    status, response_body = _post_chat(post, url, headers, model, messages, "max_tokens")
-   if status == 400 and "max_completion_tokens" in response_body.decode("utf-8", errors="replace"):
+   if status == 400 and "max_completion_tokens" in response_body.decode(
+       "utf-8", errors="replace"
+   ):
        status, response_body = _post_chat(
            post, url, headers, model, messages, "max_completion_tokens"
        )
@@ -115,20 +127,28 @@ convention).
       the second body's JSON has `max_completion_tokens: 8192` and no
       `max_tokens` key, and `model`/`messages` are unchanged between the
       two posts.
-- [ ] Test: both responses are that 400. Assert exactly two posts, and
-      the raised `ConfigError` carries the `what` prefix, HTTP 400, and
-      the retry body's excerpt.
-- [ ] Test: a 400 whose body lacks the marker raises immediately with a
-      single post.
-- [ ] Test: a non-400 failure (e.g. 500) whose body mentions
-      `max_completion_tokens` raises immediately with a single post (the
-      trigger requires both conditions).
+- [ ] Test: both responses are 400, with two DIFFERENT bodies (first
+      contains the marker, second is distinct text without it, e.g.
+      `{"error": {"message": "still rejected"}}`). Assert exactly two
+      posts, and the raised `ConfigError` carries the `what` prefix,
+      HTTP 400, and the second body's text but not the first's — this is
+      what proves binding decision 3 (the retry response is the one
+      surfaced); identical bodies could not distinguish the two.
+- [ ] Test (regression guard, passes pre-change): a 400 whose body lacks
+      the marker raises immediately with a single post.
+- [ ] Test (regression guard, passes pre-change): a non-400 failure
+      (e.g. 500) whose body mentions `max_completion_tokens` raises
+      immediately with a single post (the trigger requires both
+      conditions).
 - [ ] Test: the marker check reads past 500 bytes: a 400 body with the
       marker after 500 filler bytes still triggers the retry (guards the
       full-body-decode decision against regression to
       `_response_excerpt`).
-- [ ] Run `uv run pytest tests/test_chatwire.py`; the new tests must fail
-      against the current module.
+- [ ] Run `uv run pytest tests/test_chatwire.py`. Exactly three of the
+      new tests must fail against the current module: retry-then-success,
+      both-400, and marker-past-500-bytes. The two regression guards
+      pass against current code by design (today's behavior is already
+      correct there); do not "fix" them into failing.
 
 ### Task 2: implement the retry
 
@@ -149,7 +169,17 @@ convention).
 
 - Making the token cap configurable (`-A max_tokens=...`): separate
   feature; #386/#388 is building the taskgen config surface and nothing
-  here should collide with it.
+  here should collide with it (the only contact point is a one-hunk
+  CHANGELOG Unreleased merge conflict for whichever lands second).
+- Known residual, accepted: once `max_completion_tokens: 8192` is
+  accepted, OpenAI reasoning models count reasoning tokens against the
+  cap. A high-effort call that exhausts the cap on reasoning returns
+  HTTP 200 with `content: null` and `finish_reason: "length"`, which the
+  existing parse path reports as "endpoint returned a malformed reply" —
+  a misleading diagnosis for this exact provider+model combination. That
+  is a pre-existing property of the parse path, not introduced by the
+  retry; the remedy is the cap-configurability feature above, not a
+  change to the retry design.
 - Teaching the agent plugin's chat wire anything: it has its own client
   and does not exhibit the bug.
 - Caching the discovered parameter name across calls: each

--- a/plans/0073-chatwire-max-completion-tokens.md
+++ b/plans/0073-chatwire-max-completion-tokens.md
@@ -123,35 +123,35 @@ this revision.
 
 ### Task 1: failing tests first (TDD)
 
-- [ ] In `tests/test_chatwire.py`, add a recording post factory that
+- [x] In `tests/test_chatwire.py`, add a recording post factory that
       captures each `(url, headers, body_bytes)` and serves scripted
       responses in sequence, raising if called past the scripted count so
       over-posting fails loudly (the existing `_post` helper serves one
       static response; the new tests need per-call scripting and capture).
-- [ ] Test: first response is the OpenAI 400 `unsupported_parameter` body
+- [x] Test: first response is the OpenAI 400 `unsupported_parameter` body
       naming `max_completion_tokens`, second response is a 200 reply.
       Assert the wire returns the content, exactly two posts were made,
       the second body's JSON has `max_completion_tokens: 8192` and no
       `max_tokens` key, and `url`, `headers`, `model`, and `messages` are
       unchanged between the two posts.
-- [ ] Test: both responses are 400, with two DIFFERENT bodies (first
+- [x] Test: both responses are 400, with two DIFFERENT bodies (first
       contains the marker, second is distinct text without it, e.g.
       `{"error": {"message": "still rejected"}}`). Assert exactly two
       posts, and the raised `ConfigError` carries the `what` prefix,
       HTTP 400, and the second body's text but not the first's — this is
       what proves binding decision 3 (the retry response is the one
       surfaced); identical bodies could not distinguish the two.
-- [ ] Test (regression guard, passes pre-change): a 400 whose body lacks
+- [x] Test (regression guard, passes pre-change): a 400 whose body lacks
       the marker raises immediately with a single post.
-- [ ] Test (regression guard, passes pre-change): a non-400 failure
+- [x] Test (regression guard, passes pre-change): a non-400 failure
       (e.g. 500) whose body mentions `max_completion_tokens` raises
       immediately with a single post (the trigger requires both
       conditions).
-- [ ] Test: the marker check reads the full body: a 400 body with the
+- [x] Test: the marker check reads the full body: a 400 body with the
       marker after more than 500 characters of ASCII filler still
       triggers the retry (guards the full-body-decode decision against
       regression to `_response_excerpt`).
-- [ ] Run `uv run pytest tests/test_chatwire.py`. Exactly three of the
+- [x] Run `uv run pytest tests/test_chatwire.py`. Exactly three of the
       new tests must fail against the current module: retry-then-success,
       both-400, and marker-past-500-bytes. The two regression guards
       pass against current code by design (today's behavior is already
@@ -159,17 +159,17 @@ this revision.
 
 ### Task 2: implement the retry
 
-- [ ] Add `_MAX_COMPLETION_TOKENS = 8192` and the `_post_chat` helper
+- [x] Add `_MAX_COMPLETION_TOKENS = 8192` and the `_post_chat` helper
       (binding decision 4), with D1 docstrings.
-- [ ] Rewire `chat_completion` per binding decisions 1–3.
-- [ ] Extend the module docstring with the retry contract sentence.
-- [ ] Run `uv run pytest tests/test_chatwire.py` until green, then the
+- [x] Rewire `chat_completion` per binding decisions 1–3.
+- [x] Extend the module docstring with the retry contract sentence.
+- [x] Run `uv run pytest tests/test_chatwire.py` until green, then the
       full gates: `uv run ruff check .`, `uv run ruff format --check .`,
       `uv run mypy`, `uv run pytest --cov` (must hold 100%).
 
 ### Task 3: changelog
 
-- [ ] Add the `### Fixed` entry under `## [Unreleased]` in
+- [x] Add the `### Fixed` entry under `## [Unreleased]` in
       `CHANGELOG.md` (binding decision 6).
 
 ## Out of scope

--- a/plans/0073-chatwire-max-completion-tokens.md
+++ b/plans/0073-chatwire-max-completion-tokens.md
@@ -1,0 +1,158 @@
+# chatwire: retry with max_completion_tokens when a 400 names it Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `--auto-task` with an OpenAI gpt-5.x author fails before rollout
+(issue #390): `chat_completion` hardcodes `"max_tokens": 8192` into every
+request body, and OpenAI's reasoning models reject that parameter on
+`/chat/completions` with HTTP 400 `unsupported_parameter`, whose message
+says to use `max_completion_tokens` instead. Every consumer of the shared
+chat wire is exposed when pointed at such a model: task generation (`-A`),
+the `vlm` grader (`-G`), and summarize.
+
+**Architecture:** one self-contained change in
+`src/inspect_robots/_chatwire.py`. `chat_completion` sends the request
+exactly as today; if and only if the response is a 400 whose decoded body
+contains the substring `max_completion_tokens`, it re-sends the identical
+request once with the token cap keyed as `max_completion_tokens` instead of
+`max_tokens`, then proceeds with the normal success/error handling on the
+retry response. The server itself names the substitute parameter, so there
+is no model-name sniffing, and endpoints that accept `max_tokens` today
+(Gemini OpenAI-compat, OpenRouter, Anthropic's compat endpoint, vLLM) see
+byte-identical behavior. Callers (`taskgen.py`, `grader.py`,
+`_summarize.py`) are untouched.
+
+**Tech stack:** stdlib-only module as today (`json`, `urllib`); mypy
+strict; pytest at 100% coverage.
+
+**Spec:** issue #390 + this plan (the plan is the spec, per repo
+convention).
+
+**Critique:** pending (rounds recorded here as they complete).
+
+## Global constraints
+
+- Gates: `ruff check .`, `ruff format --check .`, `mypy` (strict,
+  src + tests), `pytest --cov` at 100%.
+- The module stays dependency-free (stdlib only); the `http_post`
+  injection seam keeps its `HttpPost` signature so existing callers and
+  tests are unaffected.
+- Ruff D1: any new function gets a contract-stating docstring.
+- No public API change (`chat_completion` signature untouched;
+  `inspect_robots.__all__` untouched).
+- Error wording: existing guided-error text (`what` prefix, `fix_hint`)
+  must survive unchanged; existing tests in `tests/test_chatwire.py`,
+  `tests/test_taskgen.py`, `tests/test_vlm_grader.py`, and
+  `tests/test_summarize.py` must pass without edits. Any pre-existing
+  test that seems to demand modification is a stop-and-flag conflict, not
+  something to edit.
+
+## Binding decisions
+
+1. **Trigger contract:** retry exactly when `status == 400` and the
+   response body, decoded as UTF-8 with `errors="replace"`, contains the
+   substring `"max_completion_tokens"`. Decode the full body for the
+   check, not `_response_excerpt` (that helper truncates to 500 chars and
+   exists for error display only). Any other status, and any 400 without
+   the marker, takes today's path with zero extra requests.
+2. **Retry request:** identical `url`, `headers`, `model`, `messages`,
+   and cap value; the only difference is the JSON key `max_tokens` →
+   `max_completion_tokens`. The cap value stays `8192` and is hoisted to
+   a module constant `_MAX_COMPLETION_TOKENS = 8192` so both branches
+   share it.
+3. **Single retry, terminal second answer:** the retry response flows
+   into the same success/error handling as a first answer, with no
+   further body inspection. A 400 from the `max_completion_tokens`
+   request therefore raises the normal guided `ConfigError` carrying the
+   *retry* response's body (that is the actionable error). No loops.
+4. **Shape of the change:** extract the request-building + posting into a
+   private helper so the two sends cannot drift:
+
+   ```python
+   def _post_chat(
+       post: HttpPost,
+       url: str,
+       headers: dict[str, str],
+       model: str,
+       messages: list[dict[str, Any]],
+       token_param: str,
+   ) -> tuple[int, bytes]:
+       """Send one chat-completions request with the token cap under token_param."""
+       body = json.dumps(
+           {"model": model, "messages": messages, token_param: _MAX_COMPLETION_TOKENS}
+       ).encode("utf-8")
+       return post(url, headers, body)
+   ```
+
+   `chat_completion` then reads:
+
+   ```python
+   status, response_body = _post_chat(post, url, headers, model, messages, "max_tokens")
+   if status == 400 and "max_completion_tokens" in response_body.decode("utf-8", errors="replace"):
+       status, response_body = _post_chat(
+           post, url, headers, model, messages, "max_completion_tokens"
+       )
+   ```
+
+5. **Docs surface:** module docstring gains one sentence stating the
+   retry contract. No user-facing docs change (the wire is internal), no
+   CLI docs change.
+6. **CHANGELOG:** one entry under `## [Unreleased]` / `### Fixed`,
+   Core-scoped, linking this plan and issue #390, following the existing
+   entry format.
+
+## Tasks
+
+### Task 1: failing tests first (TDD)
+
+- [ ] In `tests/test_chatwire.py`, add a recording post factory that
+      captures each `(url, headers, body_bytes)` and serves scripted
+      responses in sequence (the existing `_post` helper serves one
+      static response; the new tests need per-call scripting and capture).
+- [ ] Test: first response is the OpenAI 400 `unsupported_parameter` body
+      naming `max_completion_tokens`, second response is a 200 reply.
+      Assert the wire returns the content, exactly two posts were made,
+      the second body's JSON has `max_completion_tokens: 8192` and no
+      `max_tokens` key, and `model`/`messages` are unchanged between the
+      two posts.
+- [ ] Test: both responses are that 400. Assert exactly two posts, and
+      the raised `ConfigError` carries the `what` prefix, HTTP 400, and
+      the retry body's excerpt.
+- [ ] Test: a 400 whose body lacks the marker raises immediately with a
+      single post.
+- [ ] Test: a non-400 failure (e.g. 500) whose body mentions
+      `max_completion_tokens` raises immediately with a single post (the
+      trigger requires both conditions).
+- [ ] Test: the marker check reads past 500 bytes: a 400 body with the
+      marker after 500 filler bytes still triggers the retry (guards the
+      full-body-decode decision against regression to
+      `_response_excerpt`).
+- [ ] Run `uv run pytest tests/test_chatwire.py`; the new tests must fail
+      against the current module.
+
+### Task 2: implement the retry
+
+- [ ] Add `_MAX_COMPLETION_TOKENS = 8192` and the `_post_chat` helper
+      (binding decision 4), with D1 docstrings.
+- [ ] Rewire `chat_completion` per binding decisions 1–3.
+- [ ] Extend the module docstring with the retry contract sentence.
+- [ ] Run `uv run pytest tests/test_chatwire.py` until green, then the
+      full gates: `uv run ruff check .`, `uv run ruff format --check .`,
+      `uv run mypy`, `uv run pytest --cov` (must hold 100%).
+
+### Task 3: changelog
+
+- [ ] Add the `### Fixed` entry under `## [Unreleased]` in
+      `CHANGELOG.md` (binding decision 6).
+
+## Out of scope
+
+- Making the token cap configurable (`-A max_tokens=...`): separate
+  feature; #386/#388 is building the taskgen config surface and nothing
+  here should collide with it.
+- Teaching the agent plugin's chat wire anything: it has its own client
+  and does not exhibit the bug.
+- Caching the discovered parameter name across calls: each
+  `chat_completion` call is one-shot today; per-call retry costs one
+  extra request only on the affected provider+model combination and
+  keeps the module stateless.

--- a/plans/0073-chatwire-max-completion-tokens.md
+++ b/plans/0073-chatwire-max-completion-tokens.md
@@ -37,7 +37,12 @@ the retry response is the one surfaced (binding decision 3 was otherwise
 unverifiable); the TDD must-fail claim is scoped to the three tests that
 actually fail pre-change, with the other two labeled regression guards;
 and the residual reasoning-token-exhaustion failure mode is named in
-Out of scope so it is not rediscovered as a bug in this fix.
+Out of scope so it is not rediscovered as a bug in this fix. Round 2
+(fresh context) verified all three fixes landed, traced implementability,
+coverage (branch mode), and caller/test impact, and found no substantive
+issues; its nitpicks (docstring opening sentence correction, url/headers
+pinned in the retry test, raise-on-exhaustion recorder) are folded into
+this revision.
 
 ## Global constraints
 
@@ -106,9 +111,10 @@ Out of scope so it is not rediscovered as a bug in this fix.
        )
    ```
 
-5. **Docs surface:** module docstring gains one sentence stating the
-   retry contract. No user-facing docs change (the wire is internal), no
-   CLI docs change.
+5. **Docs surface:** the module docstring is updated to state the retry
+   contract, including correcting its now-false opening claim of "One
+   blocking POST" (the wire may send two). No user-facing docs change
+   (the wire is internal), no CLI docs change.
 6. **CHANGELOG:** one entry under `## [Unreleased]` / `### Fixed`,
    Core-scoped, linking this plan and issue #390, following the existing
    entry format.
@@ -119,14 +125,15 @@ Out of scope so it is not rediscovered as a bug in this fix.
 
 - [ ] In `tests/test_chatwire.py`, add a recording post factory that
       captures each `(url, headers, body_bytes)` and serves scripted
-      responses in sequence (the existing `_post` helper serves one
+      responses in sequence, raising if called past the scripted count so
+      over-posting fails loudly (the existing `_post` helper serves one
       static response; the new tests need per-call scripting and capture).
 - [ ] Test: first response is the OpenAI 400 `unsupported_parameter` body
       naming `max_completion_tokens`, second response is a 200 reply.
       Assert the wire returns the content, exactly two posts were made,
       the second body's JSON has `max_completion_tokens: 8192` and no
-      `max_tokens` key, and `model`/`messages` are unchanged between the
-      two posts.
+      `max_tokens` key, and `url`, `headers`, `model`, and `messages` are
+      unchanged between the two posts.
 - [ ] Test: both responses are 400, with two DIFFERENT bodies (first
       contains the marker, second is distinct text without it, e.g.
       `{"error": {"message": "still rejected"}}`). Assert exactly two
@@ -140,10 +147,10 @@ Out of scope so it is not rediscovered as a bug in this fix.
       (e.g. 500) whose body mentions `max_completion_tokens` raises
       immediately with a single post (the trigger requires both
       conditions).
-- [ ] Test: the marker check reads past 500 bytes: a 400 body with the
-      marker after 500 filler bytes still triggers the retry (guards the
-      full-body-decode decision against regression to
-      `_response_excerpt`).
+- [ ] Test: the marker check reads the full body: a 400 body with the
+      marker after more than 500 characters of ASCII filler still
+      triggers the retry (guards the full-body-decode decision against
+      regression to `_response_excerpt`).
 - [ ] Run `uv run pytest tests/test_chatwire.py`. Exactly three of the
       new tests must fail against the current module: retry-then-success,
       both-400, and marker-past-500-bytes. The two regression guards

--- a/src/inspect_robots/_chatwire.py
+++ b/src/inspect_robots/_chatwire.py
@@ -24,7 +24,7 @@ HttpPost = Callable[[str, dict[str, str], bytes], tuple[int, bytes]]
 
 _RESPONSE_EXCERPT_LIMIT = 500
 
-_MAX_COMPLETION_TOKENS = 8192
+_TOKEN_CAP = 8192
 
 
 def _response_excerpt(body: bytes) -> str:
@@ -56,9 +56,9 @@ def _post_chat(
     token_param: str,
 ) -> tuple[int, bytes]:
     """Send one chat-completions request with the token cap keyed under ``token_param``."""
-    body = json.dumps(
-        {"model": model, "messages": messages, token_param: _MAX_COMPLETION_TOKENS}
-    ).encode("utf-8")
+    body = json.dumps({"model": model, "messages": messages, token_param: _TOKEN_CAP}).encode(
+        "utf-8"
+    )
     return post(url, headers, body)
 
 

--- a/src/inspect_robots/_chatwire.py
+++ b/src/inspect_robots/_chatwire.py
@@ -1,9 +1,13 @@
 """Dependency-free OpenAI-compatible chat wire shared by summarize and the VLM grader.
 
-One blocking POST to ``<base_url>/chat/completions`` over stdlib ``urllib``,
+Blocking POSTs to ``<base_url>/chat/completions`` over stdlib ``urllib``,
 with an injectable transport seam (``http_post``) so callers and tests never
-touch the network. Errors are raised as guided ``ConfigError``s whose prefix
-and fix hint the caller labels for its own command surface.
+touch the network. The token cap is sent as ``max_tokens``; when a 400
+response body names ``max_completion_tokens`` (OpenAI reasoning models
+reject ``max_tokens`` and suggest that substitute), the identical request
+is retried once with the cap under that key. Errors are raised as guided
+``ConfigError``s whose prefix and fix hint the caller labels for its own
+command surface.
 """
 
 from __future__ import annotations
@@ -19,6 +23,8 @@ from inspect_robots.errors import ConfigError
 HttpPost = Callable[[str, dict[str, str], bytes], tuple[int, bytes]]
 
 _RESPONSE_EXCERPT_LIMIT = 500
+
+_MAX_COMPLETION_TOKENS = 8192
 
 
 def _response_excerpt(body: bytes) -> str:
@@ -41,6 +47,21 @@ def _urllib_post(url: str, headers: dict[str, str], body_bytes: bytes) -> tuple[
         ) from exc
 
 
+def _post_chat(
+    post: HttpPost,
+    url: str,
+    headers: dict[str, str],
+    model: str,
+    messages: list[dict[str, Any]],
+    token_param: str,
+) -> tuple[int, bytes]:
+    """Send one chat-completions request with the token cap keyed under ``token_param``."""
+    body = json.dumps(
+        {"model": model, "messages": messages, token_param: _MAX_COMPLETION_TOKENS}
+    ).encode("utf-8")
+    return post(url, headers, body)
+
+
 def chat_completion(
     base_url: str,
     api_key: str,
@@ -61,9 +82,12 @@ def chat_completion(
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
-    body = json.dumps({"model": model, "messages": messages, "max_tokens": 8192}).encode("utf-8")
     post = _urllib_post if http_post is None else http_post
-    status, response_body = post(url, headers, body)
+    status, response_body = _post_chat(post, url, headers, model, messages, "max_tokens")
+    if status == 400 and "max_completion_tokens" in response_body.decode("utf-8", errors="replace"):
+        status, response_body = _post_chat(
+            post, url, headers, model, messages, "max_completion_tokens"
+        )
     if not 200 <= status < 300:
         raise ConfigError(
             f"{what} request failed with HTTP {status}: {_response_excerpt(response_body)}\n"

--- a/tests/test_chatwire.py
+++ b/tests/test_chatwire.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import json
 import urllib.error
 import urllib.request
 from email.message import Message
@@ -75,3 +76,96 @@ def test_urllib_post_translates_url_errors_to_neutral_guidance(
 
     with pytest.raises(ConfigError, match=r"chat request failed: offline.\nfix: check the base"):
         _urllib_post("https://x.test", {}, b"{}")
+
+
+_Call = tuple[str, dict[str, str], bytes]
+
+_OPENAI_MAX_TOKENS_400 = json.dumps(
+    {
+        "error": {
+            "message": (
+                "Unsupported parameter: 'max_tokens' is not supported with this model. "
+                "Use 'max_completion_tokens' instead."
+            ),
+            "type": "invalid_request_error",
+            "param": "max_tokens",
+            "code": "unsupported_parameter",
+        }
+    }
+).encode("utf-8")
+
+_REPLY_200 = b'{"choices":[{"message":{"content":"hello"}}]}'
+
+
+def _scripted_post(responses: list[tuple[int, bytes]]) -> tuple[HttpPost, list[_Call]]:
+    """A recording transport that serves ``responses`` in order and raises past the script."""
+    calls: list[_Call] = []
+
+    def post(url: str, headers: dict[str, str], body_bytes: bytes) -> tuple[int, bytes]:
+        calls.append((url, headers, body_bytes))
+        if len(calls) > len(responses):
+            raise AssertionError(f"post called {len(calls)} times, scripted {len(responses)}")
+        return responses[len(calls) - 1]
+
+    return post, calls
+
+
+def test_retries_with_max_completion_tokens_when_a_400_names_it() -> None:
+    post, calls = _scripted_post([(400, _OPENAI_MAX_TOKENS_400), (200, _REPLY_200)])
+    messages = [{"role": "user", "content": "hi"}]
+
+    assert chat_completion("https://x.test/v1", "k", "m", messages, http_post=post) == "hello"
+
+    assert len(calls) == 2
+    first, second = calls
+    assert first[0] == second[0]
+    assert first[1] == second[1]
+    first_body = json.loads(first[2])
+    second_body = json.loads(second[2])
+    assert first_body["max_tokens"] == 8192
+    assert second_body["max_completion_tokens"] == 8192
+    assert "max_tokens" not in second_body
+    assert second_body["model"] == first_body["model"] == "m"
+    assert second_body["messages"] == first_body["messages"] == messages
+
+
+def test_retry_failure_surfaces_the_retry_response() -> None:
+    post, calls = _scripted_post(
+        [(400, _OPENAI_MAX_TOKENS_400), (400, b'{"error": {"message": "still rejected"}}')]
+    )
+
+    with pytest.raises(ConfigError) as excinfo:
+        chat_completion("https://x.test/v1", "k", "m", [], http_post=post)
+
+    assert len(calls) == 2
+    message = str(excinfo.value)
+    assert message.startswith("summary request failed with HTTP 400")
+    assert "still rejected" in message
+    assert "Unsupported parameter" not in message
+
+
+def test_a_400_without_the_marker_raises_after_a_single_post() -> None:
+    post, calls = _scripted_post([(400, b'{"error": {"message": "bad request"}}')])
+
+    with pytest.raises(ConfigError, match=r"summary request failed with HTTP 400"):
+        chat_completion("https://x.test/v1", "k", "m", [], http_post=post)
+
+    assert len(calls) == 1
+
+
+def test_a_non_400_with_the_marker_raises_after_a_single_post() -> None:
+    post, calls = _scripted_post([(500, b"try max_completion_tokens later")])
+
+    with pytest.raises(ConfigError, match=r"summary request failed with HTTP 500"):
+        chat_completion("https://x.test/v1", "k", "m", [], http_post=post)
+
+    assert len(calls) == 1
+
+
+def test_the_marker_check_reads_the_full_body() -> None:
+    long_400 = b'{"error": "' + b"x" * 600 + b' use max_completion_tokens"}'
+    post, calls = _scripted_post([(400, long_400), (200, _REPLY_200)])
+
+    assert chat_completion("https://x.test/v1", "k", "m", [], http_post=post) == "hello"
+
+    assert len(calls) == 2

--- a/tests/test_chatwire.py
+++ b/tests/test_chatwire.py
@@ -130,9 +130,8 @@ def test_retries_with_max_completion_tokens_when_a_400_names_it() -> None:
 
 
 def test_retry_failure_surfaces_the_retry_response() -> None:
-    post, calls = _scripted_post(
-        [(400, _OPENAI_MAX_TOKENS_400), (400, b'{"error": {"message": "still rejected"}}')]
-    )
+    retry_400 = b'{"error": {"message": "max_completion_tokens still rejected"}}'
+    post, calls = _scripted_post([(400, _OPENAI_MAX_TOKENS_400), (400, retry_400)])
 
     with pytest.raises(ConfigError) as excinfo:
         chat_completion("https://x.test/v1", "k", "m", [], http_post=post)
@@ -159,6 +158,16 @@ def test_a_non_400_with_the_marker_raises_after_a_single_post() -> None:
     with pytest.raises(ConfigError, match=r"summary request failed with HTTP 500"):
         chat_completion("https://x.test/v1", "k", "m", [], http_post=post)
 
+    assert len(calls) == 1
+
+
+def test_a_2xx_with_the_marker_does_not_retry() -> None:
+    reply = b'{"choices":[{"message":{"content":"use max_completion_tokens next time"}}]}'
+    post, calls = _scripted_post([(200, reply)])
+
+    result = chat_completion("https://x.test/v1", "k", "m", [], http_post=post)
+
+    assert result == "use max_completion_tokens next time"
     assert len(calls) == 1
 
 


### PR DESCRIPTION
Closes #390.

The shared chat wire (`_chatwire.chat_completion`, used by `--auto-task`, the `vlm` grader, and summarize) hardcodes `"max_tokens": 8192`, which OpenAI's gpt-5.x reasoning models reject with HTTP 400 `unsupported_parameter`. The fix retries the request once with the cap keyed as `max_completion_tokens` exactly when the 400 body names that parameter (the server itself suggests the substitute), so endpoints that accept `max_tokens` today see byte-identical behavior and there is no model-name sniffing.

Design in `plans/0073-chatwire-max-completion-tokens.md`; critique loop and implementation follow on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)