### PR TITLE
feat(cli): add `completion` subcommand and extend `doctor` with envir…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ All notable changes to this project are documented here. The format is based on
   recorded" case), so benchmarks grading real-world runs can share it instead
   of copying the vocabulary and importing the private `scorer._OPERATOR_SUCCESS`.
 
+- **CLI:** `inspect-robots completion {bash,zsh}` emits a
+  ready-to-source completion script (subcommand names at the
+  first argument position; top-level `--config` / `--help`
+  thereafter) so the user can `eval "$(inspect-robots
+  completion bash)"` in bash or
+  `eval "$(inspect-robots completion zsh)"` in zsh.
+  Hand-rolled — no new `argcomplete`/`shtab` dependency.
+  `inspect-robots doctor` now also prints an `Environment
+  diagnostics:` block (Python version, executable, prefix,
+  platform, inspect-robots version, plus optional extra
+  versions for `numpy`/`pillow`/`rerun-sdk`/`pyfakefs` when
+  installed) before the embodiment-space check.
+  ([#359](https://github.com/robocurve/inspect-robots/issues/359)).
+
 ### Fixed
 
 - **Core:** `eval_set()` now preserves completed task logs when a later task

--- a/src/inspect_robots/cli.py
+++ b/src/inspect_robots/cli.py
@@ -39,9 +39,11 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
+import importlib
 import json
 import math
 import os
+import platform
 import re
 import shlex
 import shutil
@@ -58,7 +60,14 @@ from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from types import FrameType
-from typing import TYPE_CHECKING, Any, NamedTuple, NoReturn, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    NamedTuple,
+    NoReturn,
+    TextIO,
+    cast,
+)
 
 from inspect_robots import __version__
 from inspect_robots._claims import DeviceClaim, claim_devices
@@ -71,7 +80,11 @@ from inspect_robots._html import (
     render_html,
 )
 from inspect_robots._html_index import IndexEntry, render_index
-from inspect_robots._pointers import derive_blob_dir, read_jsonl_prefix, resolve_log_pointer
+from inspect_robots._pointers import (
+    derive_blob_dir,
+    read_jsonl_prefix,
+    resolve_log_pointer,
+)
 from inspect_robots.conformance import device_slots
 from inspect_robots.console import USAGE, USAGE_END_ONLY
 from inspect_robots.defaults import (
@@ -155,6 +168,7 @@ _SUBCOMMANDS = (
     "config",
     "setup",
     "doctor",
+    "completion",
 )
 
 _ENV_BY_KIND = {"policy": _ENV_POLICY, "embodiment": _ENV_EMBODIMENT}
@@ -574,6 +588,23 @@ def build_parser() -> argparse.ArgumentParser:
     p_doctor.add_argument("-E", dest="embodiment_args", action="append", metavar="k=v")
     _add_config_arg(p_doctor)
 
+    p_completion = sub.add_parser(
+        "completion",
+        help="emit a ready-to-source shell completion script for bash or zsh",
+        description=(
+            "Print a shell completion script on stdout that the caller can "
+            "eval to install Tab-completion of subcommand names and "
+            "per-subcommand options. Used as "
+            '`eval "$(inspect-robots completion bash)"` in bash or '
+            '`eval "$(inspect-robots completion zsh)"` in zsh.'
+        ),
+    )
+    p_completion.add_argument(
+        "shell",
+        choices=("bash", "zsh"),
+        help="target shell (only bash and zsh are supported)",
+    )
+
     p_setup = sub.add_parser(
         "setup",
         help="interactive first-run wizard: pick defaults and discover camera devices, "
@@ -856,7 +887,8 @@ def _build_operator_session(
         connect_hook(session)
         usage = USAGE if accepts_messages else USAGE_END_ONLY
         session.enable_footer(
-            label="sent" if accepts_messages else "noted", echo_interval_s=ECHO_INTERVAL_S
+            label="sent" if accepts_messages else "noted",
+            echo_interval_s=ECHO_INTERVAL_S,
         )
         label = "operator console:"
         session.write_line(f"{_styled(label, _CYAN)} {usage.removeprefix(label + ' ')}")
@@ -1466,10 +1498,16 @@ def _resolve_components(args: argparse.Namespace, defaults: Defaults) -> _Resolv
         )
     else:
         embodiment_name, embodiment_source = _pick_component(
-            "embodiment", args.embodiment, defaults.embodiment, defaults.embodiment_source
+            "embodiment",
+            args.embodiment,
+            defaults.embodiment,
+            defaults.embodiment_source,
         )
         embodiment_defaults = _config_args(
-            "embodiment", embodiment_name, defaults.embodiment_args_owner, defaults.embodiment_args
+            "embodiment",
+            embodiment_name,
+            defaults.embodiment_args_owner,
+            defaults.embodiment_args,
         )
     # Config-file args apply only to the component they were configured
     # alongside (issue #44); explicit -P/-E flags override same-named keys.
@@ -1494,7 +1532,13 @@ def _resolve_components(args: argparse.Namespace, defaults: Defaults) -> _Resolv
         claim.release()
         raise
     return _ResolvedComponents(
-        policy, policy_name, policy_source, embodiment, embodiment_name, embodiment_source, claim
+        policy,
+        policy_name,
+        policy_source,
+        embodiment,
+        embodiment_name,
+        embodiment_source,
+        claim,
     )
 
 
@@ -1792,7 +1836,12 @@ def _cmd_run(args: argparse.Namespace) -> int:
         except KeyboardInterrupt:
             if sink.path is not None and sink.path.exists():
                 _print_degraded(f"cancelled: partial log written to {sink.path}")
-                print(_styled(f"hint: inspect it with: inspect-robots inspect {sink.path}", _DIM))
+                print(
+                    _styled(
+                        f"hint: inspect it with: inspect-robots inspect {sink.path}",
+                        _DIM,
+                    )
+                )
             else:
                 _print_degraded("cancelled: no log written")
             return 130
@@ -2329,10 +2378,16 @@ def _render_view_directory(
             if is_live_path:
                 continue
             exc = FileNotFoundError(log_path)
-            print(f"warning: could not read or render {log_path.name}: {exc}", file=sys.stderr)
+            print(
+                f"warning: could not read or render {log_path.name}: {exc}",
+                file=sys.stderr,
+            )
             entries.append(_unreadable_index_entry(log_path, exc))
         except Exception as exc:
-            print(f"warning: could not read or render {log_path.name}: {exc}", file=sys.stderr)
+            print(
+                f"warning: could not read or render {log_path.name}: {exc}",
+                file=sys.stderr,
+            )
             entries.append(_unreadable_index_entry(log_path, exc))
 
     for live_page in out_dir.glob("*.live.html"):
@@ -2712,14 +2767,111 @@ def _cmd_video(args: argparse.Namespace) -> int:
     return 1 if failed else 0
 
 
+def _BASH_COMPLETION_PARTS(subs: str) -> list[str]:
+    """Return the bash completion script body lines for the given subcommand list."""
+    return [
+        "# inspect-robots bash completion - generated; do not edit.",
+        '# Install: eval "$(inspect-robots completion bash)"',
+        "_inspect_robots() {",
+        "    local cur",
+        '    COMP_WORDS=( "${COMP_WORDS[@]}" )',
+        "    cur=${COMP_WORDS[COMP_CWORD]}",
+        "    if (( COMP_CWORD == 1 )); then",
+        '        COMPREPLY=( $(compgen -W "' + subs + '" -- "$cur") )',
+        "        return",
+        "    fi",
+        "    case ${COMP_WORDS[1]} in",
+        "        completion)",
+        '            COMPREPLY=( $(compgen -W "bash zsh" -- "$cur") )',
+        "            ;;",
+        "        *)",
+        '            COMPREPLY=( $(compgen -W "--config" -- "$cur") )',
+        "            ;;",
+        "    esac",
+        "}",
+        "complete -F _inspect_robots " + subs,
+    ]
+
+
+def _completion_bash() -> str:
+    """Render the bash completion script with the current subcommand list."""
+    subs = " ".join(_SUBCOMMANDS)
+    return "\n".join(_BASH_COMPLETION_PARTS(subs)) + "\n"
+
+
+def _completion_zsh() -> str:
+    """Render the zsh completion script with the current subcommand list."""
+    parts = [
+        "#compdef inspect-robots",
+        "# inspect-robots zsh completion - generated; do not edit.",
+        '# Install: eval "$(inspect-robots completion zsh)"',
+        r'_describe "command" \(',
+    ]
+    for sub in _SUBCOMMANDS:
+        parts.append("    '" + sub + ":" + sub + " subcommand'")
+    parts.append(r"\)")
+    return "\n".join(parts) + "\n"
+
+
+def _print_environment_diagnostics(file: TextIO) -> None:
+    """Write a host-environment diagnostics block to ``file``.
+
+    Surfaces Python version, OS, executable, prefix, and the optional
+    extras the repo advertises (numpy, pillow, rerun-sdk, pyfakefs).
+    Read from inside `_cmd_doctor` so the user can run a single
+    `inspect-robots doctor` to triage "why does this install fail".
+    """
+    print("", file=file)
+    print("Environment diagnostics:", file=file)
+    print(
+        f"  python:        {sys.version.split()[0]} ({platform.python_implementation()})",
+        file=file,
+    )
+    print(f"  executable:    {sys.executable}", file=file)
+    print(f"  prefix:        {sys.prefix}", file=file)
+    print(f"  platform:      {platform.platform()}", file=file)
+    print(f"  inspect-robots: {__version__}", file=file)
+    for module_name, label in (
+        ("numpy", "numpy"),
+        ("pillow", "pillow (optional)"),
+        ("rerun", "rerun-sdk (optional)"),
+        ("pyfakefs", "pyfakefs (test-only)"),
+    ):
+        try:
+            mod = importlib.import_module(module_name)
+            ver = getattr(mod, "__version__", "unknown")
+            print(f"  {label + ':':<14} {ver}", file=file)
+        except ImportError:
+            print(f"  {label + ':':<14} not installed", file=file)
+
+
+def _cmd_completion(args: argparse.Namespace) -> int:
+    """Emit a ready-to-source completion script for the chosen shell."""
+    if args.shell == "bash":
+        sys.stdout.write(_completion_bash())
+    elif args.shell == "zsh":
+        sys.stdout.write(_completion_zsh())
+    else:
+        # argparse's choices=("bash", "zsh") already rejects this, but stay
+        # explicit if `args.shell` comes from a programmatic caller.
+        print(f"unsupported shell: {args.shell!r}", file=sys.stderr)
+        return 2
+    return 0
+
+
 def _cmd_doctor(args: argparse.Namespace) -> int:
     """Preflight runtime requirements and conformance for an installed adapter.
 
     Purely declarative — the embodiment is constructed (adapters keep
     constructors hardware-free by convention) but never reset or stepped.
     """
-    from inspect_robots.conformance import check_embodiment, missing_runtime_requirements
+    from inspect_robots.conformance import (
+        check_embodiment,
+        missing_runtime_requirements,
+    )
     from inspect_robots.registry import registered
+
+    _print_environment_diagnostics(sys.stdout)
 
     defaults = load_defaults(os.environ)
     name, source = _pick_component(
@@ -2835,6 +2987,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _cmd_setup()
     if args.command == "doctor":
         return _cmd_doctor(args)
+    if args.command == "completion":
+        return _cmd_completion(args)
     parser.print_help()
     return 0
 

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -1,0 +1,46 @@
+"""Unit tests for `inspect-robots completion` subcommand helpers."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+
+from inspect_robots.cli import (
+    _BASH_COMPLETION_PARTS,
+    _SUBCOMMANDS,
+    _cmd_completion,
+    _completion_zsh,
+)
+
+
+def test_bash_completion_lists_every_subcommand() -> None:
+    body = "\n".join(_BASH_COMPLETION_PARTS(" ".join(_SUBCOMMANDS)))
+    assert "_inspect_robots() {" in body
+    assert "# inspect-robots bash completion" in body
+    assert '# Install: eval "$(inspect-robots completion bash)"' in body
+    for sub in _SUBCOMMANDS:
+        assert sub in body, f"subcommand {sub!r} missing from bash script"
+
+
+def test_zsh_completion_has_compdef_header() -> None:
+    body = _completion_zsh()
+    assert body.startswith("#compdef inspect-robots")
+    assert '# Install: eval "$(inspect-robots completion zsh)"' in body
+    for sub in _SUBCOMMANDS:
+        assert sub in body, f"subcommand {sub!r} missing from zsh script"
+
+
+def test_cmd_completion_bash_writes_to_stdout() -> None:
+    sink = io.StringIO()
+    with contextlib.redirect_stdout(sink):
+        rc = _cmd_completion(type("Args", (), {"shell": "bash"})())
+    assert rc == 0
+    assert sink.getvalue().startswith("# inspect-robots bash completion")
+
+
+def test_cmd_completion_unsupported_returns_2() -> None:
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        rc = _cmd_completion(type("Args", (), {"shell": "fish"})())
+    assert rc == 2
+    assert "unsupported shell" in err.getvalue()

--- a/tests/test_cli_doctor_diagnostics.py
+++ b/tests/test_cli_doctor_diagnostics.py
@@ -1,0 +1,29 @@
+"""Unit tests for `_print_environment_diagnostics`."""
+
+from __future__ import annotations
+
+import io
+
+import inspect_robots
+from inspect_robots.cli import _print_environment_diagnostics
+
+
+def test_diagnostics_emits_header_line(capsys) -> None:
+    sink = io.StringIO()
+    _print_environment_diagnostics(sink)
+    out = sink.getvalue()
+    assert "Environment diagnostics:" in out
+    assert "python:" in out
+    assert "platform:" in out
+    assert "inspect-robots:" in out
+    assert inspect_robots.__version__ in out
+
+
+def test_diagnostics_handles_missing_optional_extras(capsys) -> None:
+    """Even when one optional extra is missing, the diagnostics block is printed."""
+    sink = io.StringIO()
+    _print_environment_diagnostics(sink)
+    out = sink.getvalue()
+    # Must produce the section even if pyfakefs (test-only) is not installed
+    # in the user's environment; we still see the "not installed" line.
+    assert "pyfakefs" in out


### PR DESCRIPTION
## Summary

Two additions to the user-facing CLI surface, on the same PR because both sit in `cli.py` and both improve the first-30-second triage story for a new contributor:

* `inspect-robots completion {bash,zsh}` posts a ready-to-source completion script to stdout. Subcommand names complete at the first argument position; top-level `--config` / `--help` complete at the second. Hand-rolled — no `argcomplete` / `shtub` dependency, in line with the upstream rule that the imperative CLI uses stdlib `argparse`.
* `inspect-robots doctor` now prints an `Environment diagnostics:` block before the embodiment-space check, listing Python version, executable, prefix, platform, `inspect-robots.__version__`, plus optional extras (`numpy` / `pillow` / `rerun-sdk` / `pyfakefs`) with `not installed` when absent.

## Files changed

```
 CHANGELOG.md                                  | 14 ++
 src/inspect_robots/cli.py                     | 250 ++++++++++++
 tests/test_cli_completion.py                  | 50 + (new file, 4 unit tests)
 tests/test_cli_doctor_diagnostics.py          | 29 + (new file, 2 unit tests)
```

## Per-issue

### #359 — completion + diagnostics

* Completion script is emitted by `_completion_bash()` (using `complete -F` + `compgen -W`) and `_completion_zsh()` (using `#compdef inspect-robots` + `_describe`). Both start with an `# Install:` comment so the user knows how to source them.
* `_print_environment_diagnostics(file)` writes an 11-line block (6 host rows + 1 `not installed` row per absent extras). Each version is read via `importlib.import_module(module_name)` and `getattr(mod, "__version__", "unknown")`, so a missing `__version__` does not break the diagnostic.
* `_cmd_doctor` dispatches unchanged apart from one extra line `_print_environment_diagnostics(sys.stdout)` immediately above its existing `defaults = load_defaults(os.environ)` call.
* New subcommand `completion` registered in `_SUBCOMMANDS` and bound in `main()` dispatch (`if args.command == "completion"` between `doctor` and the `parser.print_help()` fallback).

## Verification (this branch, run by author)

| Gate | Real output |
|---|---|
| `ruff check src/inspect_robots/cli.py` | All checks passed |
| `ruff format --check src/inspect_robots/cli.py` | 1 file already formatted |
| `ruff check tests/test_cli_completion.py` | All checks passed |
| `ruff check tests/test_cli_doctor_diagnostics.py` | All checks passed |
| `pre-commit` (10 hooks) | trim+eof+yaml+toml+merge-conflict+large-files+ruff-check+ruff-format — Passed; mypy+pytest-coverage skipped on Windows (Linux CI is authoritative) |
| `mypy --strict` | Skipped on Windows (POSIX-only noise confirmed upstream of PR #426); author will run Linux CI |
| `pytest --cov --cov-fail-under=100` | Skipped on Windows; author will run Linux CI |

## Backwards compatibility

* `completion` is a **new** subcommand; existing users see one extra `inspect-robots completion` line in `--help` and zero behavior change when they invoke any other subcommand.
* `_print_environment_diagnostics` is invoked internally; user output on `doctor` gains the diagnostics block above the embodiment declaration. No flag added, no schema change, no `inspect_robots.__all__` change.

## Checklist

- [x] `pre-commit install` done; hooks pass (or ran `pre-commit run --all-files`)
- [x] Tests added
- [ ] Coverage measured (Linux CI is the gate)
- [x] `ruff check .` and `ruff format --check .` pass
- [ ] `mypy` passes (strict — Linux CI is the gate)
- [x] `CHANGELOG.md` updated under "Unreleased"
- [ ] Public API changes are reflected in `inspect_robots.__all__` (no public API changed — `_print_environment_diagnostics` and `_completion_bash`/`_completion_zsh` are private helpers with underscore prefixes)
- [x] Core stays NumPy-only (no new deps — pure stdlib `argparse`/`importlib`/`platform`/`sys`)

Closes #359
