### PR TITLE
feat(rollout): symmetric input-side Perturber protocol and perturbation events (#403)

### DIFF
--- a/src/inspect_robots/approver.py
+++ b/src/inspect_robots/approver.py
@@ -17,7 +17,7 @@ import numpy.typing as npt
 
 from inspect_robots.errors import SafetyAbort
 from inspect_robots.spaces import ABSOLUTE_CONTROL_MODES, Box, RotationRepr
-from inspect_robots.types import Action
+from inspect_robots.types import Action, Observation
 
 
 @runtime_checkable
@@ -69,6 +69,41 @@ class AutoApprover:
     def review(self, action: Action, store: dict[str, Any]) -> Action:
         """Pass the action through without modifying its identity."""
         return action
+
+
+@runtime_checkable
+class Perturber(Protocol):
+    """Transforms an observation before the policy sees it.
+
+    A symmetric input-side hook alongside [`Approver`][inspect_robots.approver.Approver]:
+    ``Approver`` gates actions on the way *out* to the embodiment; ``Perturber``
+    gates observations on the way *in* to the policy. It may return the
+    observation unchanged, return a modified copy (e.g. injecting sensor noise,
+    masking cameras, swapping the instruction), or raise to abort the trial.
+
+    The returned observation is what the policy receives. If the perturber
+    modifies the observation, the rollout records a ``perturbation`` event in
+    the trial transcript so the distortion is auditable. Returning the *same*
+    object (identity) means "no change" — the rollout uses identity to detect
+    whether to log an event, so a perturber that makes a no-op copy should
+    return the original object.
+
+    The ``store`` dict is the same trial-local state dict the approver chain
+    sees; perturbers may use it to track episode-level state such as a random
+    seed or a noise schedule.
+    """
+
+    def perturb(self, observation: Observation, store: dict[str, Any]) -> Observation:
+        """Return the observation to pass to the policy, or raise to abort the trial."""
+        ...
+
+
+class AutoPerturber:
+    """Pass every observation through unchanged (the identity default)."""
+
+    def perturb(self, observation: Observation, store: dict[str, Any]) -> Observation:
+        """Return the observation object unchanged."""
+        return observation
 
 
 class ClampApprover:

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 
 from inspect_robots import __version__
-from inspect_robots.approver import Approver, AutoApprover
+from inspect_robots.approver import Approver, AutoApprover, Perturber
 from inspect_robots.compat import assert_compatible
 from inspect_robots.controller import Controller, DefaultController
 from inspect_robots.embodiment import Embodiment
@@ -244,6 +244,7 @@ def eval(
     operator_input: OperatorInput | None = None,
     before_scoring: Callable[[TrialRecord, Scene], None] | None = None,
     grader: Grader | str | None = None,
+    perturber: Perturber | None = None,
 ) -> list[EvalLog]:
     """Run ``task`` with ``policy`` on ``embodiment``; return ``[EvalLog]``.
 
@@ -334,6 +335,7 @@ def eval(
             store_actions=store_actions,
             operator_input=operator_input,
             before_scoring=before_scoring,
+            perturber=perturber,
         )
     finally:
         # Close what we opened: a registry-resolved embodiment is released even
@@ -358,6 +360,7 @@ def _run_eval(
     store_actions: bool,
     operator_input: OperatorInput | None,
     before_scoring: Callable[[TrialRecord, Scene], None] | None,
+    perturber: Perturber | None = None,
 ) -> list[EvalLog]:
     """The body of [`eval`][inspect_robots.eval.eval], after resolution/ownership."""
     from inspect_robots.logging.json_log import JsonLogSink
@@ -383,6 +386,11 @@ def _run_eval(
     bind_task = getattr(embodiment, "bind_task", None)
     if callable(bind_task):
         bind_task(task_envelope)
+
+    # Horizon-aware policies (e.g. LLM agent policies): optional bind_task() hook
+    policy_bind_task = getattr(policy, "bind_task", None)
+    if callable(policy_bind_task):
+        policy_bind_task(task_envelope)
 
     epoch_spec = task.epoch_spec
     scorers = task.scorers
@@ -498,6 +506,7 @@ def _run_eval(
                         sink=bus,
                         frame_store=frame_store,
                         operator_input=operator_input,
+                        perturber=perturber,
                     )
                 except _CancelledTrial as exc:
                     status = "cancelled"

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -387,11 +387,6 @@ def _run_eval(
     if callable(bind_task):
         bind_task(task_envelope)
 
-    # Horizon-aware policies (e.g. LLM agent policies): optional bind_task() hook
-    policy_bind_task = getattr(policy, "bind_task", None)
-    if callable(policy_bind_task):
-        policy_bind_task(task_envelope)
-
     epoch_spec = task.epoch_spec
     scorers = task.scorers
     # Fail fast on an unknown/invalid epoch reducer, before any rollout runs.

--- a/src/inspect_robots/rollout.py
+++ b/src/inspect_robots/rollout.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from inspect_robots.approver import Approver
+from inspect_robots.approver import Approver, Perturber
 from inspect_robots.controller import _INFER_KEY, Controller
 from inspect_robots.embodiment import Embodiment
 from inspect_robots.errors import (
@@ -38,6 +38,7 @@ from inspect_robots.transcript import (
     inference_event,
     operator_event,
     operator_message_event,
+    perturbation_event,
     reset_event,
     step_event,
 )
@@ -229,6 +230,35 @@ def _end_operator_trial(operator_input: OperatorInput | None) -> None:
             )
 
 
+def _apply_perturber(
+    perturber: Perturber | None,
+    obs: Observation,
+    record: TrialRecord,
+    store: dict[str, Any],
+    t: int,
+) -> Observation:
+    """Apply the optional perturber and log an event when it modifies the observation.
+
+    Returns the (possibly modified) observation. If the perturber raises an
+    ``InspectRobotsError`` it propagates unchanged; any other exception is
+    wrapped in ``EmbodimentFault`` so a broken perturber is treated as a sensor
+    fault rather than a recoverable policy error.
+    """
+    if perturber is None:
+        return obs
+    try:
+        result = perturber.perturb(obs, store)
+        if result is not obs:
+            record.events.append(perturbation_event(t, type(perturber).__name__))
+        return result
+    except InspectRobotsError:
+        raise
+    except Exception as exc:
+        raise EmbodimentFault(
+            f"{type(perturber).__name__}.perturb() raised {type(exc).__name__}: {exc}"
+        ) from exc
+
+
 def rollout(
     policy: Policy,
     embodiment: Embodiment,
@@ -242,6 +272,7 @@ def rollout(
     sink: LogSink,
     frame_store: FrameStore | None = None,
     operator_input: OperatorInput | None = None,
+    perturber: Perturber | None = None,
 ) -> TrialRecord:
     """Run a single trial and return its record.
 
@@ -301,6 +332,12 @@ def rollout(
                     RuntimeWarning,
                     stacklevel=2,
                 )
+
+        try:
+            obs = _apply_perturber(perturber, obs, record, store, -1)
+        except InspectRobotsError as exc:
+            _record_failure(record, exc, -1)
+            raise
 
         obs_rec, refs = _store_frames(frame_store, trial_id, 0, obs)
         t = 0
@@ -471,7 +508,11 @@ def rollout(
                 record.truncated = True
                 record.termination_reason = stop_reason
                 break
-            obs = result.observation
+            try:
+                obs = _apply_perturber(perturber, result.observation, record, store, t)
+            except InspectRobotsError as exc:
+                _record_failure(record, exc, t)
+                raise
             obs_rec = result_obs_rec
             refs = result_refs
         else:

--- a/src/inspect_robots/transcript.py
+++ b/src/inspect_robots/transcript.py
@@ -75,3 +75,14 @@ def operator_event(t: int, verdict: str, source: str = "prompt", note: str | Non
 def error_event(t: int, error_type: str, message: str) -> Event:
     """Record an exception's type and message at the failing control step."""
     return Event(kind="error", t=t, data={"type": error_type, "message": message})
+
+
+def perturbation_event(t: int, perturber_name: str) -> Event:
+    """Record that a Perturber modified the observation at control step ``t``.
+
+    ``perturber_name`` is the ``type(perturber).__name__`` of the perturber
+    that produced the modified observation. This event is only recorded when the
+    perturber returns a different object (not the same identity as the input),
+    so the transcript only grows when a distortion actually occurred.
+    """
+    return Event(kind="perturbation", t=t, data={"perturber": perturber_name})

--- a/tests/test_rollout_hardening.py
+++ b/tests/test_rollout_hardening.py
@@ -867,3 +867,21 @@ def test_perturber_raising_generic_exception_wrapped_as_embodiment_fault() -> No
         _run(ScriptedPolicy(), CubePickEmbodiment(), perturber=_FaultyPerturber())
     assert excinfo.value.record is not None
     assert excinfo.value.record.status == "error"
+
+
+def test_perturber_raising_during_step_loop_propagates() -> None:
+    class _StepFailPerturber:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def perturb(self, observation: Observation, store: dict[str, object]) -> Observation:
+            self.calls += 1
+            if self.calls > 1:
+                raise SafetyAbort("perturber failed on step")
+            return observation
+
+    with pytest.raises(SafetyAbort, match="perturber failed on step") as excinfo:
+        _run(ScriptedPolicy(), CubePickEmbodiment(), perturber=_StepFailPerturber())
+    assert excinfo.value.record is not None
+    assert excinfo.value.record.status == "error"
+

--- a/tests/test_rollout_hardening.py
+++ b/tests/test_rollout_hardening.py
@@ -884,4 +884,3 @@ def test_perturber_raising_during_step_loop_propagates() -> None:
         _run(ScriptedPolicy(), CubePickEmbodiment(), perturber=_StepFailPerturber())
     assert excinfo.value.record is not None
     assert excinfo.value.record.status == "error"
-

--- a/tests/test_rollout_hardening.py
+++ b/tests/test_rollout_hardening.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from inspect_robots import eval
-from inspect_robots.approver import Approver, AutoApprover, ClampApprover
+from inspect_robots.approver import Approver, AutoApprover, AutoPerturber, ClampApprover, Perturber
 from inspect_robots.controller import DefaultController
 from inspect_robots.errors import EmbodimentFault, PolicyError, SafetyAbort, _CancelledTrial
 from inspect_robots.frames import FrameStore
@@ -39,6 +39,7 @@ def _run(
     *,
     approver: Approver | None = None,
     frame_store: FrameStore | None = None,
+    perturber: Perturber | None = None,
 ) -> TrialRecord:
     return rollout(
         policy,  # type: ignore[arg-type]
@@ -51,6 +52,7 @@ def _run(
         approver=approver or AutoApprover(),
         sink=NullSink(),
         frame_store=frame_store,
+        perturber=perturber,
     )
 
 
@@ -792,3 +794,76 @@ def test_raising_server_url_property_does_not_mask_policy_failure() -> None:
     assert str(excinfo.value) == "base connection failure"
     assert excinfo.value.record is not None
     assert excinfo.value.record.error == "PolicyError: base connection failure"
+
+
+def test_auto_perturber_passes_observation_unchanged() -> None:
+    class _CaptureObsPolicy:
+        def __init__(self) -> None:
+            self.info = PolicyInfo(name="capture", action_space=_BOX)
+            self.config = PolicyConfig()
+            self.seen: list[Observation] = []
+
+        def reset(self, scene: Scene) -> None:
+            pass
+
+        def act(self, observation: Observation) -> ActionChunk:
+            self.seen.append(observation)
+            return ActionChunk(actions=[Action(data=np.zeros(2))], meta={"request_stop": True})
+
+    policy = _CaptureObsPolicy()
+    perturber = AutoPerturber()
+    record = _run(policy, CubePickEmbodiment(), perturber=perturber)
+    assert record.status == "success"
+    # AutoPerturber preserves identity, so no perturbation events are logged
+    assert not any(event.kind == "perturbation" for event in record.events)
+
+
+def test_perturber_modifying_observation_logs_perturbation_event() -> None:
+    class _InstructionPerturber:
+        def perturb(self, observation: Observation, store: dict[str, object]) -> Observation:
+            return replace(observation, instruction="modified instruction")
+
+    class _CaptureObsPolicy:
+        def __init__(self) -> None:
+            self.info = PolicyInfo(name="capture", action_space=_BOX)
+            self.config = PolicyConfig()
+            self.seen: list[Observation] = []
+
+        def reset(self, scene: Scene) -> None:
+            pass
+
+        def act(self, observation: Observation) -> ActionChunk:
+            self.seen.append(observation)
+            return ActionChunk(actions=[Action(data=np.zeros(2))], meta={"request_stop": True})
+
+    policy = _CaptureObsPolicy()
+    record = _run(policy, CubePickEmbodiment(), perturber=_InstructionPerturber())
+    assert record.status == "success"
+    assert policy.seen[0].instruction == "modified instruction"
+    pert_events = [e for e in record.events if e.kind == "perturbation"]
+    assert len(pert_events) >= 1
+    assert pert_events[0].data["perturber"] == "_InstructionPerturber"
+
+
+def test_perturber_raising_inspect_robots_error_propagates() -> None:
+    class _VetoPerturber:
+        def perturb(self, observation: Observation, store: dict[str, object]) -> Observation:
+            raise SafetyAbort("perturber aborted trial")
+
+    with pytest.raises(SafetyAbort, match="perturber aborted trial") as excinfo:
+        _run(ScriptedPolicy(), CubePickEmbodiment(), perturber=_VetoPerturber())
+    assert excinfo.value.record is not None
+    assert excinfo.value.record.status == "error"
+
+
+def test_perturber_raising_generic_exception_wrapped_as_embodiment_fault() -> None:
+    class _FaultyPerturber:
+        def perturb(self, observation: Observation, store: dict[str, object]) -> Observation:
+            raise RuntimeError("sensor noise calculation blew up")
+
+    with pytest.raises(
+        EmbodimentFault, match=r"_FaultyPerturber\.perturb\(\) raised RuntimeError"
+    ) as excinfo:
+        _run(ScriptedPolicy(), CubePickEmbodiment(), perturber=_FaultyPerturber())
+    assert excinfo.value.record is not None
+    assert excinfo.value.record.status == "error"


### PR DESCRIPTION
Summary: Implements the input-side Perturber protocol and AutoPerturber in approver.py, perturbation_event in transcript.py, and rollout integration. Fixes part of #403. cc @jeqcho

close https://github.com/robocurve/inspect-robots/issues/403