### PR TITLE
﻿docs(defaults,frames): clarify _parse_value effort and FrameStore si…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -925,3 +925,31 @@ fix below).
 [0.3.0]: https://github.com/robocurve/inspect-robots/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/robocurve/inspect-robots/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/robocurve/inspect-robots/releases/tag/v0.1.0
+
+## [Unreleased]
+
+### Fixed
+
+- **Core:** `_parse_value` docstring now reflects the post-0.23.0
+  `effort` contract used repo-wide: quoted `none` is forwarded as the
+  literal wire token, bare `effort=none` parses to Python `None` and is
+  normalized by downstream components to the minimum reasoning level,
+  and only key omission skips the field (#396).
+
+### Changed
+
+- **Frames:** `FrameStore` docstring now spells out the pre/post
+  side-car contract that has been in place since #209:
+  - reset frame written at step `0` (separate from any `StepRecord`);
+    a first-decision failure still leaves reset frames on disk for
+    forensics,
+  - pre-action frames surfaced via `step.observation.image_refs`
+    (formerly `step.observation.images`),
+  - post-action frames surfaced via `step.result_image_refs`
+    (migration target of the former `step.result.observation.images`),
+  - an `n`-step trial produces `n + 1` files per continuous camera
+    (one reset, `n` pre-action, plus the trailing post-action capture
+    at `t + 1`),
+  - `default_fps` assumes adjacent stored frames span one control
+    interval; the extra reset frame must be included in playback
+    duration calculations (#405).

--- a/src/inspect_robots/defaults.py
+++ b/src/inspect_robots/defaults.py
@@ -57,9 +57,12 @@ def _parse_value(text: str) -> Any:
     """Best-effort scalar parse for ``k=v`` args (bool/int/float/None/str).
 
     A value wrapped in matching single or double quotes is returned as the
-    literal inner string with no coercion — the escape hatch for strings the
-    heuristics would otherwise claim (``-P effort="'none'"`` sends the wire
-    string ``none`` instead of omitting the parameter).
+    literal inner string with no coercion -- the escape hatch for forcing a
+    wire-level token through unchanged (``-P effort="'none'"`` sends the
+    literal string ``none``). Bare ``effort=none``, by contrast, is parsed
+    as Python ``None`` and is normalized downstream by effort-taking
+    components to the minimum reasoning level; only key omission skips
+    the field entirely.
     """
     if len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
         return text[1:-1]

--- a/src/inspect_robots/frames.py
+++ b/src/inspect_robots/frames.py
@@ -47,7 +47,29 @@ class FrameRef:
 
 
 class FrameStore:
-    """Persist frames as ``.npy`` files under ``root`` and hand back refs."""
+    """Persist frames as ``.npy`` files under ``root`` and hand back refs.
+
+    Pre/post side-car contract — implemented since #209:
+
+    - A **reset frame** is written at step index ``0`` before any action
+      is taken; reset writes do not require a ``StepRecord``, so a
+      first-decision failure may still leave reset frames on disk for
+      forensics.
+    - **Pre-action frames** correspond to the observation the agent saw
+      and are surfaced through ``step.observation.image_refs``
+      (formerly ``step.observation.images``).
+    - **Post-action frames** are the camera reading taken after the
+      action but before the next step and are surfaced through
+      ``step.result_image_refs`` (the migration target of the former
+      ``step.result.observation.images``).
+    - A camera present throughout an ``n``-step trial produces
+      ``n + 1`` files on disk (one reset, ``n`` pre-action captures,
+      and the trailing post-action capture at ``t + 1``).
+    - ``default_fps`` assumes adjacent stored frames span one control
+      interval; the sequence contains an extra reset frame, so a
+      caller computing playback duration from
+      ``len(frames) / default_fps`` must include the reset in its count.
+    """
 
     def __init__(self, root: str):
         self.root = Path(root)


### PR DESCRIPTION
…de-car contract

docs(defaults): reword _parse_value docstring to match the post-0.23.0 effort=none contract used repo-wide: quoted 'none' forwards the literal wire token, bare 'effort=none' parses to Python None and is normalized by downstream components, and only key omission skips the field. Issue #396.

docs(frames): spell out the pre/post side-car contract that FrameStore implement since #209 - reset frame at step 0, pre-action frames via step.observation.image_refs, post-action frames via step.result_image_refs, n + 1 files per n-step trial, and the default_fps adjacency assumption. Issue #405.

Both edits are docs-only; coverage and behavior unchanged.

Closes #396
Closes #405

## Summary

What does this change do and why?

## Changes

-

## Checklist

- [x] `pre-commit install` done; hooks pass (or ran `pre-commit run --all-files`)
- [ ] Tests added/updated (and the `CubePick` mock exercises the change where applicable)
- [x] Coverage stays at **100%** (`pytest --cov`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `mypy` passes (strict)
- [x] `CHANGELOG.md` updated under "Unreleased"
- [ ] Public API changes are reflected in `inspect_robots.__all__` and the API-snapshot test
- [x] Core stays NumPy-only (new deps are optional extras, lazily imported)

## Related

Closes #
