### PR TITLE
fix(eval): preserve stop signal across cleanup failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **Core:** a registry-owned embodiment cleanup failure no longer replaces an
+  escaping `SafetyAbort`, `EmbodimentFault`, or `KeyboardInterrupt`. Cleanup is
+  still attempted and its failure is reported as a warning, while the original
+  stop signal propagates so `eval_set()` cannot advance to another task
+  ([plan 0081](plans/0081-close-halt-precedence.md)).
+
 - **Core:** `eval_set()` now preserves completed task logs when a later task
   raises, reports the failure as an in-memory error log, and continues with
   the remaining tasks. A `SafetyAbort` or `EmbodimentFault` that escapes

--- a/plans/0081-close-halt-precedence.md
+++ b/plans/0081-close-halt-precedence.md
@@ -1,0 +1,69 @@
+# 0081: Preserve stop signals across owned cleanup failure
+
+## Problem
+
+`eval()` closes an embodiment that it resolves from a registry name in a
+`finally` block. If `_run_eval()` raises an escaping `SafetyAbort`,
+`EmbodimentFault`, or `KeyboardInterrupt` and `embodiment.close()` then raises
+an ordinary exception, Python replaces the original stop signal with the
+cleanup failure.
+
+That replacement breaks the existing `eval_set()` contract. The set re-raises
+escaping safety and cancellation signals, but it contains an ordinary cleanup
+exception as a task error and advances to the next task. A disconnected robot
+can therefore lose the signal that should have stopped the set.
+
+Reproduced on `main` at `84a4322`: a registry-owned embodiment raises a stop
+signal from `bind_task()` and `RuntimeError("disconnect failed")` from
+`close()`. `eval_set()` returns two synthesized error logs instead of
+re-raising the stop before the second task.
+
+## Design
+
+Keep the existing lifecycle and exception policy, with one narrow precedence
+rule:
+
+| `_run_eval()` outcome | `close()` outcome | Result |
+| --- | --- | --- |
+| return | return | return the evaluation log |
+| return | ordinary exception | propagate the cleanup exception, unchanged |
+| ordinary exception | return | propagate the original exception, unchanged |
+| ordinary exception | ordinary exception | propagate the cleanup exception, unchanged |
+| escaping safety or cancellation signal | return | propagate the original signal |
+| escaping safety or cancellation signal | ordinary exception | emit a `RuntimeWarning` and propagate the original signal |
+
+The protected signals are `SafetyAbort`, `EmbodimentFault`, and
+`KeyboardInterrupt`, including `_CancelledTrial`. The cleanup diagnostic uses
+a local `warnings.simplefilter("always", RuntimeWarning)` so a caller's warning
+filter cannot convert the diagnostic into another exception and mask the stop
+signal. Cleanup is still attempted exactly once.
+
+The helper catches `Exception`, not `BaseException`. A new
+`KeyboardInterrupt` raised by cleanup is therefore not swallowed.
+
+## Tests
+
+`tests/test_eval_orchestration.py` covers:
+
+- each protected signal escaping from a registry-owned embodiment whose
+  `close()` raises;
+- propagation of the original type and message;
+- exactly one `bind_task()` and one `close()` call, proving that `eval_set()`
+  does not advance to the second task;
+- the cleanup warning; and
+- a negative control proving that ordinary exception precedence is unchanged.
+
+The protected tests fail on the base commit because no stop signal escapes.
+
+## Documentation
+
+Update the `eval()` and `eval_set()` docstrings, the package agent guide, and
+the changelog. No public type or schema changes.
+
+## Out of scope
+
+- Changing the retained behavior for a halt caught inside a trial. It still
+  ends that task with an error log, and `eval_set()` continues as documented.
+- Adding `EvalLog.halted` or any other log field.
+- Adding a stop-after-halt rule to `eval_set()`.
+- Changing cleanup precedence for ordinary exceptions or successful runs.

