### PR TITLE
docs: clarify effort none semantics

### DIFF
--- a/src/inspect_robots/defaults.py
+++ b/src/inspect_robots/defaults.py
@@ -51,8 +51,9 @@ def _parse_value(text: str) -> Any:
 
     A value wrapped in matching single or double quotes is returned as the
     literal inner string with no coercion — the escape hatch for strings the
-    heuristics would otherwise claim (``-P effort="'none'"`` sends the wire
-    string ``none`` instead of omitting the parameter).
+    heuristics would otherwise claim (``-P effort="'none'"`` sends the literal
+    wire string ``none`` through parsing, while bare ``effort=none`` parses to
+    Python ``None`` and is normalized by effort-taking components).
     """
     if len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
         return text[1:-1]


### PR DESCRIPTION
## Summary

Updates the `_parse_value` docstring to match the current `effort=none` behavior.

## Changes

- Clarifies that quoted `none` is kept as the literal string `"none"`.
- Clarifies that bare `effort=none` is parsed as Python `None` and normalized by effort-taking components.
- No runtime behavior was changed.

## Checklist

- [ ] `pre-commit install` done; hooks pass (or ran `pre-commit run --all-files`)
- [ ] Tests added/updated (not needed for this docs-only change)
- [ ] Coverage stays at **100%** (`pytest --cov`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `mypy` passes (strict)
- [ ] `CHANGELOG.md` updated under "Unreleased" (not needed for this docs-only change)
- [ ] Public API changes are reflected in `inspect_robots.__all__` and the API-snapshot test (no public API change)
- [x] Core stays NumPy-only (no dependencies added)

## Related

Closes #396