### PR TITLE
fix(controller): handle empty ActionChunk gracefully in EnsemblingController

### DIFF
--- a/src/inspect_robots/controller.py
+++ b/src/inspect_robots/controller.py
@@ -163,6 +163,10 @@ class EnsemblingController:
     ) -> Action:
         """Query once for step ``t`` and blend every retained prediction for that step."""
         chunk = policy.act(observation)
+        if not chunk.actions:
+            from inspect_robots.errors import PolicyError
+
+            raise PolicyError(f"policy {policy.info.name!r} returned an empty ActionChunk")
         store.setdefault(_INFER_KEY, []).append((chunk.inference_latency_s, len(chunk)))
 
         buffer: list[tuple[int, list[Any], dict[str, Any]]] = store.setdefault(_ENSEMBLE_KEY, [])

--- a/tests/test_ensembling.py
+++ b/tests/test_ensembling.py
@@ -142,5 +142,5 @@ def test_empty_chunk_raises_policy_error() -> None:
     ctrl = EnsemblingController(_DELTA_SPACE, m=0.1)
     store: dict[str, object] = {}
     obs = Observation()
-    with pytest.raises(PolicyError, match="empty-chunk-policy.*empty ActionChunk"):
+    with pytest.raises(PolicyError, match=r"empty-chunk-policy.*empty ActionChunk"):
         ctrl.next_action(_EmptyChunkPolicy(), obs, 0, store)

--- a/tests/test_ensembling.py
+++ b/tests/test_ensembling.py
@@ -118,3 +118,29 @@ def test_eval_with_ensembling_succeeds(tmp_path: object) -> None:
     )
     assert logs[0].status == "success"
     assert logs[0].results.metrics["success_at_end"] == 1.0
+
+
+def test_empty_chunk_raises_policy_error() -> None:
+    from inspect_robots.errors import PolicyError
+
+    class _EmptyChunkPolicy:
+        def __init__(self) -> None:
+            self.info = PolicyInfo(name="empty-chunk-policy", action_space=_DELTA_SPACE)
+            self.config = PolicyConfig()
+
+        def reset(self, scene: Scene) -> None:
+            return None
+
+        def act(self, observation: Observation) -> ActionChunk:
+            chunk = object.__new__(ActionChunk)
+            object.__setattr__(chunk, "actions", ())
+            object.__setattr__(chunk, "control_hz", None)
+            object.__setattr__(chunk, "inference_latency_s", None)
+            object.__setattr__(chunk, "meta", {})
+            return chunk
+
+    ctrl = EnsemblingController(_DELTA_SPACE, m=0.1)
+    store: dict[str, object] = {}
+    obs = Observation()
+    with pytest.raises(PolicyError, match="empty-chunk-policy.*empty ActionChunk"):
+        ctrl.next_action(_EmptyChunkPolicy(), obs, 0, store)


### PR DESCRIPTION
### Summary

When a policy returns an empty \ActionChunk\ under \EnsemblingController\, the controller previously attempted to slice, stack, and compute weights across an empty prediction list. This triggered uncaught internal exceptions:
- \ValueError: need at least one array to stack\
- \IndexError: list index out of range\

This PR aligns \EnsemblingController\ with \DefaultController\ by explicitly checking for empty action chunks and raising a clear \PolicyError\ (\policy <name> returned an empty ActionChunk\), allowing the rollout framework to handle the failure gracefully.

### Changes
- \src/inspect_robots/controller.py\: Added \if not chunk.actions: raise PolicyError(...)\ check to \EnsemblingController.next_action()\.
- \	ests/test_ensembling.py\: Added unit test \	est_empty_chunk_raises_policy_error\ verifying the error handling.

cc @jeqcho