### PR TITLE
docs(frames): define pre/post side-car contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- **Core:** when `FrameStore` is active, both the pre-action and post-action
+  observations recorded in each `StepRecord` now omit inline camera arrays.
+  Consumers that previously read terminal images from
+  `step.result.observation.images` must load `step.result_image_refs` instead;
+  `step.image_refs` remains the pre-action mapping. A trial with `n` completed
+  steps stores the reset frame at index `0` and each post-action frame at
+  `t + 1`; a camera present throughout therefore produces `n + 1` files
+  ([#209](https://github.com/robocurve/inspect-robots/pull/209)).
+
 - **Core:** the `--epochs` below-1 guard in `run` and `eval-set` now lives in
   one shared helper, and its error reads `--epochs must be >= 1, got 0`
   (naming the offending task in `eval-set`) instead of doubling the wording
@@ -229,11 +238,6 @@ All notable changes to this project are documented here. The format is based on
   `messages`); construction guards now diagnose explicit wire conflicts,
   Messages endpoint routing mistakes, and possible silent tool drops on an
   explicit Chat Completions endpoint (plan 0044, #278).
-
-- `FrameStore` now persists each post-action observation once and exposes it
-  through `StepRecord.result_image_refs`. Stored records strip camera arrays
-  from both pre-action and post-action observations, and the terminal visual
-  state is recoverable for offline scoring.
 
 - The Rerun sink now sends a per-trial blueprint that groups labeled action
   dimensions by arm, overlays aligned measured state, and lays out cameras,

--- a/docs/guide/logging-and-rerun.md
+++ b/docs/guide/logging-and-rerun.md
@@ -172,6 +172,22 @@ memory-safe and remain scorable from disk. Trial ids repeat across runs, so
 each eval gets its own directory; read the exact path from the log's
 `stats.frames_dir` rather than globbing `<log_dir>/frames` directly.
 
+The frame sequence includes both sides of every action. The reset observation
+is stored at index `0`; the result of step `t` is stored at `t + 1`. A camera
+present throughout a trial with `n` completed steps therefore produces `n + 1`
+files, including the terminal post-action state. In each
+[`StepRecord`](/api/#inspect_robots.rollout.StepRecord),
+`image_refs` points to the pre-action frames and `result_image_refs` points to
+the post-action frames. Both corresponding `Observation.images` mappings are
+empty while a frame store is active. Consumers must load the appropriate
+`FrameRef` instead of reading inline arrays. Without a frame store, observations
+remain inline and both ref mappings are `None`.
+
+Frame storage starts immediately after reset, before the first policy action.
+If the policy fails during its first decision, reset frames can remain on disk
+even though no `StepRecord` exists. This is intentional: the initial sensor
+state is still available for failure forensics.
+
 ```python
 eval(task, policy, embodiment, log_dir="logs", store_frames=True)
 ```
@@ -206,10 +222,11 @@ the placeholder in place.
 
 `FrameStore` sanitizes trial and camera names before building
 `{trial}_{camera}_{t:06d}.npy`. When the sanitizer rewrites a name, use
-`StepRecord.image_refs` and `FrameRef.path` as the authoritative mapping instead
-of assembling the path from the transcript label. That remains the right advice
-for programmatic consumers. The `view` command performs this join internally
-with the same sanitizer and an exact-match-or-degrade contract.
+`StepRecord.image_refs` for the pre-action observation,
+`StepRecord.result_image_refs` for the post-action observation, and
+`FrameRef.path` as the authoritative file mapping instead of assembling paths
+from transcript labels or step indices. The `view` command performs its join
+internally with the same sanitizer and an exact-match-or-degrade contract.
 
 ## Wire capture
 

--- a/src/inspect_robots/_video.py
+++ b/src/inspect_robots/_video.py
@@ -113,10 +113,12 @@ def count_frames(root: Path) -> int:
 def default_fps(embodiment_info: Mapping[str, Any]) -> tuple[float, str]:
     """The playback rate a log implies, with its source for display.
 
-    Uses the embodiment's nominal ``control_hz`` (frames are stored once per
-    rollout step, so it is the best proxy the log offers). The guards mirror
-    ``_print_step_limit_notice`` — numeric, not bool, > 0 — plus finite:
-    plain ``json.load`` accepts the ``Infinity`` literal, and a hand-edited
+    Frame storage writes one reset frame and one post-action frame per completed
+    step. Adjacent frames therefore span one control interval, so the
+    embodiment's nominal ``control_hz`` is the best playback-rate proxy the log
+    offers. The guards mirror ``_print_step_limit_notice``: numeric, not bool,
+    greater than zero, and finite. Plain ``json.load`` accepts the ``Infinity``
+    literal, and a hand-edited
     ``control_hz`` must fall back rather than become ``-r inf``.
     """
     rate = embodiment_info.get("control_hz")


### PR DESCRIPTION
## Summary

Follow up on the non-blocking documentation points from the review of #209.

The frame-store behavior was implemented and tested, but two public descriptions still reflected the old pre-action-only model. This PR makes the migration and indexing contract explicit:

- move the changelog entry from "Added" to "Changed" and name the migration from `step.result.observation.images` to `step.result_image_refs`;
- document reset frame `0`, post-action frame `t + 1`, and the resulting `n + 1` files for a camera present throughout an `n`-step trial;
- distinguish `image_refs` (pre-action) from `result_image_refs` (post-action);
- record that a first-decision failure can leave reset frames for forensics without producing a `StepRecord`;
- correct `default_fps` documentation: adjacent stored frames span one control interval even though the sequence contains an extra reset frame.

No runtime behavior or public interface changes.

## Verification

- [x] `pre-commit run --all-files`
- [x] `pre-commit run --all-files --hook-stage pre-push`
- [x] Ruff lint and format checks
- [x] Strict mypy: 86 source files
- [x] Pytest: 1,619 passed, 6 skipped
- [x] Coverage: 100% line and branch
- [x] Generated API reference
- [x] Docusaurus production build

Follow-up to #209.