--- a/src/inspect_robots/CLAUDE.md
+++ b/src/inspect_robots/CLAUDE.md
@@ -25,7 +25,7 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
 | `compat.py` | `check_compatibility`/`assert_compatible` — fail-fast before rollout |
 | `conformance.py` | adapter conformance kit: `check_embodiment`/`assert_embodiment_conformant` for declarative guardrail/agent readiness; `missing_runtime_requirements` provides runtime-dependency preflight; `DeviceSlot`/`device_slots` and `OptionSlot`/`option_slots` declare and defensively read embodiment device and boolean option slots |
 | `errors.py` | error taxonomy (continue vs halt) |
-| `eval.py` | `eval()` / `eval_set()` orchestration, including the default-on atomic per-trial `actions/` JSONL side-car, per-run `bind_spaces`, `bind_frames_dir`, and `bind_scenes` sink extension binding, source-preserving operator-message persistence with console fallback for old events, and per-key JSON-safe scene-metadata persistence; `eval_set()` contains ordinary per-task exceptions as in-memory error logs so later tasks continue; `grader=` (object or registry name) and `before_scoring=` are the same pre-scoring seam, mutually exclusive, validated against the `Grader` protocol |
+| `eval.py` | `eval()` / `eval_set()` orchestration, including the default-on atomic per-trial `actions/` JSONL side-car, per-run `bind_spaces`, `bind_frames_dir`, and `bind_scenes` sink extension binding, source-preserving operator-message persistence with console fallback for old events, and per-key JSON-safe scene-metadata persistence; `eval_set()` contains ordinary per-task exceptions as in-memory error logs so later tasks continue, while an escaping safety or cancellation signal retains precedence over an ordinary registry-owned embodiment cleanup failure; `grader=` (object or registry name) and `before_scoring=` are the same pre-scoring seam, mutually exclusive, validated against the `Grader` protocol |
 | `log.py` | immutable, schema-versioned `EvalLog` + `read_eval_log`, including the shared JSON-safety helper for scene metadata and operator messages/policy transcripts parallel to epochs; `SceneResult.judgement_sources` (parallel to `epochs`) records which path produced each operator judgement |
 | `taskgen.py` | `generate_scene()`: seeded initial-frame task and rubric generation over the lazy OpenAI-compatible chat wire; returns the policy instruction in `Scene.instruction` and the grader rubric in `Scene.metadata["rubric"]` |
 | `logging/` | `LogSink` protocol and optional duck-typed `log_policy_messages()`, `bind_spaces()`, `bind_frames_dir()`, and `bind_scenes()` hooks, `JsonLogSink` (atomic final log), `LiveLogSink` (atomic throttled schema-valid running snapshots with the bound frame directory and scene identity; removes a previous run's unfinished snapshot at the next `on_eval_start`, plans 0055 and 0058), optional `RerunSink` (non-blocking worker thread for steps and transcript rows; per-trial arm-grouped blueprints from bound spaces, plan 0041; configurable live-viewer spawn port, plan 0044; rerun-sdk 0.24 live plus `.rrd` tee with per-eval directory naming and resolved-path reporting, plan 0059; drops under pressure, never delays control) |
@@ -59,7 +59,8 @@ interfaces. The package is `mypy --strict` clean and ships `py.typed`.
   which every trial errored ends with `status == "error"` even under the
   default `fail_on_error=False`.
 - `eval()` closes embodiments it resolved from registry names ("close what we
-  open"); caller-constructed objects are caller-owned.
+  open"); caller-constructed objects are caller-owned. If cleanup also fails,
+  an escaping safety or cancellation signal retains precedence.
 - The CLI releases device claims in the same `finally` that closes the
   embodiment.
 - `mock/` and core must never import `rerun`/`torch` at module top.

--- a/src/inspect_robots/eval.py
+++ b/src/inspect_robots/eval.py
@@ -91,6 +91,23 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _close_preserving_stop_signal(embodiment: Embodiment, stop: BaseException) -> None:
+    """Close an owned embodiment without replacing an escaping stop signal."""
+    try:
+        embodiment.close()
+    except Exception as exc:
+        # Warning filters owned by the caller must not turn this diagnostic into
+        # another exception that masks the safety or cancellation signal.
+        with warnings.catch_warnings():
+            warnings.simplefilter("always", RuntimeWarning)
+            warnings.warn(
+                f"embodiment.close() raised {type(exc).__name__}: {exc} while handling "
+                f"{type(stop).__name__}; preserving {type(stop).__name__}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+
 def _write_action_log(
     record: TrialRecord,
     log_dir: str,
@@ -267,7 +284,11 @@ def eval(
     ergonomic that keeps logs and the CLI reproducible. An embodiment resolved
     from a registry name is owned by ``eval()`` and is closed when the run
     finishes (even on a halt); a caller-constructed embodiment object stays
-    open — the caller owns its lifecycle.
+    open — the caller owns its lifecycle. If owned cleanup fails while a
+    ``SafetyAbort``, ``EmbodimentFault``, or ``KeyboardInterrupt`` is escaping,
+    a ``RuntimeWarning`` reports the cleanup failure and the original stop
+    signal retains precedence. Cleanup failures after other outcomes retain
+    their existing propagation behavior.
 
     ``seed=None`` draws a fresh seed from the OS and records it in the log, so
     an "unseeded" run remains reproducible after the fact (and is distinct from
@@ -340,28 +361,36 @@ def eval(
         if isinstance(embodiment, str)
         else embodiment
     )
+    stop_signal: BaseException | None = None
     try:
-        return _run_eval(
-            task,
-            policy,
-            embodiment,
-            log_dir=log_dir,
-            sinks=sinks,
-            seed=seed,
-            fail_on_error=fail_on_error,
-            controller=controller,
-            approver=approver,
-            remap=remap,
-            store_frames=store_frames,
-            store_actions=store_actions,
-            operator_input=operator_input,
-            before_scoring=before_scoring,
-        )
+        try:
+            return _run_eval(
+                task,
+                policy,
+                embodiment,
+                log_dir=log_dir,
+                sinks=sinks,
+                seed=seed,
+                fail_on_error=fail_on_error,
+                controller=controller,
+                approver=approver,
+                remap=remap,
+                store_frames=store_frames,
+                store_actions=store_actions,
+                operator_input=operator_input,
+                before_scoring=before_scoring,
+            )
+        except (SafetyAbort, EmbodimentFault, KeyboardInterrupt) as exc:
+            stop_signal = exc
+            raise
     finally:
         # Close what we opened: a registry-resolved embodiment is released even
         # when the run halts, so a real robot never leaks its connection.
         if owns_embodiment:
-            embodiment.close()
+            if stop_signal is None:
+                embodiment.close()
+            else:
+                _close_preserving_stop_signal(embodiment, stop_signal)
 
 
 def _run_eval(
@@ -848,7 +877,8 @@ def eval_set(
 
     With a string embodiment, a non-safety exception from ``close()`` can
     produce an error row even when that task's completed JSON log is already
-    on disk.
+    on disk. If cleanup also fails while an escaping safety or cancellation
+    signal is active, the stop signal retains precedence and still propagates.
 
     ``store_actions`` follows ``eval()``'s default-on action side-car contract.
 

--- a/tests/test_eval_orchestration.py
+++ b/tests/test_eval_orchestration.py
@@ -880,6 +880,95 @@ def test_eval_closes_resolved_embodiment_even_on_failure(tmp_path: Path) -> None
     assert _CLOSED == ["closed"]  # released even though the run failed fast
 
 
+@pytest.mark.parametrize(
+    ("stop_type", "message"),
+    [
+        (SafetyAbort, "unsafe"),
+        (EmbodimentFault, "robot fault"),
+        (KeyboardInterrupt, "operator stop"),
+    ],
+)
+def test_eval_set_preserves_escaping_stop_when_owned_close_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stop_type: type[BaseException],
+    message: str,
+) -> None:
+    """An owned cleanup failure must not turn a set-stopping signal into a task error."""
+    import sys
+
+    stop = stop_type(message)
+
+    class _StopAndCloseFailEmbodiment(CubePickEmbodiment):
+        def __init__(self) -> None:
+            super().__init__()
+            self.bind_calls = 0
+            self.close_calls = 0
+
+        def bind_task(self, envelope: TaskEnvelope) -> None:
+            del envelope
+            self.bind_calls += 1
+            raise stop
+
+        def close(self) -> None:
+            self.close_calls += 1
+            raise RuntimeError("disconnect failed")
+
+    owned = _StopAndCloseFailEmbodiment()
+
+    def resolve(kind: str, name: str, /, **kwargs: object) -> object:
+        del kwargs
+        assert (kind, name) == ("embodiment", "stop-and-close-fail")
+        return owned
+
+    monkeypatch.setattr(sys.modules["inspect_robots.registry"], "resolve", resolve)
+
+    with (
+        pytest.warns(RuntimeWarning, match=f"preserving {stop_type.__name__}"),
+        pytest.raises(stop_type, match=message) as exc_info,
+    ):
+        eval_set(
+            [_task(max_steps=1), _task(max_steps=1)],
+            ScriptedPolicy(),
+            "stop-and-close-fail",
+            log_dir=str(tmp_path),
+        )
+
+    assert owned.bind_calls == 1
+    assert owned.close_calls == 1
+    assert exc_info.value is stop
+
+
+def test_eval_keeps_cleanup_precedence_for_ordinary_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The narrow stop-signal rule must not change ordinary exception cleanup."""
+    import sys
+
+    class _ErrorAndCloseFailEmbodiment(CubePickEmbodiment):
+        def bind_task(self, envelope: TaskEnvelope) -> None:
+            del envelope
+            raise ConfigError("invalid task")
+
+        def close(self) -> None:
+            raise RuntimeError("disconnect failed")
+
+    def resolve(kind: str, name: str, /, **kwargs: object) -> object:
+        del kwargs
+        assert (kind, name) == ("embodiment", "error-and-close-fail")
+        return _ErrorAndCloseFailEmbodiment()
+
+    monkeypatch.setattr(sys.modules["inspect_robots.registry"], "resolve", resolve)
+
+    with pytest.raises(RuntimeError, match="disconnect failed"):
+        eval(
+            _task(max_steps=1),
+            ScriptedPolicy(),
+            "error-and-close-fail",
+            log_dir=str(tmp_path),
+        )
+
+
 # --------------------------------------------------------------------------- #
 # 6. seed=None draws recorded OS entropy; bad reducers fail fast.
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Preserve an escaping safety or cancellation signal when cleanup of a registry-owned embodiment also fails. Without this precedence rule, the cleanup exception replaces the original stop signal and `eval_set()` contains it as an ordinary task error, then advances to another task.

Cleanup is still attempted exactly once. Its ordinary failure is reported with a `RuntimeWarning`, while the original `SafetyAbort`, `EmbodimentFault`, or `KeyboardInterrupt` propagates.

## Changes

- Add a narrow owned-cleanup path for escaping stop signals.
- Keep cleanup precedence unchanged for successful runs and ordinary exceptions.
- Cover all three protected signals, exact exception identity, warning emission, one cleanup attempt, and the no-next-task boundary.
- Add a negative control for the existing ordinary-exception behavior.
- Document the precedence matrix and update the lifecycle contract and changelog.

The retained behavior for a halt caught inside a trial is unchanged: that task returns an error log and `eval_set()` continues. This PR does not add `EvalLog.halted` or a stop-after-halt rule.

## Checklist

- [x] `pre-commit run --all-files` passes.
- [x] Tests added for the regression and negative control.
- [x] Coverage remains at 100%: 1,670 passed, 6 optional skips.
- [x] `ruff check .` and `ruff format --check .` pass.
- [x] Strict `mypy` passes.
- [x] `CHANGELOG.md` updated under Unreleased.
- [x] Public API and log schema remain unchanged.
- [x] Core remains NumPy-only with no dependency changes.
- [x] API generation, Docusaurus production build, package build, and the pre-push hook pass.

## Related

- Design and regression matrix: [plan 0081](plans/0081-close-halt-precedence.md)