### PR TITLE
fix(logging): sanitize non-finite NumPy floating scalars to prevent json.dump crashes

### DIFF
--- a/src/inspect_robots/logging/json_log.py
+++ b/src/inspect_robots/logging/json_log.py
@@ -23,6 +23,8 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 if TYPE_CHECKING:
     from inspect_robots.log import EvalLog, EvalSpec
     from inspect_robots.rollout import TrialRecord
@@ -50,8 +52,9 @@ def _sanitize(obj: object) -> object:
     literals for them (``default=`` never fires for floats), which RFC 8259
     parsers reject.
     """
-    if isinstance(obj, float):
-        return obj if math.isfinite(obj) else None
+    if isinstance(obj, (float, np.floating)):
+        val = float(obj)
+        return val if math.isfinite(val) else None
     if isinstance(obj, dict):
         return {key: _sanitize(value) for key, value in obj.items()}
     if isinstance(obj, (list, tuple)):

--- a/tests/test_strict_json.py
+++ b/tests/test_strict_json.py
@@ -67,20 +67,30 @@ def test_sanitize_maps_non_finite_floats_to_none() -> None:
         "inf": float("inf"),
         "ninf": float("-inf"),
         "nan": float("nan"),
+        "np_nan32": np.float32(np.nan),
+        "np_inf32": np.float32(np.inf),
+        "np_ninf32": np.float32(-np.inf),
+        "np_nan16": np.float16(np.nan),
+        "np_fine32": np.float32(2.5),
         "fine": 1.5,
         "int": 3,
         "flag": True,
-        "nested": [float("inf"), {"d": float("nan")}, (2.0, float("-inf"))],
+        "nested": [float("inf"), {"d": float("nan")}, (2.0, float("-inf"), np.float32(np.nan))],
     }
     clean = _sanitize(dirty)
     assert clean == {
         "inf": None,
         "ninf": None,
         "nan": None,
+        "np_nan32": None,
+        "np_inf32": None,
+        "np_ninf32": None,
+        "np_nan16": None,
+        "np_fine32": 2.5,
         "fine": 1.5,
         "int": 3,
         "flag": True,
-        "nested": [None, {"d": None}, [2.0, None]],
+        "nested": [None, {"d": None}, [2.0, None, None]],
     }
 
 
@@ -196,3 +206,26 @@ def test_policy_transcript_non_finite_floats_write_as_null(tmp_path: Path) -> No
     assert isinstance(samples, list)
     transcript = samples[0]["policy_transcripts"][0]
     assert transcript == {"inf": None, "nan": None}
+
+
+def test_numpy_float_non_finite_writes_as_null(tmp_path: Path) -> None:
+    def hook(record: TrialRecord, scene: Scene) -> None:
+        record.metadata["np_nan32"] = np.float32(np.nan)
+        record.metadata["np_inf32"] = np.float32(np.inf)
+        record.metadata["np_fine32"] = np.float32(3.14)
+
+    eval(
+        _task(),
+        ScriptedPolicy(),
+        CubePickEmbodiment(),
+        log_dir=str(tmp_path),
+        before_scoring=hook,
+    )
+    (path,) = tmp_path.glob("*.json")
+    data = _read_strict(path)
+    samples = data["samples"]
+    assert isinstance(samples, list)
+    meta = samples[0]["trial_metadata"][0]
+    assert meta["np_nan32"] is None
+    assert meta["np_inf32"] is None
+    assert meta["np_fine32"] == pytest.approx(3.14, rel=1e-3)


### PR DESCRIPTION
### Summary

\JsonLogSink._sanitize\ maps non-finite float values (\NaN\, \±inf\) to \None\ (\
ull\ in JSON) so that \json.dump(..., allow_nan=False)\ generates strict RFC 8259-compliant JSON logs.

However, \_sanitize\ previously only matched Python \isinstance(obj, float)\. In NumPy, floating scalar types like \
p.float32\ and \
p.float16\ inherit from \
p.floating\ and evaluate to \False\ for \isinstance(..., float)\.

When trial metadata, custom scorer outputs, or policy logs stored non-finite \
p.float32\ / \
p.float16\ values (e.g. \
p.float32(np.nan)\ or \
p.float32(np.inf)\), they passed through \_sanitize\ unchanged, causing \json.dump(..., allow_nan=False)\ in \on_eval_end\ to raise \ValueError: Out of range float values are not JSON compliant\. This uncaught error prevented the final \.json\ eval log from being written to disk at the end of the run.

### Changes
- \src/inspect_robots/logging/json_log.py\: Extended \_sanitize\ to match \isinstance(obj, (float, np.floating))\ and safely coerce to Python floats.
- \	ests/test_strict_json.py\: Added unit and end-to-end tests for \
p.float32\ and \
p.float16\ sanitization and serialization.

cc @jeqcho