### PR TITLE
docs(scoring): point benchmark authors at is_affirmative_verdict

### DIFF
--- a/docs/guide/scoring.md
+++ b/docs/guide/scoring.md
@@ -60,6 +60,12 @@ Task(..., epochs=Epochs(count=5, reducer="pass_at_2"))
 Real robots have no privileged success oracle. The dominant method is a human
 verdict, captured *once* per trial and read back by
 [`operator_scorer`](/api/#inspect_robots.scorer.operator_scorer), keeping scoring reproducible.
+Benchmarks that read `operator_judgement` directly, instead of delegating to
+`operator_scorer`, should call
+[`is_affirmative_verdict`](/api/#inspect_robots.scorer.is_affirmative_verdict)
+rather than restate the vocabulary. It owns the recognized affirmative words
+together with the case-folding and whitespace handling around them, so a change
+reaches every consumer at once.
 Capture is the job of a [`Grader`](/api/#inspect_robots.grader.Grader): a registered
 component (`inspect_robots.graders` entry point, `grader` decorator) whose
 `grade(record, scene)` runs once per scored trial, after the rollout and


### PR DESCRIPTION
## Summary

Follow-up to #415, taking the `docs/guide/scoring.md` nit you offered.

The operator section describes reading the verdict back through `operator_scorer`, but says nothing to benchmarks that read `operator_judgement` themselves. That is the path that produced the KitchenBench copy in the first place, so naming the predicate there is where it prevents a repeat.

## Changes

- One paragraph in `docs/guide/scoring.md`, immediately after the `operator_scorer` sentence, pointing at `is_affirmative_verdict` and saying what it owns (the vocabulary plus the case and whitespace handling).

## Verified

- `scripts/gen_api_docs.py` emits the target anchor: `#### is_affirmative_verdict {#inspect_robots.scorer.is_affirmative_verdict}`, so the `/api/#...` link resolves.
- The `Reject stale mkdocstrings autorefs` check (`ci.yml:59`) passes; I used the `/api/#...` form the rest of the file uses.
- No em dashes, per the writing-style rule. Noted from your review that it applies to docs pages.

## No CHANGELOG entry

Docs only, no behavior or API change. The repo's CHANGELOG uses Added/Fixed/Changed/Removed, and comparable docs merges (#405) logged the behavior change shipping alongside rather than the wording itself. Happy to add one under `Changed` if you would rather every docs PR appear there.

## Related

Follows #415.
