### PR TITLE
[conference demo, do not merge] examples: actuate rotating-roles live eval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,5 @@ __marimo__/
 # control; share them as release assets or external storage instead.
 logs/
 *.rrd
+examples/actuate/logs/
+examples/actuate/state/

--- a/.gitignore
+++ b/.gitignore
@@ -231,3 +231,4 @@ examples/actuate/logs/
 examples/actuate/state/
 examples/actuate/logs-rig*/
 examples/actuate/state-rig*/
+examples/actuate/.campaign-*.lock

--- a/.gitignore
+++ b/.gitignore
@@ -228,6 +228,7 @@ __marimo__/
 logs/
 *.rrd
 examples/actuate/logs/
+examples/actuate/logs-validate/
 examples/actuate/state/
 examples/actuate/logs-rig*/
 examples/actuate/state-rig*/

--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,5 @@ logs/
 *.rrd
 examples/actuate/logs/
 examples/actuate/state/
+examples/actuate/logs-rig*/
+examples/actuate/state-rig*/

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -1,6 +1,6 @@
 # Actuate conference demo
 
-A live eval show for the Actuate conference. Seven LLMs compete as
+A live eval show for the Actuate conference. Eight LLMs compete as
 test-takers of an automatic-task eval, a browser screen shows who is who, and
 a leaderboard accumulates across evals. This lives on the
 `demo/actuate-conference` branch only (draft PR #397) and is never merged:
@@ -11,7 +11,7 @@ run it from the branch, iterate freely.
 Every eval draws each role from that role's eligible pool in `_roster.py`.
 The tasker and grader pools have one member each, so those roles are pinned:
 GPT-5.6 Sol always authors tasks and Gemini 3.7 Flash always grades. The
-test-taker rotates over all seven models, so Sol can be drawn against its
+test-taker rotates over all eight models, so Sol can be drawn against its
 own task and Flash can grade itself, which is intended and part of the show:
 
 - **tasker:** writes the task and rubric from the initial camera frame
@@ -75,6 +75,23 @@ Arguments after the launcher name are passed to `inspect-robots run` verbatim.
 To watch remotely, add `--rerun-connect rerun+http://<your-machine>:9888/proxy`;
 at the booth the rig config's `rerun = true` spawns a local viewer instead.
 
+## Fixed-trials campaign
+
+`run_trials.py` runs every test-taker through exactly ten scored evals, then
+prints a per-model summary and exits. Run it manually in the same tmux
+arrangement because `start.sh` stays wired to the rotating demo:
+
+```bash
+tmux new -d -s actuate-serve 'python examples/actuate/serve.py'
+tmux new -s actuate 'python examples/actuate/run_trials.py -- --config /path/to/rig-folder/config.ini'
+```
+
+Arguments after `--` reach `inspect-robots run` verbatim, exactly as with
+`run.py`. Start from a fresh leaderboard for a clean campaign because existing
+scored evals in `state/results.jsonl` count toward the ten. The runner resumes
+where it left off after a restart and exits once every test-taker has ten scored
+evals.
+
 ## Booth checklist
 
 - **Rig config:** `RIG_CONFIG` in `run.py` defaults to
@@ -90,16 +107,16 @@ at the booth the rig config's `rerun = true` spawns a local viewer instead.
   Python that has i2rt installed, such as the rig venv. On machines without
   i2rt or CAN it disables itself with a console warning and the demo runs as
   before. Reading temperatures clears any latched motor fault codes.
-- **Model IDs:** confirm the seven IDs at the top of `_roster.py` with their
+- **Model IDs:** confirm the eight IDs at the top of `_roster.py` with their
   providers. Validated on the rig so far: `claude-opus-5`, `gpt-5.6-sol`
   (test-taker over the Responses wire, plus its pinned tasker role), and
   `gemini-3.7-flash` (test-taker plus its pinned grader role). The other
-  four test-takers (`moonshotai/kimi-k3` via OpenRouter, needing
-  `OPENROUTER_API_KEY` in the demo `.env`, copy the existing key from
-  `~/robocurve/test-dir/.env`; `gemini-3.1-pro-preview`; `gpt-5`; `gpt-5.4`,
-  the base thinking model, not `-pro`) are wire-verified off-rig only
-  (function tools plus effort high, 2026-08-19): force one eval with each
-  during setup.
+  five test-takers (`moonshotai/kimi-k3` and `moonshotai/kimi-k2-thinking`
+  via OpenRouter, needing `OPENROUTER_API_KEY` in the demo `.env`, copy the
+  existing key from `~/robocurve/test-dir/.env`; `gemini-3.1-pro-preview`;
+  `gpt-5`; `gpt-5.4`, the base thinking model, not `-pro`) are wire-verified
+  off-rig only (function tools plus effort high, 2026-08-19): force one eval
+  with each during setup.
 - **Fresh leaderboard:** eval numbering and scores persist in
   `examples/actuate/state/` and survive restarts. To start the show clean at
   eval 1: `rm examples/actuate/state/status.json
@@ -115,7 +132,10 @@ at the booth the rig config's `rerun = true` spawns a local viewer instead.
 ## Files
 
 - `run.py`: orchestrator (draws roles, launches evals, records results)
+- `run_trials.py`: deterministic fixed-trials campaign built on run.py
+- `start.sh`: booth launcher for the display server plus the rotating demo
 - `serve.py`: stdlib HTTP server for the display page
 - `monitor.html`: the combined conference screen
 - `_roster.py`: booth-editable models, endpoints, key env vars, accents
+- `_thermal.py`: motor-temperature probe and thermal-gate thresholds
 - `state/`, `logs/`: gitignored run state and eval logs

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -92,6 +92,42 @@ scored evals in `state/results.jsonl` count toward the ten. The runner resumes
 where it left off after a restart and exits once every test-taker has ten scored
 evals.
 
+For the dual-rig campaign, each test-taker runs five scored trials on rig-1
+and five on rig-2. That is 8 models x 5 trials x 2 rigs = 80 evals. Measuring
+every model on both rigs keeps rig differences out of the model comparison.
+The rigs run concurrently, so each uses its own `state-rigN/` and `logs-rigN/`
+directories. Shared directories would race newest-log attribution and
+interleave the two campaigns in one `results.jsonl`.
+
+Start the rig halves in separate attended terminals. Each rig needs its own
+terminal so an operator can press Esc to end its current episode early:
+
+```bash
+tmux new -s actuate-rig1 'python examples/actuate/run_trials_rig1.py'
+tmux new -s actuate-rig2 'python examples/actuate/run_trials_rig2.py'
+```
+
+Serve each rig's monitor separately, with rig-1 on the default port 8377 and
+rig-2 on port 8378:
+
+```bash
+python examples/actuate/serve.py --state-dir examples/actuate/state-rig1 --logs-dir examples/actuate/logs-rig1
+python examples/actuate/serve.py --port 8378 --state-dir examples/actuate/state-rig2 --logs-dir examples/actuate/logs-rig2
+```
+
+Each rig's own `.env` and key setup supplies its providers, and the existing
+flock claim guard prevents concurrent runs from claiming the same rig. After
+both halves finish, print the per-rig breakdowns and pooled leaderboard with:
+
+```bash
+python examples/actuate/combine_results.py examples/actuate/state-rig1/results.jsonl examples/actuate/state-rig2/results.jsonl
+```
+
+For a fresh dual-rig campaign, clear `state-rig1/`, `state-rig2/`,
+`logs-rig1/`, and `logs-rig2/` instead of `state/`. Each half resumes from its
+own `results.jsonl` after a restart and stops when every test-taker has five
+finite scored evals on that rig.
+
 ## Booth checklist
 
 - **Rig config:** `RIG_CONFIG` in `run.py` defaults to
@@ -120,7 +156,9 @@ evals.
 - **Fresh leaderboard:** eval numbering and scores persist in
   `examples/actuate/state/` and survive restarts. To start the show clean at
   eval 1: `rm examples/actuate/state/status.json
-  examples/actuate/state/results.jsonl`.
+  examples/actuate/state/results.jsonl`. The dual-rig campaign keeps its state
+  in the per-rig dirs and is reset by clearing `state-rig1/`, `state-rig2/`,
+  `logs-rig1/`, and `logs-rig2/` instead.
 - An eval that errors (bad model ID, rejected request) shows as a score-less
   card and costs nothing else; fix `_roster.py` and start the next eval.
 - If every camera and CAN interface vanishes at once, the USB host controller
@@ -133,9 +171,12 @@ evals.
 
 - `run.py`: orchestrator (draws roles, launches evals, records results)
 - `run_trials.py`: deterministic fixed-trials campaign built on run.py
+- `run_trials_rig1.py`, `run_trials_rig2.py`: per-rig dual-campaign entry points
+- `combine_results.py`: per-rig and pooled fixed-trials summaries
 - `start.sh`: booth launcher for the display server plus the rotating demo
-- `serve.py`: stdlib HTTP server for the display page
+- `serve.py`: stdlib HTTP server with `--state-dir` and `--logs-dir` overrides
 - `monitor.html`: the combined conference screen
 - `_roster.py`: booth-editable models, endpoints, key env vars, accents
 - `_thermal.py`: motor-temperature probe and thermal-gate thresholds
 - `state/`, `logs/`: gitignored run state and eval logs
+- `state-rig*/`, `logs-rig*/`: gitignored per-rig campaign state and eval logs

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -67,6 +67,13 @@ at the booth the rig config's `rerun = true` spawns a local viewer instead.
   file the setup wizard writes: the XDG-global config drifts stale (it once
   pinned the top camera to the D435's mono IR node, giving a black-and-white
   stream).
+- **Motor thermal gate:** the loop checks motor temperatures before every
+  eval. At or above 60 C it suspends evals and shows the cooling banner, then
+  resumes below 50 C. Thresholds live in `_thermal.py`, and channel names come
+  from the rig config. The gate only exists when `run.py` is launched with a
+  Python that has i2rt installed, such as the rig venv. On machines without
+  i2rt or CAN it disables itself with a console warning and the demo runs as
+  before. Reading temperatures clears any latched motor fault codes.
 - **Model IDs:** confirm the three IDs at the top of `_roster.py` with their
   providers. Validated live so far: `claude-opus-5` (tasker and test-taker),
   `gpt-5.6-sol` (tasker and grader, test-taker over the Responses wire).

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -1,6 +1,6 @@
 # Actuate conference demo
 
-A live eval show for the Actuate conference. Three LLMs rotate through the
+A live eval show for the Actuate conference. Four LLMs rotate through the
 three roles of an automatic-task eval, a browser screen shows who is who, and
 a leaderboard accumulates across evals. This lives on the
 `demo/actuate-conference` branch only (draft PR #397) and is never merged:
@@ -8,9 +8,10 @@ run it from the branch, iterate freely.
 
 ## How it works
 
-Every eval independently draws one of the three roster models for each role
-(the same model can hold two or three roles, that is intended and part of the
-show):
+Every eval independently draws a roster model for each role from that role's
+eligible pool: GPT, Opus, and Gemini can hold any role, Kimi K3 competes as
+test-taker only. The same model can hold two or three roles, that is intended
+and part of the show:
 
 - **tasker:** writes the task and rubric from the initial camera frame
   (`--auto-task`, `-A` args)
@@ -42,7 +43,7 @@ git clone -b demo/actuate-conference https://github.com/robocurve/inspect-robots
 cd actuate-demo
 
 # the CLI auto-loads .env from the working directory
-printf 'OPENAI_API_KEY=...\nANTHROPIC_API_KEY=...\nGEMINI_API_KEY=...\n' > .env
+printf 'OPENAI_API_KEY=...\nANTHROPIC_API_KEY=...\nGEMINI_API_KEY=...\nOPENROUTER_API_KEY=...\n' > .env
 
 # with the rig's venv active:
 ./examples/actuate/start.sh

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -1,20 +1,86 @@
 # Actuate conference demo
 
-This conference demo is not shipped as part of Inspect Robots. It runs attended evaluations and
-serves a local combined monitor screen.
+A live eval show for the Actuate conference. Three LLMs rotate through the
+three roles of an automatic-task eval, a browser screen shows who is who, and
+a leaderboard accumulates across evals. This lives on the
+`demo/actuate-conference` branch only (draft PR #397) and is never merged:
+run it from the branch, iterate freely.
 
-**Credentials:** Export `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `GEMINI_API_KEY`.
+## How it works
 
-**Terminal 1:** Run `python examples/actuate/run.py [-- extra inspect-robots run args]`.
+Every eval independently draws one of the three roster models for each role
+(the same model can hold two or three roles, that is intended and part of the
+show):
 
-**Terminal 2:** Run `python examples/actuate/serve.py`.
+- **tasker:** writes the task and rubric from the initial camera frame
+  (`--auto-task`, `-A` args)
+- **test-taker:** the policy driving the robot (`agent` policy, `-P` args)
+- **grader:** judges first and last frames against the rubric (`vlm` grader,
+  `-G` args)
 
-**Display:** Open http://localhost:8377/. Tile the monitor page beside the Rerun viewer window
-spawned by the run. The `/leaderboard` route is an alias for the same combined screen.
+All three run at effort high. Each model uses its provider's
+OpenAI-compatible endpoint, except that a GPT test-taker speaks the Responses
+API (OpenAI rejects function tools with `reasoning_effort` on
+`/chat/completions`).
 
-**Booth setup:** The roster constants in `_roster.py` are meant to be edited on site. Confirm all
-model IDs with their providers before the event.
+`run.py` draws the roles, launches one `inspect-robots run` per eval, and
+records each outcome. `serve.py` renders one dark full-screen page: the
+current draw and generated task with the live eval number, a horizontal
+leaderboard (mean score over evals where the model was test-taker, top bar
+scaled to 80% of the track), and cards for the last three completed evals so
+the audience can see every eval re-rolls. Tile that page beside the Rerun
+viewer window the run spawns.
 
-**Rig config:** `run.py` always passes `--config` with the rig folder's `config.ini` (the file the
-setup wizard writes; see `RIG_CONFIG` at the top of `run.py`). The XDG-global config is not used
-because it can go stale, such as pointing the top camera at the D435's mono IR node.
+## Running it
+
+Needs the rig's existing inspect-robots env: core 0.56.0 or newer (the
+`-A`/`-G` effort channel), the `inspect-robots-agent` plugin, and the rig's
+embodiment plugin.
+
+```bash
+git clone -b demo/actuate-conference https://github.com/robocurve/inspect-robots actuate-demo
+cd actuate-demo
+
+# the CLI auto-loads .env from the working directory
+printf 'OPENAI_API_KEY=...\nANTHROPIC_API_KEY=...\nGEMINI_API_KEY=...\n' > .env
+
+# with the rig's venv active:
+tmux new -d -s actuate-serve 'python examples/actuate/serve.py'
+tmux new -s actuate 'python examples/actuate/run.py -- --config /path/to/rig-folder/config.ini'
+```
+
+Open http://localhost:8377/ (or `http://<rig-host>:8377/` from another
+machine). In the `actuate` tmux: Esc ends the episode and triggers grading,
+Enter starts the next eval with a fresh draw, `q` then Enter quits.
+
+Anything after `--` is passed to `inspect-robots run` verbatim. To watch
+remotely, add `-- --rerun-connect rerun+http://<your-machine>:9888/proxy`;
+at the booth the rig config's `rerun = true` spawns a local viewer instead.
+
+## Booth checklist
+
+- **Rig config:** `RIG_CONFIG` in `run.py` defaults to
+  `~/robocurve/rig-1/config.ini`. Edit it, or override with `-- --config
+  <path>` (the later flag wins). Always use the ini in the rig folder, the
+  file the setup wizard writes: the XDG-global config drifts stale (it once
+  pinned the top camera to the D435's mono IR node, giving a black-and-white
+  stream).
+- **Model IDs:** confirm the three IDs at the top of `_roster.py` with their
+  providers. Validated live so far: `claude-opus-5` (tasker and test-taker),
+  `gpt-5.6-sol` (tasker and grader, test-taker over the Responses wire).
+  `gemini-3.7-flash` has not been drawn yet; force one eval with it in each
+  role during setup.
+- **Fresh leaderboard:** eval numbering and scores persist in
+  `examples/actuate/state/` and survive restarts. To start the show clean at
+  eval 1: `rm examples/actuate/state/status.json
+  examples/actuate/state/results.jsonl`.
+- An eval that errors (bad model ID, rejected request) shows as a score-less
+  card and costs nothing else; fix `_roster.py` and start the next eval.
+
+## Files
+
+- `run.py`: orchestrator (draws roles, launches evals, records results)
+- `serve.py`: stdlib HTTP server for the display page
+- `monitor.html`: the combined conference screen
+- `_roster.py`: booth-editable models, endpoints, key env vars, accents
+- `state/`, `logs/`: gitignored run state and eval logs

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -1,6 +1,6 @@
 # Actuate conference demo
 
-A live eval show for the Actuate conference. Eight LLMs compete as
+A live eval show for the Actuate conference. Seven LLMs compete as
 test-takers of an automatic-task eval, a browser screen shows who is who, and
 a leaderboard accumulates across evals. This lives on the
 `demo/actuate-conference` branch only (draft PR #397) and is never merged:
@@ -11,7 +11,7 @@ run it from the branch, iterate freely.
 Every eval draws each role from that role's eligible pool in `_roster.py`.
 The tasker and grader pools have one member each, so those roles are pinned:
 GPT-5.6 Sol always authors tasks and Gemini 3.7 Flash always grades. The
-test-taker rotates over all eight models, so Sol can be drawn against its
+test-taker rotates over all seven models, so Sol can be drawn against its
 own task and Flash can grade itself, which is intended and part of the show:
 
 - **tasker:** writes the task and rubric from the initial camera frame
@@ -96,7 +96,7 @@ where it left off after a restart and exits once every test-taker has ten scored
 evals.
 
 For the dual-rig campaign, each test-taker runs five scored trials on rig-1
-and five on rig-2. That is 8 models x 5 trials x 2 rigs = 80 evals. Measuring
+and five on rig-2. That is 7 models x 5 trials x 2 rigs = 70 evals. Measuring
 every model on both rigs keeps rig differences out of the model comparison.
 The rigs run concurrently, so each uses its own `state-rigN/` and `logs-rigN/`
 directories. Shared directories would race newest-log attribution and
@@ -156,16 +156,18 @@ finite scored evals on that rig.
   Python that has i2rt installed, such as the rig venv. On machines without
   i2rt or CAN it disables itself with a console warning and the demo runs as
   before. Reading temperatures clears any latched motor fault codes.
-- **Model IDs:** confirm the eight IDs at the top of `_roster.py` with their
-  providers. Validated on the rig so far: `claude-opus-5`, `gpt-5.6-sol`
-  (test-taker over the Responses wire, plus its pinned tasker role), and
-  `gemini-3.7-flash` (test-taker plus its pinned grader role). The other
-  five test-takers (`moonshotai/kimi-k3` and `moonshotai/kimi-k2-thinking`
-  via OpenRouter, needing `OPENROUTER_API_KEY` in the demo `.env`, copy the
-  existing key from `~/robocurve/test-dir/.env`; `gemini-3.1-pro-preview`;
-  `gpt-5`; `gpt-5.4`, the base thinking model, not `-pro`) are wire-verified
-  off-rig only (function tools plus effort high, 2026-08-19): force one eval
-  with each during setup.
+- **Model IDs:** confirm the seven IDs at the top of `_roster.py` with their
+  providers. Validated on the rig: `claude-opus-5`, `gpt-5.6-sol`
+  (test-taker over the Responses wire, plus its pinned tasker role),
+  `gemini-3.7-flash` (test-taker plus its pinned grader role), and
+  `gemini-3.1-pro-preview` (2026-08-19 forced eval). `moonshotai/kimi-k3`
+  (OpenRouter, needs `OPENROUTER_API_KEY` in the demo `.env`, copy the
+  existing key from `~/robocurve/test-dir/.env`) works on the rig but runs
+  100 to 230 seconds per turn at effort high and one call wedged
+  indefinitely; the eval watchdog contains the damage. Kimi K2 Thinking was
+  removed 2026-08-19: it is text-only, and OpenRouter rejects the
+  test-taker's camera frames with "No endpoints found that support image
+  input", which would burn the unscored streak and halt the campaign.
 - **Fresh leaderboard:** eval numbering and scores persist in
   `examples/actuate/state/` and survive restarts. To start the show clean at
   eval 1: `rm examples/actuate/state/status.json

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -122,8 +122,8 @@ Both halves run from the clone root and share its single `.env` (the per-rig
 `~/robocurve/rig-N/.env` pins are not loaded). Each campaign holds a lock
 keyed to its rig config, so a second campaign against the same rig refuses
 to start, and the flock claim guard still protects the devices underneath.
-The rig scripts pin `--max-steps 12000` on both rigs so the two configs
-cannot give the halves different episode ceilings. Keep `rerun = false` on
+The rig scripts pin `--max-steps 1200` (120 seconds at 10 Hz) on both rigs
+so the two configs cannot give the halves different episode ceilings. Keep `rerun = false` on
 at least one rig, or give each rig config its own `rerun_port`, so two live
 viewers do not merge their streams. After both halves finish, print the
 per-rig breakdowns and pooled leaderboard with:

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -45,9 +45,23 @@ cd actuate-demo
 printf 'OPENAI_API_KEY=...\nANTHROPIC_API_KEY=...\nGEMINI_API_KEY=...\n' > .env
 
 # with the rig's venv active:
+./examples/actuate/start.sh
+
+# arguments after the script name reach inspect-robots run verbatim:
+./examples/actuate/start.sh --config /path/to/rig-folder/config.ini
+```
+
+The launcher starts or reuses the detached display server, then starts the
+eval loop in an attached tmux session. These are the equivalent manual
+commands:
+
+```bash
 tmux new -d -s actuate-serve 'python examples/actuate/serve.py'
 tmux new -s actuate 'python examples/actuate/run.py -- --config /path/to/rig-folder/config.ini'
 ```
+
+The launcher does not forward arguments to `serve.py`. To pass `--port`, use
+the manual recipe and add it to the `serve.py` command.
 
 Open http://localhost:8377/ (or `http://<rig-host>:8377/` from another
 machine). The loop is autonomous: each eval ends (Esc in the `actuate` tmux
@@ -55,8 +69,8 @@ ends an episode early and triggers grading) and the next one starts with a
 fresh draw after a short pause (`PAUSE_S` in `run.py`, longer after a failed
 eval). Ctrl-C in the tmux stops the whole loop.
 
-Anything after `--` is passed to `inspect-robots run` verbatim. To watch
-remotely, add `-- --rerun-connect rerun+http://<your-machine>:9888/proxy`;
+Arguments after the launcher name are passed to `inspect-robots run` verbatim.
+To watch remotely, add `--rerun-connect rerun+http://<your-machine>:9888/proxy`;
 at the booth the rig config's `rerun = true` spawns a local viewer instead.
 
 ## Booth checklist
@@ -74,11 +88,15 @@ at the booth the rig config's `rerun = true` spawns a local viewer instead.
   Python that has i2rt installed, such as the rig venv. On machines without
   i2rt or CAN it disables itself with a console warning and the demo runs as
   before. Reading temperatures clears any latched motor fault codes.
-- **Model IDs:** confirm the three IDs at the top of `_roster.py` with their
+- **Model IDs:** confirm the four IDs at the top of `_roster.py` with their
   providers. Validated live so far: `claude-opus-5` (tasker and test-taker),
   `gpt-5.6-sol` (tasker and grader, test-taker over the Responses wire).
   `gemini-3.7-flash` has not been drawn yet; force one eval with it in each
-  role during setup.
+  role during setup. Kimi K3 is test-taker only and is served via OpenRouter
+  as `moonshotai/kimi-k3`. `OPENROUTER_API_KEY` must be added to the demo
+  `.env` by copying the existing key from `~/robocurve/test-dir/.env`. It has
+  not yet been validated live, so force one eval with it as test-taker
+  during setup.
 - **Fresh leaderboard:** eval numbering and scores persist in
   `examples/actuate/state/` and survive restarts. To start the show clean at
   eval 1: `rm examples/actuate/state/status.json

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -102,16 +102,19 @@ The rigs run concurrently, so each uses its own `state-rigN/` and `logs-rigN/`
 directories. Shared directories would race newest-log attribution and
 interleave the two campaigns in one `results.jsonl`.
 
-Start the rig halves in separate attended terminals. Each rig needs its own
-terminal so an operator can press Esc to end its current episode early:
+Start the overnight page alongside the rig halves. Each rig campaign runs in
+its own attended terminal so an operator can press Esc to end its current
+episode early:
 
 ```bash
+tmux new -d -s actuate-overnight 'python examples/actuate/overnight.py'
 tmux new -s actuate-rig1 'python examples/actuate/run_trials_rig1.py'
 tmux new -s actuate-rig2 'python examples/actuate/run_trials_rig2.py'
 ```
 
-Serve each rig's monitor separately, with rig-1 on the default port 8377 and
-rig-2 on port 8378:
+The combined overnight page is available on the tailnet at
+`http://<rig-host>:8380/`. For attended watching, the individual monitor pages
+remain optional. Serve rig-1 on the default port 8377 and rig-2 on port 8378:
 
 ```bash
 python examples/actuate/serve.py --state-dir examples/actuate/state-rig1 --logs-dir examples/actuate/logs-rig1
@@ -123,10 +126,11 @@ Both halves run from the clone root and share its single `.env` (the per-rig
 keyed to its rig config, so a second campaign against the same rig refuses
 to start, and the flock claim guard still protects the devices underneath.
 The rig scripts pin `--max-steps 1200` (120 seconds at 10 Hz) on both rigs
-so the two configs cannot give the halves different episode ceilings. Keep `rerun = false` on
-at least one rig, or give each rig config its own `rerun_port`, so two live
-viewers do not merge their streams. After both halves finish, print the
-per-rig breakdowns and pooled leaderboard with:
+so the two configs cannot give the halves different episode ceilings. They
+also run without live viewer windows and record everything needed for morning
+review: a per-eval rrd with camera and joint-state timelines, stored frames,
+actions logs, and LLM transcripts. After both halves finish, print the per-rig
+breakdowns and pooled leaderboard with:
 
 ```bash
 python examples/actuate/combine_results.py examples/actuate/state-rig1/results.jsonl examples/actuate/state-rig2/results.jsonl
@@ -181,6 +185,8 @@ finite scored evals on that rig.
 - `run.py`: orchestrator (draws roles, launches evals, records results)
 - `run_trials.py`: deterministic fixed-trials campaign built on run.py
 - `run_trials_rig1.py`, `run_trials_rig2.py`: per-rig dual-campaign entry points
+- `overnight.py`: stdlib server for the combined overnight campaign view
+- `overnight.html`: phone-friendly dual-rig progress page
 - `combine_results.py`: per-rig and pooled fixed-trials summaries
 - `start.sh`: booth launcher for the display server plus the rotating demo
 - `serve.py`: stdlib HTTP server with `--state-dir` and `--logs-dir` overrides

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -115,9 +115,15 @@ python examples/actuate/serve.py --state-dir examples/actuate/state-rig1 --logs-
 python examples/actuate/serve.py --port 8378 --state-dir examples/actuate/state-rig2 --logs-dir examples/actuate/logs-rig2
 ```
 
-Each rig's own `.env` and key setup supplies its providers, and the existing
-flock claim guard prevents concurrent runs from claiming the same rig. After
-both halves finish, print the per-rig breakdowns and pooled leaderboard with:
+Both halves run from the clone root and share its single `.env` (the per-rig
+`~/robocurve/rig-N/.env` pins are not loaded). Each campaign holds a lock
+keyed to its rig config, so a second campaign against the same rig refuses
+to start, and the flock claim guard still protects the devices underneath.
+The rig scripts pin `--max-steps 12000` on both rigs so the two configs
+cannot give the halves different episode ceilings. Keep `rerun = false` on
+at least one rig, or give each rig config its own `rerun_port`, so two live
+viewers do not merge their streams. After both halves finish, print the
+per-rig breakdowns and pooled leaderboard with:
 
 ```bash
 python examples/actuate/combine_results.py examples/actuate/state-rig1/results.jsonl examples/actuate/state-rig2/results.jsonl

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -14,3 +14,7 @@ spawned by the run. The `/leaderboard` route is an alias for the same combined s
 
 **Booth setup:** The roster constants in `_roster.py` are meant to be edited on site. Confirm all
 model IDs with their providers before the event.
+
+**Rig config:** `run.py` always passes `--config` with the rig folder's `config.ini` (the file the
+setup wizard writes; see `RIG_CONFIG` at the top of `run.py`). The XDG-global config is not used
+because it can go stale, such as pointing the top camera at the D435's mono IR node.

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -50,8 +50,10 @@ tmux new -s actuate 'python examples/actuate/run.py -- --config /path/to/rig-fol
 ```
 
 Open http://localhost:8377/ (or `http://<rig-host>:8377/` from another
-machine). In the `actuate` tmux: Esc ends the episode and triggers grading,
-Enter starts the next eval with a fresh draw, `q` then Enter quits.
+machine). The loop is autonomous: each eval ends (Esc in the `actuate` tmux
+ends an episode early and triggers grading) and the next one starts with a
+fresh draw after a short pause (`PAUSE_S` in `run.py`, longer after a failed
+eval). Ctrl-C in the tmux stops the whole loop.
 
 Anything after `--` is passed to `inspect-robots run` verbatim. To watch
 remotely, add `-- --rerun-connect rerun+http://<your-machine>:9888/proxy`;

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -162,9 +162,10 @@ finite scored evals on that rig.
   `gemini-3.7-flash` (test-taker plus its pinned grader role), and
   `gemini-3.1-pro-preview` (2026-08-19 forced eval). `moonshotai/kimi-k3`
   (OpenRouter, needs `OPENROUTER_API_KEY` in the demo `.env`, copy the
-  existing key from `~/robocurve/test-dir/.env`) works on the rig but runs
-  100 to 230 seconds per turn at effort high and one call wedged
-  indefinitely; the eval watchdog contains the damage. Kimi K2 Thinking was
+  existing key from `~/robocurve/test-dir/.env`) is validated on the rig
+  but its per-turn latency depends on OpenRouter's provider routing: 4 to
+  90 seconds on a good route, 100 to 230 seconds with one observed
+  indefinite wedge on a bad one; the eval watchdog contains the damage. Kimi K2 Thinking was
   removed 2026-08-19: it is text-only, and OpenRouter rejects the
   test-taker's camera frames with "No endpoints found that support image
   input", which would burn the unscored streak and halt the campaign.

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -1,17 +1,18 @@
 # Actuate conference demo
 
