### PR TITLE
feat(log): record environment and checkpoint provenance in EvalSpec (#403)

### DIFF
--- a/src/inspect_robots/embodiment.py
+++ b/src/inspect_robots/embodiment.py
@@ -63,6 +63,10 @@ class EmbodimentInfo:
     supported_setups: frozenset[str] = field(default_factory=frozenset)
     supported_target_kinds: frozenset[str] = field(default_factory=frozenset)
     docs: str | None = None
+    # Environment provenance (e.g. simulator build ID, hardware rig ID).
+    environment_id: str | None = None
+    # Scene/asset revision hash or tag.
+    environment_revision: str | None = None
 
 
 @runtime_checkable

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -393,11 +393,6 @@ def _run_eval(
     if callable(bind_task):
         bind_task(task_envelope)
 
-    # Horizon-aware policies (e.g. LLM agent policies): optional bind_task() hook
-    policy_bind_task = getattr(policy, "bind_task", None)
-    if callable(policy_bind_task):
-        policy_bind_task(task_envelope)
-
     epoch_spec = task.epoch_spec
     scorers = task.scorers
     # Fail fast on an unknown/invalid epoch reducer, before any rollout runs.

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -244,6 +244,9 @@ def eval(
     operator_input: OperatorInput | None = None,
     before_scoring: Callable[[TrialRecord, Scene], None] | None = None,
     grader: Grader | str | None = None,
+    environment_id: str | None = None,
+    environment_revision: str | None = None,
+    policy_checkpoint: str | None = None,
 ) -> list[EvalLog]:
     """Run ``task`` with ``policy`` on ``embodiment``; return ``[EvalLog]``.
 
@@ -334,6 +337,9 @@ def eval(
             store_actions=store_actions,
             operator_input=operator_input,
             before_scoring=before_scoring,
+            environment_id=environment_id,
+            environment_revision=environment_revision,
+            policy_checkpoint=policy_checkpoint,
         )
     finally:
         # Close what we opened: a registry-resolved embodiment is released even
@@ -358,6 +364,9 @@ def _run_eval(
     store_actions: bool,
     operator_input: OperatorInput | None,
     before_scoring: Callable[[TrialRecord, Scene], None] | None,
+    environment_id: str | None = None,
+    environment_revision: str | None = None,
+    policy_checkpoint: str | None = None,
 ) -> list[EvalLog]:
     """The body of [`eval`][inspect_robots.eval.eval], after resolution/ownership."""
     from inspect_robots.logging.json_log import JsonLogSink
@@ -383,6 +392,11 @@ def _run_eval(
     bind_task = getattr(embodiment, "bind_task", None)
     if callable(bind_task):
         bind_task(task_envelope)
+
+    # Horizon-aware policies (e.g. LLM agent policies): optional bind_task() hook
+    policy_bind_task = getattr(policy, "bind_task", None)
+    if callable(policy_bind_task):
+        policy_bind_task(task_envelope)
 
     epoch_spec = task.epoch_spec
     scorers = task.scorers
@@ -427,6 +441,10 @@ def _run_eval(
         seed=seed,
         max_steps=task_envelope.max_steps,
         max_seconds=task.max_seconds,
+        environment_id=environment_id or getattr(embodiment.info, "environment_id", None),
+        environment_revision=environment_revision
+        or getattr(embodiment.info, "environment_revision", None),
+        policy_checkpoint=policy_checkpoint or getattr(policy.info, "checkpoint", None),
     )
     bus.bind_spaces(embodiment.info.action_space, embodiment.info.observation_space)
     bus.bind_frames_dir(str(frame_store.root) if frame_store is not None else None)

--- a/src/inspect_robots/log.py
+++ b/src/inspect_robots/log.py
@@ -32,6 +32,14 @@ class EvalSpec:
     ``max_steps`` is always the resolved integer budget used by the rollout.
     ``max_seconds`` preserves a benchmark's declared physical-time budget when
     that integer was derived from the embodiment's control rate.
+
+    The three optional provenance fields record what simulator build, asset
+    revision, and policy checkpoint were used, so a published number can be
+    re-derived months later even if the sim, scene assets, or policy have moved:
+
+    - ``environment_id``: simulator or hardware-rig identifier (e.g. ``"isaacsim-2026.1.0"``).
+    - ``environment_revision``: hash or tag of the scene/asset bundle (e.g. a git SHA).
+    - ``policy_checkpoint``: hash, path, or Hugging Face revision of the model checkpoint.
     """
 
     task: str
@@ -45,6 +53,10 @@ class EvalSpec:
     seed: int | None = None
     max_steps: int | None = None
     max_seconds: float | None = None
+    # Environment and checkpoint provenance (plan 0053).
+    environment_id: str | None = None
+    environment_revision: str | None = None
+    policy_checkpoint: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/inspect_robots/policy.py
+++ b/src/inspect_robots/policy.py
@@ -49,6 +49,8 @@ class PolicyInfo:
     observation_space: ObservationSpace = field(default_factory=ObservationSpace)
     # Desired control rate (Hz), if the policy was trained for a specific one.
     control_hz: float | None = None
+    # Policy checkpoint hash, revision, or identifier.
+    checkpoint: str | None = None
 
 
 @runtime_checkable

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -338,3 +338,44 @@ def test_evalspec_provenance_fields_absent_in_older_log_read_as_none(tmp_path: P
     assert restored.eval.environment_id is None
     assert restored.eval.environment_revision is None
     assert restored.eval.policy_checkpoint is None
+
+
+def test_eval_populates_provenance_from_kwargs_and_info(tmp_path: Path) -> None:
+    """eval() forwards explicit provenance kwargs or derives from embodiment/policy info."""
+    from dataclasses import replace
+
+    from inspect_robots import eval
+    from inspect_robots.mock import CubePickEmbodiment, ScriptedPolicy
+    from inspect_robots.scorer import success_at_end
+
+    task = Task(
+        name="prov_task",
+        scenes=[Scene(id="s0", instruction="reach", init_seed=0)],
+        scorer=success_at_end(),
+        max_steps=2,
+    )
+
+    # 1. From explicit kwargs
+    logs = eval(
+        task,
+        ScriptedPolicy(),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path / "run1"),
+        environment_id="sim-env-1",
+        environment_revision="git-sha-1",
+        policy_checkpoint="hf://org/model@v1",
+    )
+    assert logs[0].eval.environment_id == "sim-env-1"
+    assert logs[0].eval.environment_revision == "git-sha-1"
+    assert logs[0].eval.policy_checkpoint == "hf://org/model@v1"
+
+    # 2. Derived from info objects when kwargs are None
+    emb = CubePickEmbodiment()
+    emb.info = replace(emb.info, environment_id="emb-env", environment_revision="emb-rev")
+    pol = ScriptedPolicy()
+    pol.info = replace(pol.info, checkpoint="pol-ckpt")
+
+    logs2 = eval(task, pol, emb, log_dir=str(tmp_path / "run2"))
+    assert logs2[0].eval.environment_id == "emb-env"
+    assert logs2[0].eval.environment_revision == "emb-rev"
+    assert logs2[0].eval.policy_checkpoint == "pol-ckpt"

--- a/tests/test_eval_log.py
+++ b/tests/test_eval_log.py
@@ -288,3 +288,53 @@ def test_store_frames_runs_do_not_overwrite_each_other(tmp_path: Path) -> None:
     assert len(dirs) == 2  # distinct per-run directories
     for d in dirs:
         assert list(Path(d).glob("*.npy"))  # both runs' frames still on disk
+
+
+def test_evalspec_provenance_fields_round_trip(tmp_path: Path) -> None:
+    """EvalSpec provenance fields survive a JSON round-trip."""
+    log = EvalLog(
+        version=SCHEMA_VERSION,
+        status="success",
+        eval=EvalSpec(
+            task="demo",
+            policy="scripted",
+            embodiment="cubepick",
+            created="2026-08-27T00:00:00+00:00",
+            inspect_robots_version="0.0.0",
+            environment_id="isaacsim-2026.1.0",
+            environment_revision="abc123def456",
+            policy_checkpoint="hf://robot-org/pi0@v1.2",
+        ),
+        results=EvalResults(total_scenes=1, total_trials=1),
+        stats=EvalStats(
+            started_at="2026-08-27T00:00:00+00:00",
+            completed_at="2026-08-27T00:00:01+00:00",
+            duration_s=1.0,
+            total_steps=5,
+        ),
+    )
+    path = tmp_path / "prov.json"
+    import json
+
+    path.write_text(json.dumps(log.to_dict()), encoding="utf-8")
+    restored = read_eval_log(str(path))
+    assert restored.eval.environment_id == "isaacsim-2026.1.0"
+    assert restored.eval.environment_revision == "abc123def456"
+    assert restored.eval.policy_checkpoint == "hf://robot-org/pi0@v1.2"
+
+
+def test_evalspec_provenance_fields_absent_in_older_log_read_as_none(tmp_path: Path) -> None:
+    """A log written before provenance fields existed reads back with None defaults."""
+    data = _golden_log().to_dict()
+    # Simulate an older log that has no provenance keys.
+    data["eval"].pop("environment_id", None)
+    data["eval"].pop("environment_revision", None)
+    data["eval"].pop("policy_checkpoint", None)
+    path = tmp_path / "old.json"
+    import json
+
+    path.write_text(json.dumps(data), encoding="utf-8")
+    restored = read_eval_log(str(path))
+    assert restored.eval.environment_id is None
+    assert restored.eval.environment_revision is None
+    assert restored.eval.policy_checkpoint is None


### PR DESCRIPTION
Summary: Adds environment_id, environment_revision, and policy_checkpoint fields to EvalSpec, EmbodimentInfo, and PolicyInfo with backward-compatible deserialization and tests. Fixes part of #403. cc @jeqcho
close #403 