-A live eval show for the Actuate conference. Four LLMs rotate through the
-three roles of an automatic-task eval, a browser screen shows who is who, and
+A live eval show for the Actuate conference. Seven LLMs compete as
+test-takers of an automatic-task eval, a browser screen shows who is who, and
 a leaderboard accumulates across evals. This lives on the
 `demo/actuate-conference` branch only (draft PR #397) and is never merged:
 run it from the branch, iterate freely.
 
 ## How it works
 
-Every eval independently draws a roster model for each role from that role's
-eligible pool: GPT, Opus, and Gemini can hold any role, Kimi K3 competes as
-test-taker only. The same model can hold two or three roles, that is intended
-and part of the show:
+Every eval draws each role from that role's eligible pool in `_roster.py`.
+The tasker and grader pools have one member each, so those roles are pinned:
+GPT-5.6 Sol always authors tasks and Gemini 3.7 Flash always grades. The
+test-taker rotates over all seven models, so Sol can be drawn against its
+own task and Flash can grade itself, which is intended and part of the show:
 
 - **tasker:** writes the task and rubric from the initial camera frame
   (`--auto-task`, `-A` args)
@@ -89,14 +90,15 @@ at the booth the rig config's `rerun = true` spawns a local viewer instead.
   Python that has i2rt installed, such as the rig venv. On machines without
   i2rt or CAN it disables itself with a console warning and the demo runs as
   before. Reading temperatures clears any latched motor fault codes.
-- **Model IDs:** confirm the four IDs at the top of `_roster.py` with their
-  providers. Validated live so far: `claude-opus-5` (tasker and test-taker),
-  `gpt-5.6-sol` (tasker and grader, test-taker over the Responses wire).
-  `gemini-3.7-flash` has not been drawn yet; force one eval with it in each
-  role during setup. Kimi K3 is test-taker only and is served via OpenRouter
-  as `moonshotai/kimi-k3`. `OPENROUTER_API_KEY` must be added to the demo
-  `.env` by copying the existing key from `~/robocurve/test-dir/.env`. It has
-  not yet been validated live, so force one eval with it as test-taker
+- **Model IDs:** confirm the seven IDs at the top of `_roster.py` with their
+  providers. Validated on the rig so far: `claude-opus-5`, `gpt-5.6-sol`
+  (test-taker over the Responses wire, plus its pinned tasker role), and
+  `gemini-3.7-flash` (test-taker plus its pinned grader role). The other
+  four test-takers (`moonshotai/kimi-k3` via OpenRouter, needing
+  `OPENROUTER_API_KEY` in the demo `.env`, copy the existing key from
+  `~/robocurve/test-dir/.env`; `gemini-3.1-pro-preview`; `gpt-5`; `gpt-5.4`,
+  the base thinking model, not `-pro`) are wire-verified off-rig only
+  (function tools plus effort high, 2026-08-19): force one eval with each
   during setup.
 - **Fresh leaderboard:** eval numbering and scores persist in
   `examples/actuate/state/` and survive restarts. To start the show clean at

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -87,7 +87,10 @@ tmux new -s actuate 'python examples/actuate/run_trials.py -- --config /path/to/
 ```
 
 Arguments after `--` reach `inspect-robots run` verbatim, exactly as with
-`run.py`. Start from a fresh leaderboard for a clean campaign because existing
+`run.py`. Trials interleave as randomized blocks: every model runs once per
+round of the roster, in a fresh random order each round, so drift over the
+campaign (motor heat, lighting, scene wear) cannot align with any one model's
+slot. Start from a fresh leaderboard for a clean campaign because existing
 scored evals in `state/results.jsonl` count toward the ten. The runner resumes
 where it left off after a restart and exits once every test-taker has ten scored
 evals.

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -78,6 +78,11 @@ at the booth the rig config's `rerun = true` spawns a local viewer instead.
   examples/actuate/state/results.jsonl`.
 - An eval that errors (bad model ID, rejected request) shows as a score-less
   card and costs nothing else; fix `_roster.py` and start the next eval.
+- If every camera and CAN interface vanishes at once, the USB host controller
+  died (seen live on 2026-08-17: kernel log "xHCI host controller not
+  responding, assume dead"). Recover without a reboot, using the controller's
+  PCI address from the kernel log:
+  `echo 1 | sudo tee /sys/bus/pci/devices/<addr>/remove && sleep 3 && echo 1 | sudo tee /sys/bus/pci/rescan`
 
 ## Files
 

--- a/examples/actuate/README.md
+++ b/examples/actuate/README.md
@@ -1,0 +1,16 @@
+# Actuate conference demo
+
+This conference demo is not shipped as part of Inspect Robots. It runs attended evaluations and
+serves a local combined monitor screen.
+
+**Credentials:** Export `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `GEMINI_API_KEY`.
+
+**Terminal 1:** Run `python examples/actuate/run.py [-- extra inspect-robots run args]`.
+
+**Terminal 2:** Run `python examples/actuate/serve.py`.
+
+**Display:** Open http://localhost:8377/. Tile the monitor page beside the Rerun viewer window
+spawned by the run. The `/leaderboard` route is an alias for the same combined screen.
+
+**Booth setup:** The roster constants in `_roster.py` are meant to be edited on site. Confirm all
+model IDs with their providers before the event.

--- a/examples/actuate/_roster.py
+++ b/examples/actuate/_roster.py
@@ -36,9 +36,8 @@ ROSTER: dict[str, dict[str, object]] = {
         "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
         "api_key_env": "GEMINI_API_KEY",
         "policy": {
-            "model": "gemini-3.7-flash",
-            "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
-            "api_key_env": "GEMINI_API_KEY",
+            "model": "google/gemini-3.7-flash",
+            "wire": "interactions",
         },
     },
 }

--- a/examples/actuate/_roster.py
+++ b/examples/actuate/_roster.py
@@ -1,0 +1,30 @@
+"""Shared, booth-editable model roster for the Actuate conference demo."""
+
+from __future__ import annotations
+
+# Booth-editable. Confirm model IDs against each provider before the event.
+ROSTER: dict[str, dict[str, str]] = {
+    "GPT-5.6 Sol": {
+        "model": "gpt-5.6-sol",
+        "base_url": "https://api.openai.com/v1",
+        "api_key_env": "OPENAI_API_KEY",
+    },
+    "Opus 5": {
+        "model": "claude-opus-5",
+        "base_url": "https://api.anthropic.com/v1",
+        "api_key_env": "ANTHROPIC_API_KEY",
+    },
+    "Gemini 3.7 Flash": {
+        "model": "gemini-3.7-flash",
+        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+        "api_key_env": "GEMINI_API_KEY",
+    },
+}
+
+ACCENTS = {
+    "GPT-5.6 Sol": "#10a37f",
+    "Opus 5": "#d97757",
+    "Gemini 3.7 Flash": "#4796e3",
+}
+
+EFFORT = "high"

--- a/examples/actuate/_roster.py
+++ b/examples/actuate/_roster.py
@@ -3,25 +3,43 @@
 from __future__ import annotations
 
 # Booth-editable. Confirm model IDs against each provider before the event.
-# "policy_wire" applies only when the model is drawn as test-taker: OpenAI
-# rejects function tools with reasoning_effort on /chat/completions, so the
-# agent policy must speak the Responses API there.
-ROSTER: dict[str, dict[str, str]] = {
+# model/base_url/api_key_env drive the task maker (-A) and grader (-G) over
+# each provider's OpenAI-compatible chat endpoint. "policy" is the complete
+# -P argument set used when the model is drawn as test-taker (effort is
+# appended separately): GPT must speak the Responses API (OpenAI rejects
+# function tools with reasoning_effort on /chat/completions) and Opus runs
+# the native messages wire at speed=fast, matching the rig's usual command.
+ROSTER: dict[str, dict[str, object]] = {
     "GPT-5.6 Sol": {
         "model": "gpt-5.6-sol",
         "base_url": "https://api.openai.com/v1",
         "api_key_env": "OPENAI_API_KEY",
-        "policy_wire": "responses",
+        "policy": {
+            "model": "gpt-5.6-sol",
+            "base_url": "https://api.openai.com/v1",
+            "api_key_env": "OPENAI_API_KEY",
+            "wire": "responses",
+        },
     },
     "Opus 5": {
         "model": "claude-opus-5",
         "base_url": "https://api.anthropic.com/v1",
         "api_key_env": "ANTHROPIC_API_KEY",
+        "policy": {
+            "model": "anthropic/claude-opus-5",
+            "wire": "messages",
+            "speed": "fast",
+        },
     },
     "Gemini 3.7 Flash": {
         "model": "gemini-3.7-flash",
         "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
         "api_key_env": "GEMINI_API_KEY",
+        "policy": {
+            "model": "gemini-3.7-flash",
+            "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+            "api_key_env": "GEMINI_API_KEY",
+        },
     },
 }
 

--- a/examples/actuate/_roster.py
+++ b/examples/actuate/_roster.py
@@ -100,6 +100,17 @@ ROSTER: dict[str, dict[str, object]] = {
             "wire": "responses",
         },
     },
+    "Kimi K2 Thinking": {
+        "roles": ("test_taker",),
+        "model": "moonshotai/kimi-k2-thinking",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key_env": "OPENROUTER_API_KEY",
+        "policy": {
+            "model": "moonshotai/kimi-k2-thinking",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key_env": "OPENROUTER_API_KEY",
+        },
+    },
 }
 
 ACCENTS = {
@@ -110,6 +121,7 @@ ACCENTS = {
     "Gemini 3.1 Pro": "#3fb6c9",
     "GPT-5": "#d4608d",
     "GPT-5.4": "#c9a54a",
+    "Kimi K2 Thinking": "#a2b53c",
 }
 
 EFFORT = "high"

--- a/examples/actuate/_roster.py
+++ b/examples/actuate/_roster.py
@@ -11,8 +11,12 @@ ALL_ROLES = ("tasker", "test_taker", "grader")
 # appended separately): GPT must speak the Responses API (OpenAI rejects
 # function tools with reasoning_effort on /chat/completions) and Opus runs
 # the native messages wire at speed=fast, matching the rig's usual command.
+# Roles are pinned: GPT-5.6 Sol always authors tasks and Gemini 3.7 Flash
+# always grades (each role's pool has one member), while every entry
+# competes as test-taker.
 ROSTER: dict[str, dict[str, object]] = {
     "GPT-5.6 Sol": {
+        "roles": ("tasker", "test_taker"),
         "model": "gpt-5.6-sol",
         "base_url": "https://api.openai.com/v1",
         "api_key_env": "OPENAI_API_KEY",
@@ -24,6 +28,7 @@ ROSTER: dict[str, dict[str, object]] = {
         },
     },
     "Opus 5": {
+        "roles": ("test_taker",),
         "model": "claude-opus-5",
         "base_url": "https://api.anthropic.com/v1",
         "api_key_env": "ANTHROPIC_API_KEY",
@@ -34,6 +39,7 @@ ROSTER: dict[str, dict[str, object]] = {
         },
     },
     "Gemini 3.7 Flash": {
+        "roles": ("test_taker", "grader"),
         "model": "gemini-3.7-flash",
         "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
         "api_key_env": "GEMINI_API_KEY",
@@ -57,6 +63,43 @@ ROSTER: dict[str, dict[str, object]] = {
             "api_key_env": "OPENROUTER_API_KEY",
         },
     },
+    # There is no plain gemini-3-pro text model on the Gemini API; the
+    # pro-line text model is the 3.1 preview.
+    "Gemini 3.1 Pro": {
+        "roles": ("test_taker",),
+        "model": "gemini-3.1-pro-preview",
+        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+        "api_key_env": "GEMINI_API_KEY",
+        "policy": {
+            "model": "google/gemini-3.1-pro-preview",
+            "wire": "interactions",
+        },
+    },
+    "GPT-5": {
+        "roles": ("test_taker",),
+        "model": "gpt-5",
+        "base_url": "https://api.openai.com/v1",
+        "api_key_env": "OPENAI_API_KEY",
+        "policy": {
+            "model": "gpt-5",
+            "base_url": "https://api.openai.com/v1",
+            "api_key_env": "OPENAI_API_KEY",
+            "wire": "responses",
+        },
+    },
+    # The base thinking model, not gpt-5.4-pro.
+    "GPT-5.4": {
+        "roles": ("test_taker",),
+        "model": "gpt-5.4",
+        "base_url": "https://api.openai.com/v1",
+        "api_key_env": "OPENAI_API_KEY",
+        "policy": {
+            "model": "gpt-5.4",
+            "base_url": "https://api.openai.com/v1",
+            "api_key_env": "OPENAI_API_KEY",
+            "wire": "responses",
+        },
+    },
 }
 
 ACCENTS = {
@@ -64,6 +107,9 @@ ACCENTS = {
     "Opus 5": "#d97757",
     "Gemini 3.7 Flash": "#4796e3",
     "Kimi K3": "#9067e8",
+    "Gemini 3.1 Pro": "#3fb6c9",
+    "GPT-5": "#d4608d",
+    "GPT-5.4": "#c9a54a",
 }
 
 EFFORT = "high"

--- a/examples/actuate/_roster.py
+++ b/examples/actuate/_roster.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 # Booth-editable. Confirm model IDs against each provider before the event.
+# "policy_wire" applies only when the model is drawn as test-taker: OpenAI
+# rejects function tools with reasoning_effort on /chat/completions, so the
+# agent policy must speak the Responses API there.
 ROSTER: dict[str, dict[str, str]] = {
     "GPT-5.6 Sol": {
         "model": "gpt-5.6-sol",
         "base_url": "https://api.openai.com/v1",
         "api_key_env": "OPENAI_API_KEY",
+        "policy_wire": "responses",
     },
     "Opus 5": {
         "model": "claude-opus-5",

--- a/examples/actuate/_roster.py
+++ b/examples/actuate/_roster.py
@@ -100,17 +100,6 @@ ROSTER: dict[str, dict[str, object]] = {
             "wire": "responses",
         },
     },
-    "Kimi K2 Thinking": {
-        "roles": ("test_taker",),
-        "model": "moonshotai/kimi-k2-thinking",
-        "base_url": "https://openrouter.ai/api/v1",
-        "api_key_env": "OPENROUTER_API_KEY",
-        "policy": {
-            "model": "moonshotai/kimi-k2-thinking",
-            "base_url": "https://openrouter.ai/api/v1",
-            "api_key_env": "OPENROUTER_API_KEY",
-        },
-    },
 }
 
 ACCENTS = {
@@ -121,7 +110,6 @@ ACCENTS = {
     "Gemini 3.1 Pro": "#3fb6c9",
     "GPT-5": "#d4608d",
     "GPT-5.4": "#c9a54a",
-    "Kimi K2 Thinking": "#a2b53c",
 }
 
 EFFORT = "high"

--- a/examples/actuate/_roster.py
+++ b/examples/actuate/_roster.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+ALL_ROLES = ("tasker", "test_taker", "grader")
+
 # Booth-editable. Confirm model IDs against each provider before the event.
 # model/base_url/api_key_env drive the task maker (-A) and grader (-G) over
 # each provider's OpenAI-compatible chat endpoint. "policy" is the complete
@@ -40,12 +42,28 @@ ROSTER: dict[str, dict[str, object]] = {
             "wire": "interactions",
         },
     },
+    "Kimi K3": {
+        # test-taker only: drives the robot but never authors tasks or grades.
+        "roles": ("test_taker",),
+        # OpenRouter because the rig already holds OPENROUTER_API_KEY; for
+        # Moonshot direct use model=kimi-k3, base_url=https://api.moonshot.ai/v1,
+        # api_key_env=MOONSHOT_API_KEY.
+        "model": "moonshotai/kimi-k3",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key_env": "OPENROUTER_API_KEY",
+        "policy": {
+            "model": "moonshotai/kimi-k3",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key_env": "OPENROUTER_API_KEY",
+        },
+    },
 }
 
 ACCENTS = {
     "GPT-5.6 Sol": "#10a37f",
     "Opus 5": "#d97757",
     "Gemini 3.7 Flash": "#4796e3",
+    "Kimi K3": "#9067e8",
 }
 
 EFFORT = "high"

--- a/examples/actuate/_thermal.py
+++ b/examples/actuate/_thermal.py
@@ -1,0 +1,158 @@
+"""Read Actuate motor temperatures under a strict idle-loop safety contract.
+
+Probe only while the demo loop is idle, never during an eval. Healthy motors
+finish enabled at zero torque, the same state as normal eval teardown. Two
+caveats apply: ``motor_on`` clears firmware fault latches with ``clean_error``
+on any faulted motor, so probing is not state-neutral for a faulted motor. A
+constructor failure during bringup or a parent timeout's SIGKILL also skips a
+deterministic socket close. This is harmless because child exit closes the
+socket and SocketCAN is non-exclusive.
+"""
+
+from __future__ import annotations
+
+import configparser
+import json
+import subprocess
+import sys
+import traceback
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+GRIPPER_TYPE = "LINEAR_4310"  # GripperType enum NAME; look up via GripperType[GRIPPER_TYPE]
+TEMP_WAIT_C = 60.0  # hottest reading at/above this suspends evals
+TEMP_RESUME_C = 50.0  # once suspended, resume only below this
+COOL_POLL_S = 30  # re-probe interval while cooling
+PROBE_TIMEOUT_S = 20  # child-process deadline per probe
+COOL_PROBE_ERRORS_GIVE_UP = 5  # consecutive probe errors while cooling
+FALLBACK_CHANNELS = ("can_left", "can_right")  # used only if RIG_CONFIG has no channels
+
+
+class ThermalProbeError(RuntimeError):
+    """Report a failed motor-temperature probe with a short reason."""
+
+
+class ThermalProbeUnavailable(ThermalProbeError):
+    """Report that the probe child could not import i2rt."""
+
+
+@dataclass(frozen=True)
+class MotorTemp:
+    """One motor's MOSFET and rotor temperatures."""
+
+    channel: str
+    motor_id: int
+    temp_mos: float
+    temp_rotor: float
+
+    @property
+    def max_c(self) -> float:
+        """Return the hotter of the motor's two temperature readings."""
+        return max(self.temp_mos, self.temp_rotor)
+
+    @property
+    def label(self) -> str:
+        """Return the short channel and hexadecimal motor identifier."""
+        return f"{self.channel} 0x{self.motor_id:02x}"
+
+
+def config_channels(config_path: Path) -> tuple[str, str]:
+    """Read both CAN channels from a rig config, with safe fallbacks."""
+    config = configparser.ConfigParser(
+        inline_comment_prefixes=("#",),
+        interpolation=None,
+    )
+    try:
+        config.read(config_path)
+        args = config["embodiment.args"]
+        return args["left_channel"], args["right_channel"]
+    except (configparser.Error, KeyError):
+        return FALLBACK_CHANNELS
+
+
+def read_motor_temps(channels: Iterable[str]) -> list[MotorTemp]:
+    """Run the deadline-bound probe child and parse its temperature records."""
+    try:
+        completed = subprocess.run(
+            [sys.executable, str(__file__), "--probe", *channels],
+            capture_output=True,
+            timeout=PROBE_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise ThermalProbeError(f"probe timed out after {PROBE_TIMEOUT_S}s") from error
+    except OSError as error:
+        raise ThermalProbeError(f"could not start probe: {error}") from error
+
+    if completed.returncode == 3:
+        raise ThermalProbeUnavailable("probe child could not import i2rt")
+    if completed.returncode != 0:
+        raise ThermalProbeError(f"probe child exited {completed.returncode}")
+
+    try:
+        payload = json.loads(completed.stdout)
+        if not isinstance(payload, list):
+            raise TypeError("probe output is not a list")
+        return [
+            MotorTemp(
+                channel=str(item["channel"]),
+                motor_id=int(item["motor_id"]),
+                temp_mos=float(item["temp_mos"]),
+                temp_rotor=float(item["temp_rotor"]),
+            )
+            for item in payload
+        ]
+    except Exception as error:
+        raise ThermalProbeError(f"invalid probe output ({type(error).__name__})") from error
+
+
+def hottest(temps: Iterable[MotorTemp]) -> MotorTemp:
+    """Return the motor with the hottest MOSFET or rotor reading."""
+    return max(temps, key=lambda temp: temp.max_c)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3 or sys.argv[1] != "--probe":
+        print(f"usage: {Path(__file__).name} --probe <channel> [<channel> ...]", file=sys.stderr)
+        raise SystemExit(2)
+
+    try:
+        from i2rt.motor_drivers.dm_driver import DMChainCanInterface
+        from i2rt.robots.utils import ArmType, GripperType, _load_arm_config
+    except ImportError:
+        raise SystemExit(3) from None
+
+    try:
+        arm_type = ArmType.YAM
+        motor_list = [list(motor) for motor in _load_arm_config(arm_type).motor_list]
+        motor_list.append([0x07, GripperType[GRIPPER_TYPE].get_motor_type(arm_type)])
+        offsets = [0.0] * len(motor_list)
+        directions = [1.0] * len(motor_list)
+        temperatures = []
+        for channel in sys.argv[2:]:
+            chain = None
+            try:
+                chain = DMChainCanInterface(
+                    motor_list,
+                    offsets,
+                    directions,
+                    channel,
+                    start_thread=False,
+                    motor_chain_name=f"thermal-probe-{channel}",
+                )
+                temperatures.extend(
+                    {
+                        "channel": channel,
+                        "motor_id": state.id,
+                        "temp_mos": state.temp_mos,
+                        "temp_rotor": state.temp_rotor,
+                    }
+                    for state in chain.read_states()
+                )
+            finally:
+                if chain is not None:
+                    chain.close()
+        print(json.dumps(temperatures))
+    except Exception:
+        traceback.print_exc()
+        raise SystemExit(1) from None

--- a/examples/actuate/_thermal.py
+++ b/examples/actuate/_thermal.py
@@ -93,7 +93,7 @@ def read_motor_temps(channels: Iterable[str]) -> list[MotorTemp]:
         payload = json.loads(completed.stdout)
         if not isinstance(payload, list):
             raise TypeError("probe output is not a list")
-        return [
+        temps = [
             MotorTemp(
                 channel=str(item["channel"]),
                 motor_id=int(item["motor_id"]),
@@ -104,6 +104,9 @@ def read_motor_temps(channels: Iterable[str]) -> list[MotorTemp]:
         ]
     except Exception as error:
         raise ThermalProbeError(f"invalid probe output ({type(error).__name__})") from error
+    if not temps:
+        raise ThermalProbeError("probe returned no temperatures")
+    return temps
 
 
 def hottest(temps: Iterable[MotorTemp]) -> MotorTemp:

--- a/examples/actuate/combine_results.py
+++ b/examples/actuate/combine_results.py
@@ -1,6 +1,6 @@
 """Combine fixed-trials result files into per-file and pooled summaries.
 
-Run with:  python examples/actuate/combine_results.py state-rig1/results.jsonl
+Run with:  python examples/actuate/combine_results.py examples/actuate/state-rig*/results.jsonl
 """
 
 from __future__ import annotations
@@ -10,13 +10,14 @@ import json
 import math
 from pathlib import Path
 
+from _roster import ROSTER
+
 
 def _trial_scores(path: Path) -> dict[str, list[float]]:
-    observations: dict[str, list[float]] = {}
-    try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except Exception:
-        lines = []
+    # Seeded from the roster like the leaderboard, so a model with no scored
+    # evals still shows an n=0 row and stale non-roster names are ignored.
+    observations: dict[str, list[float]] = {name: [] for name in ROSTER}
+    lines = path.read_text(encoding="utf-8").splitlines()
 
     for line in lines:
         try:
@@ -24,8 +25,8 @@ def _trial_scores(path: Path) -> dict[str, list[float]]:
             name = result["roles"]["test_taker"]
             score = result.get("score")
             numeric_score = float(score) if score is not None else None
-            if numeric_score is not None and math.isfinite(numeric_score):
-                observations.setdefault(name, []).append(numeric_score)
+            if name in observations and numeric_score is not None and math.isfinite(numeric_score):
+                observations[name].append(numeric_score)
         except (KeyError, TypeError, ValueError, json.JSONDecodeError):
             continue
 
@@ -35,8 +36,8 @@ def _trial_scores(path: Path) -> dict[str, list[float]]:
 def _print_summary(header: str, observations: dict[str, list[float]]) -> None:
     print(f"{header}:")
     for name, scores in observations.items():
-        mean_score = sum(scores) / len(scores)
-        print(f"{name}: n={len(scores)}, mean={mean_score:.2f}")
+        mean_text = f"{sum(scores) / len(scores):.2f}" if scores else "n/a"
+        print(f"{name}: n={len(scores)}, mean={mean_text}")
 
 
 def main() -> None:
@@ -45,7 +46,12 @@ def main() -> None:
     parser.add_argument("results", nargs="+", type=Path)
     args = parser.parse_args()
 
-    pooled: dict[str, list[float]] = {}
+    # A typo'd path must not silently print a half-campaign leaderboard.
+    missing = [path for path in args.results if not path.is_file()]
+    if missing:
+        parser.error("results file not found: " + ", ".join(str(path) for path in missing))
+
+    pooled: dict[str, list[float]] = {name: [] for name in ROSTER}
     for index, path in enumerate(args.results):
         observations = _trial_scores(path)
         if index:

--- a/examples/actuate/combine_results.py
+++ b/examples/actuate/combine_results.py
@@ -1,0 +1,62 @@
+"""Combine fixed-trials result files into per-file and pooled summaries.
+
+Run with:  python examples/actuate/combine_results.py state-rig1/results.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+
+def _trial_scores(path: Path) -> dict[str, list[float]]:
+    observations: dict[str, list[float]] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        lines = []
+
+    for line in lines:
+        try:
+            result = json.loads(line)
+            name = result["roles"]["test_taker"]
+            score = result.get("score")
+            numeric_score = float(score) if score is not None else None
+            if numeric_score is not None and math.isfinite(numeric_score):
+                observations.setdefault(name, []).append(numeric_score)
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            continue
+
+    return observations
+
+
+def _print_summary(header: str, observations: dict[str, list[float]]) -> None:
+    print(f"{header}:")
+    for name, scores in observations.items():
+        mean_score = sum(scores) / len(scores)
+        print(f"{name}: n={len(scores)}, mean={mean_score:.2f}")
+
+
+def main() -> None:
+    """Print per-file and pooled summaries for result paths from the command line."""
+    parser = argparse.ArgumentParser(description="Combine Actuate fixed-trials results.")
+    parser.add_argument("results", nargs="+", type=Path)
+    args = parser.parse_args()
+
+    pooled: dict[str, list[float]] = {}
+    for index, path in enumerate(args.results):
+        observations = _trial_scores(path)
+        if index:
+            print()
+        _print_summary(str(path), observations)
+        for name, scores in observations.items():
+            pooled.setdefault(name, []).extend(scores)
+
+    print()
+    _print_summary("Pooled", pooled)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/actuate/monitor.html
+++ b/examples/actuate/monitor.html
@@ -290,7 +290,7 @@
 
   <script>
     const order = ["GPT-5.6 Sol", "Opus 5", "Gemini 3.7 Flash", "Kimi K3",
-                   "Gemini 3.1 Pro", "GPT-5", "GPT-5.4"];
+                   "Gemini 3.1 Pro", "GPT-5", "GPT-5.4", "Kimi K2 Thinking"];
     const accents = {
       "GPT-5.6 Sol": "#10a37f",
       "Opus 5": "#d97757",
@@ -298,7 +298,8 @@
       "Kimi K3": "#9067e8",
       "Gemini 3.1 Pro": "#3fb6c9",
       "GPT-5": "#d4608d",
-      "GPT-5.4": "#c9a54a"
+      "GPT-5.4": "#c9a54a",
+      "Kimi K2 Thinking": "#a2b53c"
     };
     const htmlEscapes = {
       "&": "&amp;",

--- a/examples/actuate/monitor.html
+++ b/examples/actuate/monitor.html
@@ -289,12 +289,16 @@
   </main>
 
   <script>
-    const order = ["GPT-5.6 Sol", "Opus 5", "Gemini 3.7 Flash", "Kimi K3"];
+    const order = ["GPT-5.6 Sol", "Opus 5", "Gemini 3.7 Flash", "Kimi K3",
+                   "Gemini 3.1 Pro", "GPT-5", "GPT-5.4"];
     const accents = {
       "GPT-5.6 Sol": "#10a37f",
       "Opus 5": "#d97757",
       "Gemini 3.7 Flash": "#4796e3",
-      "Kimi K3": "#9067e8"
+      "Kimi K3": "#9067e8",
+      "Gemini 3.1 Pro": "#3fb6c9",
+      "GPT-5": "#d4608d",
+      "GPT-5.4": "#c9a54a"
     };
     const htmlEscapes = {
       "&": "&amp;",

--- a/examples/actuate/monitor.html
+++ b/examples/actuate/monitor.html
@@ -53,6 +53,7 @@
       min-height: 0;
     }
     .cards { display: flex; gap: clamp(10px, 1.2vw, 22px); }
+    .cards[hidden] { display: none; }
     .card {
       flex: 1 1 0;
       min-width: 0;
@@ -346,9 +347,15 @@
         card.style.borderTopColor = color;
       }
       const instruction = document.getElementById("instruction");
-      instruction.textContent = data.task == null ? "generating…" : data.task;
-      instruction.classList.toggle("muted", data.task == null);
-      instruction.classList.toggle("pulse", data.task == null);
+      if (cooling) {
+        instruction.textContent = "paused while motors cool";
+        instruction.classList.add("muted");
+        instruction.classList.remove("pulse");
+      } else {
+        instruction.textContent = data.task == null ? "generating…" : data.task;
+        instruction.classList.toggle("muted", data.task == null);
+        instruction.classList.toggle("pulse", data.task == null);
+      }
     }
 
     function renderLeaderboard(data) {

--- a/examples/actuate/monitor.html
+++ b/examples/actuate/monitor.html
@@ -156,27 +156,24 @@
       min-height: 0;
     }
     .recent-card {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) auto;
-      grid-template-rows: auto minmax(0, 1fr);
-      gap: 4px 12px;
+      display: flex;
+      flex-direction: column;
+      gap: clamp(4px, 0.6vh, 8px);
       min-height: 0;
-      padding: clamp(7px, 0.75vw, 13px);
+      padding: clamp(8px, 0.85vw, 14px);
       overflow: hidden;
       background: #151a22;
       border: 1px solid #252d38;
       border-radius: 9px;
     }
-    .recent-meta {
+    .recent-head {
       display: flex;
-      align-items: baseline;
-      min-width: 0;
-      overflow: hidden;
-      white-space: nowrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
     }
     .eval-tag {
       flex: none;
-      margin-right: 10px;
       color: #aab2bd;
       font-size: clamp(9px, 0.62vw, 12px);
       font-weight: 800;
@@ -185,30 +182,43 @@
     }
     .who {
       min-width: 0;
-      overflow: hidden;
+      font-size: clamp(11px, 0.78vw, 15px);
+      font-weight: 700;
+      line-height: 1.45;
+    }
+    .who .role-mini {
       color: #687280;
-      font-size: clamp(10px, 0.7vw, 14px);
       font-weight: 650;
-      text-overflow: ellipsis;
     }
     .recent-task {
-      display: -webkit-box;
       min-width: 0;
-      overflow: hidden;
+      min-height: 0;
+      flex: 1;
+      overflow-y: auto;
       color: #c9cfd7;
-      font-size: clamp(10px, 0.72vw, 14px);
-      line-height: 1.22;
-      -webkit-box-orient: vertical;
-      -webkit-line-clamp: 2;
+      font-size: clamp(11px, 0.78vw, 15px);
+      line-height: 1.3;
+    }
+    .clips {
+      display: flex;
+      gap: 5px;
+      min-height: 0;
+    }
+    .clips video {
+      flex: 1 1 0;
+      min-width: 0;
+      width: 100%;
+      max-height: clamp(64px, 10vh, 150px);
+      object-fit: cover;
+      background: #0b0e13;
+      border-radius: 6px;
     }
     .score-badge {
-      grid-column: 2;
-      grid-row: 1 / 3;
-      align-self: center;
-      min-width: 52px;
-      padding: 6px 9px;
+      flex: none;
+      min-width: 48px;
+      padding: 3px 9px;
       color: #f4f6f8;
-      font-size: clamp(14px, 1vw, 20px);
+      font-size: clamp(13px, 0.95vw, 19px);
       font-weight: 800;
       text-align: center;
       background: #202833;
@@ -351,31 +361,45 @@
       }
     }
 
-    function roleName(entry, role, prefix) {
+    function roleName(entry, role, label) {
       const name = entry.roles && entry.roles[role] ? entry.roles[role] : "unknown";
       const color = accents[name] || "#687280";
-      return `${prefix} <span style="color: ${color}">${escapeHtml(name)}</span>`;
+      return `<div><span class="role-mini">${label}</span> <span style="color: ${color}">${escapeHtml(name)}</span></div>`;
     }
 
+    let lastRecent = null;
     function renderRecent(data) {
+      const snapshot = JSON.stringify(data);
       const list = document.getElementById("recent-list");
+      if (snapshot === lastRecent) {
+        document.getElementById("recent-failure").textContent = "";
+        return;
+      }
+      lastRecent = snapshot;
       list.replaceChildren();
       for (const entry of data) {
         const card = document.createElement("article");
         card.className = "recent-card";
         const index = entry.eval_index == null ? "?" : entry.eval_index;
         const score = entry.score == null ? "—" : Number(entry.score).toFixed(2);
+        const clips = entry.clips || {};
+        const clipHtml = ["left", "top", "right"]
+          .filter((cam) => typeof clips[cam] === "string")
+          .map((cam) =>
+            `<video src="/media/${encodeURIComponent(clips[cam])}" autoplay muted loop playsinline></video>`)
+          .join("");
         card.innerHTML = `
-          <div class="recent-meta">
+          <div class="recent-head">
             <span class="eval-tag">Eval #${escapeHtml(index)}</span>
-            <span class="who">
-              ${roleName(entry, "tasker", "T")} ·
-              ${roleName(entry, "test_taker", "TT")} ·
-              ${roleName(entry, "grader", "G")}
-            </span>
+            <div class="score-badge">${score}</div>
           </div>
-          <div class="recent-task">${escapeHtml(entry.task || "Task unavailable")}</div>
-          <div class="score-badge">${score}</div>`;
+          ${clipHtml ? `<div class="clips">${clipHtml}</div>` : ""}
+          <div class="who">
+            ${roleName(entry, "tasker", "Task Maker")}
+            ${roleName(entry, "test_taker", "Test-Taker")}
+            ${roleName(entry, "grader", "Grader")}
+          </div>
+          <div class="recent-task">${escapeHtml(entry.task || "Task unavailable")}</div>`;
         list.appendChild(card);
       }
       while (list.children.length < 3) {

--- a/examples/actuate/monitor.html
+++ b/examples/actuate/monitor.html
@@ -76,6 +76,12 @@
       line-height: 1.04;
       overflow-wrap: anywhere;
     }
+    .cooling {
+      align-content: center;
+      font-size: clamp(19px, 1.45vw, 30px);
+      font-weight: 750;
+      text-align: center;
+    }
     .task-box {
       min-height: 0;
       padding: clamp(10px, 1vw, 18px);
@@ -243,7 +249,8 @@
 
     <section class="current">
       <div class="section-title">Current Eval</div>
-      <div class="cards">
+      <div id="cooling" class="card cooling muted" hidden></div>
+      <div id="role-cards" class="cards">
         <article class="card" data-role="tasker">
           <div class="role">Task Maker</div>
           <div class="model">Waiting…</div>
@@ -318,6 +325,17 @@
     function renderStatus(data) {
       document.getElementById("eval-index").textContent =
         data.eval_index == null ? "Eval #–" : `Eval #${data.eval_index}`;
+      const cooling = data.cooling;
+      const coolingBanner = document.getElementById("cooling");
+      coolingBanner.hidden = !cooling;
+      document.getElementById("role-cards").hidden = Boolean(cooling);
+      if (cooling) {
+        const maxC = Number(cooling.max_c).toFixed(1);
+        const resumeC = Number(cooling.resume_c).toFixed(1).replace(/\.0$/, "");
+        coolingBanner.textContent =
+          `Cooling motors: ${maxC}°C at ${cooling.hottest}. ` +
+          `Evals resume below ${resumeC}°C.`;
+      }
       for (const role of ["tasker", "test_taker", "grader"]) {
         const card = document.querySelector(`[data-role="${role}"]`);
         const model = card.querySelector(".model");

--- a/examples/actuate/monitor.html
+++ b/examples/actuate/monitor.html
@@ -235,7 +235,7 @@
       <div class="section-title">Current Eval</div>
       <div class="cards">
         <article class="card" data-role="tasker">
-          <div class="role">Tasker</div>
+          <div class="role">Task Maker</div>
           <div class="model">Waiting…</div>
         </article>
         <article class="card" data-role="test_taker">

--- a/examples/actuate/monitor.html
+++ b/examples/actuate/monitor.html
@@ -17,7 +17,7 @@
     }
     main {
       display: grid;
-      grid-template-rows: auto minmax(0, 1.18fr) minmax(0, 0.82fr);
+      grid-template-rows: auto minmax(0, 1.1fr) minmax(0, 0.42fr) minmax(0, 0.68fr);
       gap: clamp(10px, 1.4vh, 18px);
       height: 100vh;
       padding: clamp(14px, 1.5vw, 28px);
@@ -91,20 +91,13 @@
       line-height: 1.35;
       white-space: pre-wrap;
     }
-    .bottom {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-      gap: clamp(14px, 2vw, 34px);
-      min-height: 0;
-      padding-top: clamp(8px, 1vh, 14px);
-      border-top: 1px solid #252d38;
-      overflow: hidden;
-    }
     .panel {
       display: grid;
       grid-template-rows: auto minmax(0, 1fr);
       gap: clamp(10px, 1.2vh, 16px);
       min-height: 0;
+      padding-top: clamp(8px, 1vh, 14px);
+      border-top: 1px solid #252d38;
     }
     .panel-heading {
       display: flex;
@@ -158,8 +151,8 @@
     .count { color: #687280; font-size: 0.62em; font-weight: 600; }
     .recent-list {
       display: grid;
-      grid-template-rows: repeat(3, minmax(0, 1fr));
-      gap: clamp(6px, 0.8vh, 10px);
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: clamp(10px, 1.2vw, 22px);
       min-height: 0;
     }
     .recent-card {
@@ -260,21 +253,20 @@
       </div>
     </section>
 
-    <section class="bottom">
-      <section class="panel">
-        <div class="panel-heading">
-          <div class="section-title">Leaderboard</div>
-          <div class="subtitle">mean score as test-taker</div>
-        </div>
-        <div id="chart" class="chart"></div>
-      </section>
-      <section class="panel">
-        <div class="panel-heading">
-          <div class="section-title">Previous Evals</div>
-          <div id="recent-failure" class="failure"></div>
-        </div>
-        <div id="recent-list" class="recent-list"></div>
-      </section>
+    <section class="panel">
+      <div class="panel-heading">
+        <div class="section-title">Previous Evals</div>
+        <div id="recent-failure" class="failure"></div>
+      </div>
+      <div id="recent-list" class="recent-list"></div>
+    </section>
+
+    <section class="panel">
+      <div class="panel-heading">
+        <div class="section-title">Leaderboard</div>
+        <div class="subtitle">mean score as test-taker</div>
+      </div>
+      <div id="chart" class="chart"></div>
     </section>
   </main>
 

--- a/examples/actuate/monitor.html
+++ b/examples/actuate/monitor.html
@@ -290,7 +290,7 @@
 
   <script>
     const order = ["GPT-5.6 Sol", "Opus 5", "Gemini 3.7 Flash", "Kimi K3",
-                   "Gemini 3.1 Pro", "GPT-5", "GPT-5.4", "Kimi K2 Thinking"];
+                   "Gemini 3.1 Pro", "GPT-5", "GPT-5.4"];
     const accents = {
       "GPT-5.6 Sol": "#10a37f",
       "Opus 5": "#d97757",
@@ -298,8 +298,7 @@
       "Kimi K3": "#9067e8",
       "Gemini 3.1 Pro": "#3fb6c9",
       "GPT-5": "#d4608d",
-      "GPT-5.4": "#c9a54a",
-      "Kimi K2 Thinking": "#a2b53c"
+      "GPT-5.4": "#c9a54a"
     };
     const htmlEscapes = {
       "&": "&amp;",

--- a/examples/actuate/monitor.html
+++ b/examples/actuate/monitor.html
@@ -1,0 +1,429 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Actuate Live Eval</title>
+  <style>
+    :root { color-scheme: dark; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      height: 100vh;
+      overflow: hidden;
+      background: #0e1116;
+      color: #f4f6f8;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      display: grid;
+      grid-template-rows: auto minmax(0, 1.18fr) minmax(0, 0.82fr);
+      gap: clamp(10px, 1.4vh, 18px);
+      height: 100vh;
+      padding: clamp(14px, 1.5vw, 28px);
+      overflow: hidden;
+    }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      color: #8d96a3;
+      font-size: clamp(11px, 0.8vw, 16px);
+      font-weight: 750;
+      letter-spacing: 0.22em;
+      text-transform: uppercase;
+    }
+    .eval-index {
+      color: #f4f6f8;
+      font-size: clamp(26px, 2.4vw, 46px);
+      font-weight: 850;
+      letter-spacing: 0.04em;
+    }
+    .section-title {
+      color: #8d96a3;
+      font-size: clamp(10px, 0.72vw, 14px);
+      font-weight: 750;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+    }
+    .current {
+      display: grid;
+      grid-template-rows: auto auto minmax(0, 1fr);
+      gap: clamp(8px, 1vh, 14px);
+      min-height: 0;
+    }
+    .cards { display: flex; gap: clamp(10px, 1.2vw, 22px); }
+    .card {
+      flex: 1 1 0;
+      min-width: 0;
+      padding: clamp(12px, 1.35vw, 26px);
+      background: #151a22;
+      border: 1px solid #252d38;
+      border-top: 4px solid #596270;
+      border-radius: 12px;
+    }
+    .role, .task-label {
+      color: #8d96a3;
+      font-size: clamp(10px, 0.7vw, 14px);
+      font-weight: 750;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+    }
+    .model {
+      margin-top: clamp(7px, 0.8vh, 12px);
+      font-size: clamp(25px, 2.5vw, 50px);
+      font-weight: 850;
+      line-height: 1.04;
+      overflow-wrap: anywhere;
+    }
+    .task-box {
+      min-height: 0;
+      padding: clamp(10px, 1vw, 18px);
+      overflow-y: auto;
+      background: #11161d;
+      border: 1px solid #202833;
+      border-radius: 10px;
+    }
+    .instruction {
+      margin-top: clamp(7px, 0.8vh, 12px);
+      font-size: clamp(19px, 1.45vw, 30px);
+      font-weight: 520;
+      line-height: 1.35;
+      white-space: pre-wrap;
+    }
+    .bottom {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      gap: clamp(14px, 2vw, 34px);
+      min-height: 0;
+      padding-top: clamp(8px, 1vh, 14px);
+      border-top: 1px solid #252d38;
+      overflow: hidden;
+    }
+    .panel {
+      display: grid;
+      grid-template-rows: auto minmax(0, 1fr);
+      gap: clamp(10px, 1.2vh, 16px);
+      min-height: 0;
+    }
+    .panel-heading {
+      display: flex;
+      align-items: baseline;
+      gap: 12px;
+    }
+    .subtitle { color: #687280; font-size: clamp(9px, 0.65vw, 13px); }
+    .chart {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-around;
+      min-height: 0;
+    }
+    .leader-row {
+      display: grid;
+      grid-template-columns: minmax(130px, 28%) 1fr;
+      align-items: center;
+      gap: clamp(12px, 1.3vw, 24px);
+    }
+    .leader-name {
+      font-size: clamp(16px, 1.35vw, 27px);
+      font-weight: 800;
+      line-height: 1.05;
+      text-align: right;
+    }
+    .track {
+      position: relative;
+      height: clamp(16px, 1.55vw, 30px);
+      background: #1c222c;
+      border-radius: 999px;
+    }
+    .bar {
+      width: 2px;
+      height: 100%;
+      border-radius: 999px;
+      transition: width 600ms ease;
+    }
+    .bar-value {
+      position: absolute;
+      top: 50%;
+      left: 2px;
+      display: flex;
+      align-items: baseline;
+      gap: 7px;
+      font-size: clamp(13px, 1vw, 20px);
+      font-weight: 750;
+      transform: translate(9px, -50%);
+      transition: left 600ms ease;
+      white-space: nowrap;
+    }
+    .count { color: #687280; font-size: 0.62em; font-weight: 600; }
+    .recent-list {
+      display: grid;
+      grid-template-rows: repeat(3, minmax(0, 1fr));
+      gap: clamp(6px, 0.8vh, 10px);
+      min-height: 0;
+    }
+    .recent-card {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-rows: auto minmax(0, 1fr);
+      gap: 4px 12px;
+      min-height: 0;
+      padding: clamp(7px, 0.75vw, 13px);
+      overflow: hidden;
+      background: #151a22;
+      border: 1px solid #252d38;
+      border-radius: 9px;
+    }
+    .recent-meta {
+      display: flex;
+      align-items: baseline;
+      min-width: 0;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+    .eval-tag {
+      flex: none;
+      margin-right: 10px;
+      color: #aab2bd;
+      font-size: clamp(9px, 0.62vw, 12px);
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .who {
+      min-width: 0;
+      overflow: hidden;
+      color: #687280;
+      font-size: clamp(10px, 0.7vw, 14px);
+      font-weight: 650;
+      text-overflow: ellipsis;
+    }
+    .recent-task {
+      display: -webkit-box;
+      min-width: 0;
+      overflow: hidden;
+      color: #c9cfd7;
+      font-size: clamp(10px, 0.72vw, 14px);
+      line-height: 1.22;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+    }
+    .score-badge {
+      grid-column: 2;
+      grid-row: 1 / 3;
+      align-self: center;
+      min-width: 52px;
+      padding: 6px 9px;
+      color: #f4f6f8;
+      font-size: clamp(14px, 1vw, 20px);
+      font-weight: 800;
+      text-align: center;
+      background: #202833;
+      border-radius: 999px;
+    }
+    .muted { color: #687280; }
+    .pulse { animation: pulse 1.8s ease-in-out infinite; }
+    .failure {
+      color: #687280;
+      font-size: clamp(10px, 0.7vw, 14px);
+      align-self: center;
+    }
+    @keyframes pulse { 50% { opacity: 0.42; } }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <span>Actuate · Live Eval</span>
+      <span id="eval-index" class="eval-index">Eval #–</span>
+    </header>
+
+    <section class="current">
+      <div class="section-title">Current Eval</div>
+      <div class="cards">
+        <article class="card" data-role="tasker">
+          <div class="role">Tasker</div>
+          <div class="model">Waiting…</div>
+        </article>
+        <article class="card" data-role="test_taker">
+          <div class="role">Test-Taker</div>
+          <div class="model">Waiting…</div>
+        </article>
+        <article class="card" data-role="grader">
+          <div class="role">Grader</div>
+          <div class="model">Waiting…</div>
+        </article>
+      </div>
+      <div class="task-box">
+        <div class="task-label">Task</div>
+        <div id="instruction" class="instruction muted pulse">generating…</div>
+      </div>
+    </section>
+
+    <section class="bottom">
+      <section class="panel">
+        <div class="panel-heading">
+          <div class="section-title">Leaderboard</div>
+          <div class="subtitle">mean score as test-taker</div>
+        </div>
+        <div id="chart" class="chart"></div>
+      </section>
+      <section class="panel">
+        <div class="panel-heading">
+          <div class="section-title">Previous Evals</div>
+          <div id="recent-failure" class="failure"></div>
+        </div>
+        <div id="recent-list" class="recent-list"></div>
+      </section>
+    </section>
+  </main>
+
+  <script>
+    const order = ["GPT-5.6 Sol", "Opus 5", "Gemini 3.7 Flash"];
+    const accents = {
+      "GPT-5.6 Sol": "#10a37f",
+      "Opus 5": "#d97757",
+      "Gemini 3.7 Flash": "#4796e3"
+    };
+    const htmlEscapes = {
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      "\"": "&quot;",
+      "'": "&#039;"
+    };
+    const chart = document.getElementById("chart");
+
+    function escapeHtml(value) {
+      return String(value).replace(/[&<>"']/g, (character) => htmlEscapes[character]);
+    }
+
+    for (const name of order) {
+      const row = document.createElement("div");
+      row.className = "leader-row";
+      row.dataset.name = name;
+      row.innerHTML = `
+        <div class="leader-name" style="color: ${accents[name]}">${name}</div>
+        <div class="track">
+          <div class="bar" style="background: ${accents[name]}"></div>
+          <div class="bar-value">
+            <span class="score">—</span><span class="count">n=0</span>
+          </div>
+        </div>`;
+      chart.appendChild(row);
+    }
+
+    function renderStatus(data) {
+      document.getElementById("eval-index").textContent =
+        data.eval_index == null ? "Eval #–" : `Eval #${data.eval_index}`;
+      for (const role of ["tasker", "test_taker", "grader"]) {
+        const card = document.querySelector(`[data-role="${role}"]`);
+        const model = card.querySelector(".model");
+        const name = data.roles && data.roles[role] ? data.roles[role] : "Waiting…";
+        const color = accents[name] || "#687280";
+        model.textContent = name;
+        model.style.color = color;
+        card.style.borderTopColor = color;
+      }
+      const instruction = document.getElementById("instruction");
+      instruction.textContent = data.task == null ? "generating…" : data.task;
+      instruction.classList.toggle("muted", data.task == null);
+      instruction.classList.toggle("pulse", data.task == null);
+    }
+
+    function renderLeaderboard(data) {
+      const byName = Object.fromEntries(data.map((entry) => [entry.name, entry]));
+      const scores = data.filter((entry) => entry.score != null).map((entry) => entry.score);
+      const maxScore = scores.length ? Math.max(...scores) : 0;
+      for (const name of order) {
+        const entry = byName[name] || { name, n: 0, score: null };
+        const row = document.querySelector(`[data-name="${name}"]`);
+        const percentage = entry.score != null && maxScore > 0
+          ? 80 * entry.score / maxScore
+          : null;
+        const width = percentage == null ? "2px" : `${percentage}%`;
+        row.querySelector(".bar").style.width = width;
+        row.querySelector(".bar-value").style.left = width;
+        row.querySelector(".score").textContent =
+          entry.score == null ? "—" : Number(entry.score).toFixed(2);
+        row.querySelector(".count").textContent = `n=${entry.n}`;
+      }
+    }
+
+    function roleName(entry, role, prefix) {
+      const name = entry.roles && entry.roles[role] ? entry.roles[role] : "unknown";
+      const color = accents[name] || "#687280";
+      return `${prefix} <span style="color: ${color}">${escapeHtml(name)}</span>`;
+    }
+
+    function renderRecent(data) {
+      const list = document.getElementById("recent-list");
+      list.replaceChildren();
+      for (const entry of data) {
+        const card = document.createElement("article");
+        card.className = "recent-card";
+        const index = entry.eval_index == null ? "?" : entry.eval_index;
+        const score = entry.score == null ? "—" : Number(entry.score).toFixed(2);
+        card.innerHTML = `
+          <div class="recent-meta">
+            <span class="eval-tag">Eval #${escapeHtml(index)}</span>
+            <span class="who">
+              ${roleName(entry, "tasker", "T")} ·
+              ${roleName(entry, "test_taker", "TT")} ·
+              ${roleName(entry, "grader", "G")}
+            </span>
+          </div>
+          <div class="recent-task">${escapeHtml(entry.task || "Task unavailable")}</div>
+          <div class="score-badge">${score}</div>`;
+        list.appendChild(card);
+      }
+      while (list.children.length < 3) {
+        const placeholder = document.createElement("article");
+        placeholder.className = "recent-card muted";
+        placeholder.textContent = "Waiting for a completed eval…";
+        list.appendChild(placeholder);
+      }
+      document.getElementById("recent-failure").textContent = "";
+    }
+
+    function statusWaiting() {
+      const instruction = document.getElementById("instruction");
+      instruction.textContent = "waiting for orchestrator…";
+      instruction.classList.add("muted", "pulse");
+    }
+
+    async function pollStatus() {
+      try {
+        const response = await fetch("/api/status", { cache: "no-store" });
+        if (!response.ok) throw new Error("status unavailable");
+        renderStatus(await response.json());
+      } catch (error) {
+        statusWaiting();
+      }
+    }
+
+    async function pollSummary() {
+      try {
+        const [leaderboardResponse, recentResponse] = await Promise.all([
+          fetch("/api/leaderboard", { cache: "no-store" }),
+          fetch("/api/recent", { cache: "no-store" })
+        ]);
+        if (!leaderboardResponse.ok || !recentResponse.ok) {
+          throw new Error("summary unavailable");
+        }
+        renderLeaderboard(await leaderboardResponse.json());
+        renderRecent(await recentResponse.json());
+      } catch (error) {
+        document.getElementById("recent-failure").textContent =
+          "waiting for orchestrator…";
+      }
+    }
+
+    renderRecent([]);
+    pollStatus();
+    pollSummary();
+    setInterval(pollStatus, 2000);
+    setInterval(pollSummary, 3000);
+  </script>
+</body>
+</html>

--- a/examples/actuate/monitor.html
+++ b/examples/actuate/monitor.html
@@ -17,7 +17,7 @@
     }
     main {
       display: grid;
-      grid-template-rows: auto minmax(0, 1.1fr) minmax(0, 0.42fr) minmax(0, 0.68fr);
+      grid-template-rows: auto minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
       gap: clamp(10px, 1.4vh, 18px);
       height: 100vh;
       padding: clamp(14px, 1.5vw, 28px);

--- a/examples/actuate/monitor.html
+++ b/examples/actuate/monitor.html
@@ -327,9 +327,18 @@
       const byName = Object.fromEntries(data.map((entry) => [entry.name, entry]));
       const scores = data.filter((entry) => entry.score != null).map((entry) => entry.score);
       const maxScore = scores.length ? Math.max(...scores) : 0;
+      const ranked = [...order].sort((a, b) => {
+        const sa = byName[a] ? byName[a].score : null;
+        const sb = byName[b] ? byName[b].score : null;
+        if (sa == null && sb == null) return order.indexOf(a) - order.indexOf(b);
+        if (sa == null) return 1;
+        if (sb == null) return -1;
+        return sb - sa;
+      });
       for (const name of order) {
         const entry = byName[name] || { name, n: 0, score: null };
         const row = document.querySelector(`[data-name="${name}"]`);
+        row.style.order = ranked.indexOf(name);
         const percentage = entry.score != null && maxScore > 0
           ? 80 * entry.score / maxScore
           : null;

--- a/examples/actuate/monitor.html
+++ b/examples/actuate/monitor.html
@@ -289,11 +289,12 @@
   </main>
 
   <script>
-    const order = ["GPT-5.6 Sol", "Opus 5", "Gemini 3.7 Flash"];
+    const order = ["GPT-5.6 Sol", "Opus 5", "Gemini 3.7 Flash", "Kimi K3"];
     const accents = {
       "GPT-5.6 Sol": "#10a37f",
       "Opus 5": "#d97757",
-      "Gemini 3.7 Flash": "#4796e3"
+      "Gemini 3.7 Flash": "#4796e3",
+      "Kimi K3": "#9067e8"
     };
     const htmlEscapes = {
       "&": "&amp;",

--- a/examples/actuate/overnight.html
+++ b/examples/actuate/overnight.html
@@ -338,7 +338,9 @@
         const index = entry.eval_index == null ? "?" : entry.eval_index;
         const scoreValue = finiteNumber(entry.score);
         const score = scoreValue == null ? "unscored" : scoreValue.toFixed(1);
-        const task = typeof entry.task === "string" ? entry.task : "Task unavailable";
+        const task = typeof entry.task === "string"
+          ? entry.task
+          : "eval failed before a task was generated";
         const clip = clipName(entry.clips);
         const video = clip == null
           ? ""

--- a/examples/actuate/overnight.html
+++ b/examples/actuate/overnight.html
@@ -1,0 +1,480 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Actuate Overnight</title>
+  <style>
+    :root { color-scheme: dark; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: #0e1116;
+      color: #f4f6f8;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      width: min(100%, 760px);
+      margin: 0 auto;
+      padding: 18px 14px 40px;
+    }
+    header { margin-bottom: 14px; }
+    h1 {
+      margin: 0 0 10px;
+      font-size: clamp(25px, 7vw, 38px);
+      line-height: 1.05;
+      letter-spacing: -0.025em;
+    }
+    .header-line,
+    .rig-title-row,
+    .recent-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+    }
+    .progress-label { font-size: 14px; font-weight: 750; }
+    .updated { color: #687280; font-size: 12px; }
+    .overall-track {
+      height: 4px;
+      margin-top: 8px;
+      overflow: hidden;
+      background: #252d38;
+      border-radius: 999px;
+    }
+    .overall-bar {
+      width: 0;
+      height: 100%;
+      background: #10a37f;
+      border-radius: inherit;
+      transition: width 400ms ease;
+    }
+    .unreachable {
+      margin: 0 0 14px;
+      padding: 9px 12px;
+      color: #ffb4b4;
+      font-size: 13px;
+      font-weight: 750;
+      background: #3a1d22;
+      border: 1px solid #71313a;
+      border-radius: 8px;
+    }
+    .card {
+      margin-bottom: 14px;
+      padding: 15px;
+      background: #151a22;
+      border: 1px solid #252d38;
+      border-radius: 12px;
+    }
+    .rig-title,
+    .section-title {
+      margin: 0;
+      font-size: 18px;
+      font-weight: 850;
+    }
+    .state-chip {
+      padding: 4px 8px;
+      font-size: 10px;
+      font-weight: 850;
+      letter-spacing: 0.06em;
+      white-space: nowrap;
+      border-radius: 999px;
+    }
+    .state-running { color: #85e0bd; background: #17382f; }
+    .state-cooling { color: #8dc8ff; background: #173149; }
+    .state-stalled { color: #ff9c9c; background: #452127; }
+    .state-muted { color: #9aa3af; background: #252d38; }
+    .current-eval {
+      margin: 11px 0 13px;
+      color: #c9cfd7;
+      font-size: 12px;
+      line-height: 1.4;
+    }
+    .progress-grid {
+      display: grid;
+      grid-template-columns: minmax(96px, 1fr) auto 42px;
+      align-items: center;
+      gap: 8px 10px;
+      padding-top: 12px;
+      border-top: 1px solid #252d38;
+    }
+    .model-name {
+      min-width: 0;
+      overflow: hidden;
+      font-size: 12px;
+      font-weight: 750;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .dots { display: flex; gap: 5px; }
+    .dot {
+      width: 10px;
+      height: 10px;
+      background: #252d38;
+      border: 1px solid #3b4552;
+      border-radius: 50%;
+    }
+    .dot-filled { border-color: transparent; }
+    .mean {
+      color: #c9cfd7;
+      font-size: 12px;
+      font-variant-numeric: tabular-nums;
+      text-align: right;
+    }
+    .recent-label {
+      margin: 15px 0 7px;
+      color: #687280;
+      font-size: 10px;
+      font-weight: 800;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+    .recent-strip {
+      display: grid;
+      grid-auto-columns: minmax(210px, 82%);
+      grid-auto-flow: column;
+      gap: 8px;
+      overflow-x: auto;
+      overscroll-behavior-x: contain;
+      scroll-snap-type: x proximity;
+    }
+    .recent-card {
+      min-width: 0;
+      padding: 10px;
+      overflow: hidden;
+      background: #10151c;
+      border: 1px solid #252d38;
+      border-radius: 8px;
+      scroll-snap-align: start;
+    }
+    .eval-tag {
+      color: #aab2bd;
+      font-size: 10px;
+      font-weight: 800;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    .score-badge {
+      padding: 2px 7px;
+      color: #f4f6f8;
+      font-size: 11px;
+      font-weight: 800;
+      background: #252d38;
+      border-radius: 999px;
+    }
+    .recent-model {
+      margin-top: 6px;
+      overflow: hidden;
+      font-size: 12px;
+      font-weight: 800;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .recent-task {
+      margin-top: 5px;
+      overflow: hidden;
+      color: #687280;
+      font-size: 11px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .recent-card video {
+      display: block;
+      width: 100%;
+      max-height: 120px;
+      margin-top: 8px;
+      object-fit: cover;
+      background: #0b0e13;
+      border-radius: 6px;
+    }
+    .empty-recent {
+      color: #687280;
+      font-size: 12px;
+    }
+    .leaderboard-card { padding-bottom: 8px; }
+    table {
+      width: 100%;
+      margin-top: 8px;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    th,
+    td {
+      padding: 8px 4px;
+      border-top: 1px solid #252d38;
+      text-align: right;
+    }
+    th {
+      color: #687280;
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    th:first-child,
+    td:first-child {
+      text-align: left;
+    }
+    .leader-name { font-weight: 800; }
+    .muted { color: #687280; }
+    [hidden] { display: none !important; }
+    @media (min-width: 560px) {
+      main { padding: 26px 20px 50px; }
+      .card { padding: 19px; }
+      .progress-grid {
+        grid-template-columns: minmax(160px, 1fr) auto 52px;
+      }
+      .model-name,
+      .mean,
+      .current-eval { font-size: 13px; }
+      .dot { width: 12px; height: 12px; }
+      .recent-strip { grid-auto-columns: minmax(210px, 1fr); }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>Actuate Overnight</h1>
+      <div class="header-line">
+        <div id="progress-label" class="progress-label">0/0 scored</div>
+        <div id="updated" class="updated">waiting for update</div>
+      </div>
+      <div class="overall-track">
+        <div id="overall-bar" class="overall-bar"></div>
+      </div>
+    </header>
+
+    <div id="unreachable" class="unreachable" hidden>server unreachable</div>
+    <section id="rigs"></section>
+
+    <section class="card leaderboard-card">
+      <h2 class="section-title">Pooled Leaderboard</h2>
+      <table>
+        <thead>
+          <tr><th>Model</th><th>n</th><th>Mean</th></tr>
+        </thead>
+        <tbody id="leaderboard"></tbody>
+      </table>
+    </section>
+  </main>
+
+  <script>
+    const fallbackAccent = "#687280";
+    const htmlEscapes = {
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      "\"": "&quot;",
+      "'": "&#039;"
+    };
+
+    function escapeHtml(value) {
+      return String(value).replace(/[&<>"']/g, (character) => htmlEscapes[character]);
+    }
+
+    function accentFor(name, accents) {
+      const candidate = accents && accents[name];
+      return typeof candidate === "string" && /^#[0-9a-fA-F]{6}$/.test(candidate)
+        ? candidate
+        : fallbackAccent;
+    }
+
+    function finiteNumber(value) {
+      if (value == null || value === "") return null;
+      const number = Number(value);
+      return Number.isFinite(number) ? number : null;
+    }
+
+    function trialCount(data) {
+      const rosterSize = Array.isArray(data.roster) ? data.roster.length : 0;
+      const target = finiteNumber(data.pooled && data.pooled.target);
+      return rosterSize > 0 && target != null ? target / (2 * rosterSize) : 5;
+    }
+
+    function hasResults(rig, roster) {
+      if (Array.isArray(rig.recent) && rig.recent.length > 0) return true;
+      return roster.some((name) => {
+        const result = rig.results && rig.results[name];
+        return result && Number(result.n) > 0;
+      });
+    }
+
+    function rigState(rig, roster) {
+      const notStarted = !rig.status && !hasResults(rig, roster);
+      if (notStarted) return { label: "NOT STARTED", className: "state-muted", notStarted };
+      if (rig.done) return { label: "DONE", className: "state-muted", notStarted };
+      if (rig.stalled) {
+        const minutes = Math.max(0, Math.floor(Number(rig.last_activity_s) / 60));
+        return { label: `STALLED ${minutes}m`, className: "state-stalled", notStarted };
+      }
+      const cooling = rig.status && rig.status.cooling;
+      if (cooling) {
+        const maxC = finiteNumber(cooling.max_c);
+        const temperature = maxC == null ? "?" : maxC.toFixed(1);
+        return { label: `COOLING ${temperature} C`, className: "state-cooling", notStarted };
+      }
+      return { label: "RUNNING", className: "state-running", notStarted };
+    }
+
+    function runningMinutes(startedAt) {
+      const started = Date.parse(startedAt);
+      if (!Number.isFinite(started)) return 0;
+      return Math.max(0, Math.floor((Date.now() - started) / 60000));
+    }
+
+    function clipName(clips) {
+      if (!clips || typeof clips !== "object") return null;
+      if (typeof clips.top === "string") return clips.top;
+      return Object.values(clips).find((value) => typeof value === "string") || null;
+    }
+
+    function renderRecent(rigKey, recent, accents) {
+      if (!Array.isArray(recent) || recent.length === 0) {
+        return '<div class="empty-recent">No completed evals yet</div>';
+      }
+      return recent.map((entry) => {
+        const model = typeof entry.test_taker === "string" ? entry.test_taker : "unknown";
+        const color = accentFor(model, accents);
+        const index = entry.eval_index == null ? "?" : entry.eval_index;
+        const scoreValue = finiteNumber(entry.score);
+        const score = scoreValue == null ? "unscored" : scoreValue.toFixed(1);
+        const task = typeof entry.task === "string" ? entry.task : "Task unavailable";
+        const clip = clipName(entry.clips);
+        const video = clip == null
+          ? ""
+          : `<video src="/media/${rigKey}/${encodeURIComponent(clip)}" autoplay muted loop playsinline></video>`;
+        return `
+          <article class="recent-card">
+            <div class="recent-head">
+              <span class="eval-tag">Eval #${escapeHtml(index)}</span>
+              <span class="score-badge">${escapeHtml(score)}</span>
+            </div>
+            <div class="recent-model" style="color: ${color}">${escapeHtml(model)}</div>
+            <div class="recent-task">${escapeHtml(task)}</div>
+            ${video}
+          </article>`;
+      }).join("");
+    }
+
+    function renderRig(rigKey, rig, roster, accents, trialsPerRig) {
+      const state = rigState(rig, roster);
+      const title = rigKey === "rig1" ? "Rig 1" : "Rig 2";
+      let current = "";
+      if (!rig.done && !state.notStarted) {
+        const status = rig.status || {};
+        const roles = status.roles && typeof status.roles === "object" ? status.roles : {};
+        const model = typeof roles.test_taker === "string" ? roles.test_taker : "waiting";
+        const result = rig.results && rig.results[model];
+        const completed = result ? Number(result.n) || 0 : 0;
+        const evalIndex = status.eval_index == null ? "?" : status.eval_index;
+        current = `
+          <div class="current-eval">
+            Eval #${escapeHtml(evalIndex)} - ${escapeHtml(model)} - trial
+            ${escapeHtml(completed + 1)}/${escapeHtml(trialsPerRig)} - running
+            ${escapeHtml(runningMinutes(status.started_at))} min
+          </div>`;
+      }
+      const progress = roster.map((name) => {
+        const result = rig.results && rig.results[name] ? rig.results[name] : { n: 0, mean: null };
+        const count = Math.max(0, Number(result.n) || 0);
+        const mean = finiteNumber(result.mean);
+        const color = accentFor(name, accents);
+        const dots = Array.from({ length: trialsPerRig }, (_unused, index) =>
+          index < Math.min(count, trialsPerRig)
+            ? `<span class="dot dot-filled" style="background: ${color}"></span>`
+            : '<span class="dot"></span>'
+        ).join("");
+        return `
+          <div class="model-name" style="color: ${color}" title="${escapeHtml(name)}">${escapeHtml(name)}</div>
+          <div class="dots">${dots}</div>
+          <div class="mean">${mean == null ? "-" : mean.toFixed(1)}</div>`;
+      }).join("");
+      return `
+        <article class="card">
+          <div class="rig-title-row">
+            <h2 class="rig-title">${title}</h2>
+            <span class="state-chip ${state.className}">${escapeHtml(state.label)}</span>
+          </div>
+          ${current}
+          <div class="progress-grid">${progress}</div>
+          <div class="recent-label">Recent</div>
+          <div class="recent-strip">${renderRecent(rigKey, rig.recent, accents)}</div>
+        </article>`;
+    }
+
+    function renderLeaderboard(data, trialsPerRig) {
+      const roster = Array.isArray(data.roster) ? data.roster : [];
+      const results = data.pooled && data.pooled.results ? data.pooled.results : {};
+      const ranked = [...roster].sort((left, right) => {
+        const leftEntry = results[left] || { n: 0, mean: null };
+        const rightEntry = results[right] || { n: 0, mean: null };
+        const leftMean = finiteNumber(leftEntry.mean);
+        const rightMean = finiteNumber(rightEntry.mean);
+        if (Number(leftEntry.n) === 0 && Number(rightEntry.n) !== 0) return 1;
+        if (Number(rightEntry.n) === 0 && Number(leftEntry.n) !== 0) return -1;
+        if (leftMean == null && rightMean == null) return roster.indexOf(left) - roster.indexOf(right);
+        if (leftMean == null) return 1;
+        if (rightMean == null) return -1;
+        return rightMean - leftMean;
+      });
+      document.getElementById("leaderboard").innerHTML = ranked.map((name) => {
+        const entry = results[name] || { n: 0, mean: null };
+        const mean = finiteNumber(entry.mean);
+        const color = accentFor(name, data.accents);
+        return `
+          <tr>
+            <td class="leader-name" style="color: ${color}">${escapeHtml(name)}</td>
+            <td>${escapeHtml(Number(entry.n) || 0)}/${escapeHtml(2 * trialsPerRig)}</td>
+            <td>${mean == null ? "-" : mean.toFixed(1)}</td>
+          </tr>`;
+      }).join("");
+    }
+
+    function render(data) {
+      const roster = Array.isArray(data.roster) ? data.roster : [];
+      const rigs = data.rigs || {};
+      const pooled = data.pooled || {};
+      const total = Math.max(0, Number(pooled.total_scored) || 0);
+      const target = Math.max(0, Number(pooled.target) || 0);
+      const trialsPerRig = trialCount(data);
+      document.getElementById("progress-label").textContent = `${total}/${target} scored`;
+      document.getElementById("overall-bar").style.width =
+        `${target > 0 ? Math.min(100, 100 * total / target) : 0}%`;
+      const generated = new Date(data.generated_at);
+      document.getElementById("updated").textContent = Number.isNaN(generated.getTime())
+        ? "updated unknown"
+        : `updated ${generated.toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+            second: "2-digit",
+            hour12: false
+          })}`;
+      document.getElementById("rigs").innerHTML = ["rig1", "rig2"]
+        .map((rigKey) => renderRig(
+          rigKey,
+          rigs[rigKey] || { results: {}, recent: [] },
+          roster,
+          data.accents || {},
+          trialsPerRig
+        ))
+        .join("");
+      renderLeaderboard(data, trialsPerRig);
+    }
+
+    async function refresh() {
+      try {
+        const response = await fetch("/api/overnight", { cache: "no-store" });
+        if (!response.ok) throw new Error("overnight API unavailable");
+        const data = await response.json();
+        render(data);
+        document.getElementById("unreachable").hidden = true;
+      } catch (_error) {
+        document.getElementById("unreachable").hidden = false;
+      }
+    }
+
+    refresh();
+    setInterval(refresh, 30000);
+  </script>
+</body>
+</html>

--- a/examples/actuate/overnight.py
+++ b/examples/actuate/overnight.py
@@ -20,7 +20,10 @@ import run
 from _roster import ACCENTS
 
 TRIALS_PER_RIG = 5
-STALL_AFTER_MIN = 30
+# Sized above the eval watchdog (90 min) plus teardown grace: a slow model's
+# single legitimate episode writes nothing to the state dir for its whole
+# duration, so any smaller threshold cries stalled mid-eval.
+STALL_AFTER_MIN = 100
 RIGS = {"rig1": ("state-rig1", "logs-rig1"), "rig2": ("state-rig2", "logs-rig2")}
 
 HERE = Path(__file__).parent

--- a/examples/actuate/overnight.py
+++ b/examples/actuate/overnight.py
@@ -1,0 +1,325 @@
+"""Serve a phone-friendly view of both Actuate overnight campaign rigs.
+
+Run with:  python examples/actuate/overnight.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from datetime import datetime, timezone
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+import run
+from _roster import ACCENTS
+
+TRIALS_PER_RIG = 5
+STALL_AFTER_MIN = 30
+RIGS = {"rig1": ("state-rig1", "logs-rig1"), "rig2": ("state-rig2", "logs-rig2")}
+
+HERE = Path(__file__).parent
+_MEDIA_NAME = re.compile(r"^[A-Za-z0-9._-]+\.mp4$")
+_STATUS_KEYS = ("eval_index", "started_at", "roles", "models", "cooling")
+
+
+def _eligible_names() -> list[str]:
+    try:
+        return [name for name, _model in run._eligible("test_taker")]
+    except Exception:
+        return []
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _age_seconds(now: datetime, then: datetime | None) -> float | None:
+    if then is None:
+        return None
+    return max(0.0, (now - then).total_seconds())
+
+
+def _read_status(
+    path: Path, now: datetime
+) -> tuple[dict[str, Any] | None, float | None, datetime | None]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            return None, None, None
+        modified_at = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
+    except Exception:
+        return None, None, None
+    status = {key: raw.get(key) for key in _STATUS_KEYS}
+    return status, _age_seconds(now, modified_at), modified_at
+
+
+def _numeric_score(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return None
+    return score if math.isfinite(score) else None
+
+
+def _recent_result(result: Any) -> dict[str, Any] | None:
+    try:
+        if not isinstance(result, dict):
+            return None
+        roles = result["roles"]
+        if not isinstance(roles, dict):
+            return None
+        raw_score = result.get("score")
+        score = _numeric_score(raw_score)
+        if raw_score is not None and score is None:
+            return None
+        eval_index = result.get("eval_index")
+        if not isinstance(eval_index, int) or isinstance(eval_index, bool) or eval_index < 1:
+            eval_index = None
+        test_taker = roles.get("test_taker")
+        task = result.get("task")
+        ts = result.get("ts")
+        clips = result.get("clips")
+        return {
+            "eval_index": eval_index,
+            "test_taker": test_taker if isinstance(test_taker, str) else None,
+            "score": score,
+            "task": task if isinstance(task, str) else None,
+            "ts": ts if isinstance(ts, str) else None,
+            "clips": clips if isinstance(clips, dict) else {},
+        }
+    except Exception:
+        return None
+
+
+def _read_results(
+    path: Path, roster: list[str]
+) -> tuple[dict[str, list[float]], list[dict[str, Any]], datetime | None]:
+    observations: dict[str, list[float]] = {name: [] for name in roster}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        lines = []
+
+    parsed_rows: list[dict[str, Any]] = []
+    last_result_at: datetime | None = None
+    for line in lines:
+        try:
+            result = json.loads(line)
+        except Exception:
+            continue
+        if not isinstance(result, dict):
+            continue
+
+        parsed_ts = _parse_iso(result.get("ts"))
+        if parsed_ts is not None:
+            last_result_at = parsed_ts
+
+        try:
+            name = result["roles"]["test_taker"]
+            raw_score = result.get("score")
+            score = _numeric_score(raw_score)
+            if name in observations and raw_score is not None and score is not None:
+                observations[name].append(score)
+        except Exception:
+            pass
+
+        recent = _recent_result(result)
+        if recent is not None:
+            parsed_rows.append(recent)
+
+    return observations, list(reversed(parsed_rows[-3:])), last_result_at
+
+
+def _summaries(observations: dict[str, list[float]]) -> dict[str, dict[str, Any]]:
+    return {
+        name: {
+            "n": len(scores),
+            "mean": sum(scores) / len(scores) if scores else None,
+        }
+        for name, scores in observations.items()
+    }
+
+
+def _empty_rig_payload(roster: list[str]) -> dict[str, Any]:
+    observations = {name: [] for name in roster}
+    return {
+        "status": None,
+        "status_age_s": None,
+        "results": _summaries(observations),
+        "recent": [],
+        "last_activity_s": None,
+        "done": False,
+        "stalled": False,
+    }
+
+
+def _rig_payload(rig: str, roster: list[str], now: datetime) -> dict[str, Any]:
+    try:
+        state_name, _logs_name = RIGS[rig]
+        state_dir = HERE / state_name
+        status, status_age_s, status_at = _read_status(state_dir / "status.json", now)
+        observations, recent, result_at = _read_results(state_dir / "results.jsonl", roster)
+        activity_at = max(
+            (value for value in (status_at, result_at) if value is not None),
+            default=None,
+        )
+        last_activity_s = _age_seconds(now, activity_at)
+        done = bool(roster) and all(len(observations[name]) >= TRIALS_PER_RIG for name in roster)
+        stalled = (
+            not done and last_activity_s is not None and last_activity_s > STALL_AFTER_MIN * 60
+        )
+        return {
+            "status": status,
+            "status_age_s": status_age_s,
+            "results": _summaries(observations),
+            "recent": recent,
+            "last_activity_s": last_activity_s,
+            "done": done,
+            "stalled": stalled,
+        }
+    except Exception:
+        return _empty_rig_payload(roster)
+
+
+def _overnight_payload() -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    roster = _eligible_names()
+    rigs = {rig: _rig_payload(rig, roster, now) for rig in RIGS}
+    pooled_observations: dict[str, list[float]] = {name: [] for name in roster}
+    for rig in RIGS:
+        state_name, _logs_name = RIGS[rig]
+        observations, _recent, _last_result_at = _read_results(
+            HERE / state_name / "results.jsonl", roster
+        )
+        for name in roster:
+            pooled_observations[name].extend(observations[name])
+    pooled = _summaries(pooled_observations)
+    return {
+        "generated_at": now.isoformat(),
+        "roster": roster,
+        "accents": ACCENTS,
+        "rigs": rigs,
+        "pooled": {
+            "results": pooled,
+            "total_scored": sum(entry["n"] for entry in pooled.values()),
+            "target": 2 * TRIALS_PER_RIG * len(roster),
+        },
+    }
+
+
+def _empty_payload() -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    roster = _eligible_names()
+    empty_rigs = {rig: _empty_rig_payload(roster) for rig in RIGS}
+    pooled = _summaries({name: [] for name in roster})
+    return {
+        "generated_at": now.isoformat(),
+        "roster": roster,
+        "accents": ACCENTS,
+        "rigs": empty_rigs,
+        "pooled": {
+            "results": pooled,
+            "total_scored": 0,
+            "target": 2 * TRIALS_PER_RIG * len(roster),
+        },
+    }
+
+
+class OvernightHandler(BaseHTTPRequestHandler):
+    """Serve the overnight page, aggregate API, and per-rig video clips."""
+
+    def _send(
+        self,
+        body: bytes,
+        content_type: str,
+        status: HTTPStatus = HTTPStatus.OK,
+    ) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_json(self, payload: Any) -> None:
+        try:
+            body = json.dumps(payload).encode("utf-8")
+        except Exception:
+            body = json.dumps(_empty_payload()).encode("utf-8")
+        self._send(body, "application/json; charset=utf-8")
+
+    def do_GET(self) -> None:
+        """Route one GET request without retaining response state."""
+        path = urlsplit(self.path).path
+        if path == "/api/overnight":
+            try:
+                payload = _overnight_payload()
+            except Exception:
+                payload = _empty_payload()
+            self._send_json(payload)
+            return
+        if path.startswith("/media/"):
+            parts = path.split("/")
+            if len(parts) != 4 or parts[2] not in RIGS or not _MEDIA_NAME.fullmatch(parts[3]):
+                self._send(b"Not found\n", "text/plain; charset=utf-8", HTTPStatus.NOT_FOUND)
+                return
+            state_name, _logs_name = RIGS[parts[2]]
+            try:
+                body = (HERE / state_name / "media" / parts[3]).read_bytes()
+            except OSError:
+                self._send(b"Not found\n", "text/plain; charset=utf-8", HTTPStatus.NOT_FOUND)
+                return
+            self._send(body, "video/mp4")
+            return
+        if path == "/":
+            try:
+                body = (HERE / "overnight.html").read_bytes()
+            except OSError:
+                self._send(
+                    b"Page unavailable\n",
+                    "text/plain; charset=utf-8",
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                )
+                return
+            self._send(body, "text/html; charset=utf-8")
+            return
+        self._send(b"Not found\n", "text/plain; charset=utf-8", HTTPStatus.NOT_FOUND)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        """Suppress the base server's per-request console logging."""
+        return
+
+
+def main() -> None:
+    """Serve the overnight campaign view on the selected port."""
+    parser = argparse.ArgumentParser(description="Serve the Actuate overnight campaign view.")
+    parser.add_argument("--port", type=int, default=8380)
+    args = parser.parse_args()
+    server = ThreadingHTTPServer(("", args.port), OvernightHandler)
+    print(f"Actuate overnight view available at http://localhost:{args.port}/")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nExiting.")
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/actuate/run.py
+++ b/examples/actuate/run.py
@@ -304,6 +304,9 @@ def _command(
 def main() -> None:
     if not RIG_CONFIG.is_file():
         raise SystemExit(f"rig config not found: {RIG_CONFIG}\nfix: edit RIG_CONFIG in run.py")
+    # Resolved once from RIG_CONFIG only: a --config override after "--"
+    # re-routes the eval but not the gate's probe channels, so on a rig with
+    # different channel names the gate degrades to per-round warnings.
     channels = config_channels(RIG_CONFIG)
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     LOGS_DIR.mkdir(parents=True, exist_ok=True)

--- a/examples/actuate/run.py
+++ b/examples/actuate/run.py
@@ -36,6 +36,10 @@ DOCS_EXTRA_PATHS = [
 # no log (hardware or config failure) so a broken booth does not hammer retries.
 PAUSE_S = 10
 FAILURE_PAUSE_S = 30
+# Consecutive log-less evals (hardware or config faults fail before any model
+# call) before the loop halts loudly instead of spinning junk all night; a
+# 2026-08-18 arm joint-limit fault produced ~385 junk evals in 5 hours.
+FAILURE_STREAK_STOP = 10
 STATE_DIR = HERE / "state"
 LOGS_DIR = HERE / "logs"
 STATUS_PATH = STATE_DIR / "status.json"
@@ -234,6 +238,7 @@ def main() -> None:
     extra_args = _extra_args(sys.argv[1:])
     roster = list(ROSTER.items())
     eval_index = _next_eval_index()
+    failure_streak = 0
 
     try:
         while True:
@@ -289,6 +294,13 @@ def main() -> None:
             log_text = log_path.name if log_path else "no log"
             print(f"Eval {eval_index} complete: score={score_text}, log={log_text}")
 
+            failure_streak = 0 if log_path is not None else failure_streak + 1
+            if failure_streak >= FAILURE_STREAK_STOP:
+                raise SystemExit(
+                    f"{failure_streak} consecutive evals produced no log; the rig "
+                    "is likely faulted (check arms, CAN, cameras). Fix it and "
+                    "relaunch."
+                )
             pause = PAUSE_S if log_path is not None else FAILURE_PAUSE_S
             print(f"next eval in {pause}s (Ctrl-C to stop)", flush=True)
             time.sleep(pause)

--- a/examples/actuate/run.py
+++ b/examples/actuate/run.py
@@ -137,6 +137,7 @@ def _command(
         "--policy",
         "agent",
         *_role_args("-P", test_taker),
+        *(["-P", f"wire={test_taker['policy_wire']}"] if "policy_wire" in test_taker else []),
         "--log-dir",
         str(LOGS_DIR.resolve()),
         *extra_args,

--- a/examples/actuate/run.py
+++ b/examples/actuate/run.py
@@ -25,6 +25,12 @@ HERE = Path(__file__).parent
 # run against the rig folder's file. Booth-editable; a later --config in the
 # passthrough args after "--" overrides it.
 RIG_CONFIG = Path.home() / "robocurve" / "rig-1" / "config.ini"
+# Rig cheat-sheet notes passed to the embodiment docs channel (-E docs_extra),
+# concatenated from whichever of these exist; booth-editable like the roster.
+DOCS_EXTRA_PATHS = [
+    Path.home() / "robocurve" / "test-dir" / f"rig-{name}.md"
+    for name in ("facts", "formulas", "advice")
+]
 # Seconds between evals; the longer pause applies after an eval that produced
 # no log (hardware or config failure) so a broken booth does not hammer retries.
 PAUSE_S = 10
@@ -52,7 +58,7 @@ def _write_status(status: dict[str, Any]) -> None:
     os.replace(temporary_path, STATUS_PATH)
 
 
-def _role_args(flag: str, model: dict[str, str]) -> list[str]:
+def _role_args(flag: str, model: dict[str, Any]) -> list[str]:
     return [
         flag,
         f"model={model['model']}",
@@ -63,6 +69,31 @@ def _role_args(flag: str, model: dict[str, str]) -> list[str]:
         flag,
         f"effort={EFFORT}",
     ]
+
+
+def _policy_args(model: dict[str, Any]) -> list[str]:
+    """The complete -P set for the drawn test-taker, plus the shared effort."""
+    kvs = dict(model["policy"]) if isinstance(model.get("policy"), dict) else {
+        key: model[key] for key in ("model", "base_url", "api_key_env")
+    }
+    kvs["effort"] = EFFORT
+    args: list[str] = []
+    for key, value in kvs.items():
+        args += ["-P", f"{key}={value}"]
+    return args
+
+
+def _docs_extra_args() -> list[str]:
+    """-E docs_extra from whichever rig cheat-sheet files exist, else nothing."""
+    texts = []
+    for path in DOCS_EXTRA_PATHS:
+        try:
+            texts.append(path.read_text(encoding="utf-8"))
+        except OSError:
+            continue
+    if not texts:
+        return []
+    return ["-E", "docs_extra=" + "\n\n".join(texts)]
 
 
 def _final_log_paths() -> set[Path]:
@@ -176,8 +207,8 @@ def _command(
         *_role_args("-G", grader),
         "--policy",
         "agent",
-        *_role_args("-P", test_taker),
-        *(["-P", f"wire={test_taker['policy_wire']}"] if "policy_wire" in test_taker else []),
+        *_policy_args(test_taker),
+        *_docs_extra_args(),
         "--log-dir",
         str(LOGS_DIR.resolve()),
         *extra_args,

--- a/examples/actuate/run.py
+++ b/examples/actuate/run.py
@@ -59,9 +59,14 @@ MEDIA_DIR = STATE_DIR / "media"
 
 
 def _eligible(role: str) -> list[tuple[str, dict[str, Any]]]:
-    return [
-        (name, model) for name, model in ROSTER.items() if role in model.get("roles", ALL_ROLES)
-    ]
+    eligible = []
+    for name, model in ROSTER.items():
+        roles = model.get("roles", ALL_ROLES)
+        # A booth edit that drops the tuple ("roles": "test_taker") must not
+        # silently substring-match; treat a bare string as a single role.
+        if role in ((roles,) if isinstance(roles, str) else roles):
+            eligible.append((name, model))
+    return eligible
 
 
 def _utc_now() -> str:

--- a/examples/actuate/run.py
+++ b/examples/actuate/run.py
@@ -17,6 +17,17 @@ from pathlib import Path
 from typing import Any
 
 from _roster import EFFORT, ROSTER
+from _thermal import (
+    COOL_POLL_S,
+    COOL_PROBE_ERRORS_GIVE_UP,
+    TEMP_RESUME_C,
+    TEMP_WAIT_C,
+    ThermalProbeError,
+    ThermalProbeUnavailable,
+    config_channels,
+    hottest,
+    read_motor_temps,
+)
 
 from inspect_robots.log import read_eval_log
 
@@ -200,6 +211,66 @@ def _next_eval_index() -> int:
     return index + 1 if index is not None else 1
 
 
+def _thermal_gate(eval_index: int, gate_state: dict[str, Any]) -> None:
+    if gate_state["disabled"]:
+        return
+
+    try:
+        hottest_motor = hottest(read_motor_temps(gate_state["channels"]))
+    except ThermalProbeUnavailable as error:
+        print(f"warning: thermal probe unavailable; disabling gate: {error}", flush=True)
+        gate_state["disabled"] = True
+        return
+    except ThermalProbeError as error:
+        print(f"warning: thermal probe failed; proceeding with eval: {error}", flush=True)
+        return
+
+    if hottest_motor.max_c < TEMP_WAIT_C:
+        print(
+            f"motor temps ok: max {hottest_motor.max_c:.1f}C ({hottest_motor.label})",
+            flush=True,
+        )
+        return
+
+    cooling_since = _utc_now()
+    probe_error_streak = 0
+    while True:
+        cooling = {
+            "max_c": hottest_motor.max_c,
+            "hottest": hottest_motor.label,
+            "wait_c": TEMP_WAIT_C,
+            "resume_c": TEMP_RESUME_C,
+            "since": cooling_since,
+        }
+        _write_status({"eval_index": eval_index, "cooling": cooling})
+        print(
+            f"Cooling motors: {hottest_motor.max_c:.1f}C at {hottest_motor.label}. "
+            f"Evals resume below {TEMP_RESUME_C:g}C.",
+            flush=True,
+        )
+        time.sleep(COOL_POLL_S)
+        try:
+            hottest_motor = hottest(read_motor_temps(gate_state["channels"]))
+        except ThermalProbeError as error:
+            probe_error_streak += 1
+            print(
+                f"warning: thermal probe failed while cooling "
+                f"({probe_error_streak}/{COOL_PROBE_ERRORS_GIVE_UP}): {error}",
+                flush=True,
+            )
+            if probe_error_streak >= COOL_PROBE_ERRORS_GIVE_UP:
+                print(
+                    "THERMAL GATE: TOO MANY PROBE ERRORS; PROCEEDING WITH THE EVAL.",
+                    flush=True,
+                )
+                return
+            continue
+
+        probe_error_streak = 0
+        if hottest_motor.max_c < TEMP_RESUME_C:
+            return
+
+
 def _command(
     tasker: dict[str, str],
     test_taker: dict[str, str],
@@ -233,15 +304,18 @@ def _command(
 def main() -> None:
     if not RIG_CONFIG.is_file():
         raise SystemExit(f"rig config not found: {RIG_CONFIG}\nfix: edit RIG_CONFIG in run.py")
+    channels = config_channels(RIG_CONFIG)
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     LOGS_DIR.mkdir(parents=True, exist_ok=True)
     extra_args = _extra_args(sys.argv[1:])
     roster = list(ROSTER.items())
     eval_index = _next_eval_index()
     failure_streak = 0
+    gate_state: dict[str, Any] = {"channels": channels, "disabled": False}
 
     try:
         while True:
+            _thermal_gate(eval_index, gate_state)
             tasker_name, tasker = random.choice(roster)
             test_taker_name, test_taker = random.choice(roster)
             grader_name, grader = random.choice(roster)

--- a/examples/actuate/run.py
+++ b/examples/actuate/run.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from _roster import EFFORT, ROSTER
+from _roster import ALL_ROLES, EFFORT, ROSTER
 from _thermal import (
     COOL_POLL_S,
     COOL_PROBE_ERRORS_GIVE_UP,
@@ -56,6 +56,12 @@ LOGS_DIR = HERE / "logs"
 STATUS_PATH = STATE_DIR / "status.json"
 RESULTS_PATH = STATE_DIR / "results.jsonl"
 MEDIA_DIR = STATE_DIR / "media"
+
+
+def _eligible(role: str) -> list[tuple[str, dict[str, Any]]]:
+    return [
+        (name, model) for name, model in ROSTER.items() if role in model.get("roles", ALL_ROLES)
+    ]
 
 
 def _utc_now() -> str:
@@ -311,7 +317,11 @@ def main() -> None:
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     LOGS_DIR.mkdir(parents=True, exist_ok=True)
     extra_args = _extra_args(sys.argv[1:])
-    roster = list(ROSTER.items())
+    taskers = _eligible("tasker")
+    test_takers = _eligible("test_taker")
+    graders = _eligible("grader")
+    if not taskers or not test_takers or not graders:
+        raise SystemExit("a role has no eligible models; fix the roster in _roster.py")
     eval_index = _next_eval_index()
     failure_streak = 0
     gate_state: dict[str, Any] = {"channels": channels, "disabled": False}
@@ -319,9 +329,9 @@ def main() -> None:
     try:
         while True:
             _thermal_gate(eval_index, gate_state)
-            tasker_name, tasker = random.choice(roster)
-            test_taker_name, test_taker = random.choice(roster)
-            grader_name, grader = random.choice(roster)
+            tasker_name, tasker = random.choice(taskers)
+            test_taker_name, test_taker = random.choice(test_takers)
+            grader_name, grader = random.choice(graders)
             roles = {
                 "tasker": tasker_name,
                 "test_taker": test_taker_name,

--- a/examples/actuate/run.py
+++ b/examples/actuate/run.py
@@ -10,6 +10,7 @@ import os
 import random
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -24,6 +25,10 @@ HERE = Path(__file__).parent
 # run against the rig folder's file. Booth-editable; a later --config in the
 # passthrough args after "--" overrides it.
 RIG_CONFIG = Path.home() / "robocurve" / "rig-1" / "config.ini"
+# Seconds between evals; the longer pause applies after an eval that produced
+# no log (hardware or config failure) so a broken booth does not hammer retries.
+PAUSE_S = 10
+FAILURE_PAUSE_S = 30
 STATE_DIR = HERE / "state"
 LOGS_DIR = HERE / "logs"
 STATUS_PATH = STATE_DIR / "status.json"
@@ -212,9 +217,9 @@ def main() -> None:
             log_text = log_path.name if log_path else "no log"
             print(f"Eval {eval_index} complete: score={score_text}, log={log_text}")
 
-            answer = input("Enter to run the next eval, q then Enter to quit: ")
-            if answer.strip().lower() == "q":
-                break
+            pause = PAUSE_S if log_path is not None else FAILURE_PAUSE_S
+            print(f"next eval in {pause}s (Ctrl-C to stop)", flush=True)
+            time.sleep(pause)
             eval_index += 1
     except (KeyboardInterrupt, EOFError):
         print("\nExiting.")

--- a/examples/actuate/run.py
+++ b/examples/actuate/run.py
@@ -33,6 +33,7 @@ STATE_DIR = HERE / "state"
 LOGS_DIR = HERE / "logs"
 STATUS_PATH = STATE_DIR / "status.json"
 RESULTS_PATH = STATE_DIR / "results.jsonl"
+MEDIA_DIR = STATE_DIR / "media"
 
 
 def _utc_now() -> str:
@@ -94,6 +95,29 @@ def _log_outcome(path: Path | None) -> tuple[float | None, str | None]:
         return None, None
     score = sum(scores) / len(scores) if scores else None
     return score, task if isinstance(task, str) else None
+
+
+def _render_clips(log_path: Path | None) -> dict[str, str]:
+    """Render per-camera MP4 clips for a completed eval; empty on any failure."""
+    if log_path is None:
+        return {}
+    MEDIA_DIR.mkdir(parents=True, exist_ok=True)
+    before = set(MEDIA_DIR.glob("*.mp4"))
+    try:
+        subprocess.run(
+            ["inspect-robots", "video", str(log_path), "--out", str(MEDIA_DIR), "--fps", "30"],
+            check=True,
+            capture_output=True,
+            timeout=300,
+        )
+    except Exception:
+        return {}
+    clips: dict[str, str] = {}
+    for path in sorted(set(MEDIA_DIR.glob("*.mp4")) - before):
+        for cam in ("left", "top", "right"):
+            if cam in path.name:
+                clips[cam] = path.name
+    return clips
 
 
 def _append_result(result: dict[str, Any]) -> None:
@@ -206,6 +230,7 @@ def main() -> None:
 
             log_path = _newest_final_log(existing_logs)
             score, task = _log_outcome(log_path)
+            clips = _render_clips(log_path)
             _append_result(
                 {
                     "ts": _utc_now(),
@@ -215,6 +240,7 @@ def main() -> None:
                     "task": task,
                     "score": score,
                     "log": log_path.name if log_path else None,
+                    "clips": clips,
                 }
             )
             score_text = f"{score:.2f}" if score is not None else "unscored"

--- a/examples/actuate/run.py
+++ b/examples/actuate/run.py
@@ -141,6 +141,10 @@ def _command(
         "run",
         "--config",
         str(RIG_CONFIG),
+        # The leaderboard reads the vlm grader's verdict through the operator
+        # scorer; pin it so a rig config's scorer choice cannot unscore evals.
+        "--scorer",
+        "operator",
         "--auto-task",
         *_role_args("-A", tasker),
         "--grader",

--- a/examples/actuate/run.py
+++ b/examples/actuate/run.py
@@ -19,6 +19,11 @@ from _roster import EFFORT, ROSTER
 from inspect_robots.log import read_eval_log
 
 HERE = Path(__file__).parent
+# The setup wizard writes the rig folder's config.ini; the XDG-global config
+# can go stale (it pointed the top cam at the D435's mono IR node). Always
+# run against the rig folder's file. Booth-editable; a later --config in the
+# passthrough args after "--" overrides it.
+RIG_CONFIG = Path.home() / "robocurve" / "rig-1" / "config.ini"
 STATE_DIR = HERE / "state"
 LOGS_DIR = HERE / "logs"
 STATUS_PATH = STATE_DIR / "status.json"
@@ -129,6 +134,8 @@ def _command(
     return [
         "inspect-robots",
         "run",
+        "--config",
+        str(RIG_CONFIG),
         "--auto-task",
         *_role_args("-A", tasker),
         "--grader",
@@ -145,6 +152,8 @@ def _command(
 
 
 def main() -> None:
+    if not RIG_CONFIG.is_file():
+        raise SystemExit(f"rig config not found: {RIG_CONFIG}\nfix: edit RIG_CONFIG in run.py")
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     LOGS_DIR.mkdir(parents=True, exist_ok=True)
     extra_args = _extra_args(sys.argv[1:])

--- a/examples/actuate/run.py
+++ b/examples/actuate/run.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import os
 import random
+import shutil
 import subprocess
 import sys
 import time
@@ -73,9 +74,11 @@ def _role_args(flag: str, model: dict[str, Any]) -> list[str]:
 
 def _policy_args(model: dict[str, Any]) -> list[str]:
     """The complete -P set for the drawn test-taker, plus the shared effort."""
-    kvs = dict(model["policy"]) if isinstance(model.get("policy"), dict) else {
-        key: model[key] for key in ("model", "base_url", "api_key_env")
-    }
+    kvs = (
+        dict(model["policy"])
+        if isinstance(model.get("policy"), dict)
+        else {key: model[key] for key in ("model", "base_url", "api_key_env")}
+    )
     kvs["effort"] = EFFORT
     args: list[str] = []
     for key, value in kvs.items():
@@ -128,26 +131,34 @@ def _log_outcome(path: Path | None) -> tuple[float | None, str | None]:
     return score, task if isinstance(task, str) else None
 
 
-def _render_clips(log_path: Path | None) -> dict[str, str]:
-    """Render per-camera MP4 clips for a completed eval; empty on any failure."""
+def _render_clips(log_path: Path | None, eval_index: int) -> dict[str, str]:
+    """Render per-camera MP4 clips for a completed eval; empty on any failure.
+
+    The video command names outputs by scene/epoch only, identical across
+    evals, so render into a scratch dir and move to per-eval names.
+    """
     if log_path is None:
         return {}
-    MEDIA_DIR.mkdir(parents=True, exist_ok=True)
-    before = set(MEDIA_DIR.glob("*.mp4"))
+    scratch = MEDIA_DIR / f"render_{eval_index}"
+    scratch.mkdir(parents=True, exist_ok=True)
     try:
         subprocess.run(
-            ["inspect-robots", "video", str(log_path), "--out", str(MEDIA_DIR), "--fps", "30"],
+            ["inspect-robots", "video", str(log_path), "--out", str(scratch), "--fps", "30"],
             check=True,
             capture_output=True,
             timeout=300,
         )
     except Exception:
+        shutil.rmtree(scratch, ignore_errors=True)
         return {}
     clips: dict[str, str] = {}
-    for path in sorted(set(MEDIA_DIR.glob("*.mp4")) - before):
+    for path in sorted(scratch.glob("*.mp4")):
         for cam in ("left", "top", "right"):
             if cam in path.name:
-                clips[cam] = path.name
+                destination = MEDIA_DIR / f"eval{eval_index:04d}_{cam}.mp4"
+                os.replace(path, destination)
+                clips[cam] = destination.name
+    shutil.rmtree(scratch, ignore_errors=True)
     return clips
 
 
@@ -261,7 +272,7 @@ def main() -> None:
 
             log_path = _newest_final_log(existing_logs)
             score, task = _log_outcome(log_path)
-            clips = _render_clips(log_path)
+            clips = _render_clips(log_path, eval_index)
             _append_result(
                 {
                     "ts": _utc_now(),

--- a/examples/actuate/run.py
+++ b/examples/actuate/run.py
@@ -1,0 +1,214 @@
+"""Run the attended Actuate conference demo in a continuous sequence.
+
+Run with:  python examples/actuate/run.py [-- extra inspect-robots run args]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from _roster import EFFORT, ROSTER
+
+from inspect_robots.log import read_eval_log
+
+HERE = Path(__file__).parent
+STATE_DIR = HERE / "state"
+LOGS_DIR = HERE / "logs"
+STATUS_PATH = STATE_DIR / "status.json"
+RESULTS_PATH = STATE_DIR / "results.jsonl"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _extra_args(argv: list[str]) -> list[str]:
+    if "--" not in argv:
+        return []
+    return argv[argv.index("--") + 1 :]
+
+
+def _write_status(status: dict[str, Any]) -> None:
+    temporary_path = STATUS_PATH.with_suffix(".json.tmp")
+    temporary_path.write_text(json.dumps(status) + "\n", encoding="utf-8")
+    os.replace(temporary_path, STATUS_PATH)
+
+
+def _role_args(flag: str, model: dict[str, str]) -> list[str]:
+    return [
+        flag,
+        f"model={model['model']}",
+        flag,
+        f"base_url={model['base_url']}",
+        flag,
+        f"api_key_env={model['api_key_env']}",
+        flag,
+        f"effort={EFFORT}",
+    ]
+
+
+def _final_log_paths() -> set[Path]:
+    return {path for path in LOGS_DIR.glob("*.json") if not path.name.endswith(".live.json")}
+
+
+def _newest_final_log(existing_paths: set[Path]) -> Path | None:
+    try:
+        return max(
+            _final_log_paths() - existing_paths,
+            key=lambda path: path.stat().st_mtime,
+        )
+    except (OSError, ValueError):
+        return None
+
+
+def _log_outcome(path: Path | None) -> tuple[float | None, str | None]:
+    if path is None:
+        return None, None
+    try:
+        log = read_eval_log(path)
+        scores = [
+            epoch["operator"]
+            for sample in log.samples
+            for epoch in sample.epochs
+            if "operator" in epoch
+        ]
+        task = log.samples[0].instruction if log.samples else None
+    except Exception:
+        return None, None
+    score = sum(scores) / len(scores) if scores else None
+    return score, task if isinstance(task, str) else None
+
+
+def _append_result(result: dict[str, Any]) -> None:
+    with RESULTS_PATH.open("a", encoding="utf-8") as results_file:
+        results_file.write(json.dumps(result) + "\n")
+
+
+def _positive_index(value: Any) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 1:
+        return value
+    return None
+
+
+def _next_eval_index() -> int:
+    try:
+        result_lines = RESULTS_PATH.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        result_lines = []
+
+    for line in reversed(result_lines):
+        try:
+            result = json.loads(line)
+            index = _positive_index(result.get("eval_index"))
+        except (AttributeError, json.JSONDecodeError):
+            continue
+        if index is not None:
+            return index + 1
+
+    try:
+        status = json.loads(STATUS_PATH.read_text(encoding="utf-8"))
+        index = _positive_index(status.get("eval_index"))
+    except (AttributeError, OSError, json.JSONDecodeError):
+        index = None
+    return index + 1 if index is not None else 1
+
+
+def _command(
+    tasker: dict[str, str],
+    test_taker: dict[str, str],
+    grader: dict[str, str],
+    extra_args: list[str],
+) -> list[str]:
+    return [
+        "inspect-robots",
+        "run",
+        "--auto-task",
+        *_role_args("-A", tasker),
+        "--grader",
+        "vlm",
+        *_role_args("-G", grader),
+        "--policy",
+        "agent",
+        *_role_args("-P", test_taker),
+        "--log-dir",
+        str(LOGS_DIR.resolve()),
+        *extra_args,
+    ]
+
+
+def main() -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    LOGS_DIR.mkdir(parents=True, exist_ok=True)
+    extra_args = _extra_args(sys.argv[1:])
+    roster = list(ROSTER.items())
+    eval_index = _next_eval_index()
+
+    try:
+        while True:
+            tasker_name, tasker = random.choice(roster)
+            test_taker_name, test_taker = random.choice(roster)
+            grader_name, grader = random.choice(roster)
+            roles = {
+                "tasker": tasker_name,
+                "test_taker": test_taker_name,
+                "grader": grader_name,
+            }
+            models = {
+                "tasker": tasker["model"],
+                "test_taker": test_taker["model"],
+                "grader": grader["model"],
+            }
+            _write_status(
+                {
+                    "eval_index": eval_index,
+                    "started_at": _utc_now(),
+                    "roles": roles,
+                    "models": models,
+                }
+            )
+            print(
+                f"Eval {eval_index}: tasker={tasker_name}, test-taker={test_taker_name}, "
+                f"grader={grader_name}",
+                flush=True,
+            )
+
+            existing_logs = _final_log_paths()
+            subprocess.run(
+                _command(tasker, test_taker, grader, extra_args),
+                check=False,
+            )
+
+            log_path = _newest_final_log(existing_logs)
+            score, task = _log_outcome(log_path)
+            _append_result(
+                {
+                    "ts": _utc_now(),
+                    "eval_index": eval_index,
+                    "roles": roles,
+                    "models": models,
+                    "task": task,
+                    "score": score,
+                    "log": log_path.name if log_path else None,
+                }
+            )
+            score_text = f"{score:.2f}" if score is not None else "unscored"
+            log_text = log_path.name if log_path else "no log"
+            print(f"Eval {eval_index} complete: score={score_text}, log={log_text}")
+
+            answer = input("Enter to run the next eval, q then Enter to quit: ")
+            if answer.strip().lower() == "q":
+                break
+            eval_index += 1
+    except (KeyboardInterrupt, EOFError):
+        print("\nExiting.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/actuate/run_trials.py
+++ b/examples/actuate/run_trials.py
@@ -9,6 +9,7 @@ import fcntl
 import hashlib
 import json
 import math
+import random
 import subprocess
 import sys
 import time
@@ -119,10 +120,14 @@ def run_campaign(
                     print(f"{name}: n={len(scores)}, mean={mean_score:.2f}", flush=True)
                 return
 
-            test_taker_name, test_taker = min(
-                remaining,
-                key=lambda entry: len(scores_by_model[entry[0]]),
-            )
+            # Randomized block design: fewest-completed keeps every model to
+            # one trial per round of the roster, and drawing randomly among
+            # the tied models randomizes each round's order, so a
+            # position-in-round effect (coolest motors right after a cooling
+            # pause, freshest scene reset) cannot align with any one model.
+            fewest = min(len(scores_by_model[entry[0]]) for entry in remaining)
+            block = [entry for entry in remaining if len(scores_by_model[entry[0]]) == fewest]
+            test_taker_name, test_taker = random.choice(block)
             completed_trials = len(scores_by_model[test_taker_name])
 
             run._thermal_gate(eval_index, gate_state)

--- a/examples/actuate/run_trials.py
+++ b/examples/actuate/run_trials.py
@@ -10,6 +10,7 @@ import math
 import subprocess
 import sys
 import time
+from pathlib import Path
 from typing import Any
 
 import run
@@ -43,8 +44,21 @@ def _trial_scores(test_taker_names: list[str]) -> dict[str, list[float]]:
     return observations
 
 
-def main() -> None:
-    """Run until every roster test-taker has ten finite scored evals."""
+def run_campaign(
+    rig_config: Path,
+    state_dir: Path,
+    logs_dir: Path,
+    trials_per_model: int,
+    argv: list[str],
+) -> None:
+    """Run a fixed-trials campaign with the requested rig and output directories."""
+    run.RIG_CONFIG = rig_config
+    run.STATE_DIR = state_dir
+    run.LOGS_DIR = logs_dir
+    run.STATUS_PATH = state_dir / "status.json"
+    run.RESULTS_PATH = state_dir / "results.jsonl"
+    run.MEDIA_DIR = state_dir / "media"
+
     if not run.RIG_CONFIG.is_file():
         raise SystemExit(f"rig config not found: {run.RIG_CONFIG}\nfix: edit RIG_CONFIG in run.py")
     # Resolved once from RIG_CONFIG only: a --config override after "--"
@@ -53,7 +67,7 @@ def main() -> None:
     channels = config_channels(run.RIG_CONFIG)
     run.STATE_DIR.mkdir(parents=True, exist_ok=True)
     run.LOGS_DIR.mkdir(parents=True, exist_ok=True)
-    extra_args = run._extra_args(sys.argv[1:])
+    extra_args = run._extra_args(argv)
     taskers = run._eligible("tasker")
     test_takers = run._eligible("test_taker")
     graders = run._eligible("grader")
@@ -76,7 +90,7 @@ def main() -> None:
         while True:
             scores_by_model = _trial_scores(test_taker_names)
             remaining = [
-                entry for entry in test_takers if len(scores_by_model[entry[0]]) < TRIALS_PER_MODEL
+                entry for entry in test_takers if len(scores_by_model[entry[0]]) < trials_per_model
             ]
             if not remaining:
                 for name, _model in test_takers:
@@ -113,7 +127,7 @@ def main() -> None:
             print(
                 f"Eval {eval_index}: tasker={tasker_name}, "
                 f"test-taker={test_taker_name}, grader={grader_name}; "
-                f"trial {completed_trials + 1}/{TRIALS_PER_MODEL} for {test_taker_name}",
+                f"trial {completed_trials + 1}/{trials_per_model} for {test_taker_name}",
                 flush=True,
             )
 
@@ -170,7 +184,7 @@ def main() -> None:
                 )
             eval_index += 1
             counts = _trial_scores(test_taker_names)
-            if all(len(counts[name]) >= TRIALS_PER_MODEL for name in test_taker_names):
+            if all(len(counts[name]) >= trials_per_model for name in test_taker_names):
                 # Campaign complete: skip the pause and let the top-of-loop
                 # check print the summary (a Ctrl-C during a pointless final
                 # sleep would eat it). Clear the roles from the status file so
@@ -182,6 +196,11 @@ def main() -> None:
             time.sleep(pause)
     except (KeyboardInterrupt, EOFError):
         print("\nExiting.")
+
+
+def main() -> None:
+    """Run the fixed-trials campaign with the single-rig defaults."""
+    run_campaign(run.RIG_CONFIG, run.STATE_DIR, run.LOGS_DIR, TRIALS_PER_MODEL, sys.argv[1:])
 
 
 if __name__ == "__main__":

--- a/examples/actuate/run_trials.py
+++ b/examples/actuate/run_trials.py
@@ -5,6 +5,8 @@ Run with:  python examples/actuate/run_trials.py [-- extra inspect-robots run ar
 
 from __future__ import annotations
 
+import fcntl
+import hashlib
 import json
 import math
 import subprocess
@@ -60,7 +62,25 @@ def run_campaign(
     run.MEDIA_DIR = state_dir / "media"
 
     if not run.RIG_CONFIG.is_file():
-        raise SystemExit(f"rig config not found: {run.RIG_CONFIG}\nfix: edit RIG_CONFIG in run.py")
+        raise SystemExit(
+            f"rig config not found: {run.RIG_CONFIG}\n"
+            "fix: edit RIG_CONFIG in run.py or in the launching rig script"
+        )
+    # One campaign per rig config, enforced up front: a second campaign on the
+    # same config would probe the live CAN bus mid-eval and burn a failure
+    # streak before the downstream flock claim guard surfaced the conflict.
+    # The handle stays open for the campaign's lifetime; the OS releases the
+    # lock on exit however the process dies.
+    config_key = hashlib.sha1(str(run.RIG_CONFIG.resolve()).encode()).hexdigest()[:12]
+    lock_path = state_dir.parent / f".campaign-{config_key}.lock"
+    lock_handle = lock_path.open("w")
+    try:
+        fcntl.flock(lock_handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        raise SystemExit(
+            f"another campaign is already running against {run.RIG_CONFIG}; "
+            "stop it first (each rig config supports one campaign at a time)"
+        ) from None
     # Resolved once from RIG_CONFIG only: a --config override after "--"
     # re-routes the eval but not the gate's probe channels, so on a rig with
     # different channel names the gate degrades to per-round warnings.

--- a/examples/actuate/run_trials.py
+++ b/examples/actuate/run_trials.py
@@ -29,9 +29,11 @@ UNSCORED_STREAK_STOP = 10
 # Wall-clock kill switch per eval; booth-editable. OpenRouter keeps feeding
 # keepalive bytes while a wedged upstream provider grinds, so the agent
 # plugin's httpx read timeout never fires and a single eval can hang a rig's
-# whole overnight half. A killed eval produces no final log, so the existing
-# failure-streak machinery counts and reports it.
-EVAL_TIMEOUT_S = 1800
+# whole overnight half. Sized well above a slow model's legitimate full
+# episode: at 1800 the watchdog cancelled every GPT-5/GPT-5.4 run on
+# 2026-08-19 (their 25-65s turns need 40+ minutes for a 120s-robot-time
+# episode), which burned four hours producing logged-but-unscored evals.
+EVAL_TIMEOUT_S = 5400
 # Grace between the interrupt and the hard kill. SIGINT gives the eval its
 # normal teardown (park the arms, release cameras); a bare SIGKILL left a
 # rig-2 arm slumped past its joint limit and wedged the cameras mid-campaign

--- a/examples/actuate/run_trials.py
+++ b/examples/actuate/run_trials.py
@@ -142,10 +142,15 @@ def main() -> None:
             log_text = log_path.name if log_path else "no log"
             print(f"Eval {eval_index} complete: score={score_text}, log={log_text}")
 
+            # Only a scored (finite) eval resets the unscored streak: selection
+            # retries the same lagging model, so a rig or model alternating
+            # between no-log and logged-but-unscored failures must not keep
+            # both counters at zero forever. NaN scores count as unscored for
+            # the same reason (they never count as trials).
+            scored = score is not None and math.isfinite(score)
             if log_path is None:
                 failure_streak += 1
-                unscored_streak = 0
-            elif score is None:
+            elif not scored:
                 failure_streak = 0
                 unscored_streak += 1
             else:
@@ -160,12 +165,21 @@ def main() -> None:
             if unscored_streak >= UNSCORED_STREAK_STOP:
                 raise SystemExit(
                     f"{unscored_streak} consecutive evals produced logs but no score; "
-                    f"the grader ({grader_name}) is likely broken. Fix it and relaunch."
+                    f"the grader ({grader_name}) or the repeatedly drawn test-taker "
+                    f"({test_taker_name}) is likely broken. Fix it and relaunch."
                 )
+            eval_index += 1
+            counts = _trial_scores(test_taker_names)
+            if all(len(counts[name]) >= TRIALS_PER_MODEL for name in test_taker_names):
+                # Campaign complete: skip the pause and let the top-of-loop
+                # check print the summary (a Ctrl-C during a pointless final
+                # sleep would eat it). Clear the roles from the status file so
+                # the monitor stops showing the last eval as current.
+                run._write_status({"eval_index": eval_index - 1})
+                continue
             pause = run.PAUSE_S if log_path is not None else run.FAILURE_PAUSE_S
             print(f"next eval in {pause}s (Ctrl-C to stop)", flush=True)
             time.sleep(pause)
-            eval_index += 1
     except (KeyboardInterrupt, EOFError):
         print("\nExiting.")
 

--- a/examples/actuate/run_trials.py
+++ b/examples/actuate/run_trials.py
@@ -1,0 +1,174 @@
+"""Run a deterministic fixed-trials Actuate conference campaign.
+
+Run with:  python examples/actuate/run_trials.py [-- extra inspect-robots run args]
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+import sys
+import time
+from typing import Any
+
+import run
+from _thermal import config_channels
+
+# Scored evals each test-taker must complete; booth-editable.
+TRIALS_PER_MODEL = 10
+# Consecutive logged evals without a score before halting; booth-editable.
+UNSCORED_STREAK_STOP = 10
+
+
+def _trial_scores(test_taker_names: list[str]) -> dict[str, list[float]]:
+    """Return finite scored evals for each requested test-taker."""
+    observations: dict[str, list[float]] = {name: [] for name in test_taker_names}
+    try:
+        lines = run.RESULTS_PATH.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        lines = []
+
+    for line in lines:
+        try:
+            result = json.loads(line)
+            name = result["roles"]["test_taker"]
+            score = result.get("score")
+            numeric_score = float(score) if score is not None else None
+            if name in observations and numeric_score is not None and math.isfinite(numeric_score):
+                observations[name].append(numeric_score)
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            continue
+
+    return observations
+
+
+def main() -> None:
+    """Run until every roster test-taker has ten finite scored evals."""
+    if not run.RIG_CONFIG.is_file():
+        raise SystemExit(f"rig config not found: {run.RIG_CONFIG}\nfix: edit RIG_CONFIG in run.py")
+    # Resolved once from RIG_CONFIG only: a --config override after "--"
+    # re-routes the eval but not the gate's probe channels, so on a rig with
+    # different channel names the gate degrades to per-round warnings.
+    channels = config_channels(run.RIG_CONFIG)
+    run.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    run.LOGS_DIR.mkdir(parents=True, exist_ok=True)
+    extra_args = run._extra_args(sys.argv[1:])
+    taskers = run._eligible("tasker")
+    test_takers = run._eligible("test_taker")
+    graders = run._eligible("grader")
+    if len(taskers) != 1 or len(graders) != 1:
+        raise SystemExit(
+            "the fixed-trials runner requires pinned tasker and grader roles; "
+            "fix the roster in _roster.py"
+        )
+    if not test_takers:
+        raise SystemExit("no eligible test-takers; fix the roster in _roster.py")
+    eval_index = run._next_eval_index()
+    failure_streak = 0
+    unscored_streak = 0
+    gate_state: dict[str, Any] = {"channels": channels, "disabled": False}
+    tasker_name, tasker = taskers[0]
+    grader_name, grader = graders[0]
+    test_taker_names = [name for name, _model in test_takers]
+
+    try:
+        while True:
+            scores_by_model = _trial_scores(test_taker_names)
+            remaining = [
+                entry for entry in test_takers if len(scores_by_model[entry[0]]) < TRIALS_PER_MODEL
+            ]
+            if not remaining:
+                for name, _model in test_takers:
+                    scores = scores_by_model[name]
+                    mean_score = sum(scores) / len(scores)
+                    print(f"{name}: n={len(scores)}, mean={mean_score:.2f}", flush=True)
+                return
+
+            test_taker_name, test_taker = min(
+                remaining,
+                key=lambda entry: len(scores_by_model[entry[0]]),
+            )
+            completed_trials = len(scores_by_model[test_taker_name])
+
+            run._thermal_gate(eval_index, gate_state)
+            roles = {
+                "tasker": tasker_name,
+                "test_taker": test_taker_name,
+                "grader": grader_name,
+            }
+            models = {
+                "tasker": tasker["model"],
+                "test_taker": test_taker["model"],
+                "grader": grader["model"],
+            }
+            run._write_status(
+                {
+                    "eval_index": eval_index,
+                    "started_at": run._utc_now(),
+                    "roles": roles,
+                    "models": models,
+                }
+            )
+            print(
+                f"Eval {eval_index}: tasker={tasker_name}, "
+                f"test-taker={test_taker_name}, grader={grader_name}; "
+                f"trial {completed_trials + 1}/{TRIALS_PER_MODEL} for {test_taker_name}",
+                flush=True,
+            )
+
+            existing_logs = run._final_log_paths()
+            subprocess.run(
+                run._command(tasker, test_taker, grader, extra_args),
+                check=False,
+            )
+
+            log_path = run._newest_final_log(existing_logs)
+            score, task = run._log_outcome(log_path)
+            clips = run._render_clips(log_path, eval_index)
+            run._append_result(
+                {
+                    "ts": run._utc_now(),
+                    "eval_index": eval_index,
+                    "roles": roles,
+                    "models": models,
+                    "task": task,
+                    "score": score,
+                    "log": log_path.name if log_path else None,
+                    "clips": clips,
+                }
+            )
+            score_text = f"{score:.2f}" if score is not None else "unscored"
+            log_text = log_path.name if log_path else "no log"
+            print(f"Eval {eval_index} complete: score={score_text}, log={log_text}")
+
+            if log_path is None:
+                failure_streak += 1
+                unscored_streak = 0
+            elif score is None:
+                failure_streak = 0
+                unscored_streak += 1
+            else:
+                failure_streak = 0
+                unscored_streak = 0
+            if failure_streak >= run.FAILURE_STREAK_STOP:
+                raise SystemExit(
+                    f"{failure_streak} consecutive evals produced no log; the rig "
+                    "is likely faulted (check arms, CAN, cameras). Fix it and "
+                    "relaunch."
+                )
+            if unscored_streak >= UNSCORED_STREAK_STOP:
+                raise SystemExit(
+                    f"{unscored_streak} consecutive evals produced logs but no score; "
+                    f"the grader ({grader_name}) is likely broken. Fix it and relaunch."
+                )
+            pause = run.PAUSE_S if log_path is not None else run.FAILURE_PAUSE_S
+            print(f"next eval in {pause}s (Ctrl-C to stop)", flush=True)
+            time.sleep(pause)
+            eval_index += 1
+    except (KeyboardInterrupt, EOFError):
+        print("\nExiting.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/actuate/run_trials.py
+++ b/examples/actuate/run_trials.py
@@ -23,6 +23,12 @@ from _thermal import config_channels
 TRIALS_PER_MODEL = 10
 # Consecutive logged evals without a score before halting; booth-editable.
 UNSCORED_STREAK_STOP = 10
+# Wall-clock kill switch per eval; booth-editable. OpenRouter keeps feeding
+# keepalive bytes while a wedged upstream provider grinds, so the agent
+# plugin's httpx read timeout never fires and a single eval can hang a rig's
+# whole overnight half. A killed eval produces no final log, so the existing
+# failure-streak machinery counts and reports it.
+EVAL_TIMEOUT_S = 1800
 
 
 def _trial_scores(test_taker_names: list[str]) -> dict[str, list[float]]:
@@ -157,10 +163,19 @@ def run_campaign(
             )
 
             existing_logs = run._final_log_paths()
-            subprocess.run(
-                run._command(tasker, test_taker, grader, extra_args),
-                check=False,
-            )
+            try:
+                subprocess.run(
+                    run._command(tasker, test_taker, grader, extra_args),
+                    check=False,
+                    timeout=EVAL_TIMEOUT_S,
+                )
+            except subprocess.TimeoutExpired:
+                print(
+                    f"eval exceeded {EVAL_TIMEOUT_S}s and was killed (wedged "
+                    "provider or hardware); the next eval's reset re-homes the "
+                    "arms",
+                    flush=True,
+                )
 
             log_path = run._newest_final_log(existing_logs)
             score, task = run._log_outcome(log_path)

--- a/examples/actuate/run_trials.py
+++ b/examples/actuate/run_trials.py
@@ -5,11 +5,14 @@ Run with:  python examples/actuate/run_trials.py [-- extra inspect-robots run ar
 
 from __future__ import annotations
 
+import contextlib
 import fcntl
 import hashlib
 import json
 import math
+import os
 import random
+import signal
 import subprocess
 import sys
 import time
@@ -29,6 +32,36 @@ UNSCORED_STREAK_STOP = 10
 # whole overnight half. A killed eval produces no final log, so the existing
 # failure-streak machinery counts and reports it.
 EVAL_TIMEOUT_S = 1800
+# Grace between the interrupt and the hard kill. SIGINT gives the eval its
+# normal teardown (park the arms, release cameras); a bare SIGKILL left a
+# rig-2 arm slumped past its joint limit and wedged the cameras mid-campaign
+# on 2026-08-19, failing every later eval at bring-up.
+EVAL_KILL_GRACE_S = 120
+
+
+def _run_eval_with_watchdog(cmd: list[str]) -> bool:
+    """Run one eval; True if it finished, False if the watchdog killed it.
+
+    The eval runs in its own process group. On timeout the whole group gets
+    SIGINT first so the embodiment tears down cleanly, then SIGKILL after
+    EVAL_KILL_GRACE_S for a process too wedged to honor the interrupt.
+    """
+    process = subprocess.Popen(cmd, start_new_session=True)
+    try:
+        process.wait(timeout=EVAL_TIMEOUT_S)
+        return True
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(process.pid, signal.SIGINT)
+        process.wait(timeout=EVAL_KILL_GRACE_S)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        process.wait()
+    except ProcessLookupError:
+        pass
+    return False
 
 
 def _trial_scores(test_taker_names: list[str]) -> dict[str, list[float]]:
@@ -163,17 +196,12 @@ def run_campaign(
             )
 
             existing_logs = run._final_log_paths()
-            try:
-                subprocess.run(
-                    run._command(tasker, test_taker, grader, extra_args),
-                    check=False,
-                    timeout=EVAL_TIMEOUT_S,
-                )
-            except subprocess.TimeoutExpired:
+            finished = _run_eval_with_watchdog(run._command(tasker, test_taker, grader, extra_args))
+            if not finished:
                 print(
-                    f"eval exceeded {EVAL_TIMEOUT_S}s and was killed (wedged "
-                    "provider or hardware); the next eval's reset re-homes the "
-                    "arms",
+                    f"eval exceeded {EVAL_TIMEOUT_S}s; interrupted for a clean "
+                    "park-and-release teardown (hard kill only if that hangs "
+                    f"{EVAL_KILL_GRACE_S}s)",
                     flush=True,
                 )
 

--- a/examples/actuate/run_trials_rig1.py
+++ b/examples/actuate/run_trials_rig1.py
@@ -1,0 +1,24 @@
+"""Run the rig-1 half of the dual-rig Actuate fixed-trials campaign.
+
+Run with:  python examples/actuate/run_trials_rig1.py [-- extra inspect-robots run args]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from run_trials import run_campaign
+
+TRIALS_PER_RIG = 5  # booth-editable; the combined two-rig target is 2x this
+RIG_CONFIG = Path.home() / "robocurve" / "rig-1" / "config.ini"
+HERE = Path(__file__).parent
+
+if __name__ == "__main__":
+    run_campaign(
+        RIG_CONFIG,
+        HERE / "state-rig1",
+        HERE / "logs-rig1",
+        TRIALS_PER_RIG,
+        sys.argv[1:],
+    )

--- a/examples/actuate/run_trials_rig1.py
+++ b/examples/actuate/run_trials_rig1.py
@@ -11,14 +11,20 @@ from pathlib import Path
 from run_trials import run_campaign
 
 TRIALS_PER_RIG = 5  # booth-editable; the combined two-rig target is 2x this
+# Pinned on both rigs so the campaign halves share one episode ceiling: the
+# rig configs disagree today (12000 vs 1200). Later user flags still win.
+MAX_STEPS = 12000
 RIG_CONFIG = Path.home() / "robocurve" / "rig-1" / "config.ini"
 HERE = Path(__file__).parent
 
 if __name__ == "__main__":
+    user_args = sys.argv[1:]
+    if user_args and user_args[0] == "--":
+        user_args = user_args[1:]
     run_campaign(
         RIG_CONFIG,
         HERE / "state-rig1",
         HERE / "logs-rig1",
         TRIALS_PER_RIG,
-        sys.argv[1:],
+        ["--", "--max-steps", str(MAX_STEPS), *user_args],
     )

--- a/examples/actuate/run_trials_rig1.py
+++ b/examples/actuate/run_trials_rig1.py
@@ -11,9 +11,10 @@ from pathlib import Path
 from run_trials import run_campaign
 
 TRIALS_PER_RIG = 5  # booth-editable; the combined two-rig target is 2x this
-# Pinned on both rigs so the campaign halves share one episode ceiling: the
-# rig configs disagree today (12000 vs 1200). Later user flags still win.
-MAX_STEPS = 12000
+# Pinned on both rigs so the campaign halves share one episode ceiling of
+# 120 seconds at the rigs' 10 Hz control rate (the rig configs disagree
+# today, 12000 vs 1200). Later user flags still win.
+MAX_STEPS = 1200
 RIG_CONFIG = Path.home() / "robocurve" / "rig-1" / "config.ini"
 HERE = Path(__file__).parent
 

--- a/examples/actuate/run_trials_rig1.py
+++ b/examples/actuate/run_trials_rig1.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from run_trials import run_campaign
 
 TRIALS_PER_RIG = 5  # booth-editable; the combined two-rig target is 2x this
-# Pinned on both rigs so the campaign halves share one episode ceiling of
-# 120 seconds at the rigs' 10 Hz control rate (the rig configs disagree
-# today, 12000 vs 1200). Later user flags still win.
+# Recording pins prevent overnight viewer windows, save per-eval .rrd camera,
+# joint, and action timelines, and drift-proof frame storage while sharing a
+# 120-second ceiling at the rigs' 10 Hz control rate. Later user flags win.
 MAX_STEPS = 1200
 RIG_CONFIG = Path.home() / "robocurve" / "rig-1" / "config.ini"
 HERE = Path(__file__).parent
@@ -27,5 +27,13 @@ if __name__ == "__main__":
         HERE / "state-rig1",
         HERE / "logs-rig1",
         TRIALS_PER_RIG,
-        ["--", "--max-steps", str(MAX_STEPS), *user_args],
+        [
+            "--",
+            "--max-steps",
+            str(MAX_STEPS),
+            "--store-frames",
+            "--no-rerun",
+            "--rerun-save",
+            *user_args,
+        ],
     )

--- a/examples/actuate/run_trials_rig2.py
+++ b/examples/actuate/run_trials_rig2.py
@@ -1,0 +1,24 @@
+"""Run the rig-2 half of the dual-rig Actuate fixed-trials campaign.
+
+Run with:  python examples/actuate/run_trials_rig2.py [-- extra inspect-robots run args]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from run_trials import run_campaign
+
+TRIALS_PER_RIG = 5  # booth-editable; the combined two-rig target is 2x this
+RIG_CONFIG = Path.home() / "robocurve" / "rig-2" / "config.ini"
+HERE = Path(__file__).parent
+
+if __name__ == "__main__":
+    run_campaign(
+        RIG_CONFIG,
+        HERE / "state-rig2",
+        HERE / "logs-rig2",
+        TRIALS_PER_RIG,
+        sys.argv[1:],
+    )

--- a/examples/actuate/run_trials_rig2.py
+++ b/examples/actuate/run_trials_rig2.py
@@ -11,9 +11,10 @@ from pathlib import Path
 from run_trials import run_campaign
 
 TRIALS_PER_RIG = 5  # booth-editable; the combined two-rig target is 2x this
-# Pinned on both rigs so the campaign halves share one episode ceiling: the
-# rig configs disagree today (12000 vs 1200). Later user flags still win.
-MAX_STEPS = 12000
+# Pinned on both rigs so the campaign halves share one episode ceiling of
+# 120 seconds at the rigs' 10 Hz control rate (the rig configs disagree
+# today, 12000 vs 1200). Later user flags still win.
+MAX_STEPS = 1200
 RIG_CONFIG = Path.home() / "robocurve" / "rig-2" / "config.ini"
 HERE = Path(__file__).parent
 

--- a/examples/actuate/run_trials_rig2.py
+++ b/examples/actuate/run_trials_rig2.py
@@ -11,14 +11,20 @@ from pathlib import Path
 from run_trials import run_campaign
 
 TRIALS_PER_RIG = 5  # booth-editable; the combined two-rig target is 2x this
+# Pinned on both rigs so the campaign halves share one episode ceiling: the
+# rig configs disagree today (12000 vs 1200). Later user flags still win.
+MAX_STEPS = 12000
 RIG_CONFIG = Path.home() / "robocurve" / "rig-2" / "config.ini"
 HERE = Path(__file__).parent
 
 if __name__ == "__main__":
+    user_args = sys.argv[1:]
+    if user_args and user_args[0] == "--":
+        user_args = user_args[1:]
     run_campaign(
         RIG_CONFIG,
         HERE / "state-rig2",
         HERE / "logs-rig2",
         TRIALS_PER_RIG,
-        sys.argv[1:],
+        ["--", "--max-steps", str(MAX_STEPS), *user_args],
     )

--- a/examples/actuate/run_trials_rig2.py
+++ b/examples/actuate/run_trials_rig2.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from run_trials import run_campaign
 
 TRIALS_PER_RIG = 5  # booth-editable; the combined two-rig target is 2x this
-# Pinned on both rigs so the campaign halves share one episode ceiling of
-# 120 seconds at the rigs' 10 Hz control rate (the rig configs disagree
-# today, 12000 vs 1200). Later user flags still win.
+# Recording pins prevent overnight viewer windows, save per-eval .rrd camera,
+# joint, and action timelines, and drift-proof frame storage while sharing a
+# 120-second ceiling at the rigs' 10 Hz control rate. Later user flags win.
 MAX_STEPS = 1200
 RIG_CONFIG = Path.home() / "robocurve" / "rig-2" / "config.ini"
 HERE = Path(__file__).parent
@@ -27,5 +27,13 @@ if __name__ == "__main__":
         HERE / "state-rig2",
         HERE / "logs-rig2",
         TRIALS_PER_RIG,
-        ["--", "--max-steps", str(MAX_STEPS), *user_args],
+        [
+            "--",
+            "--max-steps",
+            str(MAX_STEPS),
+            "--store-frames",
+            "--no-rerun",
+            "--rerun-save",
+            *user_args,
+        ],
     )

--- a/examples/actuate/serve.py
+++ b/examples/actuate/serve.py
@@ -182,9 +182,19 @@ class DemoHandler(BaseHTTPRequestHandler):
 
 
 def main() -> None:
+    """Serve the display using paths and a port selected on the command line."""
+    global STATE_DIR, LOGS_DIR, STATUS_PATH, RESULTS_PATH, MEDIA_DIR
+
     parser = argparse.ArgumentParser(description="Serve the Actuate conference display.")
     parser.add_argument("--port", type=int, default=8377)
+    parser.add_argument("--state-dir", type=Path, default=STATE_DIR)
+    parser.add_argument("--logs-dir", type=Path, default=LOGS_DIR)
     args = parser.parse_args()
+    STATE_DIR = args.state_dir
+    LOGS_DIR = args.logs_dir
+    STATUS_PATH = STATE_DIR / "status.json"
+    RESULTS_PATH = STATE_DIR / "results.jsonl"
+    MEDIA_DIR = STATE_DIR / "media"
     server = ThreadingHTTPServer(("", args.port), DemoHandler)
     print(f"Actuate display available at http://localhost:{args.port}/")
     try:

--- a/examples/actuate/serve.py
+++ b/examples/actuate/serve.py
@@ -1,0 +1,181 @@
+"""Serve the Actuate conference monitor and leaderboard.
+
+Run with:  python examples/actuate/serve.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from contextlib import suppress
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from _roster import ROSTER
+
+HERE = Path(__file__).parent
+STATE_DIR = HERE / "state"
+LOGS_DIR = HERE / "logs"
+STATUS_PATH = STATE_DIR / "status.json"
+RESULTS_PATH = STATE_DIR / "results.jsonl"
+
+
+def _status_payload() -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "roles": None,
+        "models": None,
+        "eval_index": None,
+        "started_at": None,
+        "task": None,
+        "rubric": None,
+    }
+    drawn_at: float | None = None
+    with suppress(Exception):
+        with STATUS_PATH.open(encoding="utf-8") as status_file:
+            status = json.load(status_file)
+        for key in ("roles", "models", "eval_index", "started_at"):
+            payload[key] = status.get(key)
+        drawn_at = STATUS_PATH.stat().st_mtime
+
+    with suppress(Exception):
+        newest_log = max(LOGS_DIR.glob("*.json"), key=lambda path: path.stat().st_mtime)
+        # A log older than the current draw belongs to a previous eval; keep
+        # the "generating" state rather than showing a stale task.
+        if drawn_at is not None and newest_log.stat().st_mtime < drawn_at:
+            return payload
+        with newest_log.open(encoding="utf-8") as log_file:
+            log = json.load(log_file)
+        sample = log["samples"][0]
+        payload["task"] = sample.get("instruction")
+        metadata = sample.get("scene_metadata") or {}
+        payload["rubric"] = metadata.get("rubric")
+    return payload
+
+
+def _leaderboard_payload() -> list[dict[str, Any]]:
+    observations: dict[str, list[float]] = {name: [] for name in ROSTER}
+    try:
+        lines = RESULTS_PATH.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        lines = []
+
+    for line in lines:
+        try:
+            result = json.loads(line)
+            name = result["roles"]["test_taker"]
+            score = result.get("score")
+            numeric_score = float(score) if score is not None else None
+            if name in observations and numeric_score is not None and math.isfinite(numeric_score):
+                observations[name].append(numeric_score)
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            continue
+
+    return [
+        {
+            "name": name,
+            "n": len(scores),
+            "score": sum(scores) / len(scores) if scores else None,
+        }
+        for name, scores in observations.items()
+    ]
+
+
+def _recent_payload() -> list[dict[str, Any]]:
+    try:
+        lines = RESULTS_PATH.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+
+    recent: list[dict[str, Any]] = []
+    for line in reversed(lines):
+        try:
+            result = json.loads(line)
+            roles = result["roles"]
+            models = result["models"]
+            if not isinstance(roles, dict) or not isinstance(models, dict):
+                continue
+            score = result.get("score")
+            numeric_score = float(score) if score is not None else None
+            if numeric_score is not None and not math.isfinite(numeric_score):
+                continue
+            task = result.get("task")
+            eval_index = result.get("eval_index")
+            if not isinstance(eval_index, int) or isinstance(eval_index, bool) or eval_index < 1:
+                eval_index = None
+            recent.append(
+                {
+                    "eval_index": eval_index,
+                    "roles": roles,
+                    "models": models,
+                    "task": task if isinstance(task, str) else None,
+                    "score": numeric_score,
+                }
+            )
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            continue
+        if len(recent) == 3:
+            break
+    return recent
+
+
+class DemoHandler(BaseHTTPRequestHandler):
+    def _send(self, body: bytes, content_type: str, status: HTTPStatus = HTTPStatus.OK) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_json(self, payload: Any) -> None:
+        self._send(json.dumps(payload).encode("utf-8"), "application/json; charset=utf-8")
+
+    def do_GET(self) -> None:
+        path = urlsplit(self.path).path
+        if path == "/api/status":
+            self._send_json(_status_payload())
+            return
+        if path == "/api/leaderboard":
+            self._send_json(_leaderboard_payload())
+            return
+        if path == "/api/recent":
+            self._send_json(_recent_payload())
+            return
+        if path in {"/", "/leaderboard"}:
+            try:
+                body = (HERE / "monitor.html").read_bytes()
+            except OSError:
+                self._send(
+                    b"Page unavailable\n",
+                    "text/plain; charset=utf-8",
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                )
+                return
+            self._send(body, "text/html; charset=utf-8")
+            return
+        self._send(b"Not found\n", "text/plain; charset=utf-8", HTTPStatus.NOT_FOUND)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Serve the Actuate conference display.")
+    parser.add_argument("--port", type=int, default=8377)
+    args = parser.parse_args()
+    server = ThreadingHTTPServer(("", args.port), DemoHandler)
+    print(f"Actuate display available at http://localhost:{args.port}/")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nExiting.")
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/actuate/serve.py
+++ b/examples/actuate/serve.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import re
 from contextlib import suppress
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -22,6 +23,8 @@ STATE_DIR = HERE / "state"
 LOGS_DIR = HERE / "logs"
 STATUS_PATH = STATE_DIR / "status.json"
 RESULTS_PATH = STATE_DIR / "results.jsonl"
+MEDIA_DIR = STATE_DIR / "media"
+_MEDIA_NAME = re.compile(r"^[A-Za-z0-9._-]+\.mp4$")
 
 
 def _status_payload() -> dict[str, Any]:
@@ -103,6 +106,7 @@ def _recent_payload() -> list[dict[str, Any]]:
             if numeric_score is not None and not math.isfinite(numeric_score):
                 continue
             task = result.get("task")
+            clips = result.get("clips")
             eval_index = result.get("eval_index")
             if not isinstance(eval_index, int) or isinstance(eval_index, bool) or eval_index < 1:
                 eval_index = None
@@ -113,6 +117,7 @@ def _recent_payload() -> list[dict[str, Any]]:
                     "models": models,
                     "task": task if isinstance(task, str) else None,
                     "score": numeric_score,
+                    "clips": clips if isinstance(clips, dict) else {},
                 }
             )
         except (KeyError, TypeError, ValueError, json.JSONDecodeError):
@@ -144,6 +149,18 @@ class DemoHandler(BaseHTTPRequestHandler):
             return
         if path == "/api/recent":
             self._send_json(_recent_payload())
+            return
+        if path.startswith("/media/"):
+            name = path[len("/media/") :]
+            if not _MEDIA_NAME.fullmatch(name):
+                self._send(b"Not found\n", "text/plain; charset=utf-8", HTTPStatus.NOT_FOUND)
+                return
+            try:
+                body = (MEDIA_DIR / name).read_bytes()
+            except OSError:
+                self._send(b"Not found\n", "text/plain; charset=utf-8", HTTPStatus.NOT_FOUND)
+                return
+            self._send(body, "video/mp4")
             return
         if path in {"/", "/leaderboard"}:
             try:

--- a/examples/actuate/serve.py
+++ b/examples/actuate/serve.py
@@ -35,12 +35,13 @@ def _status_payload() -> dict[str, Any]:
         "started_at": None,
         "task": None,
         "rubric": None,
+        "cooling": None,
     }
     drawn_at: float | None = None
     with suppress(Exception):
         with STATUS_PATH.open(encoding="utf-8") as status_file:
             status = json.load(status_file)
-        for key in ("roles", "models", "eval_index", "started_at"):
+        for key in ("roles", "models", "eval_index", "started_at", "cooling"):
             payload[key] = status.get(key)
         drawn_at = STATUS_PATH.stat().st_mtime
 

--- a/examples/actuate/start.sh
+++ b/examples/actuate/start.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v inspect-robots >/dev/null 2>&1; then
+  printf '%s\n' \
+    'error: inspect-robots not found; activate the rig venv first (source /path/to/rig-venv/bin/activate)' >&2
+  exit 1
+fi
+PYTHON="$(command -v python)"
+
+if [[ ! -f .env ]]; then
+  printf '%s\n' 'warning: .env is missing from the repository root' >&2
+fi
+
+if (( $# > 0 )) && [[ $1 == "--" ]]; then
+  shift
+fi
+
+serve_argv=("$PYTHON" "examples/actuate/serve.py")
+printf -v serve_command '%q ' "${serve_argv[@]}"
+
+loop_argv=("$PYTHON" "examples/actuate/run.py")
+if (( $# > 0 )); then
+  loop_argv+=("--" "$@")
+fi
+printf -v loop_command '%q ' "${loop_argv[@]}"
+
+if tmux has-session -t =actuate-serve 2>/dev/null; then
+  printf '%s\n' \
+    'reusing display server session; tmux kill-session -t =actuate-serve resets it'
+else
+  tmux new -d -s actuate-serve "$serve_command"
+  sleep 1
+  if tmux has-session -t =actuate-serve 2>/dev/null; then
+    :
+  else
+    printf '%s\n' \
+      'error: display server exited; run tmux new -s actuate-serve manually and check port 8377' >&2
+    exit 1
+  fi
+fi
+
+printf '%s\n' 'Display: http://localhost:8377/'
+
+if tmux has-session -t =actuate 2>/dev/null; then
+  printf '%s\n' 'error: demo loop already running; tmux attach -t =actuate' >&2
+  exit 1
+fi
+
+tmux new -s actuate "$loop_command"

--- a/examples/actuate/start.sh
+++ b/examples/actuate/start.sh
@@ -5,12 +5,30 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
 
+if [[ -n ${TMUX:-} ]]; then
+  printf '%s\n' \
+    'error: already inside tmux; run start.sh from a plain shell, or use the manual recipe in the README' >&2
+  exit 1
+fi
+
 if ! command -v inspect-robots >/dev/null 2>&1; then
   printf '%s\n' \
     'error: inspect-robots not found; activate the rig venv first (source /path/to/rig-venv/bin/activate)' >&2
   exit 1
 fi
-PYTHON="$(command -v python)"
+PYTHON="$(command -v python || true)"
+if [[ -z $PYTHON ]]; then
+  PYTHON="$(command -v python3 || true)"
+fi
+if [[ -z $PYTHON ]]; then
+  printf '%s\n' 'error: no python on PATH; activate the rig venv first' >&2
+  exit 1
+fi
+if ! "$PYTHON" -c 'import inspect_robots' >/dev/null 2>&1; then
+  printf '%s\n' \
+    "error: $PYTHON cannot import inspect_robots; activate the venv that owns inspect-robots" >&2
+  exit 1
+fi
 
 if [[ ! -f .env ]]; then
   printf '%s\n' 'warning: .env is missing from the repository root' >&2
@@ -20,14 +38,18 @@ if (( $# > 0 )) && [[ $1 == "--" ]]; then
   shift
 fi
 
-serve_argv=("$PYTHON" "examples/actuate/serve.py")
+# A pre-existing tmux server hands new sessions the server's stale
+# environment, so pin PATH explicitly and keep the crashed loop's pane open
+# long enough to read the error.
+serve_argv=(env "PATH=$PATH" "$PYTHON" "examples/actuate/serve.py")
 printf -v serve_command '%q ' "${serve_argv[@]}"
 
-loop_argv=("$PYTHON" "examples/actuate/run.py")
+loop_argv=(env "PATH=$PATH" "$PYTHON" "examples/actuate/run.py")
 if (( $# > 0 )); then
   loop_argv+=("--" "$@")
 fi
-printf -v loop_command '%q ' "${loop_argv[@]}"
+hold_wrapper='"$@"; status=$?; printf "\nrun.py exited %s; press Enter to close\n" "$status"; read -r _'
+printf -v loop_command '%q ' bash -c "$hold_wrapper" _ "${loop_argv[@]}"
 
 if tmux has-session -t =actuate-serve 2>/dev/null; then
   printf '%s\n' \
@@ -35,9 +57,7 @@ if tmux has-session -t =actuate-serve 2>/dev/null; then
 else
   tmux new -d -s actuate-serve "$serve_command"
   sleep 1
-  if tmux has-session -t =actuate-serve 2>/dev/null; then
-    :
-  else
+  if ! tmux has-session -t =actuate-serve 2>/dev/null; then
     printf '%s\n' \
       'error: display server exited; run tmux new -s actuate-serve manually and check port 8377' >&2
     exit 1

--- a/plans/0076-actuate-thermal-gate.md
+++ b/plans/0076-actuate-thermal-gate.md
@@ -1,0 +1,234 @@
+# 0076: Actuate demo thermal gate
+
+Demo-branch only (`demo/actuate-conference`, PR #397; never merges to main).
+All paths below are relative to `examples/actuate/` unless noted.
+
+## Problem
+
+The demo loop (`run.py`) runs evals back to back with fixed pauses (10 s, 30 s
+after a failure) and no awareness of motor temperature. The only thermal
+protection is the DM motor firmware's own over-temperature fault (error codes
+0xB MOSFET / 0xC rotor), which the pinned i2rt (`ac096928`,
+`enable_auto_recovery=False`) surfaces by failing the episode. At the booth
+that failure mode is ugly: the eval dies mid-audience, the loop waits 30 s,
+then relaunches against the still-hot motor, up to 10 times before the
+log-less-streak halt fires. There is no "wait until cooled" state anywhere.
+
+## Goal
+
+Before each eval, read every motor's temperature. If any motor is at or above
+a wait threshold, suspend the loop (arms stay parked and torque-off), show a
+cooling state on the console and the conference monitor, and start the next
+eval only after the hottest motor drops below a lower resume threshold
+(hysteresis). Degrade gracefully on machines without hardware.
+
+## How temperatures are read (the probe)
+
+Verified against the installed i2rt (`ac096928`) and yam plugin:
+
+- The yam `BimanualDriver` protocol does not expose temperatures, and a full
+  `get_yam_robot()` bringup is unsuitable for a probe: it costs a multi-second
+  gripper auto-calibration (physical motion) plus a PD hold.
+- `i2rt.motor_drivers.dm_driver.DMChainCanInterface(motor_list, offsets,
+  directions, channel, start_thread=False, motor_chain_name=...)` is the
+  light path. Its constructor enables each motor (`motor_on`), and each enable
+  reply is a feedback frame carrying `temperature_mos` / `temperature_rotor`.
+  With `start_thread=False` no control loop starts and no torque is ever
+  commanded. `read_states()` then returns `MotorInfo` records with
+  `temp_mos` / `temp_rotor` from those frames.
+- End state for healthy motors is identical to normal eval teardown:
+  `MotorChainRobot.close()` also leaves motors enabled at zero torque and
+  closes the CAN socket (no `motor_off` anywhere in the stack). Two caveats
+  the module docstring must state honestly: (a) `motor_on` clears firmware
+  fault latches (`clean_error`) on any motor holding one, so a probe is not
+  state-neutral for a faulted motor; (b) if the chain constructor raises
+  mid-bringup the CAN socket is not deterministically closed on that path,
+  and a parent-side timeout SIGKILL likewise skips the child's `finally`
+  close (both harmless: the probe child process exits and the OS closes the
+  socket, and SocketCAN is non-exclusive).
+- **The probe must run in a child process with a deadline.** i2rt's
+  `motor_on` contains an unbounded fault-clean loop: a motor latched in an
+  over-temperature fault that is still hot re-asserts the fault after every
+  `clean_error`, and the loop spins forever with logging suppressed. That is
+  the single most likely state for the gate's first probe after a thermal
+  incident, and it hangs rather than raises, so no exception handler can
+  catch it. Therefore the in-process probe code runs only in a child:
+  `run.py` invokes `sys.executable _thermal.py --probe <channels...>` via
+  `subprocess.run(..., timeout=PROBE_TIMEOUT_S)`; a timeout kills the child
+  and counts as an ordinary probe error.
+- Motor list: `_load_arm_config(ArmType.YAM).motor_list` (6 arm motors, CAN
+  IDs and types exactly as the real bringup uses) plus the gripper motor
+  `[0x07, GripperType.LINEAR_4310.get_motor_type(ArmType.YAM)]`. Reusing
+  `_load_arm_config` (private but stable at the pinned commit) beats
+  hardcoding IDs that would drift from i2rt.
+- The probe runs only between evals, when no other process owns the CAN
+  socket. Offsets/directions do not matter for temperature (pass zeros/ones).
+
+## Changes
+
+### New file: `_thermal.py`
+
+Booth-editable constants at the top, `_roster.py` style:
+
+```python
+GRIPPER_TYPE = "LINEAR_4310"      # GripperType enum NAME; look up via GripperType[GRIPPER_TYPE]
+TEMP_WAIT_C = 60.0                # hottest reading at/above this suspends evals
+TEMP_RESUME_C = 50.0              # once suspended, resume only below this
+COOL_POLL_S = 30                  # re-probe interval while cooling
+PROBE_TIMEOUT_S = 20              # child-process deadline per probe
+COOL_PROBE_ERRORS_GIVE_UP = 5     # consecutive probe errors while cooling
+FALLBACK_CHANNELS = ("can_left", "can_right")  # used only if RIG_CONFIG has no channels
+```
+
+No `CAN_CHANNELS` constant: channel names come from the rig config (rig-1's
+`config.ini` has `left_channel = can_left` / `right_channel = can_right`
+under `[embodiment.args]`; a hardcoded `can0`/`can1` default would make the
+gate silently inert on the very rig it targets). `FALLBACK_CHANNELS` matches
+the real rig, not the i2rt defaults.
+
+API:
+
+- `class ThermalProbeError(RuntimeError)`: any failed probe (child nonzero
+  exit, timeout, unparseable output). Carries a short reason string.
+- `class ThermalProbeUnavailable(ThermalProbeError)`: the child could not
+  import i2rt (dev machine without the driver; distinct child exit code 3).
+  The caller disables the gate for the session.
+- `config_channels(config_path) -> tuple[str, str]`: read
+  `left_channel`/`right_channel` from `[embodiment.args]` with
+  `configparser` (`inline_comment_prefixes=("#",)` — the ini carries inline
+  comments — and `interpolation=None`), falling back to `FALLBACK_CHANNELS`
+  on any missing file, section, or key, and on `configparser.Error` (a
+  malformed config must degrade to the fallback, not crash `run.py` at
+  startup).
+- `read_motor_temps(channels) -> list[MotorTemp]` where `MotorTemp` is a
+  small frozen dataclass: `channel: str`, `motor_id: int`, `temp_mos: float`,
+  `temp_rotor: float`, plus a `max_c` property and a short `label` like
+  `"can_left 0x03"`. **Parent-side**: runs
+  `subprocess.run([sys.executable, str(__file__), "--probe", *channels],
+  capture_output=True, timeout=PROBE_TIMEOUT_S)` and parses one JSON list
+  from the child's stdout. Timeout, nonzero exit, or bad JSON raise
+  `ThermalProbeError` (exit code 3 raises `ThermalProbeUnavailable`). Only
+  `except Exception`-level errors are ever translated; `KeyboardInterrupt`
+  propagates untouched.
+- `hottest(temps) -> MotorTemp`: max by `max_c`.
+- **Child side** (`if __name__ == "__main__":` with `--probe <channels...>`):
+  imports i2rt (exit 3 on ImportError), builds the motor list as above, and
+  per channel constructs `DMChainCanInterface(..., start_thread=False,
+  motor_chain_name=f"thermal-probe-{channel}")`, collects `read_states()`,
+  closes the chain in a `finally`, prints the JSON list, exit 0. Any other
+  exception: traceback to stderr, exit 1. A wedged fault-clean loop is
+  handled by the parent's timeout kill, not in the child.
+
+Module docstring states the safety contract: probe only with the loop idle
+(never during an eval), the enable-at-zero-torque end state for healthy
+motors, and the two caveats above (fault-latch clearing; constructor-failure
+socket lifetime).
+
+### `run.py`: the gate
+
+New function `_thermal_gate(eval_index, gate_state)` called at the **top of
+each loop iteration**, before roles are drawn and before the eval's
+`_write_status` (this also covers the first eval after a relaunch on a hot
+rig). Behavior:
+
+Channels are resolved once at startup with `config_channels(RIG_CONFIG)`
+(after the existing `RIG_CONFIG.is_file()` check) and passed to every probe.
+
+1. If the gate is disabled (prior `ThermalProbeUnavailable`), return.
+2. Probe. On `ThermalProbeUnavailable`: print one warning, disable the gate
+   for the rest of the session, return. On `ThermalProbeError` (which a dead
+   single channel also produces — one dead channel forfeits the whole
+   round's gate, an intentional trade-off since a dead channel is fatal to
+   the eval anyway): print a warning and return (skip this round; a
+   genuinely broken rig is already handled by the eval itself and the
+   existing `FAILURE_STREAK_STOP`). Probe errors never count toward the
+   failure streak, and every handler is `except <specific>` — never bare or
+   `BaseException` — so `KeyboardInterrupt` always reaches main's existing
+   handler.
+3. If `hottest < TEMP_WAIT_C`: print a one-line summary
+   (`motor temps ok: max 41.2C (can_left 0x03)`) and return.
+4. Otherwise enter the cooling loop: each round, write `status.json` with a
+   `cooling` payload (below), print the same line to the console, sleep
+   `COOL_POLL_S`, re-probe. Exit when `hottest < TEMP_RESUME_C`. While
+   cooling, a `ThermalProbeError` prints a warning and counts a
+   consecutive-error streak; after `COOL_PROBE_ERRORS_GIVE_UP` consecutive
+   errors, print loudly and proceed anyway (a dead CAN would otherwise
+   suspend the show forever, and the eval's own fail-fast plus the
+   failure-streak halt cover a truly broken rig). A successful probe resets
+   that streak. No overall time cap: staying suspended is the correct
+   behavior while temperatures actually read hot; the operator can Ctrl-C
+   (the existing KeyboardInterrupt handler already exits cleanly from any
+   sleep, and the probe's subprocess timeout means no probe can wedge the
+   loop).
+
+Cooling `status.json` payload (written wholesale, like the existing status
+writes; no `roles`/`models` since none are drawn yet):
+
+```json
+{"eval_index": N, "cooling": {"max_c": 63.4, "hottest": "can_left 0x03",
+ "wait_c": 60.0, "resume_c": 50.0, "since": "<iso8601>"}}
+```
+
+The next eval's normal status write replaces this file, clearing the state.
+Known cosmetic edge, accepted: if the loop is killed mid-cooling with an
+empty `results.jsonl`, `_next_eval_index`'s status-file fallback resumes at
+N+1, skipping the never-started N in the numbering.
+
+### `serve.py`
+
+`_status_payload()` gains a `"cooling": None` default and copies
+`status.get("cooling")` through, same pattern as the existing keys.
+
+### `monitor.html`
+
+When `status.cooling` is present, the current-eval section shows a cooling
+banner in place of the role draw: text like
+`Cooling motors: 63.4C at can_left 0x03. Evals resume below 50C.` styled with the
+page's existing muted/accent tokens (no new layout regions; hide it when the
+field is absent). Keep the change minimal; visual taste is reviewed by the
+main session, not delegated.
+
+### `README.md` (demo README)
+
+Booth-checklist bullet: the loop checks motor temperatures before every eval;
+at/above 60 C it suspends and shows the cooling banner, resuming below 50 C;
+thresholds live in `_thermal.py`, channel names come from the rig config;
+the gate only exists when `run.py` is launched with a python that has i2rt
+installed (the rig venv) — on machines without i2rt or CAN it disables
+itself with a console warning and the demo runs as before. Also note the
+probe clears any latched motor fault codes as a side effect of reading.
+
+## Invariants retained
+
+- The eval command line, role draw, scoring, results append, clip rendering,
+  failure-streak halt (`FAILURE_STREAK_STOP = 10`), and the 10 s / 30 s pause
+  semantics are unchanged; the gate only inserts a wait before an eval
+  starts, and thermal waiting never increments the failure streak.
+- `status.json` remains write-wholesale via the existing atomic
+  `_write_status` (tmp + `os.replace`).
+- The probe never runs concurrently with an eval subprocess (it strictly
+  precedes the launch, and its child process has exited — by success,
+  failure, or timeout kill — before the eval starts), and for healthy motors
+  it leaves the same enabled-zero-torque state normal teardown leaves.
+
+## Out of scope
+
+- Mid-eval temperature monitoring (would need CAN sharing with the live
+  control loop or a yam-plugin channel; the firmware fault plus fail-fast
+  already cover mid-eval overheating).
+- Exposing temperatures through the yam plugin/health CLI (upstream work, not
+  demo-branch work).
+- Tests: `examples/` has no test suite on this branch; correctness is gated
+  by ruff plus on-rig validation.
+
+## Validation
+
+- `ruff check examples/actuate/` and `ruff format --check` pass.
+- Dev machine (no i2rt/CAN): `run.py` starts, prints the gate-disabled or
+  probe-error warning once, and proceeds exactly as today.
+- On the rig: run one probe standalone
+  (`python examples/actuate/_thermal.py --probe can_left can_right`) and
+  confirm plausible temperatures on all 14 motors; then lower
+  `TEMP_WAIT_C` below ambient to force the cooling path and confirm the
+  console line, the monitor banner, and that raising it back resumes the
+  draw. Confirm the next eval's bringup works normally after a probe.

--- a/plans/0077-actuate-launcher-kimi-k3.md
+++ b/plans/0077-actuate-launcher-kimi-k3.md
@@ -1,0 +1,199 @@
+# 0077: Actuate demo launcher script and Kimi K3 test-taker
+
+Demo-branch only (`demo/actuate-conference`, PR #397; never merges to main).
+All paths relative to `examples/actuate/`.
+
+## Goal
+
+Two additions to the conference demo:
+
+1. A single launcher script that starts the whole demo (display server plus
+   the eval loop) instead of the README's two hand-typed tmux commands.
+2. Kimi K3 joins the roster as a **test-taker only**: it can be drawn to
+   drive the robot and it appears on the leaderboard, but it is never drawn
+   as task maker or grader.
+
+## Facts (verified 2026-08-19)
+
+- Kimi K3 released 2026-07-16 (Moonshot AI). OpenAI-compatible chat
+  completions; `reasoning_effort` accepts `low`/`high`/`max` (default
+  `max`), so the demo's shared `effort=high` needs no special-casing.
+  The model always reasons and returns `reasoning_content` alongside
+  `content`; the agent plugin's chat wire ignores unknown response fields,
+  so no plugin change is needed.
+- Served as `kimi-k3` at `https://api.moonshot.ai/v1` (needs a Moonshot
+  account) or as `moonshotai/kimi-k3` at `https://openrouter.ai/api/v1`.
+  This rig already has `OPENROUTER_API_KEY` in `~/robocurve/test-dir/.env`,
+  so the roster entry uses OpenRouter; the demo's own `.env` (symlink to the
+  checkout root's `.env`) currently lacks that key and must gain it before
+  K3 can score (operator copies the existing key; never committed).
+- The demo currently draws all three roles from one `ROSTER` via
+  `random.choice` in `run.py`; `serve.py` builds the leaderboard from
+  `ROSTER` keys; `monitor.html` hardcodes a JS `order` array and `accents`
+  map. All three surfaces need the new entry; only `run.py` needs role
+  restriction.
+
+## Changes
+
+### `_roster.py`: role eligibility plus the K3 entry
+
+- New module constant `ALL_ROLES = ("tasker", "test_taker", "grader")`.
+- Each roster entry may carry `"roles": tuple[str, ...]`; absent means all
+  three (existing entries stay untouched, restating the invariant: GPT,
+  Opus, and Gemini remain eligible for every role and their entries do not
+  change).
+- New entry, after the existing three:
+
+```python
+"Kimi K3": {
+    # test-taker only: drives the robot but never authors tasks or grades.
+    "roles": ("test_taker",),
+    # OpenRouter because the rig already holds OPENROUTER_API_KEY; for
+    # Moonshot direct use model=kimi-k3, base_url=https://api.moonshot.ai/v1,
+    # api_key_env=MOONSHOT_API_KEY.
+    "model": "moonshotai/kimi-k3",
+    "base_url": "https://openrouter.ai/api/v1",
+    "api_key_env": "OPENROUTER_API_KEY",
+    "policy": {
+        "model": "moonshotai/kimi-k3",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key_env": "OPENROUTER_API_KEY",
+    },
+},
+```
+
+  (`model`/`base_url`/`api_key_env` at the top level stay present even
+  though K3 is never a tasker/grader: `_role_args` never reads them for K3,
+  but keeping the shape uniform means a booth edit that widens `roles`
+  cannot half-work. The `policy` dict speaks the default chat wire; no
+  `wire` key.)
+- `ACCENTS` gains `"Kimi K3": "#9067e8"` (violet; distinct from the
+  existing green/orange/blue on the dark background).
+
+### `run.py`: per-role draws
+
+Replace the single `roster = list(ROSTER.items())` with three eligibility
+lists built once in `main()`:
+
+```python
+def _eligible(role: str) -> list[tuple[str, dict[str, Any]]]:
+    return [
+        (name, model)
+        for name, model in ROSTER.items()
+        if role in model.get("roles", ALL_ROLES)
+    ]
+```
+
+and draw `tasker` from `_eligible("tasker")`, `test_taker` from
+`_eligible("test_taker")`, `grader` from `_eligible("grader")`
+(`random.choice` per role, unchanged semantics otherwise — the same model
+may still hold two or three roles when eligible). Startup sanity: if any
+role's list is empty, `SystemExit` with a fix-the-roster message before the
+loop starts. The import at the top of run.py extends to
+`from _roster import ALL_ROLES, EFFORT, ROSTER`.
+
+### `monitor.html`: new model on the display
+
+- `order` array gains `"Kimi K3"` (leaderboard row order; append last).
+- JS `accents` map gains `"Kimi K3": "#9067e8"` matching `_roster.py`.
+
+### New file: `start.sh` (the launcher)
+
+Bash, executable, `#!/usr/bin/env bash`, `set -euo pipefail`. Mirrors the
+README's recipe as one command. tmux specifics that are load-bearing, not
+implementer judgment:
+
+- **Exact-match session targets everywhere.** `-t actuate` prefix-matches
+  `actuate-serve`, so a bare target makes the loop-session guard succeed
+  against the serve session and the launcher can never start the loop. Every
+  `has-session`/`attach` target uses the `=` prefix: `-t =actuate-serve`,
+  `-t =actuate`.
+- **If-guard every `has-session`** (`if tmux has-session -t =... 2>/dev/null`):
+  under `set -e` a bare call kills the script, and on a fresh boot with no
+  tmux server it also prints noise to stderr.
+- **Absolute interpreter path in the inner commands.** A pre-existing tmux
+  server hands new sessions the *server's* environment, not the launching
+  shell's, so bare `python` can resolve to system python even though the
+  step-2 guard passed. Capture `PYTHON="$(command -v python)"` up front and
+  build both inner commands with it, `%q`-quoted.
+- **Quoting:** build each inner command string with `printf '%q '` over the
+  argv (interpreter, script path, `--`, passthrough args). Never interpolate
+  `$*` raw. (`%q` emits bash-flavored quoting; tmux runs commands via its
+  default-shell, bash on this rig — fine.)
+
+Steps:
+
+1. Resolve the repo root from the script's own path; `cd` there (the CLI
+   auto-loads `.env` from the working directory, and `run.py` resolves its
+   own siblings; repo root matches where the README puts `.env`).
+2. Guard: `command -v inspect-robots` must succeed, else exit 1 with
+   "activate the rig venv first (source .../bin/activate)". Warn (do not
+   exit) if `.env` is missing at the repo root.
+3. If a passthrough arg list is given and its first element is `--`, strip
+   it (the old README recipe taught `run.py -- --config ...`; muscle-memory
+   `./start.sh -- --config ...` must not forward a literal `--` into
+   `inspect-robots run`).
+4. Serve session: if `=actuate-serve` absent, start it detached with the
+   `%q`-built `"$PYTHON" examples/actuate/serve.py` command; then sleep 1
+   and re-check `has-session -t =actuate-serve` — if it died (port already
+   bound, wrong python), exit 1 telling the operator to check
+   `tmux new -s actuate-serve` manually / port 8377. If the session already
+   existed, print that it is being reused (it may have been started from
+   another checkout; the operator can `tmux kill-session -t =actuate-serve`
+   to reset).
+5. Print the display URL (`http://localhost:8377/`; the launcher does not
+   forward serve.py args — booth simplicity, README notes `--port` requires
+   the manual recipe).
+6. If `=actuate` exists, exit with "demo loop already running; tmux attach
+   -t =actuate" rather than stacking a second loop — two concurrent loops
+   would fight over the rig.
+7. Start the eval loop **attached** (the operator needs the terminal: Esc
+   ends an episode early): `tmux new -s actuate <inner>` where `<inner>` is
+   the `%q`-built `"$PYTHON" examples/actuate/run.py -- <args...>` (omit
+   the `--` when no args).
+
+No log-file redirection: the loop's console is the operator surface at the
+booth, and `state/results.jsonl` plus the eval logs already persist
+outcomes.
+
+### `README.md`
+
+- "Running it" section: replace the two tmux lines with
+  `./examples/actuate/start.sh` (README keeps the manual recipe as the
+  "what the script does" explanation; arguments after the script name reach
+  `inspect-robots run` verbatim, same as before).
+- Booth checklist, model IDs bullet: add Kimi K3, test-taker only, served
+  via OpenRouter, `OPENROUTER_API_KEY` must be present in the demo `.env`
+  (copy the existing key from `~/robocurve/test-dir/.env`), not yet
+  validated live: force one eval with it as test-taker during setup.
+
+## Invariants retained
+
+- Existing three roster entries byte-identical; every existing role
+  pairing still possible. The thermal gate (plan 0076) is untouched: the
+  gate still runs at the top of each iteration before the role draw, and
+  the per-role draws replace only the `random.choice(roster)` calls.
+- `serve.py` needs no change: the leaderboard iterates `ROSTER` keys, so
+  K3 appears automatically with n=0 until it scores.
+- The launcher never runs git, never edits `.env`, and is idempotent for
+  the serve session.
+
+## Out of scope
+
+- Wiring `MOONSHOT_API_KEY` / Moonshot-direct (documented in the roster
+  comment as the booth-editable alternative).
+- Any plugin change for `reasoning_content` (chat wire ignores it).
+
+## Validation
+
+- `ruff check examples/actuate/` and `ruff format --check` pass;
+  `bash -n examples/actuate/start.sh` and a `shellcheck` pass if available.
+- Draw sanity offline: import run.py with a stubbed roster and confirm
+  10k draws never produce K3 as tasker or grader but do produce it as
+  test-taker; confirm empty-role SystemExit fires on a roster with no
+  eligible grader.
+- Launcher on this machine (no rig): guard message without the venv;
+  with the venv, serve session starts, URL prints, and a second invocation
+  refuses to stack the `actuate` session.
+- On the rig (operator): add `OPENROUTER_API_KEY` to the demo `.env`, force
+  one K3 test-taker eval, confirm it scores and the leaderboard row fills.

--- a/plans/0078-actuate-fixed-trials.md
+++ b/plans/0078-actuate-fixed-trials.md
@@ -1,0 +1,84 @@
+# 0078: Actuate demo fixed-trials runner
+
+Demo-branch only. New sibling script; `run.py` and `start.sh` are not
+modified.
+
+## Goal
+
+A deterministic campaign for the show format: every test-taker in the
+roster completes exactly `TRIALS_PER_MODEL = 10` scored evals (7 models,
+70 scored evals total), tasker and grader pinned as the roster already
+pins them (single-member pools). No randomization anywhere.
+
+## New file: `examples/actuate/run_trials.py`
+
+Imports `run` (same directory; `run.py` is `__main__`-guarded and
+import-safe) and reuses its machinery unchanged: `_command`,
+`_write_status`, `_extra_args`, `_docs_extra_args` (via `_command`),
+`_final_log_paths`, `_newest_final_log`, `_log_outcome`, `_render_clips`,
+`_append_result`, `_next_eval_index`, `_thermal_gate`, `_eligible`, and the
+constants `RIG_CONFIG`, `PAUSE_S`, `FAILURE_PAUSE_S`, `FAILURE_STREAK_STOP`,
+`RESULTS_PATH`, plus `config_channels` from `_thermal`.
+
+Booth-editable constant at top: `TRIALS_PER_MODEL = 10`. A second guard
+constant `UNSCORED_STREAK_STOP = 10`.
+
+Behavior (mirrors `run.py`'s loop; differences only where stated):
+
+1. Startup: same `RIG_CONFIG` check, channels via
+   `config_channels(RIG_CONFIG)`, state/log dirs, extra args, gate state.
+   Role pools via `run._eligible`: tasker and grader pools must have
+   exactly one member each; the test-taker pool order is the roster order.
+   `SystemExit` with a clear message otherwise (the pinned-roles roster is
+   a precondition, not something this script re-implements).
+2. Trial accounting, recomputed from `RESULTS_PATH` before every eval
+   (restart-safe): a completed trial for model name N is a results.jsonl
+   row with `roles.test_taker == N` and a non-null finite `score`. Rows
+   from earlier demo sessions count; the README tells the operator to
+   clear state for a fresh campaign.
+3. Selection, fully deterministic: among test-takers with fewer than
+   `TRIALS_PER_MODEL` completed trials, pick the one with the fewest;
+   ties break by roster order. (With no failures this yields strict
+   round-robin interleaving — cycle 1 all seven, cycle 2 all seven, ... —
+   and after a failure the lagging model is retried first.)
+4. When every model has `>= TRIALS_PER_MODEL`: print a per-model summary
+   (n, mean score, matching the leaderboard's scored-evals-only
+   semantics) and exit 0.
+5. Each eval: identical to `run.py` — thermal gate first, status write
+   (same shape, so `serve.py`/`monitor.html` work unchanged), launch via
+   `run._command(tasker, test_taker, grader, extra_args)`, outcome
+   parsing, clip rendering, results append, pause logic. Console line
+   additionally prints trial progress: `trial 4/10 for GPT-5`.
+6. Failure guards: `run.py`'s log-less `FAILURE_STREAK_STOP` behavior is
+   retained verbatim. New: a consecutive streak of evals that produce a
+   log but **no score** (grader broken) halts after
+   `UNSCORED_STREAK_STOP` with a message naming the grader — without
+   this, a broken grader would loop forever because unscored evals never
+   count as trials. Any scored eval resets both streaks.
+7. Ctrl-C: same `KeyboardInterrupt` exit as `run.py`.
+
+## README
+
+New short subsection after "Running it": fixed-trials campaign, run
+manually in the same tmux arrangement (`start.sh` stays wired to the
+rotating demo; the trials runner is
+`tmux new -s actuate 'python examples/actuate/run_trials.py -- ...'` with
+the serve session as usual), passthrough args after `--` identical, start
+from a fresh leaderboard for a clean campaign (existing scored evals count
+toward the 10), resumes where it left off after a restart, exits when
+every test-taker has ten scored evals.
+
+## Out of scope
+
+- Any change to `run.py`, `start.sh`, `_roster.py`, `serve.py`,
+  `monitor.html`.
+- Per-trial scene control (task authorship stays with the pinned tasker).
+
+## Validation
+
+- ruff gates pass.
+- Offline simulation with stubbed `RESULTS_PATH` content: selection is
+  round-robin from empty state; resumes correctly from partial counts
+  (e.g. one model at 10, others at 9 → picks the laggards in roster
+  order); unscored rows do not count; exits at 10/10 for all seven.
+- On-rig: covered by the existing booth checklist (force-one-eval items).

--- a/plans/0078-actuate-fixed-trials.md
+++ b/plans/0078-actuate-fixed-trials.md
@@ -1,5 +1,11 @@
 # 0078: Actuate demo fixed-trials runner
 
+> Amended 2026-08-19 (commit on demo branch): selection is now a randomized
+> block design. Fewest-completed still bounds every model to one trial per
+> round, but ties are drawn randomly instead of in roster order, so a
+> position-in-round effect cannot align with any one model. Everything else
+> in this plan stands.
+
 Demo-branch only. New sibling script; `run.py` and `start.sh` are not
 modified.
 

--- a/plans/0079-actuate-dual-rig-trials.md
+++ b/plans/0079-actuate-dual-rig-trials.md
@@ -1,0 +1,87 @@
+# 0079: Dual-rig fixed-trials campaign
+
+Demo-branch only. Splits the plan-0078 campaign across the two physical
+rigs so every test-taker runs 5 scored trials on rig-1 and 5 on rig-2
+(8 models x 5 x 2 = 80 evals; measuring every model on both rigs keeps
+rig differences out of the model comparison). The rigs run concurrently
+on this machine, so each rig gets fully separate state and log
+directories: the shared dirs would race the newest-final-log attribution
+and interleave results.jsonl.
+
+## Changes (all in `examples/actuate/`)
+
+### `run_trials.py`: extract a parameterized engine
+
+- New `run_campaign(rig_config: Path, state_dir: Path, logs_dir: Path,
+  trials_per_model: int, argv: list[str]) -> None` holding the existing
+  `main()` body. It assigns the rig-dependent module globals before the
+  loop: `run.RIG_CONFIG`, `run.STATE_DIR`, `run.LOGS_DIR`,
+  `run.STATUS_PATH` (`state_dir / "status.json"`), `run.RESULTS_PATH`
+  (`state_dir / "results.jsonl"`), `run.MEDIA_DIR` (`state_dir /
+  "media"`), plus the local trials target; passthrough args come from
+  `argv` (same `--` convention via `run._extra_args`).
+- `main()` becomes a thin call with today's defaults (rig-1 config,
+  `state/`, `logs/`, `TRIALS_PER_MODEL`), keeping the single-rig
+  invocation byte-compatible.
+- The invariant to restate at the point of modification: the engine
+  keeps the plan-0078 semantics unchanged — fewest-completed selection
+  with roster-order ties, scored = non-null finite, both streak guards
+  with the 3ad5612d reset rules, completion check after append (no dead
+  final sleep), and the roles-clearing final status write.
+
+### New: `run_trials_rig1.py`, `run_trials_rig2.py`
+
+Thin booth scripts, `_roster.py`-style docstrings, each:
+
+```python
+TRIALS_PER_RIG = 5   # booth-editable; combined target is 2x this
+RIG_CONFIG = Path.home() / "robocurve" / "rig-1" / "config.ini"  # or rig-2
+```
+
+calling `run_campaign(RIG_CONFIG, HERE / "state-rig1", HERE /
+"logs-rig1", TRIALS_PER_RIG, sys.argv[1:])` (rig-2 mirrors with
+`-rig2`). Thermal-gate channels resolve per rig automatically because
+`run_campaign` reads them from the rig config (rig-2 uses can1/can0;
+verified present in its config.ini).
+
+### `serve.py`: per-rig monitor
+
+`--state-dir` and `--logs-dir` flags (defaults: today's `state/` and
+`logs/`), applied to the module paths before serving, so each rig can
+run its own monitor: rig-1 on the default port 8377, rig-2 via
+`--port 8378 --state-dir .../state-rig2 --logs-dir .../logs-rig2`.
+
+### New: `combine_results.py`
+
+Stdlib one-shot: takes any number of results.jsonl paths, prints the
+pooled per-model n/mean (same scored = non-null finite rule) plus a
+per-file breakdown, so the booth gets the combined leaderboard of both
+rigs in one command.
+
+### `.gitignore` (repo root)
+
+Add `examples/actuate/logs-rig*/` and `examples/actuate/state-rig*/`
+beside the existing entries.
+
+### `README.md`
+
+Extend the fixed-trials section: the dual-rig split (5+5 rationale),
+the two run commands in separate tmux sessions (`actuate-rig1`,
+`actuate-rig2`; each rig needs its own attended terminal for Esc), the
+two serve commands with ports 8377/8378, `combine_results.py` for the
+pooled leaderboard, the reminder that each rig's own `.env`/key setup
+and the flock claim guard already handle concurrent runs, and that
+fresh-campaign resets now clear the per-rig dirs.
+
+## Out of scope
+
+- run.py, start.sh (still wired to the rotating single-rig demo).
+- Merging the two monitors into one page.
+
+## Validation
+
+- ruff gates; offline sims against `run_campaign` with per-rig temp
+  dirs proving: default `main()` path unchanged; two campaigns with
+  separate dirs do not interact; 5-trial target honored; per-rig
+  channels resolved from the given config path.
+- `combine_results.py` pooled means against hand-computed values.

--- a/plans/0080-actuate-overnight-viewer.md
+++ b/plans/0080-actuate-overnight-viewer.md
@@ -1,0 +1,125 @@
+# 0080: Overnight dual-rig campaign viewer
+
+Demo-branch only. The operator sleeps through most of the dual-rig
+campaign (plan 0079); this adds a single phone-friendly page showing both
+rigs' progress, and pins headless full-data recording so nothing depends
+on live viewers.
+
+## Recording pins (rig scripts)
+
+`run_trials_rig1.py` / `run_trials_rig2.py` extend their baked args
+(before the user passthrough, so later user flags still win) from
+`--max-steps 1200` to:
+
+```
+--max-steps 1200 --store-frames --no-rerun --rerun-save
+```
+
+- `--no-rerun`: overrides rig-1's `rerun = true` config so no viewer
+  windows spawn overnight.
+- `--rerun-save`: without a viewer this records the rollout (cameras,
+  joint states, actions) to a per-eval `.rrd` in the rig's log dir
+  (verified against the CLI help; the morning's logs already carry such
+  rrds).
+- `--store-frames`: drift-proofs the configs' `store_frames = true`, so
+  per-step camera frames land under `logs-rigN/frames/<run_stamp>/`.
+
+Existing storage that needs no change: per-eval EvalLog json, actions
+logs (commanded joints per step), and LLM transcripts, all under the
+per-rig log dir.
+
+## New: `examples/actuate/overnight.py`
+
+Stdlib HTTP server, `serve.py`'s patterns (ThreadingHTTPServer, no-store
+cache headers, silent request log), default `--port 8380`. Booth-editable
+constants at top:
+
+```python
+TRIALS_PER_RIG = 5     # must match the rig scripts
+STALL_AFTER_MIN = 30   # incomplete + no activity this long = stalled
+RIGS = {"rig1": ("state-rig1", "logs-rig1"), "rig2": ("state-rig2", "logs-rig2")}
+```
+
+Routes:
+
+- `/` serves `overnight.html`.
+- `/api/overnight` returns one JSON payload:
+  - `generated_at` (iso, server time).
+  - per rig (`rig1`, `rig2`): `status` (the rig's status.json passthrough:
+    eval_index, started_at, roles, models, cooling), `status_age_s`,
+    `results`: per-model `{n, mean}` over scored rows (same non-null
+    finite rule as everywhere, roster-seeded), `recent`: last 3 rows
+    (eval_index, test_taker, score, task, ts, clips), `last_activity_s`
+    (seconds since the newer of status.json mtime and last results row
+    ts), `done` (every model at TRIALS_PER_RIG), `stalled` (not done and
+    `last_activity_s` > STALL_AFTER_MIN minutes; missing dirs count as
+    not-started, never stalled).
+  - `pooled`: per-model `{n, mean}` across both rigs plus
+    `total_scored` and `target` (16 models-halves x TRIALS_PER_RIG... no:
+    `2 * TRIALS_PER_RIG * len(ROSTER-test-takers)` = 80).
+  Missing files/dirs degrade to empty sections, never 500s.
+- `/media/rig1/<name>.mp4` and `/media/rig2/<name>.mp4` serve each rig's
+  `state-rigN/media` clips with the same name-allowlist regex as
+  serve.py.
+
+Eligibility comes from `_roster` (`ROSTER`, `ACCENTS`, roles filtering as
+in `run._eligible` — import run and reuse `_eligible` to avoid a second
+roles interpretation).
+
+## New: `examples/actuate/overnight.html`
+
+Dark, mobile-first single column (the page will be read on a phone over
+the tailnet), reusing monitor.html's palette (#0e1116 bg, #151a22 cards,
+muted #687280, model accent colors from the JS map, system-ui stack).
+Auto-refresh: fetch `/api/overnight` every 30 s; a fetch failure shows a
+"server unreachable" banner rather than stale data without warning.
+Layout, top to bottom:
+
+1. Header: "Actuate Overnight" + pooled progress line `NN/80 scored` with
+   a thin progress bar + "updated HH:MM:SS" (client-rendered from
+   generated_at).
+2. Per-rig card (rig-1 then rig-2), each with:
+   - Rig title row with a state chip: `RUNNING` (green tint) /
+     `COOLING x.x C` (blue) / `STALLED Nm` (red) / `DONE` (muted) /
+     `NOT STARTED` (muted). Stalled shows minutes since last activity.
+   - Current-eval line: `Eval #N - <test-taker> - trial x/5 - running
+     M min` (from status + that model's scored count; hide when done).
+   - Progress grid: one row per test-taker in roster order: accent-tinted
+     name, TRIALS_PER_RIG dot cells (filled = scored), and the rig-local
+     mean (or a dash at n=0).
+   - Recent strip: the last 3 scored-or-not evals as small cards: eval
+     number, model, score badge (or "unscored"), one-line task, and the
+     top-cam clip when present (`autoplay muted loop playsinline`, small,
+     capped height) via `/media/rigN/...`.
+3. Pooled leaderboard table: model, n (of 10), mean, sorted by mean desc
+   with n=0 last; accent-colored model names.
+
+No external assets; all CSS inline in the file like monitor.html.
+
+## README
+
+Extend the dual-rig section: start the overnight page alongside the
+campaigns (`tmux new -d -s actuate-overnight 'python
+examples/actuate/overnight.py'`), reachable from the tailnet at
+`http://<rig-host>:8380/`; the rig scripts record everything for morning
+review (rrd with joint states, frames, actions, transcripts) with no
+live viewers; the monitor pages (8377/8378) stay optional for attended
+watching.
+
+## Out of scope
+
+- Serving or rendering rrd/frames content in the page (morning review
+  uses `inspect-robots view logs-rigN/ --serve` and the rerun viewer on
+  the recorded rrds).
+- Push notifications and auth (tailnet-only page).
+- Any change to run.py, start.sh, serve.py, monitor.html, _roster.py,
+  _thermal.py, run_trials.py.
+
+## Validation
+
+- ruff gates; a scripted check that `/api/overnight` renders correct
+  progress/stall/done states from synthetic state-rigN fixtures
+  (including missing dirs), and that the media route rejects traversal
+  names, plus a live smoke on a spare port.
+- Rig scripts: assert the pinned argv now carries the three recording
+  flags before user args.


### PR DESCRIPTION
Conference-floor demo for Actuate. Runs locally from this branch; this PR exists for visibility and iteration only and must never be merged.

Every eval independently draws one of gpt-5.6-sol / claude-opus-5 / gemini-3.7-flash for each of the three roles (tasker, test-taker, grader), all at effort high, over each provider's OpenAI-compatible endpoint (taskgen -A, vlm grader -G, agent policy -P; the -A/-G effort channel is #395). A stdlib server shows one screen beside the live Rerun viewer: the current draw and generated task with the live eval number, a horizontal leaderboard of mean score as test-taker with the top bar scaled to 80% of the track, and the last three completed evals so the per-eval randomness is visible. State and logs stay under gitignored examples/actuate/{state,logs}.

Nothing under src/, tests/, or plugins/ is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)